### PR TITLE
feat(channel): transport abstraction + named-channel routing (PR 1.1)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,172 @@
+# parachute-channel — the channel fabric
+
+**Status:** in progress · started 2026-06-07 · steward: Uni (for Aaron)
+
+The plan to evolve `parachute-channel` from a single Telegram→Claude bridge into a
+**channel fabric**: multiple named channels, each routable to a specific Claude Code
+session, with the module's own built-in chat UI to prove messaging, scripts to stand
+up sessions wired to their channel, and — later — deep vault integration so messages
+persist as notes and a UI/runner can drive sessions through the vault.
+
+This redefines the module from the workspace CLAUDE.md's "Channel — webhook fan-out,
+exploration, may retire" line into **the agent-session gateway / the vault's nervous
+system**. When this firms up, that table row and the committed-core map get updated
+(architectural-shift discipline → `parachute-patterns/migrations/`).
+
+## Why now
+
+The June 15 2026 billing change meters `claude -p` / Agent SDK usage on subscription
+plans against a small separate credit pool ($20 Pro / $100 Max5x / $200 Max20x at API
+rates), while **interactive sessions stay on subscription limits, unchanged**. Our
+weave/automation pattern (long-running interactive sessions per vault) is exactly the
+shape that survives. The channel is how those resident sessions get a real UI and how
+recurring jobs reach them — replacing the `claude -p`-per-job model (which runner keeps
+as a second executor for API-key users).
+
+## The architecture
+
+```
+                  parachute-channel daemon (one, many channels)
+   ┌──────────────────────────────────────────────────────────────┐
+   │  named channels, each bound to a transport                    │
+   │   • "aaron-dev"    transport: http-ui   (built-in chat page)   │
+   │   • "ops"          transport: http-ui                          │
+   │   • "tele-aaron"   transport: telegram  (demoted, still works) │
+   │   • "vault-default" transport: vault    (Stage 2)             │
+   └──────┬───────────────────────────────────┬───────────────────┘
+          │       route by channel name        │
+   ┌──────▼──────┐                     ┌────────▼─────┐
+   │ bridge      │  subscribes:        │ bridge       │ subscribes:
+   │ "aaron-dev" │                     │ "ops"        │
+   └──────┬──────┘                     └────────┬─────┘
+   ┌──────▼──────┐                     ┌────────▼─────┐
+   │ CC session  │  (tmux: dev)        │ CC session   │ (tmux: ops)
+   └─────────────┘                     └──────────────┘
+```
+
+**Core principles**
+- **Transport abstraction.** The daemon core (channels, routing, SSE fan-out, permission
+  relay) is transport-agnostic. Telegram, http-ui, and (later) vault are interchangeable
+  transport impls behind one interface.
+- **Routing = subscription.** The daemon hosts named channels; each bridge subscribes to a
+  channel by name (`PARACHUTE_CHANNEL_NAME`); the daemon routes inbound on channel X only
+  to bridges subscribed to X, and that session's outbound back out X's transport. Daemon
+  stays a dumb router; reconnects/restarts are free. **(Decision 1 — resolved: session-side
+  subscription, not a daemon-side map.)**
+- **One daemon, many channels.** Matches the multi-session design already in the code and
+  keeps the built-in UI a single place. **(Decision 2 — resolved.)**
+- **MCP channel mechanism is primary.** The existing `notifications/claude/channel` wake is
+  the standard, simple path. We verify it works on our Claude Code version up front (Stage 0)
+  and do NOT build hook-based workarounds unless that check proves it necessary.
+- **Agent-agnostic by construction.** The contract with a session is "read/write the channel
+  + be woken." The Claude-specific bridge is one adapter; Codex/Gemini could plug in later.
+
+## Testing discipline (non-negotiable, gate between every stage)
+
+Two tiers, mirroring hub's `e2e/` but realizing the deferred Tier 2:
+
+- **Tier 1 — automated/deterministic.** Unit + integration tests (`bun test`) on routing,
+  transport dispatch, channel registry, access control. Plus a scripted e2e (`e2e/run.sh`
+  shape) that boots the daemon, attaches a mock bridge, sends through each transport, and
+  asserts exact delivery. `bun run typecheck` always alongside `bun test`.
+- **Tier 2 — LLM-run e2e (NEW — built here).** Boots the daemon + a **real Claude Code
+  session** wired through the bridge, sends a message via the http-ui transport, and an LLM
+  judges that a correct, on-topic reply came back through the channel. This is the headline
+  test: it exercises the actual wake→act→reply loop end to end. Lives in `e2e/llm/`.
+  - Uses `ANTHROPIC_API_KEY` if present (keeps test spend off the subscription credit pool).
+  - Positive control first (per negative-scans-need-positive-controls): prove the session
+    is alive and the channel is wired before asserting on content.
+
+**No stage is "done" until both tiers pass and a reviewer subagent has signed off.**
+
+---
+
+## Stage 0 — foundation check  ·  ☐
+
+- [ ] Confirm idle-session wake works on our Claude Code version via the existing Telegram
+      channel (send to an idle session, verify it wakes). ~30 min. If it fails, that's
+      timing info, not a reason to build workarounds — re-decide with Aaron.
+- [ ] Pin the Claude Code version under test; note it in this file.
+
+## Stage 1 — the channel fabric (freestanding, no vault)  ·  ☐
+
+**PR 1.1 — transport abstraction + named-channel routing.** ☐
+- [ ] Extract a `Transport` interface (inbound → `{channel, content, meta}`; outbound:
+      `reply/react/edit/download`). Telegram becomes `transports/telegram.ts`.
+- [ ] Daemon hosts a **channel registry** (name → transport + config), loaded from
+      `~/.parachute/channel/channels.json` and exposed via `/.parachute/config[/schema]`
+      (runner's self-describing-config pattern, so a UI can manage it later).
+- [ ] Routing: `/events?channel=<name>` subscribes a bridge; `broadcastEvent` filters by
+      channel. Outbound carries channel context.
+- [ ] Bridge subscribes via `PARACHUTE_CHANNEL_NAME`; degrade-warn unchanged.
+- [ ] **Tests:** routing unit tests (right session gets the message, others don't);
+      Telegram path unchanged (regression). typecheck + bun test green.
+- [ ] Reviewer subagent.
+
+**PR 1.2 — http-ui transport + built-in chat UI.** ☐
+- [ ] `transports/http-ui.ts`: inbound via `POST /api/channels/<name>/send`; outbound
+      delivered to the UI over SSE (`/ui/events?channel=<name>`).
+- [ ] Minimal built-in chat page served by the daemon (`/ui` or `/ui/<channel>`): channel
+      picker + message box + live transcript. No framework needed; vanilla is fine.
+- [ ] **Tier 2 LLM-run e2e (headline):** boot daemon + real CC session subscribed to a test
+      channel; POST a message; LLM judges the reply. Build the `e2e/llm/` harness here.
+- [ ] Loopback-only; no auth in Stage 1 (named in Decision 3; hub-JWT lands when exposed).
+- [ ] Reviewer subagent.
+
+**PR 1.3 — session launcher scripts (tmux).** ☐
+- [ ] `scripts/launch-session.sh <name> <channel>`: start `claude` interactive in
+      `tmux new-session -d -s <name>-agent`, with the bridge wired to `<channel>` in its
+      `.mcp.json`. Idempotent (don't double-launch; reattach if up).
+- [ ] `scripts/list-sessions.sh` / `stop-session.sh`.
+- [ ] Doc the channel→session mapping flow.
+- [ ] **Tests:** scripted check that a launched session attaches to the right channel and
+      round-trips a message (can reuse the Tier 2 harness with the script as setup).
+- [ ] Reviewer subagent.
+
+**Stage 1 done =** launch two sessions in tmux, open two chat pages, type into each, watch
+two different Claude Code sessions answer — binding set by config. Demo + both test tiers green.
+
+## Stage 2 — vault integration (vault as another transport)  ·  ☐
+
+- [ ] `#channel-message` note schema: `direction` (inbound|outbound), `thread`, `sender`,
+      `body`, `handled_at`. Trigger fires **inbound-only** (loop avoidance via direction
+      predicate + existing `_pending_at`/`_rendered_at` idempotency markers).
+- [ ] `transports/vault.ts`: activated by a vault trigger webhook on new inbound
+      `#channel-message`; writes replies back as outbound notes via the vault REST API.
+- [ ] Generalize the vault trigger system from scribe-flavored → inter-module event bus,
+      exposed via config-schema so the **vault config UI** grows a Triggers section.
+      (Coordinated PR in parachute-vault.)
+- [ ] Tag-scoped vault token for the channel (read/write only `#channel-message`).
+- [ ] External surface (my-vault-ui) goes dumb: talks only to the vault; persistence +
+      offline come free. (Coordinated PR in my-vault-ui.)
+- [ ] **Tests:** Tier 1 (trigger fires inbound-only, no reply-loop; note round-trip through
+      bytes) + Tier 2 (UI writes a vault note → session wakes via trigger → reply lands as a
+      note → UI sees it).
+- [ ] Reviewer subagent on each repo's PR. Cross-repo convergence audit.
+
+## Stage 3 — bulk: runner on the bus + hub registration  ·  ☐
+
+- [ ] Runner gains a `channel` executor: a scheduled job writes a recurring inbound
+      `#channel-message` note addressed to a session. Falls out of Stage 2's schema; the
+      `claude -p` executor stays for API-key users.
+- [ ] Channel self-registers with hub (module.json + scope-guard JWT), like runner did.
+- [ ] Session lifecycle/supervision: graduate the launcher scripts to a small module or
+      fold into hub-as-supervisor **only if the scripts prove insufficient** (decide then).
+- [ ] **Tests:** Tier 1 + Tier 2 across the runner→channel→session→vault path.
+- [ ] Reviewer subagent. Architectural-shift migration file in `parachute-patterns/migrations/`.
+
+---
+
+## Decisions log
+- **D1 routing** — session-side subscription by channel name (not daemon-side map). Resolved 2026-06-07.
+- **D2 topology** — one daemon, many channels. Resolved 2026-06-07.
+- **D3 http-ui auth** — none in Stage 1 (loopback only); hub-JWT when exposed. Resolved 2026-06-07.
+- **D4 wake mechanism** — MCP channel notification is primary; no hook workarounds unless Stage 0 proves necessary. Resolved 2026-06-07 (Aaron).
+- **D5 Tier 2 e2e** — does not pre-exist; built here, modeled on hub Tier 1. Resolved 2026-06-07.
+
+## Open questions (non-blocking, revisit at the stage that needs them)
+- Per-channel access control for http-ui/vault transports (Telegram's `access.json` is
+  transport-specific; the registry may need a per-channel access block).
+- Multi-machine: one daemon per vault-host vs. a hub catalog entry routing to the right
+  daemon. (Stage 3.)
+- Thread/conversation modeling depth for `#channel-message` (flat vs. nested). (Stage 2.)

--- a/PLAN.md
+++ b/PLAN.md
@@ -81,12 +81,20 @@ Two tiers, mirroring hub's `e2e/` but realizing the deferred Tier 2:
 
 ---
 
-## Stage 0 — foundation check  ·  ☐
+## Stage 0 — foundation check  ·  ✅ PASS (2026-06-07)
 
-- [ ] Confirm idle-session wake works on our Claude Code version via the existing Telegram
-      channel (send to an idle session, verify it wakes). ~30 min. If it fails, that's
-      timing info, not a reason to build workarounds — re-decide with Aaron.
-- [ ] Pin the Claude Code version under test; note it in this file.
+- [x] **Idle-wake confirmed on Claude Code v2.1.166 (Opus 4.8, Max).** Method: an
+      isolated standalone MCP server (no Telegram dependency) declaring the same
+      `claude/channel` capability the real bridge uses, attached to a real interactive
+      `claude` session in tmux launched with `--dangerously-load-development-channels=server:probe`.
+      With the session sitting **idle at the prompt**, an unsolicited
+      `notifications/claude/channel` was fired; the session woke ~6s later, called the
+      ack tool, replied, and returned to idle — zero human input. The `notifications/claude/channel`
+      wake mechanism is the primary path (D4 confirmed); no hook workarounds needed.
+- [x] CC version pinned: **2.1.166**. Note: the client echoes `experimental caps: {}`
+      (does not advertise `claude/channel` back), but the channel banner shows active and
+      delivery works — the empty echo is cosmetic, matching the real bridge's known
+      degrade-warning edge (#9). Watch this if a future CC version changes behavior.
 
 ## Stage 1 — the channel fabric (freestanding, no vault)  ·  ☐
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "scripts": {
     "daemon": "bun src/daemon.ts",
     "bridge": "bun src/bridge.ts",
-    "test": "bun test src/"
+    "test": "bun test src/",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0"

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -165,7 +165,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
         const err = await res.text();
         return { content: [{ type: "text", text: `reply failed: ${err}` }], isError: true };
       }
-      const data = (await res.json()) as { sent: number[] };
+      const data = (await res.json()) as { sent: string[] };
       const ids = data.sent;
       const parts = ids.length === 1 ? `(id: ${ids[0]})` : `(ids: ${ids.join(", ")})`;
       return { content: [{ type: "text", text: `sent ${ids.length} part${ids.length > 1 ? "s" : ""} ${parts}` }] };

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -21,6 +21,12 @@ import { z } from "zod";
 
 const DAEMON_URL = process.env.PARACHUTE_CHANNEL_URL ?? "http://127.0.0.1:1941";
 
+// The named channel this bridge subscribes to. Defaults to "telegram" for
+// backwards-compat with single-bot installs. The daemon routes inbound on this
+// channel only to bridges subscribed to it, and every outbound tool call below
+// carries this channel so the daemon dispatches to the right transport.
+const CHANNEL = process.env.PARACHUTE_CHANNEL_NAME ?? "telegram";
+
 // ---------------------------------------------------------------------------
 // MCP server setup
 // ---------------------------------------------------------------------------
@@ -36,12 +42,12 @@ const mcp = new Server(
       tools: {},
     },
     instructions: [
-      "The sender reads Telegram, not this session. Anything you want them to see must go through the reply tool — your transcript output never reaches their chat.",
+      "The sender reads this channel, not your transcript. Anything you want them to see must go through the reply tool — your transcript output never reaches them.",
       "",
-      'Messages from Telegram arrive as <channel source="parachute-channel" chat_id="..." message_id="..." user="..." ts="...">.',
-      "Reply with the reply tool — pass chat_id back. Use reply_to (message_id) to thread a specific message; omit it for normal responses.",
+      'Inbound messages arrive as <channel source="parachute-channel" ...> with metadata attributes describing the sender and message.',
+      "Reply with the reply tool — the daemon routes it back out the same channel. Pass back any addressing fields the inbound tag carried (e.g. chat_id). Use reply_to (message_id) to thread a specific message; omit it for normal responses.",
       "",
-      "If the tag has an image_path attribute, Read that file — it is a photo the sender attached.",
+      "If the tag has an image_path attribute, Read that file — it is an attachment the sender sent.",
       "If the tag has attachment_file_id, call download_attachment with that file_id to fetch the file, then Read the returned path.",
       "",
       "Use react to add emoji reactions. Use edit_message for interim progress updates (edits do not push notifications — send a new reply when a long task completes so the user's device pings).",
@@ -70,7 +76,7 @@ mcp.setNotificationHandler(
       await fetch(`${DAEMON_URL}/api/permission`, {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify(params),
+        body: JSON.stringify({ channel: CHANNEL, ...params }),
       });
     } catch (err) {
       process.stderr.write(`parachute-channel bridge: failed to relay permission request: ${err}\n`);
@@ -144,13 +150,16 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
 
 mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
   const args = req.params.arguments as Record<string, unknown>;
+  // Every outbound call carries the channel so the daemon dispatches to the
+  // right transport. Tool args (chat_id, text, …) ride alongside.
+  const body = { channel: CHANNEL, ...args };
 
   switch (req.params.name) {
     case "reply": {
       const res = await fetch(`${DAEMON_URL}/api/reply`, {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify(args),
+        body: JSON.stringify(body),
       });
       if (!res.ok) {
         const err = await res.text();
@@ -166,7 +175,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
       const res = await fetch(`${DAEMON_URL}/api/react`, {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify(args),
+        body: JSON.stringify(body),
       });
       if (!res.ok) {
         const err = await res.text();
@@ -179,7 +188,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
       const res = await fetch(`${DAEMON_URL}/api/edit`, {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify(args),
+        body: JSON.stringify(body),
       });
       if (!res.ok) {
         const err = await res.text();
@@ -192,7 +201,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
       const res = await fetch(`${DAEMON_URL}/api/download`, {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify(args),
+        body: JSON.stringify(body),
       });
       if (!res.ok) {
         const err = await res.text();
@@ -214,7 +223,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
 async function connectToEvents(): Promise<void> {
   while (true) {
     try {
-      const res = await fetch(`${DAEMON_URL}/events`);
+      const res = await fetch(`${DAEMON_URL}/events?channel=${encodeURIComponent(CHANNEL)}`);
       if (!res.ok || !res.body) {
         throw new Error(`SSE connect failed: ${res.status}`);
       }
@@ -353,7 +362,7 @@ mcp.oninitialized = () => {
 // ---------------------------------------------------------------------------
 
 await mcp.connect(new StdioServerTransport());
-process.stderr.write("parachute-channel bridge: connected to Claude Code, connecting to daemon...\n");
+process.stderr.write(`parachute-channel bridge: connected to Claude Code (channel="${CHANNEL}"), connecting to daemon...\n`);
 
 // Start SSE listener (runs forever, reconnects on failure)
 connectToEvents();

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -27,6 +27,7 @@ import type {
   PermissionArgs,
   DownloadArgs,
 } from "./transport.ts";
+import { ChannelConfigError } from "./transport.ts";
 import { loadRegistry, defaultStateDir, type Channel } from "./registry.ts";
 import { ClientRegistry } from "./routing.ts";
 
@@ -72,7 +73,11 @@ function contextFor(channel: string): TransportContext {
   return {
     channel,
     emit(msg: InboundMessage): void {
-      registry.routeToChannel(msg.channel, "message", {
+      // Route on the bound `channel`, NOT msg.channel — the transport's own
+      // channel is authoritative. This makes it impossible for a transport to
+      // emit onto another channel (closing a silent cross-channel-leak footgun)
+      // even if a future transport sets msg.channel incorrectly.
+      registry.routeToChannel(channel, "message", {
         content: msg.content,
         meta: msg.meta,
         source: msg.source,
@@ -211,7 +216,7 @@ const server = Bun.serve({
         const result = await transport.reply(toReplyArgs(body));
         return json({ sent: result.sent });
       } catch (err) {
-        return json({ error: String(err) }, 500);
+        return errResponse(err);
       }
     }
 
@@ -237,7 +242,7 @@ const server = Bun.serve({
         await transport.react(args);
         return json({ ok: true });
       } catch (err) {
-        return json({ error: String(err) }, 500);
+        return errResponse(err);
       }
     }
 
@@ -263,7 +268,7 @@ const server = Bun.serve({
         await transport.edit(args);
         return json({ ok: true });
       } catch (err) {
-        return json({ error: String(err) }, 500);
+        return errResponse(err);
       }
     }
 
@@ -290,7 +295,7 @@ const server = Bun.serve({
         const result = await transport.sendPermission(args);
         return json({ sent: result.sent });
       } catch (err) {
-        return json({ error: String(err) }, 500);
+        return errResponse(err);
       }
     }
 
@@ -305,7 +310,7 @@ const server = Bun.serve({
         const result = await transport.download(args);
         return json({ path: result.path });
       } catch (err) {
-        return json({ error: String(err) }, 500);
+        return errResponse(err);
       }
     }
 
@@ -316,6 +321,15 @@ const server = Bun.serve({
 // ---------------------------------------------------------------------------
 // Request helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Map a thrown error to a response: ChannelConfigError → 400 (operator must fix
+ * config), anything else → 500 (runtime fault). Lets callers distinguish the two.
+ */
+function errResponse(err: unknown): Response {
+  if (err instanceof ChannelConfigError) return json({ error: err.message }, 400);
+  return json({ error: String(err) }, 500);
+}
 
 function channelError(channel: string | undefined): Response {
   if (!channel) {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1,298 +1,87 @@
 #!/usr/bin/env bun
 /**
- * parachute-channel daemon — the single process that owns messaging platform
- * connections. Telegram today, anything tomorrow.
+ * parachute-channel daemon — the transport-agnostic orchestrator.
  *
- * Runs as a long-lived HTTP server (launchd, systemd, or manual). Bridges
- * connect to it via SSE (/events) to receive inbound messages and via HTTP
- * endpoints to send outbound messages. The daemon is the ONLY process that
- * touches the Telegram API — no races, no multi-consumer conflicts.
+ * Runs as a long-lived HTTP server (launchd, systemd, or manual). It loads a
+ * channel registry (name → transport), starts each transport, and routes
+ * inbound traffic to the bridges subscribed to that channel. Bridges connect
+ * via SSE (`/events?channel=<name>`) for inbound and POST outbound to the HTTP
+ * API with a `channel` field.
+ *
+ * Telegram is one transport behind the registry; the daemon core touches no
+ * platform API directly.
  *
  * Default port: 1941 (PARACHUTE_CHANNEL_PORT env).
  */
 
-import { TelegramApi, type TelegramMessage, type TelegramCallbackQuery, type TelegramUpdate } from "./telegram/api.ts";
-import { readFileSync, writeFileSync, mkdirSync, existsSync, chmodSync } from "fs";
+import { mkdirSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
+import type {
+  Transport,
+  TransportContext,
+  InboundMessage,
+  ReplyArgs,
+  ReactArgs,
+  EditArgs,
+  PermissionArgs,
+  DownloadArgs,
+} from "./transport.ts";
+import { loadRegistry, defaultStateDir, type Channel } from "./registry.ts";
+import { ClientRegistry } from "./routing.ts";
 
 // ---------------------------------------------------------------------------
 // Config
 // ---------------------------------------------------------------------------
 
-const STATE_DIR = process.env.PARACHUTE_CHANNEL_STATE_DIR ??
-  join(homedir(), ".parachute", "channel");
-const ENV_FILE = join(STATE_DIR, ".env");
-const ACCESS_FILE = join(STATE_DIR, "access.json");
+const STATE_DIR = defaultStateDir();
 const INBOX_DIR = join(STATE_DIR, "inbox");
 const PORT = parseInt(process.env.PARACHUTE_CHANNEL_PORT ?? "1941", 10);
+
+/** Channel a bridge subscribes to when `?channel=` is omitted (back-compat). */
+const DEFAULT_CHANNEL = "telegram";
 
 mkdirSync(STATE_DIR, { recursive: true });
 mkdirSync(INBOX_DIR, { recursive: true });
 
-// Load .env (same pattern as the official plugin)
-try {
-  if (existsSync(ENV_FILE)) {
-    chmodSync(ENV_FILE, 0o600);
-    for (const line of readFileSync(ENV_FILE, "utf8").split("\n")) {
-      const m = line.match(/^(\w+)=(.*)$/);
-      if (m && process.env[m[1]] === undefined) process.env[m[1]] = m[2];
-    }
-  }
-} catch {}
+// ---------------------------------------------------------------------------
+// Registry + routing
+// ---------------------------------------------------------------------------
 
-const TOKEN = process.env.TELEGRAM_BOT_TOKEN;
-if (!TOKEN) {
+let channels: Map<string, Channel>;
+try {
+  channels = loadRegistry({ stateDir: STATE_DIR });
+} catch (err) {
+  console.error(`parachute-channel: failed to load channel registry: ${err}`);
+  process.exit(1);
+}
+
+if (channels.size === 0) {
   console.error(
-    `parachute-channel: TELEGRAM_BOT_TOKEN required\n` +
-    `  set in ${ENV_FILE} or shell env\n` +
-    `  format: TELEGRAM_BOT_TOKEN=123456789:AAH...`
+    `parachute-channel: no channels configured.\n` +
+      `  Add ${join(STATE_DIR, "channels.json")} or set TELEGRAM_BOT_TOKEN\n` +
+      `  (env or ${join(STATE_DIR, ".env")}) for a default telegram channel.`,
   );
   process.exit(1);
 }
 
-// ---------------------------------------------------------------------------
-// Access control — reuse the official plugin's access.json format, plus one
-// parachute-channel extension: `allowInChats`.
-//
-// Fields (all inherited from the official plugin except `allowInChats`):
-//   dmPolicy      — "open" short-circuits all gating; anything else requires
-//                   the user to pass `allowFrom`.
-//   allowFrom     — user-ID allowlist. Checked against `msg.from.id` /
-//                   `cq.from.id`.
-//   allowInChats  — OPTIONAL chat-ID allowlist. Two roles:
-//                   (1) For DMs (positive chat_id === user_id), the chat must
-//                       be listed AND the user must pass `allowFrom`.
-//                   (2) For groups (negative chat_id), inclusion grants entry
-//                       to ANY member of that group — `allowFrom` is bypassed.
-//                       This lets the agent participate in shared spaces
-//                       without enumerating every member.
-//                   Absent → user-allowlist only (backwards-compatible, no
-//                   per-chat gating, no group bypass). Empty array → FAIL-
-//                   CLOSED: no chats allowed. To permit a DM while gating
-//                   groups, list the user's own ID in `allowInChats`.
-//   groups, pending — used by the official plugin's pairing flow; read but
-//                     not otherwise acted on here.
-// ---------------------------------------------------------------------------
+const registry = new ClientRegistry();
 
-interface AccessConfig {
-  dmPolicy: "open" | "pairing" | "allowlist";
-  allowFrom: string[];
-  allowInChats?: string[];
-  groups: Record<string, unknown>;
-  pending: Record<string, unknown>;
-}
-
-function loadAccess(): AccessConfig {
-  try {
-    return JSON.parse(readFileSync(ACCESS_FILE, "utf8"));
-  } catch {
-    return { dmPolicy: "open", allowFrom: [], groups: {}, pending: {} };
-  }
-}
-
-function isAllowed(userId: number, chatId: number | string | undefined): boolean {
-  const access = loadAccess();
-  if (access.dmPolicy === "open") return true;
-
-  // Group-chat bypass: if a group chat (negative chat_id, Telegram convention)
-  // is explicitly allowlisted via `allowInChats`, any user who can post in
-  // that group may reach the bot. This lets the agent participate in shared
-  // spaces like Regen Hub working groups without having to enumerate every
-  // member in `allowFrom`. DMs (chat_id === user_id, positive) are NOT
-  // covered by this bypass — they still require `allowFrom`.
-  const chatIdStr = chatId === undefined ? undefined : String(chatId);
-  const isGroup = chatIdStr !== undefined && chatIdStr.startsWith("-");
-  if (isGroup && access.allowInChats?.includes(chatIdStr!)) return true;
-
-  if (!access.allowFrom.includes(String(userId))) return false;
-  if (access.allowInChats !== undefined) {
-    if (chatIdStr === undefined) return false;
-    if (!access.allowInChats.includes(chatIdStr)) return false;
-  }
-  return true;
-}
-
-// ---------------------------------------------------------------------------
-// SSE clients (bridges)
-// ---------------------------------------------------------------------------
-
-type SSEClient = {
-  id: string;
-  controller: ReadableStreamDefaultController<string>;
-  connectedAt: number;
-};
-
-const clients = new Map<string, SSEClient>();
-
-function broadcastEvent(event: string, data: unknown): void {
-  const payload = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
-  for (const [id, client] of clients) {
-    try {
-      client.controller.enqueue(payload);
-    } catch {
-      clients.delete(id);
-    }
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Telegram polling
-// ---------------------------------------------------------------------------
-
-const api = new TelegramApi(TOKEN);
-let offset: number | undefined;
-let pollActive = true;
-
-async function pollLoop(): Promise<void> {
-  const me = await api.getMe();
-  console.log(`parachute-channel: polling as @${me.username}`);
-
-  while (pollActive) {
-    try {
-      const updates = await api.getUpdates(offset, 30);
-      for (const update of updates) {
-        offset = update.update_id + 1;
-        if (update.callback_query) {
-          await handleCallbackQuery(update.callback_query);
-        } else if (update.message) {
-          await handleMessage(update.message);
-        }
-      }
-    } catch (err) {
-      console.error("parachute-channel: poll error:", err);
-      await new Promise((r) => setTimeout(r, 5000));
-    }
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Permission relay — text-reply intercept
-// ---------------------------------------------------------------------------
-
-const PERMISSION_REPLY_RE = /^\s*(y|yes|n|no)\s+([a-km-z]{5})\s*$/i;
-const CALLBACK_DATA_RE = /^perm_(allow|deny)_([a-km-z]{5})$/;
-
-async function handleCallbackQuery(cq: TelegramCallbackQuery): Promise<void> {
-  const userId = cq.from.id;
-  if (!isAllowed(userId, cq.message?.chat.id)) {
-    await api.answerCallbackQuery(cq.id).catch(() => {});
-    return;
-  }
-
-  const data = cq.data ?? "";
-  const match = CALLBACK_DATA_RE.exec(data);
-  if (!match) {
-    await api.answerCallbackQuery(cq.id).catch(() => {});
-    return;
-  }
-
-  const behavior = match[1] as "allow" | "deny";
-  const requestId = match[2];
-  broadcastEvent("permission_verdict", { request_id: requestId, behavior });
-
-  // Answer the callback query (stops button loading spinner)
-  const label = behavior === "allow" ? "✅ Allowed" : "❌ Denied";
-  await api.answerCallbackQuery(cq.id, { text: label }).catch(() => {});
-
-  // Edit the original message to show the outcome and remove buttons
-  if (cq.message) {
-    const chatId = String(cq.message.chat.id);
-    const originalText = cq.message.text ?? "";
-    await api.editMessageText(chatId, cq.message.message_id, `${label}\n\n${originalText}`).catch(() => {});
-  }
-}
-
-async function handleMessage(msg: TelegramMessage): Promise<void> {
-  const userId = msg.from?.id;
-  if (!userId || !isAllowed(userId, msg.chat.id)) return;
-
-  const userTag = msg.from?.username ? `@${msg.from.username}` : (msg.from?.first_name ?? `user ${userId}`);
-  console.log(`parachute-channel: rx from ${userTag} in chat ${msg.chat.id} (${clients.size} bridge(s))`);
-
-  // Permission-reply intercept: if this looks like "yes xxxxx" or "no xxxxx"
-  // for a pending permission request, emit a permission_verdict SSE event
-  // instead of forwarding as a chat message.
-  const text = msg.text ?? "";
-  const permMatch = PERMISSION_REPLY_RE.exec(text);
-  if (permMatch) {
-    const requestId = permMatch[2]!.toLowerCase();
-    const behavior = permMatch[1]!.toLowerCase().startsWith("y") ? "allow" : "deny";
-    broadcastEvent("permission_verdict", { request_id: requestId, behavior });
-    // React to confirm receipt
-    const emoji = behavior === "allow" ? "✅" : "❌";
-    try {
-      await api.setMessageReaction(String(msg.chat.id), msg.message_id, emoji);
-    } catch {}
-    return;
-  }
-
-  // Determine attachment info
-  let attachmentKind: string | undefined;
-  let attachmentFileId: string | undefined;
-  let attachmentSize: number | undefined;
-  let attachmentMime: string | undefined;
-  let imagePath: string | undefined;
-
-  if (msg.voice) {
-    attachmentKind = "voice";
-    attachmentFileId = msg.voice.file_id;
-    attachmentSize = msg.voice.file_size;
-    attachmentMime = msg.voice.mime_type ?? "audio/ogg";
-  } else if (msg.audio) {
-    attachmentKind = "audio";
-    attachmentFileId = msg.audio.file_id;
-    attachmentSize = msg.audio.file_size;
-    attachmentMime = msg.audio.mime_type;
-  } else if (msg.document) {
-    attachmentKind = "document";
-    attachmentFileId = msg.document.file_id;
-    attachmentSize = msg.document.file_size;
-    attachmentMime = msg.document.mime_type;
-  } else if (msg.photo && msg.photo.length > 0) {
-    // Download the largest photo variant and save to inbox
-    const largest = msg.photo[msg.photo.length - 1];
-    attachmentKind = "photo";
-    attachmentFileId = largest.file_id;
-    attachmentSize = largest.file_size;
-    attachmentMime = "image/jpeg";
-    try {
-      const fileInfo = await api.getFile(largest.file_id);
-      const data = await api.downloadFile(fileInfo.file_path);
-      const ext = fileInfo.file_path.split(".").pop() ?? "jpg";
-      const localPath = join(INBOX_DIR, `${Date.now()}-${largest.file_unique_id}.${ext}`);
-      writeFileSync(localPath, data);
-      imagePath = localPath;
-    } catch (err) {
-      console.error("parachute-channel: failed to download photo:", err);
-    }
-  }
-
-  // Service events (new_chat_members, left_chat_member, pinned_message,
-  // migrate_*, chat-title changes, etc.) arrive as messages with no text,
-  // no caption, and no media. We have no way for the agent to act on them,
-  // and the previous "(voice message)" placeholder caused the agent to
-  // report a nonexistent voice memo on every bot-add. Drop silently.
-  if (!msg.text && !msg.caption && !attachmentKind) return;
-  const content = msg.text ?? msg.caption ?? `(${attachmentKind})`;
-  const ts = new Date(msg.date * 1000).toISOString();
-
-  // Build the channel notification payload — matches the official plugin's shape
-  const meta: Record<string, string> = {
-    chat_id: String(msg.chat.id),
-    message_id: String(msg.message_id),
-    user: msg.from?.username ?? msg.from?.first_name ?? "unknown",
-    user_id: String(userId),
-    ts,
+/** Build the per-channel context a transport routes through. */
+function contextFor(channel: string): TransportContext {
+  return {
+    channel,
+    emit(msg: InboundMessage): void {
+      registry.routeToChannel(msg.channel, "message", {
+        content: msg.content,
+        meta: msg.meta,
+        source: msg.source,
+      });
+    },
+    emitPermissionVerdict(v): void {
+      registry.routeToChannel(channel, "permission_verdict", v);
+    },
   };
-  if (attachmentKind) meta.attachment_kind = attachmentKind;
-  if (attachmentFileId) meta.attachment_file_id = attachmentFileId;
-  if (attachmentSize) meta.attachment_size = String(attachmentSize);
-  if (attachmentMime) meta.attachment_mime = attachmentMime;
-  if (imagePath) meta.image_path = imagePath;
-
-  // Broadcast to all connected bridges
-  broadcastEvent("message", { content, meta, source: "telegram" });
 }
 
 // ---------------------------------------------------------------------------
@@ -306,6 +95,12 @@ function json(data: unknown, status = 200): Response {
   });
 }
 
+/** Resolve the transport for a channel from a request body, or null on miss. */
+function transportFor(channel: string | undefined): Transport | null {
+  if (!channel) return null;
+  return channels.get(channel)?.transport ?? null;
+}
+
 const server = Bun.serve({
   port: PORT,
   hostname: "127.0.0.1",
@@ -314,29 +109,81 @@ const server = Bun.serve({
   async fetch(req) {
     const url = new URL(req.url);
 
-    // Health check
+    // Health check — per-channel client counts.
     if (url.pathname === "/health") {
       return json({
         status: "ok",
-        clients: clients.size,
-        polling: pollActive,
+        channels: [...channels.values()].map((c) => ({
+          name: c.name,
+          kind: c.transport.kind,
+          clients: registry.countForChannel(c.name),
+        })),
+        total_clients: registry.size,
       });
     }
 
-    // SSE event stream — bridges connect here
+    // Self-describing config (runner pattern) — read-only, no secrets.
+    if (req.method === "GET" && url.pathname === "/.parachute/config") {
+      return json({
+        channels: [...channels.values()].map((c) => ({
+          name: c.name,
+          transport: c.transport.kind,
+        })),
+      });
+    }
+
+    if (req.method === "GET" && url.pathname === "/.parachute/config/schema") {
+      return json({
+        title: "parachute-channel config",
+        description: "Named channels, each bound to a transport.",
+        type: "object",
+        properties: {
+          channels: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                name: { type: "string", description: "Unique channel name bridges subscribe to." },
+                transport: {
+                  type: "string",
+                  enum: ["telegram"],
+                  description: "Transport kind backing this channel.",
+                },
+                config: {
+                  type: "object",
+                  description: "Transport-specific config (secrets live here, not returned by /config).",
+                },
+              },
+              required: ["name", "transport"],
+            },
+          },
+        },
+        required: ["channels"],
+      });
+    }
+
+    // SSE event stream — bridges subscribe by channel.
     if (req.method === "GET" && url.pathname === "/events") {
+      let channel = url.searchParams.get("channel") ?? undefined;
+      if (!channel) {
+        channel = DEFAULT_CHANNEL;
+        console.warn(
+          `parachute-channel: /events without ?channel= — defaulting to "${DEFAULT_CHANNEL}". ` +
+            `This back-compat default is deprecated; pass ?channel=<name>.`,
+        );
+      }
+      const subscribedChannel = channel;
       const clientId = crypto.randomUUID();
       const stream = new ReadableStream<string>({
         start(controller) {
-          clients.set(clientId, {
-            id: clientId,
-            controller,
-            connectedAt: Date.now(),
+          registry.add(clientId, {
+            channel: subscribedChannel,
+            enqueue: (payload) => controller.enqueue(payload),
           });
           controller.enqueue(": connected\n\n");
         },
         cancel() {
-          clients.delete(clientId);
+          registry.remove(clientId);
         },
       });
       return new Response(stream, {
@@ -352,47 +199,17 @@ const server = Bun.serve({
     if (req.method === "POST" && url.pathname === "/api/reply") {
       try {
         const body = (await req.json()) as {
-          chat_id: string;
+          channel?: string;
+          chat_id?: string;
           text?: string;
           reply_to?: string;
           files?: string[];
+          meta?: Record<string, string>;
         };
-
-        const sentIds: number[] = [];
-
-        // Send text if provided
-        if (body.text) {
-          // Chunk long messages (Telegram 4096 char limit)
-          const chunks = chunkText(body.text, 4096);
-          for (const chunk of chunks) {
-            const id = await api.sendMessage(
-              body.chat_id,
-              chunk,
-              body.reply_to ? { reply_to_message_id: parseInt(body.reply_to) } : undefined,
-            );
-            sentIds.push(id);
-          }
-        }
-
-        // Send files if provided
-        if (body.files) {
-          for (const filePath of body.files) {
-            const ext = filePath.split(".").pop()?.toLowerCase() ?? "";
-            const imageExts = ["jpg", "jpeg", "png", "gif", "webp"];
-            const voiceExts = ["ogg", "oga", "opus"];
-            let id: number;
-            if (imageExts.includes(ext)) {
-              id = await api.sendPhoto(body.chat_id, filePath);
-            } else if (voiceExts.includes(ext)) {
-              id = await api.sendVoice(body.chat_id, filePath);
-            } else {
-              id = await api.sendDocument(body.chat_id, filePath);
-            }
-            sentIds.push(id);
-          }
-        }
-
-        return json({ sent: sentIds });
+        const transport = transportFor(body.channel);
+        if (!transport) return channelError(body.channel);
+        const result = await transport.reply(toReplyArgs(body));
+        return json({ sent: result.sent });
       } catch (err) {
         return json({ error: String(err) }, 500);
       }
@@ -402,11 +219,22 @@ const server = Bun.serve({
     if (req.method === "POST" && url.pathname === "/api/react") {
       try {
         const body = (await req.json()) as {
-          chat_id: string;
+          channel?: string;
+          chat_id?: string;
           message_id: string;
           emoji: string;
+          meta?: Record<string, string>;
         };
-        await api.setMessageReaction(body.chat_id, parseInt(body.message_id), body.emoji);
+        const transport = transportFor(body.channel);
+        if (!transport) return channelError(body.channel);
+        if (!transport.react) return methodMissing(body.channel!, "react");
+        const args: ReactArgs = {
+          channel: body.channel!,
+          message_id: body.message_id,
+          emoji: body.emoji,
+          meta: mergeMeta(body),
+        };
+        await transport.react(args);
         return json({ ok: true });
       } catch (err) {
         return json({ error: String(err) }, 500);
@@ -417,52 +245,50 @@ const server = Bun.serve({
     if (req.method === "POST" && url.pathname === "/api/edit") {
       try {
         const body = (await req.json()) as {
-          chat_id: string;
+          channel?: string;
+          chat_id?: string;
           message_id: string;
           text: string;
+          meta?: Record<string, string>;
         };
-        await api.editMessageText(body.chat_id, parseInt(body.message_id), body.text);
+        const transport = transportFor(body.channel);
+        if (!transport) return channelError(body.channel);
+        if (!transport.edit) return methodMissing(body.channel!, "edit");
+        const args: EditArgs = {
+          channel: body.channel!,
+          message_id: body.message_id,
+          text: body.text,
+          meta: mergeMeta(body),
+        };
+        await transport.edit(args);
         return json({ ok: true });
       } catch (err) {
         return json({ error: String(err) }, 500);
       }
     }
 
-    // Permission prompt — bridge forwards permission_request here, daemon
-    // sends to all allowlisted Telegram users.
+    // Permission prompt — bridge forwards permission_request here.
     if (req.method === "POST" && url.pathname === "/api/permission") {
       try {
         const body = (await req.json()) as {
+          channel?: string;
           request_id: string;
           tool_name: string;
           description: string;
           input_preview: string;
         };
-        const access = loadAccess();
-        const targets = access.allowFrom;
-        if (targets.length === 0) {
-          return json({ error: "no allowlisted users to send permission prompt to" }, 400);
-        }
-        const text =
-          `🔐 Permission: ${body.tool_name}\n\n` +
-          `${body.description}\n\n` +
-          `${body.input_preview}`;
-        const replyMarkup = {
-          inline_keyboard: [[
-            { text: "✅ Allow", callback_data: `perm_allow_${body.request_id}` },
-            { text: "❌ Deny", callback_data: `perm_deny_${body.request_id}` },
-          ]],
+        const transport = transportFor(body.channel);
+        if (!transport) return channelError(body.channel);
+        if (!transport.sendPermission) return methodMissing(body.channel!, "sendPermission");
+        const args: PermissionArgs = {
+          channel: body.channel!,
+          request_id: body.request_id,
+          tool_name: body.tool_name,
+          description: body.description,
+          input_preview: body.input_preview,
         };
-        const sent: number[] = [];
-        for (const chatId of targets) {
-          try {
-            const id = await api.sendMessage(chatId, text, { reply_markup: replyMarkup });
-            sent.push(id);
-          } catch (err) {
-            console.error(`parachute-channel: permission prompt to ${chatId} failed:`, err);
-          }
-        }
-        return json({ sent });
+        const result = await transport.sendPermission(args);
+        return json({ sent: result.sent });
       } catch (err) {
         return json({ error: String(err) }, 500);
       }
@@ -471,13 +297,13 @@ const server = Bun.serve({
     // Download attachment
     if (req.method === "POST" && url.pathname === "/api/download") {
       try {
-        const body = (await req.json()) as { file_id: string };
-        const fileInfo = await api.getFile(body.file_id);
-        const data = await api.downloadFile(fileInfo.file_path);
-        const ext = fileInfo.file_path.split(".").pop() ?? "bin";
-        const localPath = join(INBOX_DIR, `${Date.now()}-${body.file_id.slice(-10)}.${ext}`);
-        writeFileSync(localPath, data);
-        return json({ path: localPath });
+        const body = (await req.json()) as { channel?: string; file_id: string };
+        const transport = transportFor(body.channel);
+        if (!transport) return channelError(body.channel);
+        if (!transport.download) return methodMissing(body.channel!, "download");
+        const args: DownloadArgs = { channel: body.channel!, file_id: body.file_id };
+        const result = await transport.download(args);
+        return json({ path: result.path });
       } catch (err) {
         return json({ error: String(err) }, 500);
       }
@@ -487,38 +313,81 @@ const server = Bun.serve({
   },
 });
 
-function chunkText(text: string, maxLen: number): string[] {
-  if (text.length <= maxLen) return [text];
-  const chunks: string[] = [];
-  let remaining = text;
-  while (remaining.length > 0) {
-    if (remaining.length <= maxLen) {
-      chunks.push(remaining);
-      break;
-    }
-    // Try to break at a newline
-    let breakAt = remaining.lastIndexOf("\n", maxLen);
-    if (breakAt < maxLen * 0.5) breakAt = maxLen; // no good newline, hard break
-    chunks.push(remaining.slice(0, breakAt));
-    remaining = remaining.slice(breakAt).replace(/^\n/, "");
+// ---------------------------------------------------------------------------
+// Request helpers
+// ---------------------------------------------------------------------------
+
+function channelError(channel: string | undefined): Response {
+  if (!channel) {
+    return json({ error: "missing 'channel' field in request body" }, 400);
   }
-  return chunks;
+  return json(
+    {
+      error: `unknown channel "${channel}" — known channels: ${[...channels.keys()].join(", ") || "(none)"}`,
+    },
+    400,
+  );
+}
+
+function methodMissing(channel: string, method: string): Response {
+  const kind = channels.get(channel)?.transport.kind ?? "unknown";
+  return json(
+    { error: `transport "${kind}" for channel "${channel}" does not support ${method}` },
+    400,
+  );
+}
+
+/**
+ * Build the meta map for outbound calls. Telegram addressing historically came
+ * in as a top-level `chat_id`; preserve that by folding it into `meta.chat_id`
+ * while letting an explicit `meta` object take precedence/extend.
+ */
+function mergeMeta(body: { chat_id?: string; meta?: Record<string, string> }): Record<string, string> {
+  const meta: Record<string, string> = { ...(body.meta ?? {}) };
+  if (body.chat_id !== undefined && meta.chat_id === undefined) meta.chat_id = body.chat_id;
+  return meta;
+}
+
+function toReplyArgs(body: {
+  channel?: string;
+  chat_id?: string;
+  text?: string;
+  reply_to?: string;
+  files?: string[];
+  meta?: Record<string, string>;
+}): ReplyArgs {
+  return {
+    channel: body.channel!,
+    text: body.text,
+    files: body.files,
+    reply_to: body.reply_to,
+    meta: mergeMeta(body),
+  };
 }
 
 // ---------------------------------------------------------------------------
-// Startup
+// Startup — start every transport
 // ---------------------------------------------------------------------------
 
 console.log(`parachute-channel: daemon listening on http://127.0.0.1:${PORT}`);
 console.log(`parachute-channel: state dir: ${STATE_DIR}`);
-console.log(`parachute-channel: ${clients.size} bridge(s) connected`);
+console.log(
+  `parachute-channel: ${channels.size} channel(s): ${[...channels.values()]
+    .map((c) => `${c.name}→${c.transport.kind}`)
+    .join(", ")}`,
+);
 
-// Graceful shutdown
-process.on("SIGINT", () => { pollActive = false; server.stop(); process.exit(0); });
-process.on("SIGTERM", () => { pollActive = false; server.stop(); process.exit(0); });
+for (const channel of channels.values()) {
+  channel.transport.start(contextFor(channel.name)).catch((err) => {
+    console.error(`parachute-channel: transport "${channel.name}" start failed:`, err);
+  });
+}
 
-// Start polling (runs forever)
-pollLoop().catch((err) => {
-  console.error("parachute-channel: poll loop fatal:", err);
-  process.exit(1);
-});
+// Graceful shutdown — stop all transports.
+async function shutdown(): Promise<void> {
+  await Promise.allSettled([...channels.values()].map((c) => c.transport.stop()));
+  server.stop();
+  process.exit(0);
+}
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);

--- a/src/registry.test.ts
+++ b/src/registry.test.ts
@@ -1,0 +1,136 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  resolveChannelEntries,
+  instantiateTransport,
+  loadRegistry,
+  type ChannelEntry,
+} from "./registry.ts";
+
+let dir: string;
+const savedToken = process.env.TELEGRAM_BOT_TOKEN;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "channel-registry-"));
+  delete process.env.TELEGRAM_BOT_TOKEN;
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+  if (savedToken === undefined) delete process.env.TELEGRAM_BOT_TOKEN;
+  else process.env.TELEGRAM_BOT_TOKEN = savedToken;
+});
+
+describe("default-channel synthesis (back-compat)", () => {
+  test("no channels.json + TELEGRAM_BOT_TOKEN set → single default telegram channel", () => {
+    process.env.TELEGRAM_BOT_TOKEN = "dummy-token";
+    const entries = resolveChannelEntries({ stateDir: dir, loadEnv: false });
+    expect(entries).toEqual([{ name: "telegram", transport: "telegram" }]);
+  });
+
+  test("no channels.json + token only in state-dir .env → synthesized after loadEnv", () => {
+    writeFileSync(join(dir, ".env"), "TELEGRAM_BOT_TOKEN=from-env-file\n");
+    const entries = resolveChannelEntries({ stateDir: dir, loadEnv: true });
+    expect(entries).toEqual([{ name: "telegram", transport: "telegram" }]);
+    expect(process.env.TELEGRAM_BOT_TOKEN).toBe("from-env-file");
+  });
+
+  test("no channels.json + no token → empty list (caller decides to error)", () => {
+    const entries = resolveChannelEntries({ stateDir: dir, loadEnv: false });
+    expect(entries).toEqual([]);
+  });
+});
+
+describe("explicit channels.json parsing", () => {
+  test("parses multiple named channels", () => {
+    const file = {
+      channels: [
+        { name: "tele-aaron", transport: "telegram", config: { token: "t1" } },
+        { name: "ops", transport: "telegram", config: { token: "t2" } },
+      ],
+    };
+    writeFileSync(join(dir, "channels.json"), JSON.stringify(file));
+    const entries = resolveChannelEntries({ stateDir: dir, loadEnv: false });
+    expect(entries).toHaveLength(2);
+    expect(entries[0]!.name).toBe("tele-aaron");
+    expect(entries[1]!.transport).toBe("telegram");
+  });
+
+  test("channels.json takes precedence over the token fallback", () => {
+    process.env.TELEGRAM_BOT_TOKEN = "dummy";
+    writeFileSync(
+      join(dir, "channels.json"),
+      JSON.stringify({ channels: [{ name: "explicit", transport: "telegram", config: { token: "x" } }] }),
+    );
+    const entries = resolveChannelEntries({ stateDir: dir, loadEnv: false });
+    expect(entries).toEqual([{ name: "explicit", transport: "telegram", config: { token: "x" } }]);
+  });
+
+  test("missing 'channels' array throws clearly", () => {
+    writeFileSync(join(dir, "channels.json"), JSON.stringify({ nope: true }));
+    expect(() => resolveChannelEntries({ stateDir: dir, loadEnv: false })).toThrow(/channels/);
+  });
+
+  test("entry missing name or transport throws clearly", () => {
+    writeFileSync(join(dir, "channels.json"), JSON.stringify({ channels: [{ name: "x" }] }));
+    expect(() => resolveChannelEntries({ stateDir: dir, loadEnv: false })).toThrow(/transport/);
+  });
+});
+
+describe("instantiateTransport", () => {
+  test("telegram entry yields a telegram transport", () => {
+    const entry: ChannelEntry = { name: "t", transport: "telegram", config: { token: "tok" } };
+    const t = instantiateTransport(entry);
+    expect(t.kind).toBe("telegram");
+  });
+
+  test("unknown transport kind errors clearly", () => {
+    const entry: ChannelEntry = { name: "weird", transport: "carrier-pigeon" };
+    expect(() => instantiateTransport(entry)).toThrow(/unknown transport kind "carrier-pigeon"/);
+  });
+
+  test("telegram entry with no token errors clearly", () => {
+    const entry: ChannelEntry = { name: "t", transport: "telegram" };
+    expect(() => instantiateTransport(entry)).toThrow(/token required/);
+  });
+});
+
+describe("loadRegistry", () => {
+  test("builds a live channel map keyed by name", () => {
+    writeFileSync(
+      join(dir, "channels.json"),
+      JSON.stringify({
+        channels: [
+          { name: "a", transport: "telegram", config: { token: "t1", stateDir: dir } },
+          { name: "b", transport: "telegram", config: { token: "t2", stateDir: dir } },
+        ],
+      }),
+    );
+    const reg = loadRegistry({ stateDir: dir, loadEnv: false });
+    expect([...reg.keys()].sort()).toEqual(["a", "b"]);
+    expect(reg.get("a")!.transport.kind).toBe("telegram");
+  });
+
+  test("duplicate channel names throw", () => {
+    writeFileSync(
+      join(dir, "channels.json"),
+      JSON.stringify({
+        channels: [
+          { name: "dup", transport: "telegram", config: { token: "t1", stateDir: dir } },
+          { name: "dup", transport: "telegram", config: { token: "t2", stateDir: dir } },
+        ],
+      }),
+    );
+    expect(() => loadRegistry({ stateDir: dir, loadEnv: false })).toThrow(/duplicate channel name/);
+  });
+
+  test("unknown transport kind surfaces from loadRegistry", () => {
+    writeFileSync(
+      join(dir, "channels.json"),
+      JSON.stringify({ channels: [{ name: "x", transport: "smoke-signal" }] }),
+    );
+    expect(() => loadRegistry({ stateDir: dir, loadEnv: false })).toThrow(/unknown transport kind/);
+  });
+});

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,0 +1,133 @@
+/**
+ * Channel registry.
+ *
+ * Loads named channels from `channels.json` in the channel state dir and
+ * instantiates a Transport per entry. A channel is a name bound to a transport
+ * kind plus optional transport config.
+ *
+ * Backwards-compat: if `channels.json` is absent but a Telegram bot token is
+ * available (TELEGRAM_BOT_TOKEN env, set directly or loaded from the state-dir
+ * `.env`), a single default channel `{ name: "telegram", transport: "telegram" }`
+ * is synthesized so existing single-bot installs keep working with zero config.
+ */
+
+import { readFileSync, existsSync, chmodSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+import type { Transport } from "./transport.ts";
+import { TelegramTransport, type TelegramTransportConfig } from "./transports/telegram.ts";
+
+export interface ChannelEntry {
+  name: string;
+  transport: string;
+  config?: Record<string, unknown>;
+}
+
+export interface ChannelsFile {
+  channels: ChannelEntry[];
+}
+
+/** A live channel: its config entry plus the instantiated transport. */
+export interface Channel {
+  name: string;
+  transport: Transport;
+  entry: ChannelEntry;
+}
+
+export function defaultStateDir(): string {
+  return (
+    process.env.PARACHUTE_CHANNEL_STATE_DIR ?? join(homedir(), ".parachute", "channel")
+  );
+}
+
+/**
+ * Load TELEGRAM_BOT_TOKEN (and any other vars) from the state dir's `.env` into
+ * process.env if not already set. Mirrors the original daemon's behavior.
+ */
+export function loadEnvFile(stateDir: string): void {
+  const envFile = join(stateDir, ".env");
+  try {
+    if (existsSync(envFile)) {
+      chmodSync(envFile, 0o600);
+      for (const line of readFileSync(envFile, "utf8").split("\n")) {
+        const m = line.match(/^(\w+)=(.*)$/);
+        if (m && process.env[m[1]!] === undefined) process.env[m[1]!] = m[2]!;
+      }
+    }
+  } catch {}
+}
+
+/** Instantiate the Transport for a single channel entry. */
+export function instantiateTransport(entry: ChannelEntry): Transport {
+  switch (entry.transport) {
+    case "telegram":
+      return new TelegramTransport((entry.config ?? {}) as TelegramTransportConfig);
+    default:
+      throw new Error(
+        `registry: unknown transport kind "${entry.transport}" for channel "${entry.name}" ` +
+          `(known: telegram)`,
+      );
+  }
+}
+
+/**
+ * Resolve the channel entries for this install. Reads channels.json if present;
+ * otherwise synthesizes a default telegram channel when a token is available.
+ *
+ * `loadEnv` (default true) loads the state-dir `.env` so the token fallback can
+ * see a `.env`-only token. Tests pass `loadEnv: false` to stay hermetic.
+ */
+export function resolveChannelEntries(opts: {
+  stateDir?: string;
+  loadEnv?: boolean;
+} = {}): ChannelEntry[] {
+  const stateDir = opts.stateDir ?? defaultStateDir();
+  if (opts.loadEnv !== false) loadEnvFile(stateDir);
+
+  const channelsFile = join(stateDir, "channels.json");
+  if (existsSync(channelsFile)) {
+    const parsed = JSON.parse(readFileSync(channelsFile, "utf8")) as ChannelsFile;
+    if (!parsed || !Array.isArray(parsed.channels)) {
+      throw new Error(`registry: ${channelsFile} must have a "channels" array`);
+    }
+    for (const entry of parsed.channels) {
+      if (!entry.name || !entry.transport) {
+        throw new Error(
+          `registry: each channel needs "name" and "transport" (got ${JSON.stringify(entry)})`,
+        );
+      }
+    }
+    return parsed.channels;
+  }
+
+  // Backwards-compat: no channels.json → synthesize a default telegram channel
+  // when a bot token is available.
+  if (process.env.TELEGRAM_BOT_TOKEN) {
+    return [{ name: "telegram", transport: "telegram" }];
+  }
+
+  return [];
+}
+
+/**
+ * Build the live channel map: resolve entries, instantiate each transport.
+ * Throws if an entry names an unknown transport kind.
+ */
+export function loadRegistry(opts: {
+  stateDir?: string;
+  loadEnv?: boolean;
+} = {}): Map<string, Channel> {
+  const entries = resolveChannelEntries(opts);
+  const channels = new Map<string, Channel>();
+  for (const entry of entries) {
+    if (channels.has(entry.name)) {
+      throw new Error(`registry: duplicate channel name "${entry.name}"`);
+    }
+    channels.set(entry.name, {
+      name: entry.name,
+      transport: instantiateTransport(entry),
+      entry,
+    });
+  }
+  return channels;
+}

--- a/src/routing.test.ts
+++ b/src/routing.test.ts
@@ -1,0 +1,184 @@
+import { describe, test, expect } from "bun:test";
+import { ClientRegistry, sseFrame, type ClientSink } from "./routing.ts";
+
+/** A fake sink that records every payload pushed to it. */
+function fakeClient(channel: string): ClientSink & { received: string[] } {
+  const received: string[] = [];
+  return {
+    channel,
+    received,
+    enqueue(payload: string) {
+      received.push(payload);
+    },
+  };
+}
+
+describe("sseFrame", () => {
+  test("serializes an event + JSON data block", () => {
+    expect(sseFrame("message", { a: 1 })).toBe('event: message\ndata: {"a":1}\n\n');
+  });
+});
+
+describe("ClientRegistry routing", () => {
+  test("delivers to subscribers of the channel and NOT others", () => {
+    const reg = new ClientRegistry();
+    const a1 = fakeClient("A");
+    const a2 = fakeClient("A");
+    const b1 = fakeClient("B");
+    reg.add("a1", a1);
+    reg.add("a2", a2);
+    reg.add("b1", b1);
+
+    const delivered = reg.routeToChannel("A", "message", { content: "hi" });
+
+    expect(delivered).toBe(2);
+    expect(a1.received).toHaveLength(1);
+    expect(a2.received).toHaveLength(1);
+    expect(b1.received).toHaveLength(0); // the core property: B never sees A's message
+    expect(a1.received[0]).toContain('"content":"hi"');
+  });
+
+  test("emitting on B does not reach A", () => {
+    const reg = new ClientRegistry();
+    const a1 = fakeClient("A");
+    const b1 = fakeClient("B");
+    reg.add("a1", a1);
+    reg.add("b1", b1);
+
+    reg.routeToChannel("B", "message", { content: "for-b" });
+
+    expect(b1.received).toHaveLength(1);
+    expect(a1.received).toHaveLength(0);
+  });
+
+  test("routing to an unsubscribed channel delivers to nobody", () => {
+    const reg = new ClientRegistry();
+    reg.add("a1", fakeClient("A"));
+    expect(reg.routeToChannel("ghost", "message", {})).toBe(0);
+  });
+
+  test("countForChannel + subscribedChannels reflect subscriptions", () => {
+    const reg = new ClientRegistry();
+    reg.add("a1", fakeClient("A"));
+    reg.add("a2", fakeClient("A"));
+    reg.add("b1", fakeClient("B"));
+    expect(reg.size).toBe(3);
+    expect(reg.countForChannel("A")).toBe(2);
+    expect(reg.countForChannel("B")).toBe(1);
+    expect(reg.countForChannel("C")).toBe(0);
+    expect(reg.subscribedChannels().sort()).toEqual(["A", "B"]);
+  });
+
+  test("a throwing client is dropped and does not block delivery to others", () => {
+    const reg = new ClientRegistry();
+    const good = fakeClient("A");
+    const bad: ClientSink = {
+      channel: "A",
+      enqueue() {
+        throw new Error("stream closed");
+      },
+    };
+    reg.add("good", good);
+    reg.add("bad", bad);
+
+    const delivered = reg.routeToChannel("A", "message", { content: "x" });
+
+    expect(delivered).toBe(1); // only the good client counted
+    expect(good.received).toHaveLength(1);
+    expect(reg.has("bad")).toBe(false); // bad client evicted
+    expect(reg.has("good")).toBe(true);
+  });
+
+  test("remove unsubscribes a client", () => {
+    const reg = new ClientRegistry();
+    const a1 = fakeClient("A");
+    reg.add("a1", a1);
+    reg.remove("a1");
+    reg.routeToChannel("A", "message", {});
+    expect(a1.received).toHaveLength(0);
+    expect(reg.size).toBe(0);
+  });
+});
+
+describe("ClientRegistry live SSE integration", () => {
+  test("two SSE clients on different channels each get only their channel", async () => {
+    const reg = new ClientRegistry();
+
+    const server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      idleTimeout: 0,
+      fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname === "/events") {
+          const channel = url.searchParams.get("channel") ?? "default";
+          const id = crypto.randomUUID();
+          const stream = new ReadableStream<string>({
+            start(controller) {
+              reg.add(id, { channel, enqueue: (p) => controller.enqueue(p) });
+              controller.enqueue(": connected\n\n");
+            },
+            cancel() {
+              reg.remove(id);
+            },
+          });
+          return new Response(stream, {
+            headers: { "content-type": "text/event-stream" },
+          });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    });
+
+    const base = `http://127.0.0.1:${server.port}`;
+
+    async function openAndRead(channel: string): Promise<{
+      read: () => Promise<string>;
+      cancel: () => void;
+    }> {
+      const res = await fetch(`${base}/events?channel=${channel}`);
+      const reader = res.body!.getReader();
+      const decoder = new TextDecoder();
+      return {
+        async read() {
+          // Read until we get a non-comment data frame.
+          while (true) {
+            const { value, done } = await reader.read();
+            if (done) return "";
+            const chunk = decoder.decode(value, { stream: true });
+            if (chunk.includes("event:")) return chunk;
+          }
+        },
+        cancel() {
+          reader.cancel().catch(() => {});
+        },
+      };
+    }
+
+    const a = await openAndRead("A");
+    const b = await openAndRead("B");
+
+    // Wait until both clients have registered.
+    const start = Date.now();
+    while (reg.size < 2 && Date.now() - start < 1000) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
+    expect(reg.size).toBe(2);
+
+    // Emit only on A.
+    reg.routeToChannel("A", "message", { content: "only-A" });
+
+    const aFrame = await a.read();
+    expect(aFrame).toContain("only-A");
+
+    // B should receive nothing on channel A; emit on B to prove B's stream is live.
+    reg.routeToChannel("B", "message", { content: "only-B" });
+    const bFrame = await b.read();
+    expect(bFrame).toContain("only-B");
+    expect(bFrame).not.toContain("only-A");
+
+    a.cancel();
+    b.cancel();
+    server.stop(true);
+  });
+});

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -1,0 +1,76 @@
+/**
+ * SSE client registry + channel routing.
+ *
+ * Each connected bridge subscribes to exactly one named channel. An event
+ * emitted on channel X must reach ONLY the clients subscribed to X. This module
+ * factors that filtering into a pure, importable class so routing can be
+ * asserted without a live socket (see routing.test.ts).
+ *
+ * The class is transport-agnostic: it knows nothing about Telegram. It just
+ * holds (clientId → {channel, enqueue}) and fans an event out to the matching
+ * subset.
+ */
+
+/** What the registry needs from a client: which channel it watches + how to push. */
+export interface ClientSink {
+  channel: string;
+  /** Push a pre-serialized SSE payload string to this client. */
+  enqueue(payload: string): void;
+}
+
+/** Serialize an SSE event frame. */
+export function sseFrame(event: string, data: unknown): string {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+export class ClientRegistry {
+  private clients = new Map<string, ClientSink>();
+
+  add(id: string, sink: ClientSink): void {
+    this.clients.set(id, sink);
+  }
+
+  remove(id: string): void {
+    this.clients.delete(id);
+  }
+
+  has(id: string): boolean {
+    return this.clients.has(id);
+  }
+
+  get size(): number {
+    return this.clients.size;
+  }
+
+  /** Count of clients subscribed to a given channel. */
+  countForChannel(channel: string): number {
+    let n = 0;
+    for (const c of this.clients.values()) if (c.channel === channel) n++;
+    return n;
+  }
+
+  /** All distinct channel names with at least one subscriber. */
+  subscribedChannels(): string[] {
+    return [...new Set([...this.clients.values()].map((c) => c.channel))];
+  }
+
+  /**
+   * Route an event to every client subscribed to `channel`, and to no one else.
+   * Returns the number of clients the event was delivered to. Clients whose
+   * enqueue throws (closed stream) are dropped.
+   */
+  routeToChannel(channel: string, event: string, data: unknown): number {
+    const payload = sseFrame(event, data);
+    let delivered = 0;
+    for (const [id, client] of this.clients) {
+      if (client.channel !== channel) continue;
+      try {
+        client.enqueue(payload);
+        delivered++;
+      } catch {
+        this.clients.delete(id);
+      }
+    }
+    return delivered;
+  }
+}

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -70,6 +70,14 @@ export interface TransportContext {
   emitPermissionVerdict(v: { request_id: string; behavior: string }): void;
 }
 
+/**
+ * Thrown by a transport for an operator-configuration problem (a 4xx-class
+ * fault: e.g. no allowlisted users to prompt), as opposed to a runtime failure.
+ * The daemon maps this to HTTP 400 so callers can distinguish "fix your config"
+ * from "the server broke".
+ */
+export class ChannelConfigError extends Error {}
+
 export interface Transport {
   /** Stable identifier for the transport kind, e.g. "telegram". */
   readonly kind: string;

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -1,0 +1,90 @@
+/**
+ * Transport abstraction for parachute-channel.
+ *
+ * A Transport is one messaging backend (Telegram today, http-ui / vault later).
+ * The daemon core — channel registry, routing, SSE fan-out, permission relay —
+ * is transport-agnostic and talks to every backend through this interface.
+ *
+ * Addressing that is specific to a backend (Telegram chat_id, message_id as
+ * Telegram ints, etc.) travels inside `meta`. Keep `meta` as the escape hatch
+ * so a non-Telegram transport never has to invent Telegram fields.
+ */
+
+/** An inbound message, routed by the daemon to the bridges subscribed to `channel`. */
+export interface InboundMessage {
+  /** The named channel this message arrived on. */
+  channel: string;
+  /** The human-readable body the session sees. */
+  content: string;
+  /** Backend-specific addressing + provenance (chat_id, message_id, user, …). */
+  meta: Record<string, string>;
+  /** The transport kind that produced this message (e.g. "telegram"). */
+  source: string;
+}
+
+export interface ReplyArgs {
+  channel: string;
+  text?: string;
+  files?: string[];
+  reply_to?: string;
+  meta?: Record<string, string>;
+}
+
+export interface ReactArgs {
+  channel: string;
+  message_id: string;
+  emoji: string;
+  meta?: Record<string, string>;
+}
+
+export interface EditArgs {
+  channel: string;
+  message_id: string;
+  text: string;
+  meta?: Record<string, string>;
+}
+
+export interface PermissionArgs {
+  channel: string;
+  request_id: string;
+  tool_name: string;
+  description: string;
+  input_preview: string;
+}
+
+export interface DownloadArgs {
+  channel: string;
+  file_id: string;
+}
+
+/**
+ * The daemon hands each transport a context bound to that transport's channel.
+ * The transport calls back into it to route inbound traffic.
+ */
+export interface TransportContext {
+  /** The channel name this transport instance is bound to. */
+  channel: string;
+  /** Route an inbound message to the bridges subscribed to this channel. */
+  emit(msg: InboundMessage): void;
+  /** Route a permission verdict (from the transport's UI) back to subscribers. */
+  emitPermissionVerdict(v: { request_id: string; behavior: string }): void;
+}
+
+export interface Transport {
+  /** Stable identifier for the transport kind, e.g. "telegram". */
+  readonly kind: string;
+  /** Begin receiving inbound traffic; wire up `ctx.emit`. */
+  start(ctx: TransportContext): Promise<void>;
+  /** Stop receiving and release resources. */
+  stop(): Promise<void>;
+  /** Send an outbound message. Required for every transport. */
+  reply(args: ReplyArgs): Promise<{ sent: string[] }>;
+  /** Optional: add an emoji reaction. */
+  react?(args: ReactArgs): Promise<void>;
+  /** Optional: edit a previously sent message. */
+  edit?(args: EditArgs): Promise<void>;
+  /** Optional: surface a permission prompt with allow/deny affordances. */
+  sendPermission?(args: PermissionArgs): Promise<{ sent: string[] }>;
+  /** Optional: fetch an attachment, returning a local path. */
+  download?(args: DownloadArgs): Promise<{ path: string }>;
+}

--- a/src/transports/telegram.test.ts
+++ b/src/transports/telegram.test.ts
@@ -5,6 +5,7 @@ import {
   TelegramTransport,
   type AccessConfig,
 } from "./telegram.ts";
+import { ChannelConfigError } from "../transport.ts";
 
 // ---------------------------------------------------------------------------
 // Access control — these cases moved here from the daemon. The policy is now a
@@ -112,5 +113,19 @@ describe("TelegramTransport", () => {
   test("reply without a chat_id in meta errors clearly", async () => {
     const t = new TelegramTransport({ token: "tok", stateDir: "/tmp/parachute-channel-test-telegram" });
     await expect(t.reply({ channel: "telegram", text: "hi" })).rejects.toThrow(/chat_id is required/);
+  });
+
+  test("sendPermission with no allowlisted users throws ChannelConfigError (→ 400, not 500)", async () => {
+    // Fresh state dir → no access.json → default access has empty allowFrom.
+    const t = new TelegramTransport({ token: "tok", stateDir: "/tmp/parachute-channel-test-noperm" });
+    await expect(
+      t.sendPermission({
+        channel: "telegram",
+        request_id: "abcde",
+        tool_name: "Bash",
+        description: "run a command",
+        input_preview: "ls",
+      }),
+    ).rejects.toBeInstanceOf(ChannelConfigError);
   });
 });

--- a/src/transports/telegram.test.ts
+++ b/src/transports/telegram.test.ts
@@ -1,0 +1,116 @@
+import { describe, test, expect } from "bun:test";
+import {
+  isAllowedFor,
+  chunkText,
+  TelegramTransport,
+  type AccessConfig,
+} from "./telegram.ts";
+
+// ---------------------------------------------------------------------------
+// Access control — these cases moved here from the daemon. The policy is now a
+// pure function (isAllowedFor) so it's testable without a live connection.
+// ---------------------------------------------------------------------------
+
+function access(partial: Partial<AccessConfig>): AccessConfig {
+  return { dmPolicy: "allowlist", allowFrom: [], groups: {}, pending: {}, ...partial };
+}
+
+describe("isAllowedFor", () => {
+  test("open policy allows anyone", () => {
+    const a = access({ dmPolicy: "open", allowFrom: [] });
+    expect(isAllowedFor(a, 999, 999)).toBe(true);
+    expect(isAllowedFor(a, 1, -100)).toBe(true);
+  });
+
+  test("allowlist: user in allowFrom is allowed, others denied", () => {
+    const a = access({ allowFrom: ["42"] });
+    expect(isAllowedFor(a, 42, 42)).toBe(true);
+    expect(isAllowedFor(a, 7, 7)).toBe(false);
+  });
+
+  test("allowInChats group bypass: any member of an allowlisted group gets in", () => {
+    const a = access({ allowFrom: ["42"], allowInChats: ["-100200300"] });
+    // A user NOT in allowFrom, posting in the allowlisted group → allowed.
+    expect(isAllowedFor(a, 999, "-100200300")).toBe(true);
+    // Same user in a different group → denied.
+    expect(isAllowedFor(a, 999, "-555")).toBe(false);
+  });
+
+  test("allowInChats DM gating: requires BOTH allowFrom AND allowInChats", () => {
+    const a = access({ allowFrom: ["42"], allowInChats: ["42"] });
+    // user 42 DMing (chat_id === user_id) → both lists include 42 → allowed.
+    expect(isAllowedFor(a, 42, 42)).toBe(true);
+    // user 42 in a chat NOT in allowInChats → denied.
+    expect(isAllowedFor(a, 42, 99)).toBe(false);
+    // user not in allowFrom → denied even if chat is listed.
+    expect(isAllowedFor(access({ allowFrom: ["1"], allowInChats: ["42"] }), 42, 42)).toBe(false);
+  });
+
+  test("allowInChats empty array fails closed for DMs", () => {
+    const a = access({ allowFrom: ["42"], allowInChats: [] });
+    expect(isAllowedFor(a, 42, 42)).toBe(false);
+  });
+
+  test("allowInChats absent → user-allowlist only (back-compat, no per-chat gating)", () => {
+    const a = access({ allowFrom: ["42"] });
+    expect(isAllowedFor(a, 42, 12345)).toBe(true);
+    expect(isAllowedFor(a, 42, undefined)).toBe(true);
+  });
+
+  test("allowFrom empty + allowlist policy → fail-closed (denies everyone)", () => {
+    const a = access({ dmPolicy: "allowlist", allowFrom: [] });
+    expect(isAllowedFor(a, 1, 1)).toBe(false);
+    expect(isAllowedFor(a, 42, -100)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Chunking
+// ---------------------------------------------------------------------------
+
+describe("chunkText", () => {
+  test("short text → single chunk", () => {
+    expect(chunkText("hello", 4096)).toEqual(["hello"]);
+  });
+
+  test("long text splits into <=maxLen chunks", () => {
+    const text = "a".repeat(10000);
+    const chunks = chunkText(text, 4096);
+    expect(chunks.length).toBe(3);
+    for (const c of chunks) expect(c.length).toBeLessThanOrEqual(4096);
+    expect(chunks.join("")).toBe(text);
+  });
+
+  test("prefers newline breaks when one is available in the back half", () => {
+    const head = "x".repeat(3000);
+    const tail = "y".repeat(3000);
+    const chunks = chunkText(`${head}\n${tail}`, 4096);
+    expect(chunks[0]).toBe(head); // broke at the newline, which it stripped
+    expect(chunks[1]).toBe(tail);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Transport shape
+// ---------------------------------------------------------------------------
+
+describe("TelegramTransport", () => {
+  test("requires a token", () => {
+    expect(() => new TelegramTransport({})).toThrow(/token required/);
+  });
+
+  test("kind is 'telegram' and outbound methods exist", () => {
+    const t = new TelegramTransport({ token: "tok", stateDir: "/tmp/parachute-channel-test-telegram" });
+    expect(t.kind).toBe("telegram");
+    expect(typeof t.reply).toBe("function");
+    expect(typeof t.react).toBe("function");
+    expect(typeof t.edit).toBe("function");
+    expect(typeof t.sendPermission).toBe("function");
+    expect(typeof t.download).toBe("function");
+  });
+
+  test("reply without a chat_id in meta errors clearly", async () => {
+    const t = new TelegramTransport({ token: "tok", stateDir: "/tmp/parachute-channel-test-telegram" });
+    await expect(t.reply({ channel: "telegram", text: "hi" })).rejects.toThrow(/chat_id is required/);
+  });
+});

--- a/src/transports/telegram.ts
+++ b/src/transports/telegram.ts
@@ -22,6 +22,7 @@ import type {
   PermissionArgs,
   DownloadArgs,
 } from "../transport.ts";
+import { ChannelConfigError } from "../transport.ts";
 import { readFileSync, writeFileSync, mkdirSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
@@ -368,7 +369,7 @@ export class TelegramTransport implements Transport {
     const access = loadAccess(this.accessFile);
     const targets = access.allowFrom;
     if (targets.length === 0) {
-      throw new Error("no allowlisted users to send permission prompt to");
+      throw new ChannelConfigError("no allowlisted users to send permission prompt to");
     }
     const text =
       `🔐 Permission: ${args.tool_name}\n\n` +

--- a/src/transports/telegram.ts
+++ b/src/transports/telegram.ts
@@ -1,0 +1,424 @@
+/**
+ * Telegram transport for parachute-channel.
+ *
+ * Owns everything Telegram: the getUpdates long-poll, message + callback-query
+ * handling, attachment download, access control (access.json), the permission
+ * inline-keyboard + y/n verdict intercept, and 4096-char chunking.
+ *
+ * This is the reference Transport implementation. Behavior is preserved
+ * verbatim from the pre-refactor daemon — the only change is that inbound
+ * messages and permission verdicts now go through `ctx.emit` /
+ * `ctx.emitPermissionVerdict` instead of a global broadcast, so the daemon can
+ * route them to the right channel's subscribers.
+ */
+
+import { TelegramApi, type TelegramMessage, type TelegramCallbackQuery } from "../telegram/api.ts";
+import type {
+  Transport,
+  TransportContext,
+  ReplyArgs,
+  ReactArgs,
+  EditArgs,
+  PermissionArgs,
+  DownloadArgs,
+} from "../transport.ts";
+import { readFileSync, writeFileSync, mkdirSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+
+// ---------------------------------------------------------------------------
+// Access control — reuse the official plugin's access.json format, plus one
+// parachute-channel extension: `allowInChats`.
+//
+// Fields (all inherited from the official plugin except `allowInChats`):
+//   dmPolicy      — "open" short-circuits all gating; anything else requires
+//                   the user to pass `allowFrom`.
+//   allowFrom     — user-ID allowlist. Checked against `msg.from.id` /
+//                   `cq.from.id`.
+//   allowInChats  — OPTIONAL chat-ID allowlist. Two roles:
+//                   (1) For DMs (positive chat_id === user_id), the chat must
+//                       be listed AND the user must pass `allowFrom`.
+//                   (2) For groups (negative chat_id), inclusion grants entry
+//                       to ANY member of that group — `allowFrom` is bypassed.
+//                       This lets the agent participate in shared spaces
+//                       without enumerating every member.
+//                   Absent → user-allowlist only (backwards-compatible, no
+//                   per-chat gating, no group bypass). Empty array → FAIL-
+//                   CLOSED: no chats allowed. To permit a DM while gating
+//                   groups, list the user's own ID in `allowInChats`.
+//   groups, pending — used by the official plugin's pairing flow; read but
+//                     not otherwise acted on here.
+// ---------------------------------------------------------------------------
+
+export interface AccessConfig {
+  dmPolicy: "open" | "pairing" | "allowlist";
+  allowFrom: string[];
+  allowInChats?: string[];
+  groups: Record<string, unknown>;
+  pending: Record<string, unknown>;
+}
+
+export function loadAccess(accessFile: string): AccessConfig {
+  try {
+    return JSON.parse(readFileSync(accessFile, "utf8"));
+  } catch {
+    return { dmPolicy: "open", allowFrom: [], groups: {}, pending: {} };
+  }
+}
+
+/**
+ * Pure access decision, factored out so the policy is unit-testable without a
+ * live Telegram connection. See telegram.test.ts.
+ */
+export function isAllowedFor(
+  access: AccessConfig,
+  userId: number,
+  chatId: number | string | undefined,
+): boolean {
+  if (access.dmPolicy === "open") return true;
+
+  // Group-chat bypass: if a group chat (negative chat_id, Telegram convention)
+  // is explicitly allowlisted via `allowInChats`, any user who can post in
+  // that group may reach the bot. This lets the agent participate in shared
+  // spaces like Regen Hub working groups without having to enumerate every
+  // member in `allowFrom`. DMs (chat_id === user_id, positive) are NOT
+  // covered by this bypass — they still require `allowFrom`.
+  const chatIdStr = chatId === undefined ? undefined : String(chatId);
+  const isGroup = chatIdStr !== undefined && chatIdStr.startsWith("-");
+  if (isGroup && access.allowInChats?.includes(chatIdStr!)) return true;
+
+  if (!access.allowFrom.includes(String(userId))) return false;
+  if (access.allowInChats !== undefined) {
+    if (chatIdStr === undefined) return false;
+    if (!access.allowInChats.includes(chatIdStr)) return false;
+  }
+  return true;
+}
+
+const PERMISSION_REPLY_RE = /^\s*(y|yes|n|no)\s+([a-km-z]{5})\s*$/i;
+const CALLBACK_DATA_RE = /^perm_(allow|deny)_([a-km-z]{5})$/;
+
+/** Config for a Telegram transport instance. */
+export interface TelegramTransportConfig {
+  /** Bot token. Falls back to TELEGRAM_BOT_TOKEN env when omitted. */
+  token?: string;
+  /** Directory holding access.json + inbox/. Defaults to the channel state dir. */
+  stateDir?: string;
+}
+
+export class TelegramTransport implements Transport {
+  readonly kind = "telegram";
+
+  private api: TelegramApi;
+  private accessFile: string;
+  private inboxDir: string;
+  private offset: number | undefined;
+  private pollActive = false;
+  private pollTask: Promise<void> | undefined;
+
+  constructor(config: TelegramTransportConfig = {}) {
+    const token = config.token ?? process.env.TELEGRAM_BOT_TOKEN;
+    if (!token) {
+      throw new Error(
+        "TelegramTransport: bot token required (config.token or TELEGRAM_BOT_TOKEN)",
+      );
+    }
+    const stateDir =
+      config.stateDir ??
+      process.env.PARACHUTE_CHANNEL_STATE_DIR ??
+      join(homedir(), ".parachute", "channel");
+    this.api = new TelegramApi(token);
+    this.accessFile = join(stateDir, "access.json");
+    this.inboxDir = join(stateDir, "inbox");
+    mkdirSync(this.inboxDir, { recursive: true });
+  }
+
+  private isAllowed(userId: number, chatId: number | string | undefined): boolean {
+    return isAllowedFor(loadAccess(this.accessFile), userId, chatId);
+  }
+
+  async start(ctx: TransportContext): Promise<void> {
+    this.pollActive = true;
+    this.pollTask = this.pollLoop(ctx);
+    // Don't await the loop — it runs forever.
+  }
+
+  async stop(): Promise<void> {
+    this.pollActive = false;
+    // The current getUpdates long-poll may still be in flight; we don't await
+    // it (it returns within the 30s timeout and then sees pollActive=false).
+  }
+
+  private async pollLoop(ctx: TransportContext): Promise<void> {
+    try {
+      const me = await this.api.getMe();
+      console.log(`parachute-channel[${ctx.channel}]: polling as @${me.username}`);
+    } catch (err) {
+      console.error(`parachute-channel[${ctx.channel}]: getMe failed:`, err);
+    }
+
+    while (this.pollActive) {
+      try {
+        const updates = await this.api.getUpdates(this.offset, 30);
+        for (const update of updates) {
+          this.offset = update.update_id + 1;
+          if (update.callback_query) {
+            await this.handleCallbackQuery(ctx, update.callback_query);
+          } else if (update.message) {
+            await this.handleMessage(ctx, update.message);
+          }
+        }
+      } catch (err) {
+        console.error(`parachute-channel[${ctx.channel}]: poll error:`, err);
+        await new Promise((r) => setTimeout(r, 5000));
+      }
+    }
+  }
+
+  private async handleCallbackQuery(
+    ctx: TransportContext,
+    cq: TelegramCallbackQuery,
+  ): Promise<void> {
+    const userId = cq.from.id;
+    if (!this.isAllowed(userId, cq.message?.chat.id)) {
+      await this.api.answerCallbackQuery(cq.id).catch(() => {});
+      return;
+    }
+
+    const data = cq.data ?? "";
+    const match = CALLBACK_DATA_RE.exec(data);
+    if (!match) {
+      await this.api.answerCallbackQuery(cq.id).catch(() => {});
+      return;
+    }
+
+    const behavior = match[1] as "allow" | "deny";
+    const requestId = match[2]!;
+    ctx.emitPermissionVerdict({ request_id: requestId, behavior });
+
+    // Answer the callback query (stops button loading spinner)
+    const label = behavior === "allow" ? "✅ Allowed" : "❌ Denied";
+    await this.api.answerCallbackQuery(cq.id, { text: label }).catch(() => {});
+
+    // Edit the original message to show the outcome and remove buttons
+    if (cq.message) {
+      const chatId = String(cq.message.chat.id);
+      const originalText = cq.message.text ?? "";
+      await this.api
+        .editMessageText(chatId, cq.message.message_id, `${label}\n\n${originalText}`)
+        .catch(() => {});
+    }
+  }
+
+  private async handleMessage(ctx: TransportContext, msg: TelegramMessage): Promise<void> {
+    const userId = msg.from?.id;
+    if (!userId || !this.isAllowed(userId, msg.chat.id)) return;
+
+    const userTag = msg.from?.username
+      ? `@${msg.from.username}`
+      : msg.from?.first_name ?? `user ${userId}`;
+    console.log(
+      `parachute-channel[${ctx.channel}]: rx from ${userTag} in chat ${msg.chat.id}`,
+    );
+
+    // Permission-reply intercept: if this looks like "yes xxxxx" or "no xxxxx"
+    // for a pending permission request, emit a permission_verdict instead of
+    // forwarding as a chat message.
+    const text = msg.text ?? "";
+    const permMatch = PERMISSION_REPLY_RE.exec(text);
+    if (permMatch) {
+      const requestId = permMatch[2]!.toLowerCase();
+      const behavior = permMatch[1]!.toLowerCase().startsWith("y") ? "allow" : "deny";
+      ctx.emitPermissionVerdict({ request_id: requestId, behavior });
+      // React to confirm receipt
+      const emoji = behavior === "allow" ? "✅" : "❌";
+      try {
+        await this.api.setMessageReaction(String(msg.chat.id), msg.message_id, emoji);
+      } catch {}
+      return;
+    }
+
+    // Determine attachment info
+    let attachmentKind: string | undefined;
+    let attachmentFileId: string | undefined;
+    let attachmentSize: number | undefined;
+    let attachmentMime: string | undefined;
+    let imagePath: string | undefined;
+
+    if (msg.voice) {
+      attachmentKind = "voice";
+      attachmentFileId = msg.voice.file_id;
+      attachmentSize = msg.voice.file_size;
+      attachmentMime = msg.voice.mime_type ?? "audio/ogg";
+    } else if (msg.audio) {
+      attachmentKind = "audio";
+      attachmentFileId = msg.audio.file_id;
+      attachmentSize = msg.audio.file_size;
+      attachmentMime = msg.audio.mime_type;
+    } else if (msg.document) {
+      attachmentKind = "document";
+      attachmentFileId = msg.document.file_id;
+      attachmentSize = msg.document.file_size;
+      attachmentMime = msg.document.mime_type;
+    } else if (msg.photo && msg.photo.length > 0) {
+      // Download the largest photo variant and save to inbox
+      const largest = msg.photo[msg.photo.length - 1]!;
+      attachmentKind = "photo";
+      attachmentFileId = largest.file_id;
+      attachmentSize = largest.file_size;
+      attachmentMime = "image/jpeg";
+      try {
+        const fileInfo = await this.api.getFile(largest.file_id);
+        const data = await this.api.downloadFile(fileInfo.file_path);
+        const ext = fileInfo.file_path.split(".").pop() ?? "jpg";
+        const localPath = join(this.inboxDir, `${Date.now()}-${largest.file_unique_id}.${ext}`);
+        writeFileSync(localPath, data);
+        imagePath = localPath;
+      } catch (err) {
+        console.error(`parachute-channel[${ctx.channel}]: failed to download photo:`, err);
+      }
+    }
+
+    // Service events (new_chat_members, left_chat_member, pinned_message,
+    // migrate_*, chat-title changes, etc.) arrive as messages with no text,
+    // no caption, and no media. We have no way for the agent to act on them,
+    // and the previous "(voice message)" placeholder caused the agent to
+    // report a nonexistent voice memo on every bot-add. Drop silently.
+    if (!msg.text && !msg.caption && !attachmentKind) return;
+    const content = msg.text ?? msg.caption ?? `(${attachmentKind})`;
+    const ts = new Date(msg.date * 1000).toISOString();
+
+    // Build the channel notification payload — matches the official plugin's shape
+    const meta: Record<string, string> = {
+      chat_id: String(msg.chat.id),
+      message_id: String(msg.message_id),
+      user: msg.from?.username ?? msg.from?.first_name ?? "unknown",
+      user_id: String(userId),
+      ts,
+    };
+    if (attachmentKind) meta.attachment_kind = attachmentKind;
+    if (attachmentFileId) meta.attachment_file_id = attachmentFileId;
+    if (attachmentSize) meta.attachment_size = String(attachmentSize);
+    if (attachmentMime) meta.attachment_mime = attachmentMime;
+    if (imagePath) meta.image_path = imagePath;
+
+    ctx.emit({ channel: ctx.channel, content, meta, source: "telegram" });
+  }
+
+  // -------------------------------------------------------------------------
+  // Outbound — Telegram chat_id travels in args.meta.chat_id
+  // -------------------------------------------------------------------------
+
+  private chatIdFrom(meta: Record<string, string> | undefined, field = "chat_id"): string {
+    const chatId = meta?.[field];
+    if (!chatId) {
+      throw new Error(`telegram transport: meta.${field} is required`);
+    }
+    return chatId;
+  }
+
+  async reply(args: ReplyArgs): Promise<{ sent: string[] }> {
+    const chatId = this.chatIdFrom(args.meta);
+    const sentIds: string[] = [];
+
+    if (args.text) {
+      // Chunk long messages (Telegram 4096 char limit)
+      const chunks = chunkText(args.text, 4096);
+      for (const chunk of chunks) {
+        const id = await this.api.sendMessage(
+          chatId,
+          chunk,
+          args.reply_to ? { reply_to_message_id: parseInt(args.reply_to) } : undefined,
+        );
+        sentIds.push(String(id));
+      }
+    }
+
+    if (args.files) {
+      for (const filePath of args.files) {
+        const ext = filePath.split(".").pop()?.toLowerCase() ?? "";
+        const imageExts = ["jpg", "jpeg", "png", "gif", "webp"];
+        const voiceExts = ["ogg", "oga", "opus"];
+        let id: number;
+        if (imageExts.includes(ext)) {
+          id = await this.api.sendPhoto(chatId, filePath);
+        } else if (voiceExts.includes(ext)) {
+          id = await this.api.sendVoice(chatId, filePath);
+        } else {
+          id = await this.api.sendDocument(chatId, filePath);
+        }
+        sentIds.push(String(id));
+      }
+    }
+
+    return { sent: sentIds };
+  }
+
+  async react(args: ReactArgs): Promise<void> {
+    const chatId = this.chatIdFrom(args.meta);
+    await this.api.setMessageReaction(chatId, parseInt(args.message_id), args.emoji);
+  }
+
+  async edit(args: EditArgs): Promise<void> {
+    const chatId = this.chatIdFrom(args.meta);
+    await this.api.editMessageText(chatId, parseInt(args.message_id), args.text);
+  }
+
+  async sendPermission(args: PermissionArgs): Promise<{ sent: string[] }> {
+    const access = loadAccess(this.accessFile);
+    const targets = access.allowFrom;
+    if (targets.length === 0) {
+      throw new Error("no allowlisted users to send permission prompt to");
+    }
+    const text =
+      `🔐 Permission: ${args.tool_name}\n\n` +
+      `${args.description}\n\n` +
+      `${args.input_preview}`;
+    const replyMarkup = {
+      inline_keyboard: [
+        [
+          { text: "✅ Allow", callback_data: `perm_allow_${args.request_id}` },
+          { text: "❌ Deny", callback_data: `perm_deny_${args.request_id}` },
+        ],
+      ],
+    };
+    const sent: string[] = [];
+    for (const chatId of targets) {
+      try {
+        const id = await this.api.sendMessage(chatId, text, { reply_markup: replyMarkup });
+        sent.push(String(id));
+      } catch (err) {
+        console.error(`parachute-channel: permission prompt to ${chatId} failed:`, err);
+      }
+    }
+    return { sent };
+  }
+
+  async download(args: DownloadArgs): Promise<{ path: string }> {
+    const fileInfo = await this.api.getFile(args.file_id);
+    const data = await this.api.downloadFile(fileInfo.file_path);
+    const ext = fileInfo.file_path.split(".").pop() ?? "bin";
+    const localPath = join(this.inboxDir, `${Date.now()}-${args.file_id.slice(-10)}.${ext}`);
+    writeFileSync(localPath, data);
+    return { path: localPath };
+  }
+}
+
+/** Split text into <=maxLen chunks, preferring newline breaks. Exported for tests. */
+export function chunkText(text: string, maxLen: number): string[] {
+  if (text.length <= maxLen) return [text];
+  const chunks: string[] = [];
+  let remaining = text;
+  while (remaining.length > 0) {
+    if (remaining.length <= maxLen) {
+      chunks.push(remaining);
+      break;
+    }
+    // Try to break at a newline
+    let breakAt = remaining.lastIndexOf("\n", maxLen);
+    if (breakAt < maxLen * 0.5) breakAt = maxLen; // no good newline, hard break
+    chunks.push(remaining.slice(0, breakAt));
+    remaining = remaining.slice(breakAt).replace(/^\n/, "");
+  }
+  return chunks;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,11 +3,12 @@
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
     "strict": true,
+    "noUncheckedIndexedAccess": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "outDir": "dist",
-    "declaration": true,
     "types": ["bun-types"]
   },
   "include": ["src"]


### PR DESCRIPTION
PR 1.1 of the channel-fabric arc (see PLAN.md). Refactors parachute-channel from
Telegram-coupled to a **transport-abstracted, named-channel-routed fabric**.
Telegram becomes one transport implementation. Behavior-preserving for the
Telegram path; additive routing on top.

## Transport abstraction
`src/transport.ts` defines the `Transport` interface: `start(ctx)/stop()` plus
`reply` (required) and optional `react/edit/sendPermission/download`. Backend-
specific addressing (Telegram `chat_id`, `message_id`) travels inside `meta`, so
non-Telegram transports never invent Telegram fields. `src/transports/telegram.ts`
holds **all** Telegram logic, moved verbatim: getUpdates poll, message/callback
handling, attachment download, access control (`access.json` + `allowInChats`
group bypass), the permission inline-keyboard + `y/n <id>` verdict intercept, and
4096-char chunking. On inbound it calls `ctx.emit(...)`; on a verdict
`ctx.emitPermissionVerdict(...)`.

## Routing model — subscribe by channel
The daemon hosts named channels (a registry). Each bridge subscribes to one
channel via `/events?channel=<name>` (set by `PARACHUTE_CHANNEL_NAME`). The core
property: an inbound message emitted on channel **A** is delivered **only** to
clients subscribed to A, never to B. This is factored into a pure, importable
`ClientRegistry.routeToChannel` (`src/routing.ts`) so it's unit-testable without a
socket. Outbound endpoints take a `channel` field and dispatch to that channel's
transport; missing/unknown channel or unsupported method → 400 with a clear error.
`/health` now reports per-channel client counts; `/.parachute/config[/schema]`
expose the channel list **without secrets** (runner self-describing-config pattern).

## Backwards-compat (zero-config Telegram)
- No `channels.json` but `TELEGRAM_BOT_TOKEN` set (env or state-dir `.env`) →
  synthesize a single default channel `{name:"telegram",transport:"telegram"}`.
- `/events` without `?channel=` defaults to `"telegram"` (with a deprecation log).
- Bridge defaults `PARACHUTE_CHANNEL_NAME` to `"telegram"`.
- The wake path (`notifications/claude/channel` + permission relay) is **unchanged**.

## Tests + verification
- `bun test src/` → **34 pass / 0 fail**, 71 expect() calls, 3 files.
  - **registry**: default-channel synthesis (env + `.env`); explicit `channels.json`
    parsing + precedence; unknown-transport / missing-field errors.
  - **routing**: the core "A reaches A, not B" property; throwing-client eviction;
    a **live two-client SSE integration test** (Bun.serve on an ephemeral port).
  - **telegram**: the access-control cases (open, allowlist, `allowInChats` group
    bypass, DM AND-gating, empty-array fail-closed, fail-closed empty allowFrom) +
    chunking.
- `bun run typecheck` (`tsc --noEmit`) → **clean**. tsconfig gains
  `allowImportingTsExtensions` + `noUncheckedIndexedAccess`; added a `typecheck` script.
- Sanity boot: `TELEGRAM_BOT_TOKEN=dummy bun src/daemon.ts` starts; `/health`
  returns the new shape with a `telegram` channel; dummy-token poll fails-and-
  retries harmlessly. Bridge boots, subscribes to its channel, degrades on a
  dead daemon URL.

## Decisions / notes
- `tsconfig` previously errored on `.ts` import extensions under bare `tsc`; the
  fix (`allowImportingTsExtensions`+`noEmit`) makes the typecheck gate meaningful.
  Vestigial `outDir`/`declaration` dropped (the bins run `.ts` via bun, no build).
- Wake/notification path untouched — only the SSE subscription URL gained `?channel=`
  and outbound bodies gained a `channel` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)