### PR TITLE
feat: bridge stderr-warn when client missing claude/channel capability (#9)

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -288,6 +288,60 @@ async function connectToEvents(): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
+// Missing-subscription warning
+//
+// If Claude Code attaches to this bridge but didn't opt into the
+// experimental `claude/channel` capability (e.g. forgot
+// `--dangerously-load-development-channels=server:<name>`), the MCP tools
+// register fine but every inbound notification the bridge emits is silently
+// dropped. That looks identical to a working setup until a message arrives
+// and nothing lands in the session.
+//
+// Signals, in priority order:
+//   1. On `oninitialized`, read `getClientCapabilities().experimental` — the
+//      canonical MCP hook. If `claude/channel` is missing, warn.
+//   2. If no initialize ever arrives (bridge is running but no client
+//      connected), warn after a grace period so `bun src/bridge.ts` invoked
+//      standalone tells you so.
+//
+// The warning doesn't exit — outbound tool calls still work in degraded mode.
+// Gated on NODE_ENV !== "test" so tests can import this module silently.
+// ---------------------------------------------------------------------------
+
+const SUBSCRIPTION_WARN_MS = 15_000;
+const IS_TEST = process.env.NODE_ENV === "test";
+
+let initReceived = false;
+const warnIfNoInit = setTimeout(() => {
+  if (initReceived || IS_TEST) return;
+  process.stderr.write(
+    "parachute-channel bridge: no MCP initialize received after 15s — " +
+    "the bridge is running but no client has connected.\n",
+  );
+}, SUBSCRIPTION_WARN_MS);
+if (typeof warnIfNoInit.unref === "function") warnIfNoInit.unref();
+
+mcp.oninitialized = () => {
+  initReceived = true;
+  clearTimeout(warnIfNoInit);
+  if (IS_TEST) return;
+  const caps = mcp.getClientCapabilities();
+  const hasChannel = caps?.experimental?.["claude/channel"] !== undefined;
+  if (!hasChannel) {
+    process.stderr.write(
+      [
+        "parachute-channel bridge: WARNING — client did not advertise claude/channel support.",
+        "  Inbound Telegram messages will not reach this session.",
+        "  Did you launch Claude Code with:",
+        "      --dangerously-load-development-channels=server:parachute-channel",
+        "  (See https://github.com/ParachuteComputer/parachute-channel/issues/8)",
+        "",
+      ].join("\n"),
+    );
+  }
+};
+
+// ---------------------------------------------------------------------------
 // Start
 // ---------------------------------------------------------------------------
 

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -325,20 +325,27 @@ mcp.oninitialized = () => {
   initReceived = true;
   clearTimeout(warnIfNoInit);
   if (IS_TEST) return;
-  const caps = mcp.getClientCapabilities();
-  const hasChannel = caps?.experimental?.["claude/channel"] !== undefined;
-  if (!hasChannel) {
-    process.stderr.write(
-      [
-        "parachute-channel bridge: WARNING — client did not advertise claude/channel support.",
-        "  Inbound Telegram messages will not reach this session.",
-        "  Did you launch Claude Code with:",
-        "      --dangerously-load-development-channels=server:parachute-channel",
-        "  (See https://github.com/ParachuteComputer/parachute-channel/issues/8)",
-        "",
-      ].join("\n"),
-    );
-  }
+  // The MCP SDK dispatches `notifications/initialized` and the preceding
+  // `initialize` request as separate microtasks; the notification's sync
+  // handler can fire before the request handler populates client
+  // capabilities. Defer the check to a later tick so `_clientCapabilities`
+  // is populated by the time we inspect it.
+  setTimeout(() => {
+    const caps = mcp.getClientCapabilities();
+    const hasChannel = caps?.experimental?.["claude/channel"] !== undefined;
+    if (!hasChannel) {
+      process.stderr.write(
+        [
+          "parachute-channel bridge: WARNING — client did not advertise claude/channel support.",
+          "  Inbound Telegram messages will not reach this session.",
+          "  Did you launch Claude Code with:",
+          "      --dangerously-load-development-channels=server:parachute-channel",
+          "  (See https://github.com/ParachuteComputer/parachute-channel/issues/8)",
+          "",
+        ].join("\n"),
+      );
+    }
+  }, 0);
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #9. When Claude Code attaches to the bridge without `--dangerously-load-development-channels=server:<name>`, tool calls register fine but every inbound `notifications/claude/channel` event is silently dropped — looks identical to a working setup until a message arrives and nothing lands in the session. Costs operators 30+ minutes of chasing the wrong suspect (MCP config, daemon, bot token, etc.).

This PR hooks the MCP SDK's `oninitialized` callback and inspects `getClientCapabilities().experimental["claude/channel"]`. If missing, the bridge writes a labeled stderr warning pointing at the likely cause and linking issue #8 (the `=` binding gotcha). Also warns after a 15s grace period if no MCP initialize ever arrives — useful when invoking `bun src/bridge.ts` standalone for debugging.

## Why `setTimeout(..., 0)` (subtle, worth a look)

The MCP SDK (`@modelcontextprotocol/sdk@1.29.0`) dispatches `notifications/initialized` and the preceding `initialize` request as separate microtasks:
- `_onnotification` → `Promise.resolve().then(handler)` — one microtask hop, no further awaits
- `_onrequest` → zod validation + several awaits before invoking `_oninitialize`

Result: the `initialized` notification can fire before `_oninitialize` has populated `_clientCapabilities`, causing `getClientCapabilities()` to return `undefined` — and the warning would fire spuriously even when the client had subscribed correctly. I caught this in smoke testing and deferred the capability check one macrotask later (second commit).

Reproducible in a debug log:
```
DEBUG caps=undefined priv=undefined           # oninitialized fires first
WARNING ...                                   # spurious warning
DEBUG _oninitialize req={...}                 # request handler starts
DEBUG after _oninitialize priv={claude/channel:{}}  # caps NOW populated
```

After the fix, the capability check runs after all pending microtasks and sees the populated caps.

## Implementation notes

- Signal is MCP's `oninitialized` callback + `getClientCapabilities()`. No heuristic needed — this is the canonical hook.
- Doesn't exit on warning — outbound tool calls still work in degraded mode. Just writes to stderr.
- Gated on `NODE_ENV !== "test"` so a future test harness can import the module silently.
- The 15s grace-period timer is `unref()`'d so it doesn't keep the process alive on its own.

## Test plan

No test harness in the repo yet (separate follow-up). Manual smoke with a synthetic MCP handshake via stdin:

```bash
# Case 1: client does NOT advertise claude/channel → warning fires
(printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"0"}}}\n{"jsonrpc":"2.0","method":"notifications/initialized"}\n'; sleep 2) | bun src/bridge.ts
# → stderr: "parachute-channel bridge: WARNING — client did not advertise claude/channel support. ..."

# Case 2: client advertises claude/channel → no warning
(printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{"experimental":{"claude/channel":{}}},"clientInfo":{"name":"smoke","version":"0"}}}\n{"jsonrpc":"2.0","method":"notifications/initialized"}\n'; sleep 2) | bun src/bridge.ts
# → stderr: only "parachute-channel bridge: connected to Claude Code..." — no warning

# Case 3: no client connects → grace-period warning at 15s
bun src/bridge.ts < /dev/null
# → 15s later: "parachute-channel bridge: no MCP initialize received after 15s — the bridge is running but no client has connected."
```

All three run clean locally.

## Task list

- [x] Hook `mcp.oninitialized` to inspect `getClientCapabilities().experimental`
- [x] Labeled stderr warning with `--dangerously-load-development-channels=server:...` hint and link to #8
- [x] 15s grace-period timer if no initialize received
- [x] `NODE_ENV !== "test"` gate
- [x] Defer capability check to next tick (race-condition fix)
- [x] Manual repro — all three cases verified

## Commits

1. `a26d526` — initial implementation
2. `2e59a5b` — defer capability check past microtask ordering race

🤖 Generated with [Claude Code](https://claude.com/claude-code)