### PR TITLE
feat: bootstrap parachute-channel — daemon + bridge architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.log

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,102 @@
+# parachute-channel
+
+Messaging gateway for Claude Code. Telegram today, anything tomorrow.
+
+## Architecture
+
+Two components — daemon and bridge — connected by SSE:
+
+```
+Telegram API
+    ↕ getUpdates / sendMessage / etc.
+daemon (port 1941, long-running, one per machine)
+    ↕ SSE for inbound, HTTP for outbound
+bridge (stdio MCP, spawned per-session by Claude Code)
+    ↕ stdio MCP notifications + tools
+Claude Code session
+```
+
+The **daemon** is the only process that touches the Telegram API. It owns the getUpdates long-poll exclusively — no multi-consumer races by construction. Multiple bridges can connect simultaneously.
+
+The **bridge** is a stateless MCP server that Claude Code spawns as a subprocess. It declares `claude/channel` capability so Claude Code registers a notification listener. It connects to the daemon's SSE `/events` stream and forwards each event as a `notifications/claude/channel` MCP notification. Outbound tool calls (reply, react, edit, download) proxy to the daemon's HTTP API.
+
+## Why not the official telegram plugin?
+
+The official plugin has a known bug (anthropics/claude-code#38098, open): every Claude Code session with the plugin enabled at any scope auto-spawns a Telegram poller child, even without `--channels`. This causes multi-consumer races that drop ~50% of messages. The plugin system's `enabledPlugins` resolution is session-global and can't be scoped to one session. This gateway solves the problem by design: one daemon, any number of bridges.
+
+## Running
+
+### Daemon (start once, runs forever)
+
+```bash
+bun src/daemon.ts
+# or via launchd — see below
+```
+
+Requires `TELEGRAM_BOT_TOKEN` in env or `~/.parachute/channel/.env`.
+
+### Bridge (registered in .mcp.json, Claude Code spawns it)
+
+Registered in `~/UnforcedAGI/.mcp.json`:
+```json
+{
+  "mcpServers": {
+    "parachute-channel": {
+      "command": "bun",
+      "args": ["<path>/src/bridge.ts"],
+      "env": { "PARACHUTE_CHANNEL_URL": "http://127.0.0.1:1941" }
+    }
+  }
+}
+```
+
+Launch Claude Code with:
+```bash
+claude --dangerously-load-development-channels server:parachute-channel
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `TELEGRAM_BOT_TOKEN` | (required) | Telegram bot token from BotFather |
+| `PARACHUTE_CHANNEL_PORT` | `1941` | Daemon HTTP port |
+| `PARACHUTE_CHANNEL_URL` | `http://127.0.0.1:1941` | Bridge → daemon URL |
+| `PARACHUTE_CHANNEL_STATE_DIR` | `~/.parachute/channel` | Token, access config, inbox |
+
+## State directory
+
+`~/.parachute/channel/`:
+- `.env` — `TELEGRAM_BOT_TOKEN=...`
+- `access.json` — allowlist (compatible with the official plugin's format)
+- `inbox/` — downloaded attachments
+
+## MCP tools exposed to Claude
+
+| Tool | Description |
+|---|---|
+| `reply` | Send text + file attachments to a chat. Images → photos, .ogg → voice, others → documents. |
+| `react` | Add emoji reaction to a message |
+| `edit_message` | Edit a previously sent message |
+| `download_attachment` | Download a Telegram file by file_id, returns local path |
+
+## Testing
+
+```bash
+# Health check
+curl http://127.0.0.1:1941/health
+
+# Send a test message
+curl -X POST http://127.0.0.1:1941/api/reply \
+  -H "content-type: application/json" \
+  -d '{"chat_id":"<CHAT_ID>","text":"hello from parachute-channel"}'
+```
+
+## Future
+
+The daemon + bridge split makes adding new backends straightforward:
+- Discord: add `src/discord/` with a Discord gateway poller, register alongside telegram
+- SMS/iMessage: same pattern
+- Custom web frontend: same pattern — the bridge doesn't change
+
+The bridge's MCP contract (`notifications/claude/channel` + tool surface) stays the same regardless of backend.

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,211 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "parachute-channel",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.0",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+      },
+      "peerDependencies": {
+        "typescript": "^5",
+      },
+    },
+  },
+  "packages": {
+    "@hono/node-server": ["@hono/node-server@1.19.13", "", { "peerDependencies": { "hono": "^4" } }, "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
+    "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+
+    "@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
+
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
+    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.3.2", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "hono": ["hono@4.12.12", "", {}, "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "parachute-channel",
+  "version": "0.1.0",
+  "description": "Messaging gateway for Claude Code — Telegram today, anything tomorrow",
+  "license": "AGPL-3.0",
+  "type": "module",
+  "bin": {
+    "parachute-channel": "src/daemon.ts",
+    "parachute-channel-bridge": "src/bridge.ts"
+  },
+  "scripts": {
+    "daemon": "bun src/daemon.ts",
+    "bridge": "bun src/bridge.ts",
+    "test": "bun test src/"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0"
+  },
+  "peerDependencies": {
+    "typescript": "^5"
+  },
+  "devDependencies": {
+    "@types/bun": "latest"
+  }
+}

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1,0 +1,254 @@
+#!/usr/bin/env bun
+/**
+ * parachute-channel bridge — a stdio MCP server that Claude Code spawns.
+ *
+ * Connects to the parachute-channel daemon via SSE for inbound messages
+ * and proxies outbound tool calls (reply, react, edit, download) to the
+ * daemon's HTTP API. This is the only file Claude Code interacts with.
+ *
+ * The bridge is stateless and lightweight — safe to spawn in multiple
+ * sessions simultaneously because it never touches the Telegram API.
+ * The daemon handles all platform communication.
+ */
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  ListToolsRequestSchema,
+  CallToolRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+
+const DAEMON_URL = process.env.PARACHUTE_CHANNEL_URL ?? "http://127.0.0.1:1941";
+
+// ---------------------------------------------------------------------------
+// MCP server setup
+// ---------------------------------------------------------------------------
+
+const mcp = new Server(
+  { name: "parachute-channel", version: "0.1.0" },
+  {
+    capabilities: {
+      experimental: {
+        "claude/channel": {},
+        "claude/channel/permission": {},
+      },
+      tools: {},
+    },
+    instructions: [
+      "The sender reads Telegram, not this session. Anything you want them to see must go through the reply tool — your transcript output never reaches their chat.",
+      "",
+      'Messages from Telegram arrive as <channel source="parachute-channel" chat_id="..." message_id="..." user="..." ts="...">.',
+      "Reply with the reply tool — pass chat_id back. Use reply_to (message_id) to thread a specific message; omit it for normal responses.",
+      "",
+      "If the tag has an image_path attribute, Read that file — it is a photo the sender attached.",
+      "If the tag has attachment_file_id, call download_attachment with that file_id to fetch the file, then Read the returned path.",
+      "",
+      "Use react to add emoji reactions. Use edit_message for interim progress updates (edits do not push notifications — send a new reply when a long task completes so the user's device pings).",
+      "",
+      'reply accepts file paths (files: ["/abs/path.png"]) for attachments.',
+    ].join("\n"),
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Tools — match the official plugin's tool surface
+// ---------------------------------------------------------------------------
+
+mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [
+    {
+      name: "reply",
+      description: "Send a message to a Telegram chat. Supports text, file attachments (images sent as photos, .ogg as voice, others as documents), and quote-reply threading.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          chat_id: { type: "string", description: "Telegram chat ID to send to" },
+          text: { type: "string", description: "Message text (optional if files provided)" },
+          reply_to: { type: "string", description: "Message ID to quote-reply (optional)" },
+          files: {
+            type: "array",
+            items: { type: "string" },
+            description: "Absolute file paths to attach (optional)",
+          },
+        },
+        required: ["chat_id"],
+      },
+    },
+    {
+      name: "react",
+      description: "Add an emoji reaction to a Telegram message. Only Telegram's fixed emoji whitelist is accepted (👍 👎 ❤ 🔥 👀 etc).",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          chat_id: { type: "string", description: "Telegram chat ID" },
+          message_id: { type: "string", description: "Message ID to react to" },
+          emoji: { type: "string", description: "Emoji reaction" },
+        },
+        required: ["chat_id", "message_id", "emoji"],
+      },
+    },
+    {
+      name: "edit_message",
+      description: "Edit a message the bot previously sent. Useful for progress updates. Edits don't trigger push notifications.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          chat_id: { type: "string", description: "Telegram chat ID" },
+          message_id: { type: "string", description: "Message ID to edit" },
+          text: { type: "string", description: "New text" },
+        },
+        required: ["chat_id", "message_id", "text"],
+      },
+    },
+    {
+      name: "download_attachment",
+      description: "Download a Telegram file attachment by file_id. Returns the local path.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          file_id: { type: "string", description: "Telegram file_id from the attachment_file_id attribute" },
+        },
+        required: ["file_id"],
+      },
+    },
+  ],
+}));
+
+mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
+  const args = req.params.arguments as Record<string, unknown>;
+
+  switch (req.params.name) {
+    case "reply": {
+      const res = await fetch(`${DAEMON_URL}/api/reply`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(args),
+      });
+      if (!res.ok) {
+        const err = await res.text();
+        return { content: [{ type: "text", text: `reply failed: ${err}` }], isError: true };
+      }
+      const data = (await res.json()) as { sent: number[] };
+      const ids = data.sent;
+      const parts = ids.length === 1 ? `(id: ${ids[0]})` : `(ids: ${ids.join(", ")})`;
+      return { content: [{ type: "text", text: `sent ${ids.length} part${ids.length > 1 ? "s" : ""} ${parts}` }] };
+    }
+
+    case "react": {
+      const res = await fetch(`${DAEMON_URL}/api/react`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(args),
+      });
+      if (!res.ok) {
+        const err = await res.text();
+        return { content: [{ type: "text", text: `react failed: ${err}` }], isError: true };
+      }
+      return { content: [{ type: "text", text: "reacted" }] };
+    }
+
+    case "edit_message": {
+      const res = await fetch(`${DAEMON_URL}/api/edit`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(args),
+      });
+      if (!res.ok) {
+        const err = await res.text();
+        return { content: [{ type: "text", text: `edit failed: ${err}` }], isError: true };
+      }
+      return { content: [{ type: "text", text: "edited" }] };
+    }
+
+    case "download_attachment": {
+      const res = await fetch(`${DAEMON_URL}/api/download`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(args),
+      });
+      if (!res.ok) {
+        const err = await res.text();
+        return { content: [{ type: "text", text: `download failed: ${err}` }], isError: true };
+      }
+      const data = (await res.json()) as { path: string };
+      return { content: [{ type: "text", text: data.path }] };
+    }
+
+    default:
+      return { content: [{ type: "text", text: `unknown tool: ${req.params.name}` }], isError: true };
+  }
+});
+
+// ---------------------------------------------------------------------------
+// SSE connection to daemon — forward inbound messages as MCP notifications
+// ---------------------------------------------------------------------------
+
+async function connectToEvents(): Promise<void> {
+  while (true) {
+    try {
+      const res = await fetch(`${DAEMON_URL}/events`);
+      if (!res.ok || !res.body) {
+        throw new Error(`SSE connect failed: ${res.status}`);
+      }
+
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+
+        let currentEvent = "";
+        let currentData = "";
+
+        for (const line of lines) {
+          if (line.startsWith("event: ")) {
+            currentEvent = line.slice(7);
+          } else if (line.startsWith("data: ")) {
+            currentData += line.slice(6);
+          } else if (line === "") {
+            // End of event
+            if (currentEvent === "message" && currentData) {
+              try {
+                const parsed = JSON.parse(currentData) as {
+                  content: string;
+                  meta: Record<string, string>;
+                  source: string;
+                };
+                await mcp.notification({
+                  method: "notifications/claude/channel",
+                  params: {
+                    content: parsed.content,
+                    meta: { source: "parachute-channel", ...parsed.meta },
+                  },
+                });
+              } catch (err) {
+                process.stderr.write(`parachute-channel bridge: failed to parse/forward event: ${err}\n`);
+              }
+            }
+            currentEvent = "";
+            currentData = "";
+          }
+        }
+      }
+    } catch (err) {
+      process.stderr.write(`parachute-channel bridge: SSE error, reconnecting in 3s: ${err}\n`);
+    }
+    await new Promise((r) => setTimeout(r, 3000));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Start
+// ---------------------------------------------------------------------------
+
+await mcp.connect(new StdioServerTransport());
+process.stderr.write("parachute-channel bridge: connected to Claude Code, connecting to daemon...\n");
+
+// Start SSE listener (runs forever, reconnects on failure)
+connectToEvents();

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1,0 +1,383 @@
+#!/usr/bin/env bun
+/**
+ * parachute-channel daemon — the single process that owns messaging platform
+ * connections. Telegram today, anything tomorrow.
+ *
+ * Runs as a long-lived HTTP server (launchd, systemd, or manual). Bridges
+ * connect to it via SSE (/events) to receive inbound messages and via HTTP
+ * endpoints to send outbound messages. The daemon is the ONLY process that
+ * touches the Telegram API — no races, no multi-consumer conflicts.
+ *
+ * Default port: 1941 (PARACHUTE_CHANNEL_PORT env).
+ */
+
+import { TelegramApi, type TelegramMessage, type TelegramUpdate } from "./telegram/api.ts";
+import { readFileSync, writeFileSync, mkdirSync, existsSync, chmodSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const STATE_DIR = process.env.PARACHUTE_CHANNEL_STATE_DIR ??
+  join(homedir(), ".parachute", "channel");
+const ENV_FILE = join(STATE_DIR, ".env");
+const ACCESS_FILE = join(STATE_DIR, "access.json");
+const INBOX_DIR = join(STATE_DIR, "inbox");
+const PORT = parseInt(process.env.PARACHUTE_CHANNEL_PORT ?? "1941", 10);
+
+mkdirSync(STATE_DIR, { recursive: true });
+mkdirSync(INBOX_DIR, { recursive: true });
+
+// Load .env (same pattern as the official plugin)
+try {
+  if (existsSync(ENV_FILE)) {
+    chmodSync(ENV_FILE, 0o600);
+    for (const line of readFileSync(ENV_FILE, "utf8").split("\n")) {
+      const m = line.match(/^(\w+)=(.*)$/);
+      if (m && process.env[m[1]] === undefined) process.env[m[1]] = m[2];
+    }
+  }
+} catch {}
+
+const TOKEN = process.env.TELEGRAM_BOT_TOKEN;
+if (!TOKEN) {
+  console.error(
+    `parachute-channel: TELEGRAM_BOT_TOKEN required\n` +
+    `  set in ${ENV_FILE} or shell env\n` +
+    `  format: TELEGRAM_BOT_TOKEN=123456789:AAH...`
+  );
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Access control — reuse the official plugin's access.json format
+// ---------------------------------------------------------------------------
+
+// Matches the official telegram plugin's access.json format
+interface AccessConfig {
+  dmPolicy: "open" | "pairing" | "allowlist";
+  allowFrom: string[];
+  groups: Record<string, unknown>;
+  pending: Record<string, unknown>;
+}
+
+function loadAccess(): AccessConfig {
+  try {
+    return JSON.parse(readFileSync(ACCESS_FILE, "utf8"));
+  } catch {
+    return { dmPolicy: "open", allowFrom: [], groups: {}, pending: {} };
+  }
+}
+
+function isAllowed(userId: number): boolean {
+  const access = loadAccess();
+  if (access.dmPolicy === "open") return true;
+  return access.allowFrom.includes(String(userId));
+}
+
+// ---------------------------------------------------------------------------
+// SSE clients (bridges)
+// ---------------------------------------------------------------------------
+
+type SSEClient = {
+  id: string;
+  controller: ReadableStreamDefaultController<string>;
+  connectedAt: number;
+};
+
+const clients = new Map<string, SSEClient>();
+
+function broadcastEvent(event: string, data: unknown): void {
+  const payload = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+  for (const [id, client] of clients) {
+    try {
+      client.controller.enqueue(payload);
+    } catch {
+      clients.delete(id);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Telegram polling
+// ---------------------------------------------------------------------------
+
+const api = new TelegramApi(TOKEN);
+let offset: number | undefined;
+let pollActive = true;
+
+async function pollLoop(): Promise<void> {
+  const me = await api.getMe();
+  console.log(`parachute-channel: polling as @${me.username}`);
+
+  while (pollActive) {
+    try {
+      const updates = await api.getUpdates(offset, 30);
+      for (const update of updates) {
+        offset = update.update_id + 1;
+        if (update.message) {
+          await handleMessage(update.message);
+        }
+      }
+    } catch (err) {
+      console.error("parachute-channel: poll error:", err);
+      await new Promise((r) => setTimeout(r, 5000));
+    }
+  }
+}
+
+async function handleMessage(msg: TelegramMessage): Promise<void> {
+  const userId = msg.from?.id;
+  if (!userId || !isAllowed(userId)) return;
+
+  // Determine attachment info
+  let attachmentKind: string | undefined;
+  let attachmentFileId: string | undefined;
+  let attachmentSize: number | undefined;
+  let attachmentMime: string | undefined;
+  let imagePath: string | undefined;
+
+  if (msg.voice) {
+    attachmentKind = "voice";
+    attachmentFileId = msg.voice.file_id;
+    attachmentSize = msg.voice.file_size;
+    attachmentMime = msg.voice.mime_type ?? "audio/ogg";
+  } else if (msg.audio) {
+    attachmentKind = "audio";
+    attachmentFileId = msg.audio.file_id;
+    attachmentSize = msg.audio.file_size;
+    attachmentMime = msg.audio.mime_type;
+  } else if (msg.document) {
+    attachmentKind = "document";
+    attachmentFileId = msg.document.file_id;
+    attachmentSize = msg.document.file_size;
+    attachmentMime = msg.document.mime_type;
+  } else if (msg.photo && msg.photo.length > 0) {
+    // Download the largest photo variant and save to inbox
+    const largest = msg.photo[msg.photo.length - 1];
+    attachmentKind = "photo";
+    attachmentFileId = largest.file_id;
+    attachmentSize = largest.file_size;
+    attachmentMime = "image/jpeg";
+    try {
+      const fileInfo = await api.getFile(largest.file_id);
+      const data = await api.downloadFile(fileInfo.file_path);
+      const ext = fileInfo.file_path.split(".").pop() ?? "jpg";
+      const localPath = join(INBOX_DIR, `${Date.now()}-${largest.file_unique_id}.${ext}`);
+      writeFileSync(localPath, data);
+      imagePath = localPath;
+    } catch (err) {
+      console.error("parachute-channel: failed to download photo:", err);
+    }
+  }
+
+  const content = msg.text ?? msg.caption ?? "(voice message)";
+  const ts = new Date(msg.date * 1000).toISOString();
+
+  // Build the channel notification payload — matches the official plugin's shape
+  const meta: Record<string, string> = {
+    chat_id: String(msg.chat.id),
+    message_id: String(msg.message_id),
+    user: msg.from?.username ?? msg.from?.first_name ?? "unknown",
+    user_id: String(userId),
+    ts,
+  };
+  if (attachmentKind) meta.attachment_kind = attachmentKind;
+  if (attachmentFileId) meta.attachment_file_id = attachmentFileId;
+  if (attachmentSize) meta.attachment_size = String(attachmentSize);
+  if (attachmentMime) meta.attachment_mime = attachmentMime;
+  if (imagePath) meta.image_path = imagePath;
+
+  // Broadcast to all connected bridges
+  broadcastEvent("message", { content, meta, source: "telegram" });
+}
+
+// ---------------------------------------------------------------------------
+// HTTP server
+// ---------------------------------------------------------------------------
+
+function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const server = Bun.serve({
+  port: PORT,
+  hostname: "127.0.0.1",
+  idleTimeout: 0,
+
+  async fetch(req) {
+    const url = new URL(req.url);
+
+    // Health check
+    if (url.pathname === "/health") {
+      return json({
+        status: "ok",
+        clients: clients.size,
+        polling: pollActive,
+      });
+    }
+
+    // SSE event stream — bridges connect here
+    if (req.method === "GET" && url.pathname === "/events") {
+      const clientId = crypto.randomUUID();
+      const stream = new ReadableStream<string>({
+        start(controller) {
+          clients.set(clientId, {
+            id: clientId,
+            controller,
+            connectedAt: Date.now(),
+          });
+          controller.enqueue(": connected\n\n");
+        },
+        cancel() {
+          clients.delete(clientId);
+        },
+      });
+      return new Response(stream, {
+        headers: {
+          "content-type": "text/event-stream",
+          "cache-control": "no-cache",
+          connection: "keep-alive",
+        },
+      });
+    }
+
+    // Reply
+    if (req.method === "POST" && url.pathname === "/api/reply") {
+      try {
+        const body = (await req.json()) as {
+          chat_id: string;
+          text?: string;
+          reply_to?: string;
+          files?: string[];
+        };
+
+        const sentIds: number[] = [];
+
+        // Send text if provided
+        if (body.text) {
+          // Chunk long messages (Telegram 4096 char limit)
+          const chunks = chunkText(body.text, 4096);
+          for (const chunk of chunks) {
+            const id = await api.sendMessage(
+              body.chat_id,
+              chunk,
+              body.reply_to ? { reply_to_message_id: parseInt(body.reply_to) } : undefined,
+            );
+            sentIds.push(id);
+          }
+        }
+
+        // Send files if provided
+        if (body.files) {
+          for (const filePath of body.files) {
+            const ext = filePath.split(".").pop()?.toLowerCase() ?? "";
+            const imageExts = ["jpg", "jpeg", "png", "gif", "webp"];
+            const voiceExts = ["ogg", "oga", "opus"];
+            let id: number;
+            if (imageExts.includes(ext)) {
+              id = await api.sendPhoto(body.chat_id, filePath);
+            } else if (voiceExts.includes(ext)) {
+              id = await api.sendVoice(body.chat_id, filePath);
+            } else {
+              id = await api.sendDocument(body.chat_id, filePath);
+            }
+            sentIds.push(id);
+          }
+        }
+
+        return json({ sent: sentIds });
+      } catch (err) {
+        return json({ error: String(err) }, 500);
+      }
+    }
+
+    // React
+    if (req.method === "POST" && url.pathname === "/api/react") {
+      try {
+        const body = (await req.json()) as {
+          chat_id: string;
+          message_id: string;
+          emoji: string;
+        };
+        await api.setMessageReaction(body.chat_id, parseInt(body.message_id), body.emoji);
+        return json({ ok: true });
+      } catch (err) {
+        return json({ error: String(err) }, 500);
+      }
+    }
+
+    // Edit message
+    if (req.method === "POST" && url.pathname === "/api/edit") {
+      try {
+        const body = (await req.json()) as {
+          chat_id: string;
+          message_id: string;
+          text: string;
+        };
+        await api.editMessageText(body.chat_id, parseInt(body.message_id), body.text);
+        return json({ ok: true });
+      } catch (err) {
+        return json({ error: String(err) }, 500);
+      }
+    }
+
+    // Download attachment
+    if (req.method === "POST" && url.pathname === "/api/download") {
+      try {
+        const body = (await req.json()) as { file_id: string };
+        const fileInfo = await api.getFile(body.file_id);
+        const data = await api.downloadFile(fileInfo.file_path);
+        const ext = fileInfo.file_path.split(".").pop() ?? "bin";
+        const localPath = join(INBOX_DIR, `${Date.now()}-${body.file_id.slice(-10)}.${ext}`);
+        writeFileSync(localPath, data);
+        return json({ path: localPath });
+      } catch (err) {
+        return json({ error: String(err) }, 500);
+      }
+    }
+
+    return json({ error: "not found" }, 404);
+  },
+});
+
+function chunkText(text: string, maxLen: number): string[] {
+  if (text.length <= maxLen) return [text];
+  const chunks: string[] = [];
+  let remaining = text;
+  while (remaining.length > 0) {
+    if (remaining.length <= maxLen) {
+      chunks.push(remaining);
+      break;
+    }
+    // Try to break at a newline
+    let breakAt = remaining.lastIndexOf("\n", maxLen);
+    if (breakAt < maxLen * 0.5) breakAt = maxLen; // no good newline, hard break
+    chunks.push(remaining.slice(0, breakAt));
+    remaining = remaining.slice(breakAt).replace(/^\n/, "");
+  }
+  return chunks;
+}
+
+// ---------------------------------------------------------------------------
+// Startup
+// ---------------------------------------------------------------------------
+
+console.log(`parachute-channel: daemon listening on http://127.0.0.1:${PORT}`);
+console.log(`parachute-channel: state dir: ${STATE_DIR}`);
+console.log(`parachute-channel: ${clients.size} bridge(s) connected`);
+
+// Graceful shutdown
+process.on("SIGINT", () => { pollActive = false; server.stop(); process.exit(0); });
+process.on("SIGTERM", () => { pollActive = false; server.stop(); process.exit(0); });
+
+// Start polling (runs forever)
+pollLoop().catch((err) => {
+  console.error("parachute-channel: poll loop fatal:", err);
+  process.exit(1);
+});

--- a/src/telegram/api.ts
+++ b/src/telegram/api.ts
@@ -1,0 +1,131 @@
+/**
+ * Minimal Telegram Bot API client. Only the methods we actually use.
+ */
+
+export interface TelegramUpdate {
+  update_id: number;
+  message?: TelegramMessage;
+}
+
+export interface TelegramMessage {
+  message_id: number;
+  chat: { id: number; type: string; title?: string };
+  from?: { id: number; first_name: string; username?: string; is_bot: boolean };
+  date: number;
+  text?: string;
+  voice?: { file_id: string; file_unique_id: string; duration: number; mime_type?: string; file_size?: number };
+  audio?: { file_id: string; file_unique_id: string; duration: number; mime_type?: string; file_size?: number };
+  document?: { file_id: string; file_unique_id: string; file_name?: string; mime_type?: string; file_size?: number };
+  photo?: Array<{ file_id: string; file_unique_id: string; width: number; height: number; file_size?: number }>;
+  caption?: string;
+}
+
+export class TelegramApi {
+  private base: string;
+
+  constructor(private token: string) {
+    this.base = `https://api.telegram.org/bot${token}`;
+  }
+
+  async getUpdates(offset?: number, timeout = 30): Promise<TelegramUpdate[]> {
+    const params = new URLSearchParams({ timeout: String(timeout) });
+    if (offset !== undefined) params.set("offset", String(offset));
+    const res = await fetch(`${this.base}/getUpdates?${params}`);
+    if (!res.ok) throw new Error(`getUpdates ${res.status}: ${await res.text()}`);
+    const json = (await res.json()) as { ok: boolean; result: TelegramUpdate[] };
+    if (!json.ok) throw new Error(`getUpdates not ok: ${JSON.stringify(json)}`);
+    return json.result;
+  }
+
+  async sendMessage(chatId: number | string, text: string, opts?: { reply_to_message_id?: number }): Promise<number> {
+    const body: Record<string, unknown> = { chat_id: chatId, text };
+    if (opts?.reply_to_message_id) body.reply_to_message_id = opts.reply_to_message_id;
+    const res = await fetch(`${this.base}/sendMessage`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) throw new Error(`sendMessage ${res.status}: ${await res.text()}`);
+    const json = (await res.json()) as { ok: boolean; result: { message_id: number } };
+    return json.result.message_id;
+  }
+
+  async sendDocument(chatId: number | string, filePath: string, caption?: string): Promise<number> {
+    const form = new FormData();
+    form.append("chat_id", String(chatId));
+    const file = Bun.file(filePath);
+    form.append("document", file);
+    if (caption) form.append("caption", caption);
+    const res = await fetch(`${this.base}/sendDocument`, { method: "POST", body: form });
+    if (!res.ok) throw new Error(`sendDocument ${res.status}: ${await res.text()}`);
+    const json = (await res.json()) as { ok: boolean; result: { message_id: number } };
+    return json.result.message_id;
+  }
+
+  async sendPhoto(chatId: number | string, filePath: string, caption?: string): Promise<number> {
+    const form = new FormData();
+    form.append("chat_id", String(chatId));
+    const file = Bun.file(filePath);
+    form.append("photo", file);
+    if (caption) form.append("caption", caption);
+    const res = await fetch(`${this.base}/sendPhoto`, { method: "POST", body: form });
+    if (!res.ok) throw new Error(`sendPhoto ${res.status}: ${await res.text()}`);
+    const json = (await res.json()) as { ok: boolean; result: { message_id: number } };
+    return json.result.message_id;
+  }
+
+  async sendVoice(chatId: number | string, filePath: string, caption?: string): Promise<number> {
+    const form = new FormData();
+    form.append("chat_id", String(chatId));
+    const file = Bun.file(filePath);
+    form.append("voice", file);
+    if (caption) form.append("caption", caption);
+    const res = await fetch(`${this.base}/sendVoice`, { method: "POST", body: form });
+    if (!res.ok) throw new Error(`sendVoice ${res.status}: ${await res.text()}`);
+    const json = (await res.json()) as { ok: boolean; result: { message_id: number } };
+    return json.result.message_id;
+  }
+
+  async setMessageReaction(chatId: number | string, messageId: number, emoji: string): Promise<void> {
+    const res = await fetch(`${this.base}/setMessageReaction`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        chat_id: chatId,
+        message_id: messageId,
+        reaction: [{ type: "emoji", emoji }],
+      }),
+    });
+    if (!res.ok) throw new Error(`setMessageReaction ${res.status}: ${await res.text()}`);
+  }
+
+  async editMessageText(chatId: number | string, messageId: number, text: string): Promise<void> {
+    const res = await fetch(`${this.base}/editMessageText`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ chat_id: chatId, message_id: messageId, text }),
+    });
+    if (!res.ok) throw new Error(`editMessageText ${res.status}: ${await res.text()}`);
+  }
+
+  async getFile(fileId: string): Promise<{ file_path: string }> {
+    const res = await fetch(`${this.base}/getFile?file_id=${fileId}`);
+    if (!res.ok) throw new Error(`getFile ${res.status}: ${await res.text()}`);
+    const json = (await res.json()) as { ok: boolean; result: { file_path: string } };
+    return json.result;
+  }
+
+  async downloadFile(filePath: string): Promise<Buffer> {
+    const url = `https://api.telegram.org/file/bot${this.token}/${filePath}`;
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`downloadFile ${res.status}`);
+    return Buffer.from(await res.arrayBuffer());
+  }
+
+  async getMe(): Promise<{ username: string; first_name: string }> {
+    const res = await fetch(`${this.base}/getMe`);
+    if (!res.ok) throw new Error(`getMe ${res.status}: ${await res.text()}`);
+    const json = (await res.json()) as { ok: boolean; result: { username: string; first_name: string } };
+    return json.result;
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "declaration": true,
+    "types": ["bun-types"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- **Daemon** (`src/daemon.ts`): long-running HTTP server on port 1941 that exclusively owns the Telegram getUpdates poll. Exposes SSE `/events` for inbound messages and HTTP endpoints for reply/react/edit/download. No multi-consumer races by construction.
- **Bridge** (`src/bridge.ts`): lightweight stdio MCP server that Claude Code spawns per-session. Connects to daemon's SSE, forwards events as `notifications/claude/channel`, and proxies outbound tool calls. Stateless — safe to spawn in any number of sessions.
- **Telegram API client** (`src/telegram/api.ts`): minimal fetch-based client, no grammY dependency.
- Addresses anthropics/claude-code#38098 by moving Telegram out of the plugin system entirely.

## Architecture
```
Telegram API ↔ daemon (port 1941) ↔ SSE/HTTP ↔ bridge (stdio MCP) ↔ Claude Code
```

## Test plan
- [x] Daemon starts, polls Telegram, reports health at `/health`
- [x] Outbound: daemon sends messages to Telegram via `/api/reply` — verified with Aaron's phone
- [x] Inbound: Aaron's Telegram replies arrive as SSE events on `/events` — verified via curl
- [ ] Bridge integration: Claude Code spawns bridge, messages flow through MCP — requires session restart with `--dangerously-load-development-channels server:parachute-channel`

🤖 Generated with [Claude Code](https://claude.com/claude-code)