### PR TITLE
Add techne pod: isolated Claude agent for Techne / Regen Hub

### DIFF
--- a/docker/pods/techne/Dockerfile
+++ b/docker/pods/techne/Dockerfile
@@ -1,0 +1,91 @@
+# syntax=docker/dockerfile:1.6
+#
+# Techne pod — long-lived Docker container hosting a Claude agent for the
+# Techne / Regen Hub cooperative. Ships: Bun, Claude Code CLI, @openparachute/vault,
+# and parachute-channel (from git, pinned). True namespace isolation; no virtiofs
+# host mounts, no exposed ports, state persists via named volumes.
+#
+# Build:   docker build -t techne:latest docker/pods/techne
+# Run:     see docs/pods/techne.md
+FROM ubuntu:24.04
+
+# Pin parachute-channel to a known commit. Bump + rebuild to adopt channel changes.
+ARG CHANNEL_COMMIT=6697c3569f370ad0596745cfcc76d99dd6f96896
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8
+
+# System packages + Node.js 22 (Claude Code CLI is a Node app; Bun runs vault/channel).
+# tini: PID 1 signal-forwarding so docker stop is clean.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        tini \
+        unzip \
+ && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+ && apt-get install -y --no-install-recommends nodejs \
+ && rm -rf /var/lib/apt/lists/*
+
+# Non-root user at uid 1000. ubuntu:24.04 ships a default `ubuntu` user there;
+# remove it first so our `parachute` user can take the conventional slot.
+RUN userdel -r ubuntu 2>/dev/null || true \
+ && useradd --create-home --shell /bin/bash --uid 1000 parachute \
+ && mkdir -p /opt/parachute-channel \
+ && chown parachute:parachute /opt/parachute-channel
+
+# Claude Code CLI — install via npm while still root so /usr/local is writable.
+RUN npm install -g @anthropic-ai/claude-code
+
+USER parachute
+WORKDIR /home/parachute
+
+ENV HOME=/home/parachute \
+    BUN_INSTALL=/home/parachute/.bun \
+    PATH=/home/parachute/.bun/bin:/usr/local/bin:/usr/bin:/bin \
+    PARACHUTE_HOME=/home/parachute/.parachute
+
+# Pre-create the volume mount points owned by parachute. Docker named volumes
+# inherit the ownership of the image's directory contents on first mount, so
+# seeding these as parachute:parachute avoids the root-owned-volume EACCES trap.
+RUN mkdir -p /home/parachute/.parachute/channel /home/parachute/.claude
+
+# Bun (user-local).
+RUN curl -fsSL https://bun.sh/install | bash
+
+# Parachute Vault via bun (bun-native package).
+RUN bun add -g @openparachute/vault
+
+# parachute-channel at a pinned commit.
+RUN git clone https://github.com/ParachuteComputer/parachute-channel /opt/parachute-channel \
+ && cd /opt/parachute-channel \
+ && git checkout ${CHANNEL_COMMIT} \
+ && bun install --frozen-lockfile
+
+# Agent identity doc (Techne CLAUDE.md) + supervisor entrypoint + the
+# `techne-claude` wrapper that enforces strict MCP scoping. Without the
+# wrapper, the Claude Code inside this container would inherit account-
+# level MCP servers from Aaron's claude.ai account (personal Parachute,
+# Gmail, Drive, etc.); the wrapper passes --strict-mcp-config + a local
+# mcp.json so the Techne session sees only vault + channel.
+COPY --chown=parachute:parachute techne-CLAUDE.md /home/parachute/techne/CLAUDE.md
+COPY --chown=parachute:parachute entrypoint.sh /home/parachute/entrypoint.sh
+RUN chmod +x /home/parachute/entrypoint.sh \
+ && ln -sf techne/CLAUDE.md /home/parachute/CLAUDE.md
+
+USER root
+COPY techne-claude /usr/local/bin/techne-claude
+RUN chmod +x /usr/local/bin/techne-claude
+USER parachute
+
+# Persistence (see docs/pods/techne.md):
+#   /home/parachute/.parachute  ← techne-data volume   (vault DBs + channel state)
+#   /home/parachute/.claude     ← techne-claude volume (Claude Code auth tokens)
+#
+# No EXPOSE: vault (1940) and channel (1941) bind inside the container only.
+# Telegram is reached via outbound HTTPS.
+
+ENTRYPOINT ["/usr/bin/tini", "--", "/home/parachute/entrypoint.sh"]
+CMD []

--- a/docker/pods/techne/entrypoint.sh
+++ b/docker/pods/techne/entrypoint.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Techne pod supervisor.
+#
+# Runs two long-lived services:
+#   - parachute-vault server  (always, on 127.0.0.1:1940 — auto-creates a
+#     default vault on first boot, so no `vault init` needed)
+#   - parachute-channel daemon (on 127.0.0.1:1941 — only after a Telegram
+#     bot token is available, so the container boots cleanly before Aaron
+#     has provisioned one)
+#
+# If TELEGRAM_BOT_TOKEN is passed via `docker run -e`, the token is persisted
+# to the channel state dir on first start; subsequent starts don't need it.
+
+set -u
+umask 077
+
+STATE_DIR="${HOME}/.parachute"
+CHANNEL_STATE_DIR="${STATE_DIR}/channel"
+CHANNEL_ENV_FILE="${CHANNEL_STATE_DIR}/.env"
+CHANNEL_SRC="/opt/parachute-channel/src/daemon.ts"
+
+mkdir -p "${STATE_DIR}" "${CHANNEL_STATE_DIR}"
+
+# Persist a shell-injected bot token to the channel .env so restarts don't
+# require the env var. Never overwrite a token already on disk.
+if [[ -n "${TELEGRAM_BOT_TOKEN:-}" && ! -s "${CHANNEL_ENV_FILE}" ]]; then
+  printf 'TELEGRAM_BOT_TOKEN=%s\n' "${TELEGRAM_BOT_TOKEN}" > "${CHANNEL_ENV_FILE}"
+  chmod 600 "${CHANNEL_ENV_FILE}"
+  echo "[techne] wrote TELEGRAM_BOT_TOKEN to ${CHANNEL_ENV_FILE}"
+fi
+
+echo "[techne] starting parachute-vault on 127.0.0.1:1940"
+parachute vault serve &
+VAULT_PID=$!
+
+# --- Provision the strict-mode MCP config for `techne-claude` ---
+# The wrapper at /usr/local/bin/techne-claude needs a JSON file listing
+# just parachute-vault + parachute-channel. We regenerate it on every boot
+# where it's missing so rebuilt images always end up with a fresh,
+# working token (old tokens stay in vault DB until pruned manually).
+MCP_CONFIG="${HOME}/techne/mcp.json"
+if [[ ! -s "${MCP_CONFIG}" ]]; then
+  echo "[techne] provisioning MCP config at ${MCP_CONFIG}"
+
+  # Wait up to 30s for vault to be healthy so `parachute vault tokens create`
+  # can talk to it. The server's first-boot auto-init can take a second or two.
+  for _ in {1..30}; do
+    if parachute vault status 2>/dev/null | grep -q "healthy"; then break; fi
+    sleep 1
+  done
+
+  MCP_TOKEN=$(parachute vault tokens create 2>&1 | grep -oE 'pvt_[A-Za-z0-9_-]+' | head -1)
+  if [[ -z "${MCP_TOKEN}" ]]; then
+    echo "[techne] WARNING: could not mint MCP token — techne-claude will fail until ${MCP_CONFIG} is populated by hand"
+  else
+    umask 077
+    cat > "${MCP_CONFIG}" <<JSON
+{
+  "mcpServers": {
+    "parachute-vault": {
+      "type": "http",
+      "url": "http://127.0.0.1:1940/vaults/default/mcp",
+      "headers": { "Authorization": "Bearer ${MCP_TOKEN}" }
+    },
+    "parachute-channel": {
+      "command": "bun",
+      "args": ["/opt/parachute-channel/src/bridge.ts"],
+      "env": { "PARACHUTE_CHANNEL_URL": "http://127.0.0.1:1941" }
+    }
+  }
+}
+JSON
+    umask 077
+    echo "[techne] wrote ${MCP_CONFIG}"
+  fi
+fi
+
+CHANNEL_PID=""
+start_channel() {
+  echo "[techne] starting parachute-channel daemon on 127.0.0.1:1941"
+  bun "${CHANNEL_SRC}" &
+  CHANNEL_PID=$!
+}
+
+has_token() {
+  [[ -s "${CHANNEL_ENV_FILE}" ]] || [[ -n "${TELEGRAM_BOT_TOKEN:-}" ]]
+}
+
+if has_token; then
+  start_channel
+else
+  echo "[techne] no TELEGRAM_BOT_TOKEN yet — channel will start as soon as one appears at ${CHANNEL_ENV_FILE}"
+fi
+
+shutdown() {
+  echo "[techne] signal received; shutting down"
+  [[ -n "${CHANNEL_PID}" ]] && kill "${CHANNEL_PID}" 2>/dev/null || true
+  kill "${VAULT_PID}" 2>/dev/null || true
+  exit 0
+}
+trap shutdown TERM INT
+
+# Supervisor loop. Vault is the anchor: if it dies, the container exits and
+# Docker's restart policy takes over. Channel is restarted with backoff on
+# its own, and started on demand once a token lands.
+while true; do
+  if ! kill -0 "${VAULT_PID}" 2>/dev/null; then
+    echo "[techne] vault exited — container will exit so Docker restarts us"
+    exit 1
+  fi
+
+  if [[ -z "${CHANNEL_PID}" ]]; then
+    if has_token; then start_channel; fi
+  elif ! kill -0 "${CHANNEL_PID}" 2>/dev/null; then
+    echo "[techne] channel daemon exited — restarting in 10s"
+    CHANNEL_PID=""
+    sleep 10
+    if has_token; then start_channel; fi
+  fi
+
+  sleep 5
+done

--- a/docker/pods/techne/techne-CLAUDE.md
+++ b/docker/pods/techne/techne-CLAUDE.md
@@ -1,0 +1,43 @@
+# Techne
+
+You are the Techne agent — Claude, embedded in the Techne cooperative (also known as Regen Hub), a community in Boulder, Colorado supporting co-working and collaboration.
+
+You run inside a long-lived Docker container (the "Techne pod") on Aaron Gabriel's machine. You reach the community through Telegram, via the `parachute-channel` bridge, and you have your own knowledge vault at `~/.parachute/`.
+
+## Who you serve
+
+The Techne community — co-op members in a small, private Telegram group — is a group of fully trusted collaborators. Everyone in the group can help shape this vault: what goes in it, how it's organized, what's worth tracking. Treat their contributions as peer input, not requests for review.
+
+Aaron Gabriel drives **pod-level** questions: scope, membership, infrastructure, security, who's trusted enough to be in the room. If something touches those, surface to him. Everything else — content, structure, day-to-day coordination — is the group's call.
+
+## This vault is community-owned in spirit
+
+Your vault's shape should grow from what the community actually needs, not from a pre-imposed structure. Start light: capture what's asked for, organize when there's a real reason to.
+
+## How you show up
+
+- **Register: peer, not assistant.** You are a member of the group, taking notes and surfacing patterns. Not a service desk.
+- **Brevity is respect.** Group chats are shared attention. One clear sentence beats three.
+- **Ask before volunteering.** If someone says something interesting, ask if they want it captured; don't just capture it.
+- **Privacy defaults on.** Treat group messages as group-visible but not public. Treat DMs as private to the sender.
+- **Surface patterns, don't impose them.** If you notice a recurring topic across a week, say "seems like X is coming up a lot — want me to pull together what's been said?" — rather than restructuring on your own.
+
+## How to engage
+
+- **Listen by default.** Most of the time, just be present. You don't need to reply to every message.
+- **Act when addressed.** @-mentions, direct questions, and explicit "capture this" or "remember this" requests are your cue to engage.
+- **Organize when it would clearly help.** If several people are converging on a topic, or a pattern is obvious, *offer* to pull it together — don't just do it.
+- **Ask when unclear.** If you're not sure whether to capture, organize, or surface something, ask the person who brought it up.
+- **DMs are normal.** Members will often direct-message you for things they don't want in-group. Treat DMs as private to that member; don't surface their content in the group.
+- **Check before recalling.** When answering "what did we decide about X," read the vault first — the group's own records are the source of truth, not your recollection.
+
+## Your tools
+
+- **Vault MCP** (`parachute-vault`) — `create-note`, `update-note`, `query-notes`, `list-tags`, `update-tag`, `delete-*`, `find-path`, `vault-info`. Backs to a SQLite DB at `~/.parachute/vaults/default/vault.db`.
+- **Channel MCP** (`parachute-channel`) — `reply`, `react`, `edit_message`, `download_attachment`. Inbound messages arrive as `notifications/claude/channel` events.
+
+Read the vault before writing to it. Use `vault-info` to understand what's already there when you arrive in a new context.
+
+## Escalation
+
+If something touches pod-level matters — scope, membership, infrastructure, security, who's in the group — send Aaron a DM and wait for direction. Content and coordination questions don't escalate; those are the group's to decide.

--- a/docker/pods/techne/techne-claude
+++ b/docker/pods/techne/techne-claude
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# techne-claude — the wrapper every Techne Claude session should go through.
+#
+# Why not just `claude`?
+#   - Claude Code inherits account-level MCP servers from Aaron's claude.ai
+#     account (his personal Parachute vault, Gmail, Drive, etc). The Techne
+#     pod must not see any of those.
+#   - `--strict-mcp-config` tells Claude to use ONLY the servers in the file
+#     we pass, ignoring every other MCP source. Combined with a local JSON
+#     listing just `parachute-vault` and `parachute-channel`, this gives the
+#     Techne agent exactly the two MCPs that belong to the pod and nothing
+#     else.
+#   - `--dangerously-load-development-channels server:parachute-channel`
+#     opts this session into the experimental `claude/channel` capability
+#     for our bridge. Without it, the bridge registers as a regular MCP
+#     (tools only), and Claude Code silently drops the bridge's
+#     `notifications/claude/channel` events on the floor — meaning inbound
+#     Telegram messages never reach the session. The "dangerously" prefix
+#     bypasses Anthropic's curated channel-server allowlist, which our
+#     self-named `parachute-channel` is not on. This flag is hidden from
+#     `claude --help`; discovered via the parachute-channel CLAUDE.md and
+#     confirmed against the 2.1.114 CLI binary.
+#   - The cd into ~/techne puts CLAUDE.md in Claude's auto-discovery path.
+#
+# Config layout:
+#   ~/techne/mcp.json   — the MCP config with vault + channel (holds a
+#                          vault bearer token; file is 0600, volume-persisted)
+#   ~/techne/CLAUDE.md  — the agent identity doc, auto-loaded from CWD
+#
+# If ~/techne/mcp.json is missing, this wrapper fails loudly rather than
+# silently falling back to the account-contaminated default.
+
+set -u
+
+MCP_CONFIG="${HOME}/techne/mcp.json"
+
+if [[ ! -s "${MCP_CONFIG}" ]]; then
+  cat >&2 <<EOF
+techne-claude: ${MCP_CONFIG} missing or empty.
+
+This file is written by the pod's entrypoint on first boot. If you're
+seeing this error, the container may not have finished bootstrapping, or
+the file was deleted. Recreate with:
+
+  parachute vault tokens create   # note the pvt_... token
+  cat > ${MCP_CONFIG} <<'JSON'
+  {
+    "mcpServers": {
+      "parachute-vault": {
+        "type": "http",
+        "url": "http://127.0.0.1:1940/vaults/default/mcp",
+        "headers": { "Authorization": "Bearer <paste token here>" }
+      },
+      "parachute-channel": {
+        "command": "bun",
+        "args": ["/opt/parachute-channel/src/bridge.ts"],
+        "env": { "PARACHUTE_CHANNEL_URL": "http://127.0.0.1:1941" }
+      }
+    }
+  }
+  JSON
+  chmod 600 ${MCP_CONFIG}
+EOF
+  exit 1
+fi
+
+cd "${HOME}/techne"
+# Both of these flags use the `=` binding form, on purpose:
+#   --mcp-config is variadic, so space-separating its value can let the
+#     parser swallow subsequent positional args as extra config paths.
+#   --dangerously-load-development-channels takes the server identifier
+#     (the `server:` prefix is required) as its value. Space-separating
+#     works in `--print` mode — where a following `--print <prompt>` acts
+#     as a natural terminator — but in interactive mode (no trailing
+#     args) the parser can treat `server:parachute-channel` as the
+#     initial-prompt positional, leaving the flag with an empty channels
+#     list. The MCP-server-lookup then fails at runtime with
+#     "no MCP server configured with that name". The `=` form binds the
+#     value unambiguously in every mode.
+# Without the channels flag at all, the session silently drops the
+# bridge's notifications/claude/channel events — inbound Telegram never
+# reaches Claude. See docs/pods/techne.md for the full writeup.
+exec claude \
+  --strict-mcp-config "--mcp-config=${MCP_CONFIG}" \
+  "--dangerously-load-development-channels=server:parachute-channel" \
+  "$@"

--- a/docs/pods/techne.md
+++ b/docs/pods/techne.md
@@ -1,0 +1,189 @@
+# Techne pod — runbook
+
+Long-lived Docker container hosting a Claude agent for the Techne / Regen Hub cooperative. Ships Bun, Claude Code CLI, `@openparachute/vault`, and `parachute-channel` (from git, pinned).
+
+Image source: [`docker/pods/techne/`](../../docker/pods/techne). This runbook is the operational companion — the Dockerfile and entrypoint carry the how-it-boots; this page carries the day-two operations.
+
+> **Status:** v1. First pod of its kind; expected to become the template for `unforced`, and others. When you find gaps in the runbook, fix them here.
+
+## Design at a glance
+
+| Concern | Choice |
+|---|---|
+| Base | `ubuntu:24.04` |
+| Container user | `parachute` (uid 1000), non-root |
+| PID 1 | `tini` → `entrypoint.sh` (supervises vault + channel) |
+| Vault auto-init | First run of `parachute vault serve` creates a default vault — no `vault init` needed |
+| Channel install | Cloned from GitHub at a pinned commit (build-arg `CHANNEL_COMMIT`) |
+| Ports exposed | None. Vault (1940) and channel (1941) bind inside the container; Telegram is outbound-only |
+| Persistence | Two named volumes — `techne-data` for vault + channel state, `techne-claude` for Claude auth |
+| Isolation | Namespace-isolated Docker container. No virtiofs. `/Users`, `/Applications`, `/Volumes` are not reachable |
+
+## Build
+
+```bash
+cd parachute-channel
+docker build -t techne:latest docker/pods/techne
+```
+
+Update the pinned channel commit by passing `--build-arg CHANNEL_COMMIT=<sha>`.
+
+## First run
+
+```bash
+docker volume create techne-data
+docker volume create techne-claude
+
+docker run -d \
+  --name techne \
+  --restart unless-stopped \
+  -v techne-data:/home/parachute/.parachute \
+  -v techne-claude:/home/parachute/.claude \
+  techne:latest
+
+docker logs -f techne
+```
+
+Container is up. Vault auto-creates its default DB on first boot; channel sits idle logging `no TELEGRAM_BOT_TOKEN yet` until a token lands.
+
+## Authenticate Claude (one-time, interactive)
+
+```bash
+docker exec -it techne bash -lc claude
+```
+
+Claude Code prints a URL; paste it into a browser, complete the sign-in, paste the code back into the container. Auth lands in the `techne-claude` volume and survives container restarts and rebuilds.
+
+## Starting a Techne agent session — use `techne-claude`, not `claude`
+
+Everyday Techne sessions must go through the wrapper:
+
+```bash
+docker exec -it techne techne-claude
+```
+
+The wrapper does four things `claude` alone won't:
+
+1. `cd ~/techne` so `CLAUDE.md` is auto-loaded from the working directory.
+2. Pass `--strict-mcp-config --mcp-config=~/techne/mcp.json` so the session sees **only** `parachute-vault` and `parachute-channel`. Without this, Claude Code inherits account-level MCP servers from Aaron's `claude.ai` account — including his personal Parachute vault, Gmail, Drive, etc. — which the Techne agent must not have access to.
+3. Pass `--dangerously-load-development-channels=server:parachute-channel` (note the `=`). This flag opts the session into the experimental `claude/channel` MCP capability. Without it, the channel MCP registers its tools (`reply`, `react`, etc.) but Claude silently drops the bridge's `notifications/claude/channel` events — meaning inbound Telegram messages never reach the session. The flag is hidden from `claude --help`; its existence is documented in `parachute-channel/CLAUDE.md`. The `dangerously-` prefix is there because the flag bypasses Anthropic's curated channel-server allowlist — our self-named `parachute-channel` server is not on that list and so requires this opt-in. The `=` binding matters: space-separating the value (`--dangerously-load-development-channels server:parachute-channel`) works in `--print` mode because the trailing `--print <prompt>` terminates the parser's search for a value, but in interactive mode it lets `server:parachute-channel` be swallowed as the initial-prompt positional — leaving the flag with an empty channels list, which surfaces at runtime as `"no MCP server configured with that name"`.
+4. Fail loudly if `~/techne/mcp.json` is missing (the pod's entrypoint writes it on first boot by minting a vault token; see "MCP provisioning" below).
+
+`claude` without the wrapper is still useful for `claude mcp add`, `claude doctor`, interactive authentication, and similar admin work — but don't use it for Techne agent sessions.
+
+## MCP provisioning
+
+On every container boot, `entrypoint.sh` checks for `~/techne/mcp.json`. If it's missing (first boot, or post-rebuild), the entrypoint:
+
+1. Waits for the vault server to come up healthy.
+2. Mints a fresh bearer token with `parachute vault tokens create`.
+3. Writes a 0600 JSON file listing `parachute-vault` (HTTP to `127.0.0.1:1940`) and `parachute-channel` (stdio-spawning the bridge) — with the minted token baked in.
+
+The file lives in the image layer (not the volume), so rebuilds trigger re-provisioning. Old tokens pile up in `vault.db` until pruned with `parachute vault tokens revoke <id>`.
+
+## Provide the Telegram bot token
+
+Aaron creates the bot via [@BotFather](https://t.me/BotFather) — get a token like `123456789:AAH...`.
+
+Two ways to hand it over:
+
+**A — persist to the volume (recommended once you have a token):**
+
+```bash
+docker exec -it techne bash -lc \
+  'printf "TELEGRAM_BOT_TOKEN=%s\n" "PASTE_TOKEN_HERE" > ~/.parachute/channel/.env && chmod 600 ~/.parachute/channel/.env'
+docker restart techne
+```
+
+**B — inject via env var at run time** (useful for the very first `docker run`):
+
+```bash
+docker run -d --name techne --restart unless-stopped \
+  -v techne-data:/home/parachute/.parachute \
+  -v techne-claude:/home/parachute/.claude \
+  -e TELEGRAM_BOT_TOKEN=PASTE_TOKEN_HERE \
+  techne:latest
+```
+
+The entrypoint writes injected tokens to `~/.parachute/channel/.env` on first boot, so the `-e` flag becomes optional after.
+
+## Adding the bot to a Telegram group
+
+1. In Telegram, create a group (or use an existing one).
+2. Add your bot by username, then promote it to admin if you want it to see all messages (Telegram's privacy mode otherwise limits bots to commands + @-mentions).
+3. Send a test message in the group. `docker logs -f techne` should show the daemon receiving it.
+
+## Everyday operations
+
+| Task | Command |
+|---|---|
+| Tail logs | `docker logs -f techne` |
+| Open a shell | `docker exec -it techne bash` |
+| Start a Claude session inside | `docker exec -it techne bash -lc 'cd ~/techne && claude'` |
+| Restart the container | `docker restart techne` |
+| Stop the container | `docker stop techne` |
+| Start after stop | `docker start techne` |
+| Rotate the bot token | overwrite `~/.parachute/channel/.env` inside the container, then `docker restart techne` |
+| Inspect vault data | `docker exec -it techne sqlite3 ~/.parachute/vaults/default/vault.db` |
+
+## Back up the vault
+
+The whole `techne-data` volume is one tar away from a backup:
+
+```bash
+docker run --rm -v techne-data:/data -v "$PWD":/backup ubuntu:24.04 \
+  tar -czf /backup/techne-data-$(date -u +%Y%m%dT%H%M%SZ).tar.gz -C /data .
+```
+
+Restore is the reverse, into a fresh empty volume.
+
+## Rebuild from scratch
+
+```bash
+docker stop techne && docker rm techne
+docker rmi techne:latest
+# techne-data and techne-claude are left intact; the rebuilt container picks them up.
+docker build -t techne:latest docker/pods/techne
+# Re-run — same `docker run` as above.
+```
+
+Full reset (destroys vault + Claude auth — Aaron will need to re-auth and the community loses notes):
+
+```bash
+docker stop techne && docker rm techne
+docker volume rm techne-data techne-claude
+```
+
+## Verifying host isolation
+
+Proof that no host filesystem is reachable from inside the container:
+
+```bash
+docker exec techne ls /Users
+# → ls: cannot access '/Users': No such file or directory
+```
+
+Run this after any image change and paste the output in the relevant PR.
+
+## Future work: always-on Techne
+
+Today, a Techne Claude session is a foreground process started by `docker exec -it techne techne-claude` from Aaron's laptop. Close the terminal and the agent is gone — Telegram messages that arrive with no session attached are broadcast to zero SSE clients and drop on the floor (the daemon has no persistent inbox for text). That's fine for smoke tests and supervised use; it won't do for an agent the cooperative can ping at any hour.
+
+The image ships Bun + Claude Code + the wrapper, but nothing that keeps a session alive across disconnects. Paths to consider when we want always-on:
+
+- **`tmux` inside the container.** Add `tmux` to the Dockerfile, have entrypoint launch `tmux new-session -d -s techne techne-claude`, and `docker exec -it techne tmux attach -t techne` to observe. Cheapest change; the session survives attach/detach and container restarts (via a small "resurrect on boot" hook). Downside: a crashed session silently stays crashed until someone attaches.
+- **Supervisor-managed session.** Extend `entrypoint.sh` to run `techne-claude` as a third supervised process alongside vault + channel, restarting on exit. Clean in Docker terms; harder to attach to for interactive work, and Claude Code's TTY assumptions may fight headless execution.
+- **Daemon-managed session via the Claude Agent SDK.** Skip the CLI entirely for the always-on role and drive a session programmatically (the SDK exposes the same MCP + channels surface). Most invasive, but lines up with how other pods are likely to run.
+
+Parking this here so the next person picking it up has the shape. Don't build any of it until we've run Techne through a real cooperative task or two and learned what "always-on" actually needs to mean.
+
+## Future pods
+
+This runbook is the template. To spin up a second pod (`unforced`, etc.):
+
+1. Copy `docker/pods/techne/` to `docker/pods/<name>/`.
+2. Edit the in-container `CLAUDE.md` to describe that pod's identity and scope.
+3. Rename the volumes (`<name>-data`, `<name>-claude`) and container name everywhere.
+4. Duplicate this runbook at `docs/pods/<name>.md`, adjusting the differences.
+
+Don't try to parameterize it yet — one copy is fine, the shape will settle after the second pod.

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -171,6 +171,9 @@ async function handleMessage(msg: TelegramMessage): Promise<void> {
   const userId = msg.from?.id;
   if (!userId || !isAllowed(userId)) return;
 
+  const userTag = msg.from?.username ? `@${msg.from.username}` : (msg.from?.first_name ?? `user ${userId}`);
+  console.log(`parachute-channel: rx from ${userTag} in chat ${msg.chat.id} (${clients.size} bridge(s))`);
+
   // Permission-reply intercept: if this looks like "yes xxxxx" or "no xxxxx"
   // for a pending permission request, emit a permission_verdict SSE event
   // instead of forwarding as a chat message.


### PR DESCRIPTION
## Summary

First pod — a long-lived Docker container hosting a Claude agent for the Techne / Regen Hub cooperative. Bundles `parachute-vault`, `parachute-channel` (cloned at a pinned commit), and the Claude Code CLI behind a strict-MCP wrapper. True namespace isolation: no host filesystem reach, no exposed ports, state persists only in named Docker volumes.

This runbook is also the template for future pods (`unforced`, etc.); `docs/pods/techne.md` calls out what to copy and rename. Don't parameterize until there's a second pod.

## What's in the PR

- `docker/pods/techne/Dockerfile` — Ubuntu 24.04 base, non-root `parachute` user at uid 1000 (displacing Ubuntu's stock `ubuntu` user at that slot), `tini` PID 1, Node 22 for the Claude Code CLI, Bun for `@openparachute/vault` and `parachute-channel`.
- `docker/pods/techne/entrypoint.sh` — supervises vault (always) + channel (only once a `TELEGRAM_BOT_TOKEN` lands on disk or via `-e`); auto-provisions `~/techne/mcp.json` on first boot by minting a vault bearer token.
- `docker/pods/techne/techne-claude` — the wrapper every Techne Claude session goes through. Pins the session to the pod's vault + channel MCPs only (no contamination from Aaron's account-level MCP servers) and opts into the experimental `claude/channel` capability so inbound Telegram events actually reach the session.
- `docker/pods/techne/techne-CLAUDE.md` — the in-container agent identity doc.
- `docs/pods/techne.md` — operational runbook: build, first-run, Claude auth, bot-token provisioning, everyday ops, backup, rebuild, host-isolation proof, and a "Future work: always-on Techne" section.
- `src/daemon.ts` — one-line rx log per inbound message so operators can see messages landing at the daemon without needing to attach an SSE tap.

## Host isolation proof

```
$ docker exec techne ls /Users
ls: cannot access '/Users': No such file or directory
$ docker exec techne ls /Applications
ls: cannot access '/Applications': No such file or directory
$ docker exec techne ls /Volumes
ls: cannot access '/Volumes': No such file or directory
```

The container is namespace-isolated; nothing on Aaron's Mac filesystem is reachable from inside it. Vault (1940) and channel (1941) bind on `127.0.0.1` inside the container only; Telegram is reached via outbound HTTPS. No `EXPOSE`, no port mappings on `docker run`.

## Flag-ambiguity narrative (the 30-minute landmine)

The wrapper passes `--dangerously-load-development-channels=server:parachute-channel` — with an **`=`** binding, deliberately.

Space-separating the value (`--dangerously-load-development-channels server:parachute-channel`) works in `--print` mode, because a following `--print <prompt>` acts as a natural terminator: the parser hands `server:parachute-channel` back to the flag, and the session registers the channels capability correctly.

In **interactive** mode (no trailing args), the same space form fails: the parser treats `server:parachute-channel` as the *initial-prompt positional* and leaves the flag with an empty channels list. At runtime this surfaces as:

```
server:parachute-channel · no MCP server configured with that name
```

…which is not a Claude Code bug about MCP config; it's a variadic-parse ambiguity on a hidden flag. The `=` binding makes the value unambiguous in every mode. The wrapper's header comment writes this down so the next reader doesn't have to rediscover it, and `docs/pods/techne.md` mentions it in the wrapper-duties list.

Related: even after the channels capability is correctly registered, the `/mcp` slash-command UI shows the entry as "no MCP server configured with that name" — this appears to be a cosmetic display-lookup bug (the slash command likely looks up `server:parachute-channel` as a whole string rather than stripping the `server:` prefix). DX issue to follow.

## How to smoke-test this pod

From scratch, end to end:

```bash
# 1. Build the image
cd parachute-channel
docker build -t techne:latest docker/pods/techne

# 2. Create volumes + run
docker volume create techne-data
docker volume create techne-claude
docker run -d --name techne --restart unless-stopped \
  -v techne-data:/home/parachute/.parachute \
  -v techne-claude:/home/parachute/.claude \
  techne:latest

# 3. Authenticate Claude Code (one-time, interactive)
docker exec -it techne bash -lc claude
# complete the browser auth flow; this lands in techne-claude volume

# 4. Drop in a Telegram bot token
docker exec -it techne bash -lc \
  'printf "TELEGRAM_BOT_TOKEN=%s\n" "PASTE_TOKEN_HERE" > ~/.parachute/channel/.env && chmod 600 ~/.parachute/channel/.env'
docker restart techne

# 5. In Telegram: add the bot to a group, promote to admin (so bot privacy
#    doesn't hide non-@mention messages), send a test.

# 6. Attach an agent session
docker exec -it techne techne-claude

# 7. In Telegram, DM the bot or @-mention it in the group;
#    the agent session should respond.
```

Expected signal at the daemon:

```
parachute-channel: rx from @UnforcedAG in chat 1190596288 (1 bridge(s))
```

## Not in this PR (followups)

- DX issues against `parachute-channel` (split or bundled, TBD):
  - Quickstart docs should explicitly show `--dangerously-load-development-channels=server:<name>` with the `=` called out.
  - Bridge should stderr-warn if Claude hasn't subscribed to `claude/channel` after a grace window.
  - Report the cosmetic `/mcp` display-lookup bug wherever it fits best.
- Always-on Techne (tmux / supervisor / Agent-SDK shapes) — documented as future work in the runbook; not built.
- `@openparachute/channel` publish follow-up so the image can pull the bridge from npm instead of `git clone` at a pinned commit.

## Test plan

- [ ] `docker build -t techne:latest docker/pods/techne` — image builds clean on a fresh machine
- [ ] `docker run` with empty volumes — vault auto-inits, channel logs "no TELEGRAM_BOT_TOKEN yet"
- [ ] Drop a bot token; restart — channel picks it up, starts polling Telegram
- [ ] `docker exec techne ls /Users` — fails (host isolation holds)
- [ ] `docker exec -it techne techne-claude --print "say ok"` — returns `ok` cleanly
- [ ] Aaron DMs the bot from Telegram — daemon logs `rx from ...`, agent session receives the notification, replies round-trip back
- [ ] Same for group `@-mention` after bot is admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)