### PR TITLE
feat: InlineKeyboard buttons for permission relay

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -11,7 +11,7 @@
  * Default port: 1941 (PARACHUTE_CHANNEL_PORT env).
  */
 
-import { TelegramApi, type TelegramMessage, type TelegramUpdate } from "./telegram/api.ts";
+import { TelegramApi, type TelegramMessage, type TelegramCallbackQuery, type TelegramUpdate } from "./telegram/api.ts";
 import { readFileSync, writeFileSync, mkdirSync, existsSync, chmodSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
@@ -117,7 +117,9 @@ async function pollLoop(): Promise<void> {
       const updates = await api.getUpdates(offset, 30);
       for (const update of updates) {
         offset = update.update_id + 1;
-        if (update.message) {
+        if (update.callback_query) {
+          await handleCallbackQuery(update.callback_query);
+        } else if (update.message) {
           await handleMessage(update.message);
         }
       }
@@ -133,6 +135,37 @@ async function pollLoop(): Promise<void> {
 // ---------------------------------------------------------------------------
 
 const PERMISSION_REPLY_RE = /^\s*(y|yes|n|no)\s+([a-km-z]{5})\s*$/i;
+const CALLBACK_DATA_RE = /^perm_(allow|deny)_([a-km-z]{5})$/;
+
+async function handleCallbackQuery(cq: TelegramCallbackQuery): Promise<void> {
+  const userId = cq.from.id;
+  if (!isAllowed(userId)) {
+    await api.answerCallbackQuery(cq.id).catch(() => {});
+    return;
+  }
+
+  const data = cq.data ?? "";
+  const match = CALLBACK_DATA_RE.exec(data);
+  if (!match) {
+    await api.answerCallbackQuery(cq.id).catch(() => {});
+    return;
+  }
+
+  const behavior = match[1] as "allow" | "deny";
+  const requestId = match[2];
+  broadcastEvent("permission_verdict", { request_id: requestId, behavior });
+
+  // Answer the callback query (stops button loading spinner)
+  const label = behavior === "allow" ? "✅ Allowed" : "❌ Denied";
+  await api.answerCallbackQuery(cq.id, { text: label }).catch(() => {});
+
+  // Edit the original message to show the outcome and remove buttons
+  if (cq.message) {
+    const chatId = String(cq.message.chat.id);
+    const originalText = cq.message.text ?? "";
+    await api.editMessageText(chatId, cq.message.message_id, `${label}\n\n${originalText}`).catch(() => {});
+  }
+}
 
 async function handleMessage(msg: TelegramMessage): Promise<void> {
   const userId = msg.from?.id;
@@ -368,12 +401,17 @@ const server = Bun.serve({
         const text =
           `🔐 Permission: ${body.tool_name}\n\n` +
           `${body.description}\n\n` +
-          `${body.input_preview}\n\n` +
-          `Reply "yes ${body.request_id}" or "no ${body.request_id}"`;
+          `${body.input_preview}`;
+        const replyMarkup = {
+          inline_keyboard: [[
+            { text: "✅ Allow", callback_data: `perm_allow_${body.request_id}` },
+            { text: "❌ Deny", callback_data: `perm_deny_${body.request_id}` },
+          ]],
+        };
         const sent: number[] = [];
         for (const chatId of targets) {
           try {
-            const id = await api.sendMessage(chatId, text);
+            const id = await api.sendMessage(chatId, text, { reply_markup: replyMarkup });
             sent.push(id);
           } catch (err) {
             console.error(`parachute-channel: permission prompt to ${chatId} failed:`, err);

--- a/src/telegram/api.ts
+++ b/src/telegram/api.ts
@@ -2,9 +2,17 @@
  * Minimal Telegram Bot API client. Only the methods we actually use.
  */
 
+export interface TelegramCallbackQuery {
+  id: string;
+  from: { id: number; first_name: string; username?: string; is_bot: boolean };
+  message?: TelegramMessage;
+  data?: string;
+}
+
 export interface TelegramUpdate {
   update_id: number;
   message?: TelegramMessage;
+  callback_query?: TelegramCallbackQuery;
 }
 
 export interface TelegramMessage {
@@ -37,9 +45,10 @@ export class TelegramApi {
     return json.result;
   }
 
-  async sendMessage(chatId: number | string, text: string, opts?: { reply_to_message_id?: number }): Promise<number> {
+  async sendMessage(chatId: number | string, text: string, opts?: { reply_to_message_id?: number; reply_markup?: unknown }): Promise<number> {
     const body: Record<string, unknown> = { chat_id: chatId, text };
     if (opts?.reply_to_message_id) body.reply_to_message_id = opts.reply_to_message_id;
+    if (opts?.reply_markup) body.reply_markup = opts.reply_markup;
     const res = await fetch(`${this.base}/sendMessage`, {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -99,13 +108,26 @@ export class TelegramApi {
     if (!res.ok) throw new Error(`setMessageReaction ${res.status}: ${await res.text()}`);
   }
 
-  async editMessageText(chatId: number | string, messageId: number, text: string): Promise<void> {
+  async editMessageText(chatId: number | string, messageId: number, text: string, opts?: { reply_markup?: unknown }): Promise<void> {
+    const body: Record<string, unknown> = { chat_id: chatId, message_id: messageId, text };
+    if (opts?.reply_markup) body.reply_markup = opts.reply_markup;
     const res = await fetch(`${this.base}/editMessageText`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ chat_id: chatId, message_id: messageId, text }),
+      body: JSON.stringify(body),
     });
     if (!res.ok) throw new Error(`editMessageText ${res.status}: ${await res.text()}`);
+  }
+
+  async answerCallbackQuery(callbackQueryId: string, opts?: { text?: string }): Promise<void> {
+    const body: Record<string, unknown> = { callback_query_id: callbackQueryId };
+    if (opts?.text) body.text = opts.text;
+    const res = await fetch(`${this.base}/answerCallbackQuery`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) throw new Error(`answerCallbackQuery ${res.status}: ${await res.text()}`);
   }
 
   async getFile(fileId: string): Promise<{ file_path: string }> {


### PR DESCRIPTION
## Summary

- Permission prompts now include ✅ Allow / ❌ Deny inline keyboard buttons
- Tapping a button broadcasts `permission_verdict` SSE, answers the callback query, and edits the message to show outcome
- Text-based `yes <id>` / `no <id>` fallback preserved
- Added `answerCallbackQuery`, `callback_query` type, and `reply_markup` support to Telegram API client

Closes #4

## Test plan

- [ ] Permission prompt arrives on Telegram with inline buttons
- [ ] Tapping ✅ Allow approves the tool and updates the message
- [ ] Tapping ❌ Deny denies the tool and updates the message
- [ ] Text reply "yes abcde" still works as fallback
- [ ] Non-allowlisted users' button taps are silently ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)