### PR TITLE
Always-on Techne: tmux-hosted restart loop for the agent session

### DIFF
--- a/docker/pods/techne/Dockerfile
+++ b/docker/pods/techne/Dockerfile
@@ -18,12 +18,16 @@ ENV DEBIAN_FRONTEND=noninteractive \
 
 # System packages + Node.js 22 (Claude Code CLI is a Node app; Bun runs vault/channel).
 # tini: PID 1 signal-forwarding so docker stop is clean.
+# tmux: hosts the always-on `techne` session running techne-claude-loop, so
+#       Aaron can attach to observe or talk to the agent without launching a
+#       new session each time. See docs/pods/techne.md → "How Techne runs".
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
         git \
         tini \
+        tmux \
         unzip \
  && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
  && apt-get install -y --no-install-recommends nodejs \
@@ -77,7 +81,8 @@ RUN chmod +x /home/parachute/entrypoint.sh \
 
 USER root
 COPY techne-claude /usr/local/bin/techne-claude
-RUN chmod +x /usr/local/bin/techne-claude
+COPY techne-claude-loop /usr/local/bin/techne-claude-loop
+RUN chmod +x /usr/local/bin/techne-claude /usr/local/bin/techne-claude-loop
 USER parachute
 
 # Persistence (see docs/pods/techne.md):

--- a/docker/pods/techne/entrypoint.sh
+++ b/docker/pods/techne/entrypoint.sh
@@ -92,8 +92,31 @@ else
   echo "[techne] no TELEGRAM_BOT_TOKEN yet — channel will start as soon as one appears at ${CHANNEL_ENV_FILE}"
 fi
 
+# --- Always-on Techne agent in tmux ---
+# A detached tmux session named `techne` runs `techne-claude-loop`, which
+# keeps a Claude session alive 24/7 so inbound Telegram messages reach the
+# agent even when nobody is at the keyboard. Aaron observes/interacts via
+# `docker exec -it techne tmux attach -t techne` and detaches with Ctrl+B,d
+# without killing it.
+#
+# We mirror the pane to a logfile (~/.techne-logs/loop.log) via tmux
+# pipe-pane so there's a tail-able artifact even when no client is attached.
+TECHNE_LOG_DIR="${HOME}/.techne-logs"
+mkdir -p "${TECHNE_LOG_DIR}"
+
+start_agent_tmux() {
+  echo "[techne] starting always-on tmux session 'techne' (techne-claude-loop)"
+  tmux new-session -d -s techne -n agent /usr/local/bin/techne-claude-loop
+  tmux pipe-pane -t techne:agent -o "cat >> ${TECHNE_LOG_DIR}/loop.log"
+}
+
+if ! tmux has-session -t techne 2>/dev/null; then
+  start_agent_tmux
+fi
+
 shutdown() {
   echo "[techne] signal received; shutting down"
+  tmux kill-server 2>/dev/null || true
   [[ -n "${CHANNEL_PID}" ]] && kill "${CHANNEL_PID}" 2>/dev/null || true
   kill "${VAULT_PID}" 2>/dev/null || true
   exit 0
@@ -102,7 +125,9 @@ trap shutdown TERM INT
 
 # Supervisor loop. Vault is the anchor: if it dies, the container exits and
 # Docker's restart policy takes over. Channel is restarted with backoff on
-# its own, and started on demand once a token lands.
+# its own, and started on demand once a token lands. The tmux session is
+# recreated if it disappears (rare; the loop wrapper is what keeps Claude
+# alive, and the loop only exits if it crashes itself).
 while true; do
   if ! kill -0 "${VAULT_PID}" 2>/dev/null; then
     echo "[techne] vault exited — container will exit so Docker restarts us"
@@ -116,6 +141,11 @@ while true; do
     CHANNEL_PID=""
     sleep 10
     if has_token; then start_channel; fi
+  fi
+
+  if ! tmux has-session -t techne 2>/dev/null; then
+    echo "[techne] tmux session 'techne' missing — recreating"
+    start_agent_tmux
   fi
 
   sleep 5

--- a/docker/pods/techne/techne-claude-loop
+++ b/docker/pods/techne/techne-claude-loop
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# techne-claude-loop — keep the Techne Claude session alive forever.
+#
+# This script is the long-lived process inside the pod's `techne` tmux
+# session. It runs `techne-claude` (the strict-MCP + channels-opt-in
+# wrapper); when Claude exits — `/exit`, rate limit, network blip,
+# crash — it logs the exit, sleeps with exponential backoff, and runs
+# it again.
+#
+# Behavior summary:
+#   - Healthy run (>= HEALTHY_RUN_S seconds): reset failure counter and
+#     backoff to baseline. The agent earned its restart.
+#   - Fast fail (< FAST_FAIL_THRESHOLD_S seconds): increment counter.
+#   - After MAX_FAST_FAILS consecutive fast fails: post a Telegram
+#     warning to the pod owner (TECHNE_OWNER_CHAT_ID) via the channel
+#     daemon's /api/reply, reset counter, sleep at the cap. This keeps
+#     us from spamming Aaron during a sustained outage while still
+#     surfacing the first bad run quickly.
+#
+# Conversation context note: each restart starts a fresh Claude session
+# with an empty conversation. The vault is the persistent memory layer,
+# not the session — losing in-conversation context here is by design.
+#
+# To attach:    docker exec -it techne tmux attach -t techne
+# To detach:    Ctrl+B then d  (does NOT kill the session)
+# Logfile:      ~/.techne-logs/loop.log  (mirrored from the tmux pane)
+
+set -u
+
+OWNER_CHAT_ID="${TECHNE_OWNER_CHAT_ID:-1190596288}"
+DAEMON_URL="${PARACHUTE_CHANNEL_URL:-http://127.0.0.1:1941}"
+
+MAX_FAST_FAILS=5
+FAST_FAIL_THRESHOLD_S=30
+HEALTHY_RUN_S=300
+BACKOFF_INITIAL=10
+BACKOFF_MAX=120
+
+fast_fails=0
+backoff="${BACKOFF_INITIAL}"
+
+ts() { date -u "+%Y-%m-%dT%H:%M:%SZ"; }
+log() { printf "[techne-loop %s] %s\n" "$(ts)" "$*"; }
+
+alert_owner() {
+  local text="$1"
+  # Build the JSON via bun so we don't have to hand-escape the message.
+  # If bun isn't available for some reason we degrade to logging only.
+  local payload
+  if ! payload=$(bun -e '
+    const [chatId, text] = process.argv.slice(2);
+    process.stdout.write(JSON.stringify({ chat_id: chatId, text }));
+  ' "${OWNER_CHAT_ID}" "${text}" 2>/dev/null); then
+    log "alert: could not build payload (bun missing?), would have sent: ${text}"
+    return
+  fi
+  if curl -fsS -X POST "${DAEMON_URL}/api/reply" \
+      -H 'Content-Type: application/json' \
+      -d "${payload}" > /dev/null 2>&1; then
+    log "alert: sent owner notification via channel"
+  else
+    log "alert: channel /api/reply unreachable, would have sent: ${text}"
+  fi
+}
+
+log "starting loop; owner=${OWNER_CHAT_ID} daemon=${DAEMON_URL}"
+
+while true; do
+  log "starting techne-claude (fast-fails: ${fast_fails})"
+  start=$(date +%s)
+  techne-claude
+  exit_code=$?
+  end=$(date +%s)
+  duration=$(( end - start ))
+  log "techne-claude exited code=${exit_code} after ${duration}s"
+
+  if (( duration >= HEALTHY_RUN_S )); then
+    fast_fails=0
+    backoff="${BACKOFF_INITIAL}"
+  elif (( duration < FAST_FAIL_THRESHOLD_S )); then
+    fast_fails=$(( fast_fails + 1 ))
+  fi
+
+  if (( fast_fails >= MAX_FAST_FAILS )); then
+    alert_owner "⚠️ Techne agent exited fast ${fast_fails} times in a row (last code ${exit_code}). Investigate with: docker exec -it techne tmux attach -t techne — or: docker logs techne. Loop continues with ${BACKOFF_MAX}s backoff."
+    fast_fails=0
+    backoff="${BACKOFF_MAX}"
+  fi
+
+  log "sleeping ${backoff}s before restart"
+  sleep "${backoff}"
+  backoff=$(( backoff * 2 ))
+  if (( backoff > BACKOFF_MAX )); then backoff="${BACKOFF_MAX}"; fi
+done

--- a/docs/pods/techne.md
+++ b/docs/pods/techne.md
@@ -12,7 +12,7 @@ Image source: [`docker/pods/techne/`](../../docker/pods/techne). This runbook is
 |---|---|
 | Base | `ubuntu:24.04` |
 | Container user | `parachute` (uid 1000), non-root |
-| PID 1 | `tini` → `entrypoint.sh` (supervises vault + channel) |
+| PID 1 | `tini` → `entrypoint.sh` (supervises vault + channel + always-on tmux session) |
 | Vault auto-init | First run of `parachute vault serve` creates a default vault — no `vault init` needed |
 | Channel install | Cloned from GitHub at a pinned commit (build-arg `CHANNEL_COMMIT`) |
 | Ports exposed | None. Vault (1940) and channel (1941) bind inside the container; Telegram is outbound-only |
@@ -54,15 +54,29 @@ docker exec -it techne bash -lc claude
 
 Claude Code prints a URL; paste it into a browser, complete the sign-in, paste the code back into the container. Auth lands in the `techne-claude` volume and survives container restarts and rebuilds.
 
-## Starting a Techne agent session — use `techne-claude`, not `claude`
+## How Techne runs — always-on via tmux
 
-Everyday Techne sessions must go through the wrapper:
+The pod's entrypoint starts a detached `tmux` session named `techne` running `/usr/local/bin/techne-claude-loop`. The loop runs `techne-claude` in a forever-restart loop with backoff, so a crash, rate-limit, network blip, or `/exit` doesn't take the agent offline — it spins back up within seconds. This is what keeps inbound Telegram messages reaching Claude when nobody is at the keyboard.
 
-```bash
-docker exec -it techne techne-claude
-```
+| Action | Command |
+|---|---|
+| Attach to the agent session | `docker exec -it techne tmux attach -t techne` |
+| Detach **without killing it** | `Ctrl+B` then `d` |
+| Kick the loop | `docker exec techne tmux kill-session -t techne` (entrypoint recreates within ~5s) |
+| Tail the agent's pane log | `docker exec techne tail -f /home/parachute/.techne-logs/loop.log` |
+| Daemon health | `docker exec techne curl -s http://127.0.0.1:1941/health` |
 
-The wrapper does four things `claude` alone won't:
+**Don't start a second `techne-claude` outside the tmux session.** Each Claude session spawns its own `bridge.ts`, both bridges subscribe to the daemon's SSE stream, and every inbound message gets handled twice — including double replies. If you need to run something interactively, attach to the existing session.
+
+When you attach, you see the live conversation. Type to talk to the agent — the same as a regular `claude` session. Detach with `Ctrl+B` then `d` when done; the session keeps running. Don't `Ctrl+D` (that exits Claude, the loop will restart it but you've also blown away the conversation context).
+
+Conversation context lives only inside one Claude run. When the loop restarts the session — whether by your `/exit` or a crash — the new run starts with no in-memory history. **The vault is the persistent memory layer.** Anything Techne should remember across restarts has to be written there.
+
+If the loop hits `MAX_FAST_FAILS` consecutive sub-30-second exits in a row (i.e. Claude can't get off the ground), it posts a Telegram message to the pod owner via the channel daemon's `/api/reply`, then sleeps at the cap to avoid spamming. Owner is `TECHNE_OWNER_CHAT_ID` in the loop (defaults to Aaron's UID `1190596288`).
+
+### Wrapper details
+
+`techne-claude` (what the loop runs) does four things `claude` alone won't:
 
 1. `cd ~/techne` so `CLAUDE.md` is auto-loaded from the working directory.
 2. Pass `--strict-mcp-config --mcp-config=~/techne/mcp.json` so the session sees **only** `parachute-vault` and `parachute-channel`. Without this, Claude Code inherits account-level MCP servers from Aaron's `claude.ai` account — including his personal Parachute vault, Gmail, Drive, etc. — which the Techne agent must not have access to.
@@ -70,6 +84,10 @@ The wrapper does four things `claude` alone won't:
 4. Fail loudly if `~/techne/mcp.json` is missing (the pod's entrypoint writes it on first boot by minting a vault token; see "MCP provisioning" below).
 
 `claude` without the wrapper is still useful for `claude mcp add`, `claude doctor`, interactive authentication, and similar admin work — but don't use it for Techne agent sessions.
+
+### First-run order matters
+
+The tmux loop expects Claude to already be authenticated; if `~/.claude` is empty, Claude prints an OAuth URL and waits for you to paste a code. Inside the tmux pane with no client attached, that wait is invisible — the loop appears stuck. Always do the one-time `docker exec -it techne bash -lc claude` *before* relying on the always-on session. Once auth lands in the `techne-claude` volume, the loop's restarts pick it up automatically.
 
 ## MCP provisioning
 
@@ -113,18 +131,33 @@ The entrypoint writes injected tokens to `~/.parachute/channel/.env` on first bo
 2. Add your bot by username, then promote it to admin if you want it to see all messages (Telegram's privacy mode otherwise limits bots to commands + @-mentions).
 3. Send a test message in the group. `docker logs -f techne` should show the daemon receiving it.
 
+## End-to-end smoke test
+
+After a fresh build + run + Claude auth + bot-token + group setup:
+
+1. `docker exec -it techne tmux attach -t techne` — drops you into the live always-on Claude session. You should see the agent's prompt, possibly mid-conversation if anything has come in. Detach immediately with `Ctrl+B` then `d`.
+2. From Telegram, DM the bot (or @-mention it in the group). A `<channel …>` tag should land in the agent's pane within a couple of seconds — *without* you having launched `techne-claude` manually first. The agent's reply should round-trip back into Telegram.
+3. `docker exec techne tail -n 5 /home/parachute/.techne-logs/loop.log` — should show `[techne-loop ...] starting techne-claude (fast-fails: 0)` and nothing alarming.
+
+If step 2 fails: see "How Techne runs" → first-run order. The most common cause is forgetting the one-time `claude` auth step, which leaves the loop blocked at the OAuth prompt.
+
 ## Everyday operations
 
 | Task | Command |
 |---|---|
-| Tail logs | `docker logs -f techne` |
+| Attach to the live agent | `docker exec -it techne tmux attach -t techne` |
+| Detach from agent | `Ctrl+B` then `d` |
+| Tail container logs | `docker logs -f techne` |
+| Tail agent pane log | `docker exec techne tail -f /home/parachute/.techne-logs/loop.log` |
 | Open a shell | `docker exec -it techne bash` |
-| Start a Claude session inside | `docker exec -it techne bash -lc 'cd ~/techne && claude'` |
+| Run an admin Claude session | `docker exec -it techne bash -lc 'cd ~/techne && claude'` (see warning above — don't do this while the always-on session is running) |
 | Restart the container | `docker restart techne` |
 | Stop the container | `docker stop techne` |
 | Start after stop | `docker start techne` |
+| Force the agent loop to restart | `docker exec techne tmux kill-session -t techne` (entrypoint recreates within ~5s) |
 | Rotate the bot token | overwrite `~/.parachute/channel/.env` inside the container, then `docker restart techne` |
 | Inspect vault data | `docker exec -it techne sqlite3 ~/.parachute/vaults/default/vault.db` |
+| Daemon health | `docker exec techne curl -s http://127.0.0.1:1941/health` |
 
 ## Back up the vault
 
@@ -165,17 +198,15 @@ docker exec techne ls /Users
 
 Run this after any image change and paste the output in the relevant PR.
 
-## Future work: always-on Techne
+## Future work
 
-Today, a Techne Claude session is a foreground process started by `docker exec -it techne techne-claude` from Aaron's laptop. Close the terminal and the agent is gone — Telegram messages that arrive with no session attached are broadcast to zero SSE clients and drop on the floor (the daemon has no persistent inbox for text). That's fine for smoke tests and supervised use; it won't do for an agent the cooperative can ping at any hour.
+Always-on now ships (see "How Techne runs" above). Things still parked:
 
-The image ships Bun + Claude Code + the wrapper, but nothing that keeps a session alive across disconnects. Paths to consider when we want always-on:
-
-- **`tmux` inside the container.** Add `tmux` to the Dockerfile, have entrypoint launch `tmux new-session -d -s techne techne-claude`, and `docker exec -it techne tmux attach -t techne` to observe. Cheapest change; the session survives attach/detach and container restarts (via a small "resurrect on boot" hook). Downside: a crashed session silently stays crashed until someone attaches.
-- **Supervisor-managed session.** Extend `entrypoint.sh` to run `techne-claude` as a third supervised process alongside vault + channel, restarting on exit. Clean in Docker terms; harder to attach to for interactive work, and Claude Code's TTY assumptions may fight headless execution.
-- **Daemon-managed session via the Claude Agent SDK.** Skip the CLI entirely for the always-on role and drive a session programmatically (the SDK exposes the same MCP + channels surface). Most invasive, but lines up with how other pods are likely to run.
-
-Parking this here so the next person picking it up has the shape. Don't build any of it until we've run Techne through a real cooperative task or two and learned what "always-on" actually needs to mean.
+- **Periodic restart for context drift.** A long-running Claude session accumulates context window and can drift in personality or recall over days. The loop today restarts only on exit; consider a soft restart every N hours (or every N inbound messages) once we have data on what "too long" looks like in practice.
+- **Drift / health observability beyond pane log.** Today the only liveness signals are `/health` (channel daemon perspective) and tail of the pane log. A periodic synthetic ping ("agent, reply with `pong`") via the channel would prove end-to-end that Claude is processing, not just that the process is alive.
+- **Bounded loop log.** `~/.techne-logs/loop.log` grows unbounded. Rotate or cap it.
+- **Multi-pane tmux** (e.g. one pane for the agent, one for daemon logs) so an attached operator sees both at once. Marginal value, no urgency.
+- **Daemon-managed session via the Claude Agent SDK.** A more invasive alternative to the tmux+CLI stack; probably the right shape if/when we move beyond one pod and want richer programmatic control. Not on the critical path.
 
 ## Future pods
 


### PR DESCRIPTION
## Summary

Keeps the Techne Claude session alive 24/7 inside the pod so inbound Telegram messages reach the agent even when nobody is attached. Implements the `tmux`-based approach team-lead sketched for the always-on gap.

Before this PR, `techne-claude` was a foreground process started by hand via `docker exec -it techne techne-claude`. Close the terminal → agent is gone, and any Telegram message arriving with no SSE client attached is dropped on the floor (daemon has no text inbox). That's fine for supervised smoke tests; it isn't workable for an agent the cooperative can ping at any hour.

## What changes

- **`docker/pods/techne/Dockerfile`** — `tmux` added to the apt-get install list; `techne-claude-loop` copied to `/usr/local/bin` alongside `techne-claude`.
- **`docker/pods/techne/techne-claude-loop`** (new) — bash wrapper that runs `techne-claude` in a forever-restart loop with exponential backoff. After `MAX_FAST_FAILS` consecutive sub-30-second exits, posts a Telegram warning to the pod owner via the channel daemon's `POST /api/reply`, resets the counter, and sleeps at the backoff cap. Resets on any run ≥ 5 minutes.
- **`docker/pods/techne/entrypoint.sh`** — after vault + channel boot, starts a detached `tmux` session named `techne` running the loop. `tmux pipe-pane` mirrors the pane to `~/.techne-logs/loop.log` so there's a tail-able artifact even when nobody is attached. Supervisor loop recreates the tmux session if it disappears. Shutdown path kills the tmux server before the other supervised processes.
- **`docs/pods/techne.md`** — new **"How Techne runs — always-on via tmux"** section (attach/detach, kick-the-loop, pane log, daemon health, conversation-context rules, first-run-order note); **"Everyday operations"** table updated; new **"End-to-end smoke test"** section; the old "Future work: always-on Techne" placeholder pared down to the bits still genuinely parked (periodic restart for context drift, synthetic health ping, bounded loop log, multi-pane tmux, Agent-SDK rewrite).

Scope held to pod files + runbook, as requested. No daemon or bridge changes.

## Design decisions that differ from the sketch

- **Alert path reuses `/api/reply` rather than introducing a new mechanism.** Zero new endpoints, runs through plumbing we already trust. Loop builds the JSON body via `bun -e` so it doesn't have to hand-escape user-visible text.
- **Fast-fail counter resets on healthy (≥ 5 min) runs.** So a well-behaved agent that hits a blip later doesn't carry stale fast-fail credit into a future incident.
- **First-run-order is a runbook warning, not an entrypoint gate.** If `~/.claude` is empty, Claude prints an OAuth URL and waits forever — inside a detached tmux pane that looks like "loop stuck". Rather than encode an auth probe in the entrypoint (fragile — path/format could change), the runbook directs operators to do `docker exec -it techne bash -lc claude` before relying on the always-on session. For the current techne container, auth is already in the volume, so a rebuild picks it up automatically.

## Gate results

- `bash -n docker/pods/techne/entrypoint.sh` → OK
- `bash -n docker/pods/techne/techne-claude-loop` → OK
- `bash -n docker/pods/techne/techne-claude` → OK (unchanged)
- Dockerfile lines visually reviewed (install order unchanged, `tmux` packaged with the existing apt group, `COPY`/`chmod` pattern matches the pre-existing wrapper copy)
- No runtime smoke test in this PR — behavior depends on a rebuilt image, and rebuilding production techne inside this PR would be unsafe. The smoke-test walkthrough is in `docs/pods/techne.md` → "End-to-end smoke test" and will run after Aaron rebuilds.

## Rebuild-to-adopt

Rebuild required; existing container needs to be replaced. The `techne-data` and `techne-claude` volumes are preserved (auth + vault + bot token + allowlist all survive):

```bash
docker stop techne && docker rm techne
docker rmi techne:latest
docker build -t techne:latest docker/pods/techne
docker run -d --name techne --restart unless-stopped \
  -v techne-data:/home/parachute/.parachute \
  -v techne-claude:/home/parachute/.claude \
  techne:latest
```

After the new container is up:

1. `docker exec -it techne tmux attach -t techne` — drops you into the live always-on session.
2. Detach with `Ctrl+B` then `d`.
3. DM the bot from Telegram — a `<channel …>` tag should appear in the pane within a couple of seconds, without any manual `techne-claude` launch.
4. `docker exec techne tail /home/parachute/.techne-logs/loop.log` — should show `[techne-loop ...] starting techne-claude (fast-fails: 0)` and nothing alarming.

## Test plan

- [ ] Rebuild the image; `docker run` starts cleanly
- [ ] `docker exec techne ls /Users` still fails (isolation holds)
- [ ] `docker exec techne tmux has-session -t techne` returns 0
- [ ] `docker exec -it techne tmux attach -t techne` drops into a live Claude session
- [ ] DM the bot in Telegram — agent replies without any `techne-claude` launch
- [ ] Group `@-mention` round-trip (as before)
- [ ] `docker exec techne tail /home/parachute/.techne-logs/loop.log` shows the startup line
- [ ] `docker exec techne kill <claude-pid>` (or `/exit` via tmux) — loop restarts claude automatically, pane log shows the restart with the exit code
- [ ] Simulate fast-fail: temporarily break `/usr/local/bin/techne-claude` (`chmod -x`), watch 5 fast-fails, confirm Telegram alert lands, restore

## Not in this PR

- Periodic session restart for context drift
- Synthetic end-to-end health ping
- Bounded loop log (rotation/cap)
- Multi-pane tmux (agent + daemon logs side by side)
- Agent-SDK-driven alternative to CLI-in-tmux

All moved to `docs/pods/techne.md` → "Future work" for when we have data from real use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)