### PR TITLE
feat: add allowInChats chat-level allowlist (#11)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,35 @@ claude --dangerously-load-development-channels server:parachute-channel
 - `access.json` — allowlist (compatible with the official plugin's format)
 - `inbox/` — downloaded attachments
 
+## Access control (`access.json`)
+
+Schema is compatible with the official Telegram plugin, plus one parachute-channel extension: `allowInChats`.
+
+| Field | Type | Description |
+|---|---|---|
+| `dmPolicy` | `"open" \| "pairing" \| "allowlist"` | `"open"` disables all gating. Anything else requires `allowFrom`. |
+| `allowFrom` | `string[]` | User-ID allowlist. Matches `msg.from.id` / `cq.from.id`. |
+| `allowInChats` | `string[]` (optional) | **Optional** chat-ID allowlist. When present, `msg.chat.id` / `cq.message.chat.id` must also be listed — AND gate with `allowFrom`. |
+| `groups`, `pending` | — | Used by the official plugin's pairing flow; read but not otherwise acted on here. |
+
+### `allowInChats` semantics
+
+- **Absent** → behave as today (user-allowlist only). Backwards-compatible.
+- **Present with entries** → both `allowFrom` and `allowInChats` must pass.
+- **Present but empty (`[]`)** → **fail-closed**: no chats allowed. If you want user-only gating, omit the field rather than setting it to `[]`.
+
+Private DMs to the bot have `chat.id === user_id` (Telegram convention). To permit a user's DM while gating groups, list their user ID in `allowInChats` too:
+
+```json
+{
+  "dmPolicy": "allowlist",
+  "allowFrom": ["1190596288"],
+  "allowInChats": ["1190596288", "-1003765557903"],
+  "groups": {},
+  "pending": {}
+}
+```
+
 ## MCP tools exposed to Claude
 
 | Tool | Description |

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -52,13 +52,29 @@ if (!TOKEN) {
 }
 
 // ---------------------------------------------------------------------------
-// Access control — reuse the official plugin's access.json format
+// Access control — reuse the official plugin's access.json format, plus one
+// parachute-channel extension: `allowInChats`.
+//
+// Fields (all inherited from the official plugin except `allowInChats`):
+//   dmPolicy      — "open" short-circuits all gating; anything else requires
+//                   the user to pass `allowFrom`.
+//   allowFrom     — user-ID allowlist. Checked against `msg.from.id` /
+//                   `cq.from.id`.
+//   allowInChats  — OPTIONAL chat-ID allowlist. If present, `msg.chat.id` /
+//                   `cq.message.chat.id` must also be listed. Absent means
+//                   user-allowlist only (backwards-compatible). Empty array
+//                   means FAIL-CLOSED: no chats allowed. Note: a user's DM
+//                   to the bot has `chat.id === user_id` (Telegram
+//                   convention), so to permit DMs while gating groups, list
+//                   the user's own ID in `allowInChats`.
+//   groups, pending — used by the official plugin's pairing flow; read but
+//                     not otherwise acted on here.
 // ---------------------------------------------------------------------------
 
-// Matches the official telegram plugin's access.json format
 interface AccessConfig {
   dmPolicy: "open" | "pairing" | "allowlist";
   allowFrom: string[];
+  allowInChats?: string[];
   groups: Record<string, unknown>;
   pending: Record<string, unknown>;
 }
@@ -71,10 +87,15 @@ function loadAccess(): AccessConfig {
   }
 }
 
-function isAllowed(userId: number): boolean {
+function isAllowed(userId: number, chatId: number | string | undefined): boolean {
   const access = loadAccess();
   if (access.dmPolicy === "open") return true;
-  return access.allowFrom.includes(String(userId));
+  if (!access.allowFrom.includes(String(userId))) return false;
+  if (access.allowInChats !== undefined) {
+    if (chatId === undefined) return false;
+    if (!access.allowInChats.includes(String(chatId))) return false;
+  }
+  return true;
 }
 
 // ---------------------------------------------------------------------------
@@ -139,7 +160,7 @@ const CALLBACK_DATA_RE = /^perm_(allow|deny)_([a-km-z]{5})$/;
 
 async function handleCallbackQuery(cq: TelegramCallbackQuery): Promise<void> {
   const userId = cq.from.id;
-  if (!isAllowed(userId)) {
+  if (!isAllowed(userId, cq.message?.chat.id)) {
     await api.answerCallbackQuery(cq.id).catch(() => {});
     return;
   }
@@ -169,7 +190,7 @@ async function handleCallbackQuery(cq: TelegramCallbackQuery): Promise<void> {
 
 async function handleMessage(msg: TelegramMessage): Promise<void> {
   const userId = msg.from?.id;
-  if (!userId || !isAllowed(userId)) return;
+  if (!userId || !isAllowed(userId, msg.chat.id)) return;
 
   const userTag = msg.from?.username ? `@${msg.from.username}` : (msg.from?.first_name ?? `user ${userId}`);
   console.log(`parachute-channel: rx from ${userTag} in chat ${msg.chat.id} (${clients.size} bridge(s))`);


### PR DESCRIPTION
## Summary

Closes #11. Adds an optional `allowInChats: string[]` field to `access.json` so pods bound to a specific Telegram group (e.g. `techne` → Regen Hub) refuse inbound traffic from other chats — even from otherwise-allowlisted users.

- `src/daemon.ts` — `AccessConfig` gets `allowInChats?: string[]`; `isAllowed(userId, chatId)` now AND-gates on the chat ID when the field is present; both call sites (`handleCallbackQuery`, `handleMessage`) thread the chat ID through.
- `CLAUDE.md` — new "Access control" section documenting the schema and the `allowInChats` semantics.
- Source-level comment block expanded to cover each field.

## Design decisions worth flagging

- **Empty array is fail-closed.** The issue author's write-up suggested "absent or empty → behave as today." I went the other way: empty `[]` means "no chats allowed." Rationale from team-lead: principle of least privilege — an explicit empty allowlist is most naturally read as "deny all," and if you want user-only gating you should omit the field rather than set it to `[]`. Documented clearly both in `CLAUDE.md` and the source comment.
- **Callback query without chat context → deny when `allowInChats` is configured.** `cq.message?.chat.id` can in principle be undefined (Telegram lets a callback query carry no message). In that case, if `allowInChats` is set, we fail closed. In practice every callback we generate is on a message we sent, so this is belt-and-braces.
- **DM convention.** Private DMs use `chat.id === user_id`. To permit DMs while gating groups, operators list the user's own ID in `allowInChats` — documented with a worked example in `CLAUDE.md`.

## Test plan

No test harness in the repo yet — manual repro below. (Follow-up to add a test harness is a separate conversation; not blocking this PR.)

Manual repro — covers each branch of `isAllowed`:

```bash
# 1. Baseline — allowFrom only (no allowInChats). Backwards-compatible.
cat > ~/.parachute/channel/access.json <<JSON
{"dmPolicy":"allowlist","allowFrom":["<your-uid>"],"groups":{},"pending":{}}
JSON
# DM the bot + message in a group where it's present → both delivered.

# 2. Chat-allowlist present, group allowed, DM NOT allowed.
cat > ~/.parachute/channel/access.json <<JSON
{"dmPolicy":"allowlist","allowFrom":["<your-uid>"],"allowInChats":["<group-chat-id>"],"groups":{},"pending":{}}
JSON
# DM → blocked (no daemon log line). Group message → delivered.

# 3. Chat-allowlist present, DM + group both allowed.
cat > ~/.parachute/channel/access.json <<JSON
{"dmPolicy":"allowlist","allowFrom":["<your-uid>"],"allowInChats":["<your-uid>","<group-chat-id>"],"groups":{},"pending":{}}
JSON
# Both DM and group → delivered.

# 4. Fail-closed: empty array = nothing allowed.
cat > ~/.parachute/channel/access.json <<JSON
{"dmPolicy":"allowlist","allowFrom":["<your-uid>"],"allowInChats":[],"groups":{},"pending":{}}
JSON
# DM + group → both blocked.

# 5. dmPolicy: "open" short-circuits everything.
cat > ~/.parachute/channel/access.json <<JSON
{"dmPolicy":"open","allowFrom":[],"allowInChats":[],"groups":{},"pending":{}}
JSON
# Everything delivered — open wins.
```

Also smoke-tested callback-query path: with `allowInChats` configured and a permission prompt sent to a disallowed chat, the Allow/Deny buttons do nothing (callback silently answered, no verdict broadcast).

## Task list

- [x] `AccessConfig` gets `allowInChats?: string[]`
- [x] `isAllowed(userId, chatId)` — AND gate when field present
- [x] Both call sites updated
- [x] Source comment block documents new field
- [x] `CLAUDE.md` documents new field with worked example
- [ ] Manual repro above (operator to run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)