### PR TITLE
chore: rename package to @openparachute/channel

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "parachute-channel",
+  "name": "@openparachute/channel",
   "version": "0.1.0",
   "description": "Messaging gateway for Claude Code — Telegram today, anything tomorrow",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## Summary
- Rename `parachute-channel` → `@openparachute/channel` in package.json

Part of the coordinated move to `@openparachute` npm scope across all repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)