### PR TITLE
docs: promote --dangerously-load-development-channels= (#8)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,8 +52,14 @@ Registered in `~/UnforcedAGI/.mcp.json`:
 
 Launch Claude Code with:
 ```bash
-claude --dangerously-load-development-channels server:parachute-channel
+claude --dangerously-load-development-channels=server:parachute-channel
 ```
+
+The `=` binding is load-bearing. Space-separating the value (`--dangerously-load-development-channels server:parachute-channel`) works in `--print` mode but in interactive mode the parser swallows `server:parachute-channel` as the initial-prompt positional, leaving the flag with an empty channels list. At runtime this surfaces as `"server:parachute-channel · no MCP server configured with that name"`, which points operators at the wrong suspect (the MCP config is fine; the flag-parser is what dropped the value). Always use the `=` form — it's unambiguous in every mode. See [#8](https://github.com/ParachuteComputer/parachute-channel/issues/8).
+
+If you hit an adjacent issue:
+- The bridge now warns on stderr if the capability isn't registered, so this misconfig surfaces immediately instead of looking like everything is fine until a message arrives — see [#9](https://github.com/ParachuteComputer/parachute-channel/issues/9).
+- A cosmetic `/mcp` display warning may appear even with the correct flag — expected, ignore. See [#10](https://github.com/ParachuteComputer/parachute-channel/issues/10).
 
 ## Environment variables
 


### PR DESCRIPTION
## Summary

Closes #8. Updates the canonical invocation in `CLAUDE.md` to use the `=` binding instead of a space — this is the form that works in both interactive and `--print` mode. Space-separating lets the arg parser consume `server:<name>` as the initial-prompt positional in interactive mode, surfacing at runtime as:

```
server:parachute-channel · no MCP server configured with that name
```

…which points operators at the wrong suspect (the MCP config is fine; the flag-parser ate the value). Documented in a short explainer paragraph alongside the code block, plus cross-references to adjacent issues so operators who trip on them find the trail.

## Cross-references added

- [#9](https://github.com/ParachuteComputer/parachute-channel/issues/9) — bridge now warns on stderr if the capability isn't registered (shipped in the prior PR). Frames the warning as the safety net for this exact misconfig.
- [#10](https://github.com/ParachuteComputer/parachute-channel/issues/10) — the cosmetic `/mcp` display warning, which can look adjacent-but-unrelated. Marked as "expected, ignore" pending investigation.

## Files changed

- `CLAUDE.md` — one-line invocation update + explainer paragraph.

Not touched (already correct):
- `docs/pods/techne.md` — already uses the `=` form and has a long, correct explanation of the gotcha from the techne pod's investigation.
- `docker/pods/techne/techne-claude` — wrapper already uses the `=` form with an accurate header comment.
- No root `README.md` in this repo.

## Test plan

- [x] Grep confirms no remaining instances of `--dangerously-load-development-channels <space>` in tracked files.
- [x] Rendered markdown preview looks reasonable (links resolve, code block highlights).
- [x] `CLAUDE.md` reads top-to-bottom without a jarring detour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)