### PR TITLE
feat: permission relay + launchd plist for channel daemon

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -17,6 +17,7 @@ import {
   ListToolsRequestSchema,
   CallToolRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
 
 const DAEMON_URL = process.env.PARACHUTE_CHANNEL_URL ?? "http://127.0.0.1:1941";
 
@@ -47,6 +48,33 @@ const mcp = new Server(
       "",
       'reply accepts file paths (files: ["/abs/path.png"]) for attachments.',
     ].join("\n"),
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Permission relay — receive permission_request from CC, forward to daemon
+// ---------------------------------------------------------------------------
+
+mcp.setNotificationHandler(
+  z.object({
+    method: z.literal("notifications/claude/channel/permission_request"),
+    params: z.object({
+      request_id: z.string(),
+      tool_name: z.string(),
+      description: z.string(),
+      input_preview: z.string(),
+    }),
+  }),
+  async ({ params }) => {
+    try {
+      await fetch(`${DAEMON_URL}/api/permission`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(params),
+      });
+    } catch (err) {
+      process.stderr.write(`parachute-channel bridge: failed to relay permission request: ${err}\n`);
+    }
   },
 );
 
@@ -229,6 +257,22 @@ async function connectToEvents(): Promise<void> {
                 });
               } catch (err) {
                 process.stderr.write(`parachute-channel bridge: failed to parse/forward event: ${err}\n`);
+              }
+            } else if (currentEvent === "permission_verdict" && currentData) {
+              try {
+                const parsed = JSON.parse(currentData) as {
+                  request_id: string;
+                  behavior: string;
+                };
+                await mcp.notification({
+                  method: "notifications/claude/channel/permission",
+                  params: {
+                    request_id: parsed.request_id,
+                    behavior: parsed.behavior,
+                  },
+                });
+              } catch (err) {
+                process.stderr.write(`parachute-channel bridge: failed to forward permission verdict: ${err}\n`);
               }
             }
             currentEvent = "";

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -128,9 +128,32 @@ async function pollLoop(): Promise<void> {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Permission relay — text-reply intercept
+// ---------------------------------------------------------------------------
+
+const PERMISSION_REPLY_RE = /^\s*(y|yes|n|no)\s+([a-km-z]{5})\s*$/i;
+
 async function handleMessage(msg: TelegramMessage): Promise<void> {
   const userId = msg.from?.id;
   if (!userId || !isAllowed(userId)) return;
+
+  // Permission-reply intercept: if this looks like "yes xxxxx" or "no xxxxx"
+  // for a pending permission request, emit a permission_verdict SSE event
+  // instead of forwarding as a chat message.
+  const text = msg.text ?? "";
+  const permMatch = PERMISSION_REPLY_RE.exec(text);
+  if (permMatch) {
+    const requestId = permMatch[2]!.toLowerCase();
+    const behavior = permMatch[1]!.toLowerCase().startsWith("y") ? "allow" : "deny";
+    broadcastEvent("permission_verdict", { request_id: requestId, behavior });
+    // React to confirm receipt
+    const emoji = behavior === "allow" ? "✅" : "❌";
+    try {
+      await api.setMessageReaction(String(msg.chat.id), msg.message_id, emoji);
+    } catch {}
+    return;
+  }
 
   // Determine attachment info
   let attachmentKind: string | undefined;
@@ -322,6 +345,41 @@ const server = Bun.serve({
         };
         await api.editMessageText(body.chat_id, parseInt(body.message_id), body.text);
         return json({ ok: true });
+      } catch (err) {
+        return json({ error: String(err) }, 500);
+      }
+    }
+
+    // Permission prompt — bridge forwards permission_request here, daemon
+    // sends to all allowlisted Telegram users.
+    if (req.method === "POST" && url.pathname === "/api/permission") {
+      try {
+        const body = (await req.json()) as {
+          request_id: string;
+          tool_name: string;
+          description: string;
+          input_preview: string;
+        };
+        const access = loadAccess();
+        const targets = access.allowFrom;
+        if (targets.length === 0) {
+          return json({ error: "no allowlisted users to send permission prompt to" }, 400);
+        }
+        const text =
+          `🔐 Permission: ${body.tool_name}\n\n` +
+          `${body.description}\n\n` +
+          `${body.input_preview}\n\n` +
+          `Reply "yes ${body.request_id}" or "no ${body.request_id}"`;
+        const sent: number[] = [];
+        for (const chatId of targets) {
+          try {
+            const id = await api.sendMessage(chatId, text);
+            sent.push(id);
+          } catch (err) {
+            console.error(`parachute-channel: permission prompt to ${chatId} failed:`, err);
+          }
+        }
+        return json({ sent });
       } catch (err) {
         return json({ error: String(err) }, 500);
       }


### PR DESCRIPTION
## Summary

- **Permission relay**: Bridge receives `permission_request` notifications from Claude Code, forwards to daemon's new `POST /api/permission` endpoint, which sends the prompt to all allowlisted Telegram users. Users reply "yes xxxxx" / "no xxxxx"; daemon intercepts the verdict pattern, broadcasts `permission_verdict` SSE event, bridge forwards back as `notifications/claude/channel/permission`. Matches the official telegram plugin's protocol.
- **Launchd plist**: `computer.parachute.channel` mirrors the vault daemon's pattern — wrapper script sources PATH + .env, exec's bun. `KeepAlive: true` for crash restart.

## Test plan

- [x] `POST /api/permission` sends formatted prompt to Aaron's Telegram
- [x] Daemon starts via launchd, health check passes
- [ ] End-to-end: Claude Code permission dialog → Telegram prompt → "yes xxxxx" reply → tool approved
- [ ] Verify text replies matching verdict pattern don't also forward as chat messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)