### PR TITLE
feat(channel): http-ui transport + built-in chat UI + Tier 2 LLM-run e2e (PR 1.2)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -111,15 +111,20 @@ Two tiers, mirroring hub's `e2e/` but realizing the deferred Tier 2:
       Telegram path unchanged (regression). typecheck + bun test green.
 - [ ] Reviewer subagent.
 
-**PR 1.2 — http-ui transport + built-in chat UI.** ☐
-- [ ] `transports/http-ui.ts`: inbound via `POST /api/channels/<name>/send`; outbound
-      delivered to the UI over SSE (`/ui/events?channel=<name>`).
-- [ ] Minimal built-in chat page served by the daemon (`/ui` or `/ui/<channel>`): channel
-      picker + message box + live transcript. No framework needed; vanilla is fine.
-- [ ] **Tier 2 LLM-run e2e (headline):** boot daemon + real CC session subscribed to a test
-      channel; POST a message; LLM judges the reply. Build the `e2e/llm/` harness here.
-- [ ] Loopback-only; no auth in Stage 1 (named in Decision 3; hub-JWT lands when exposed).
-- [ ] Reviewer subagent.
+**PR 1.2 — http-ui transport + built-in chat UI.** 🔄 (reviewer pending)
+- [x] `transports/http-ui.ts`: inbound via `POST /api/channels/<name>/send`; outbound
+      delivered to the UI over SSE (`/ui/events?channel=<name>`). Daemon gained an optional
+      `Transport.ingestHttp` so transports contribute routes without owning `Bun.serve`.
+- [x] Minimal built-in chat page served by the daemon (`/ui`): channel picker + message box
+      + live transcript, vanilla single-file.
+- [x] Bridge tool surface made transport-neutral — `reply` no longer requires a Telegram
+      `chat_id` (the gap that blocked http-ui replies; caught by the e2e). `download` left
+      Telegram-specific (file_id) as a noted follow-up.
+- [x] **Tier 2 LLM-run e2e (headline) — PASSES.** `e2e/llm/run.ts`: boots daemon + a real
+      interactive CC session in tmux, POSTs a message, verifies the reply deterministically
+      (positive control + sentinel + content) AND via an LLM judge. `bun run test:e2e`.
+- [x] Loopback-only; no auth in Stage 1 (Decision 3).
+- [ ] Reviewer subagent + merge.
 
 **PR 1.3 — session launcher scripts (tmux).** ☐
 - [ ] `scripts/launch-session.sh <name> <channel>`: start `claude` interactive in

--- a/e2e/llm/README.md
+++ b/e2e/llm/README.md
@@ -1,0 +1,63 @@
+# Tier 2 — LLM-run end-to-end test
+
+The headline test of the channel fabric. It exercises the **real** wake → act →
+reply loop against a **real** interactive Claude Code session — the thing a
+scripted unit test can't reach — and verifies the result two ways: deterministic
+assertions **and** an LLM judge.
+
+This realizes the "Tier 2" the [hub e2e harness](../../../parachute-hub/e2e/README.md)
+deferred ("an LLM-driven runbook … separate, later"). Where hub's Tier 1 is the
+deterministic regression net, this is the loop-closing integration test for a
+module whose entire job is "a message goes in, a live session acts and replies."
+
+## What it does
+
+1. Boots the daemon with one `http-ui` channel (`e2e`), on a temp state dir + port.
+2. Subscribes a browser-style UI SSE listener to that channel.
+3. Launches a real interactive `claude` session in **tmux**, its bridge subscribed
+   to the same channel (the exact setup PR 1.3's launcher scripts automate).
+4. POSTs a message into the channel — as the built-in chat UI would.
+5. Asserts the session woke and replied **through the channel**:
+   - **positive control** — the bridge must actually connect (else the test is
+     vacuous and fails loudly rather than passing on silence);
+   - **deterministic** — the reply echoes a sentinel token (proves it's a genuine
+     round-trip response to our message) and contains the expected answer;
+   - **LLM judge** — a `claude -p` call scores the reply for semantic correctness.
+
+Both the deterministic and the LLM checks must pass. Exit `0` on PASS, non-zero on FAIL.
+
+## Running
+
+```bash
+bun run test:e2e          # from the repo root
+# or
+bun e2e/llm/run.ts
+```
+
+Requires `tmux` and the `claude` CLI on PATH.
+
+**Auth.** The session-under-test is **interactive**, so it's covered by your Claude
+subscription (this is the whole point — interactive sessions are unmetered, unlike
+`claude -p`). The LLM **judge** uses `claude -p`: if `ANTHROPIC_API_KEY` is set it
+runs in `--bare` mode (keyed — keeps judge spend off the subscription credit pool);
+otherwise it uses your logged-in subscription. In CI (no interactive login), set
+`ANTHROPIC_API_KEY`.
+
+This is a **local / pre-merge gate**, not a blocking CI step — it spawns an
+interactive TUI session, which CI environments generally can't. `bun test` (Tier 1)
+is the CI gate; this is run before merging changes that touch the wake/transport path.
+
+## Env knobs
+
+| Var | Default | Meaning |
+|---|---|---|
+| `E2E_PORT` | `19471` | Daemon port for the run. |
+| `E2E_KEEP` | — | `1` = skip teardown (keep tmux session + state dir for debugging). |
+| `E2E_JUDGE_MODEL` | `claude-haiku-4-5-20251001` | Model for the LLM judge (fast/cheap). |
+| `E2E_REPLY_TIMEOUT_MS` | `90000` | How long to wait for the session's reply. |
+
+## Debugging a failure
+
+Run with `E2E_KEEP=1`, then inspect:
+- `tmux attach -t parachute-channel-e2e` — watch the live session.
+- `/tmp/parachute-channel-e2e-<port>/daemon.log` — daemon output.

--- a/e2e/llm/run.ts
+++ b/e2e/llm/run.ts
@@ -1,0 +1,253 @@
+#!/usr/bin/env bun
+/**
+ * Tier 2 — LLM-run end-to-end test for parachute-channel.
+ *
+ * This is the headline test of the channel fabric: it exercises the REAL
+ * wake → act → reply loop against a REAL interactive Claude Code session, the
+ * thing a scripted unit test can't reach. It realizes the "Tier 2" the hub e2e
+ * README deferred ("an LLM-driven runbook … separate, later").
+ *
+ *   1. Boot the daemon with one http-ui channel ("e2e"), temp state dir + port.
+ *   2. Subscribe a browser-style UI SSE listener to that channel.
+ *   3. Launch a real interactive `claude` session in tmux, its bridge subscribed
+ *      to the same channel (the same setup the launcher scripts will automate).
+ *   4. POST a message into the channel (as the built-in UI would).
+ *   5. Assert the session woke and replied THROUGH the channel — two ways:
+ *        • deterministic (positive control + sentinel + expected content)
+ *        • an LLM judge scoring semantic correctness
+ *
+ * Both must pass. Exit 0 on PASS, non-zero on FAIL.
+ *
+ * Auth: the session-under-test is interactive (subscription-covered). The LLM
+ * judge uses `claude -p`; if ANTHROPIC_API_KEY is set it runs in --bare mode
+ * (keyed, keeps judge spend off the subscription credit pool). Run from the repo
+ * root: `bun e2e/llm/run.ts`. Env knobs: E2E_PORT, E2E_KEEP=1 (skip teardown),
+ * E2E_JUDGE_MODEL (default haiku), E2E_REPLY_TIMEOUT_MS.
+ */
+
+import { mkdirSync, writeFileSync, rmSync, existsSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const PORT = parseInt(process.env.E2E_PORT ?? "19471", 10);
+const BASE = `http://127.0.0.1:${PORT}`;
+const CHANNEL = "e2e";
+const SESSION = "parachute-channel-e2e";
+const STATE_DIR = `/tmp/parachute-channel-e2e-${PORT}`;
+const WORKDIR = join(STATE_DIR, "workdir");
+const KEEP = process.env.E2E_KEEP === "1";
+const JUDGE_MODEL = process.env.E2E_JUDGE_MODEL ?? "claude-haiku-4-5-20251001";
+const REPLY_TIMEOUT_MS = parseInt(process.env.E2E_REPLY_TIMEOUT_MS ?? "90000", 10);
+
+// A static sentinel the session must echo back — proves the reply is a genuine
+// response to OUR message routed through the channel, not anything incidental.
+const SENTINEL = "ACK-E2E-7Q3F";
+const PROMPT =
+  `You are connected to a test channel. Reply THROUGH the channel using the reply tool ` +
+  `(your transcript text never reaches the sender). In your reply, put the exact token ${SENTINEL} ` +
+  `first, then the capital city of France. Keep it to one short line. Reply only via the reply tool.`;
+
+// ---------------------------------------------------------------------------
+// small utils
+// ---------------------------------------------------------------------------
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const log = (m: string) => console.log(`[e2e] ${m}`);
+const fail = (m: string): never => {
+  console.error(`\n❌ FAIL: ${m}\n`);
+  throw new Error(m);
+};
+
+function sh(cmd: string[]): { code: number; stdout: string; stderr: string } {
+  const p = Bun.spawnSync(cmd, { stdout: "pipe", stderr: "pipe" });
+  return { code: p.exitCode, stdout: p.stdout.toString(), stderr: p.stderr.toString() };
+}
+const tmux = (...args: string[]) => sh(["tmux", ...args]);
+const pane = () => tmux("capture-pane", "-p", "-t", SESSION).stdout;
+
+async function waitFor(desc: string, timeoutMs: number, probe: () => Promise<boolean>): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      if (await probe()) return;
+    } catch {}
+    await sleep(500);
+  }
+  fail(`timed out waiting for: ${desc}`);
+}
+
+// ---------------------------------------------------------------------------
+// teardown
+// ---------------------------------------------------------------------------
+let daemon: ReturnType<typeof Bun.spawn> | undefined;
+function teardown(): void {
+  try { tmux("kill-session", "-t", SESSION); } catch {}
+  try { daemon?.kill(); } catch {}
+  if (!KEEP) { try { rmSync(STATE_DIR, { recursive: true, force: true }); } catch {} }
+  else log(`E2E_KEEP=1 — left state dir at ${STATE_DIR}`);
+}
+
+// ---------------------------------------------------------------------------
+// UI SSE listener — collects `reply` frames the session sends back
+// ---------------------------------------------------------------------------
+const replies: { id: string; text: string }[] = [];
+async function listenUi(signal: AbortSignal): Promise<void> {
+  const res = await fetch(`${BASE}/ui/events?channel=${CHANNEL}`, { signal });
+  if (!res.body) fail("UI SSE stream had no body");
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let event = "";
+  let data = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop() ?? "";
+    for (const line of lines) {
+      if (line.startsWith("event: ")) event = line.slice(7);
+      else if (line.startsWith("data: ")) data += line.slice(6);
+      else if (line === "") {
+        if (event === "reply" && data) {
+          try {
+            const p = JSON.parse(data) as { id: string; text: string };
+            replies.push({ id: p.id, text: p.text });
+            log(`◀ reply received: ${JSON.stringify(p.text).slice(0, 120)}`);
+          } catch {}
+        }
+        event = ""; data = "";
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// LLM judge
+// ---------------------------------------------------------------------------
+async function judge(question: string, reply: string): Promise<{ pass: boolean; reason: string }> {
+  const keyed = !!process.env.ANTHROPIC_API_KEY;
+  const judgePrompt =
+    `A test harness sent this message to an AI session over a chat channel:\n---\n${question}\n---\n` +
+    `The session replied through the channel with:\n---\n${reply}\n---\n` +
+    `Did the session correctly receive that message and reply sensibly and on-topic ` +
+    `(a reply that includes the requested token and correctly names Paris)? ` +
+    `Respond with a single JSON object and nothing else: {"verdict":"PASS"|"FAIL","reason":"<short>"}.`;
+  const cmd = ["claude", "-p", judgePrompt, "--model", JUDGE_MODEL, "--output-format", "json"];
+  if (keyed) cmd.splice(2, 0, "--bare");
+  log(`judging with ${JUDGE_MODEL}${keyed ? " (--bare, keyed)" : " (subscription)"} …`);
+  const r = sh(cmd);
+  if (r.code !== 0) fail(`judge invocation failed (code ${r.code}): ${r.stderr.slice(0, 400)}`);
+  let resultText = r.stdout;
+  try { resultText = (JSON.parse(r.stdout) as { result: string }).result; } catch {}
+  const m = resultText.match(/\{[\s\S]*\}/);
+  if (!m) fail(`judge produced no JSON verdict. raw: ${resultText.slice(0, 300)}`);
+  const v = JSON.parse(m[0]) as { verdict: string; reason: string };
+  return { pass: v.verdict.toUpperCase() === "PASS", reason: v.reason };
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+async function main(): Promise<void> {
+  log(`repo root: ${REPO_ROOT}`);
+  if (existsSync(STATE_DIR)) rmSync(STATE_DIR, { recursive: true, force: true });
+  mkdirSync(WORKDIR, { recursive: true });
+
+  // 1. channel config + bridge mcp config
+  writeFileSync(
+    join(STATE_DIR, "channels.json"),
+    JSON.stringify({ channels: [{ name: CHANNEL, transport: "http-ui" }] }, null, 2),
+  );
+  writeFileSync(
+    join(WORKDIR, ".mcp.json"),
+    JSON.stringify(
+      {
+        mcpServers: {
+          "parachute-channel": {
+            command: "bun",
+            args: [join(REPO_ROOT, "src", "bridge.ts")],
+            env: { PARACHUTE_CHANNEL_URL: BASE, PARACHUTE_CHANNEL_NAME: CHANNEL },
+          },
+        },
+      },
+      null,
+      2,
+    ),
+  );
+
+  // 2. boot the daemon
+  log(`booting daemon on ${BASE} (state ${STATE_DIR})`);
+  daemon = Bun.spawn(["bun", join(REPO_ROOT, "src", "daemon.ts")], {
+    env: { ...process.env, PARACHUTE_CHANNEL_STATE_DIR: STATE_DIR, PARACHUTE_CHANNEL_PORT: String(PORT) },
+    stdout: Bun.file(join(STATE_DIR, "daemon.log")),
+    stderr: Bun.file(join(STATE_DIR, "daemon.log")),
+  });
+  await waitFor("daemon /health ok", 15000, async () => (await fetch(`${BASE}/health`)).ok);
+  log("daemon up");
+
+  // 3. UI SSE listener
+  const sseAbort = new AbortController();
+  listenUi(sseAbort.signal).catch(() => {});
+
+  // 4. launch the interactive session in tmux
+  log("launching interactive claude session in tmux …");
+  tmux("kill-session", "-t", SESSION);
+  tmux(
+    "new-session", "-d", "-s", SESSION, "-x", "220", "-y", "50",
+    `cd ${WORKDIR} && exec claude --dangerously-load-development-channels=server:parachute-channel --dangerously-skip-permissions`,
+  );
+
+  // handle the one-time channels-dev-mode confirmation prompt. It renders a beat
+  // AFTER launch, so poll for it rather than sleep-then-check-once (a fixed wait
+  // races the prompt and leaves the session stuck, with no bridge ever spawning).
+  let ackedDev = false;
+  await waitFor("session ready (channel attached)", 30000, async () => {
+    const p = pane();
+    if (!ackedDev && /local development/i.test(p) && /Enter to confirm/i.test(p)) {
+      log("accepting channels dev-mode prompt");
+      tmux("send-keys", "-t", SESSION, "Enter");
+      ackedDev = true;
+      return false;
+    }
+    return /inject directly in this session/i.test(p);
+  });
+
+  // 5. positive control — the bridge must actually connect (else the test is vacuous)
+  await waitFor("bridge to connect to the e2e channel", 45000, async () => {
+    const h = (await (await fetch(`${BASE}/health`)).json()) as { channels: { name: string; clients: number }[] };
+    return (h.channels.find((c) => c.name === CHANNEL)?.clients ?? 0) >= 1;
+  });
+  log("✓ positive control: bridge connected to the channel");
+
+  // 6. send the message into the channel (as the built-in UI would)
+  log(`▶ sending test message into channel "${CHANNEL}"`);
+  const send = await fetch(`${BASE}/api/channels/${CHANNEL}/send`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ text: PROMPT }),
+  });
+  if (!send.ok) fail(`send failed: ${send.status} ${await send.text()}`);
+
+  // 7. wait for the session to wake and reply through the channel
+  await waitFor("a reply from the session", REPLY_TIMEOUT_MS, async () => replies.length > 0);
+  const reply = replies.map((r) => r.text).join("\n");
+  sseAbort.abort();
+  log(`session pane after reply:\n${pane().split("\n").filter(Boolean).slice(-6).join("\n")}`);
+
+  // 8. deterministic assertions (Tier 1 within the e2e)
+  if (!reply.includes(SENTINEL)) fail(`reply missing sentinel ${SENTINEL} — round-trip not proven. got: ${reply}`);
+  if (!/paris/i.test(reply)) fail(`reply missing expected content "Paris". got: ${reply}`);
+  log("✓ deterministic checks: sentinel echoed + correct content");
+
+  // 9. LLM judge (Tier 2)
+  const verdict = await judge(PROMPT, reply);
+  if (!verdict.pass) fail(`LLM judge returned FAIL: ${verdict.reason}`);
+  log(`✓ LLM judge: PASS — ${verdict.reason}`);
+
+  console.log(`\n✅ PASS — full wake→act→reply loop verified end to end (deterministic + LLM-judged).\n`);
+}
+
+main()
+  .then(() => { teardown(); process.exit(0); })
+  .catch((err) => { console.error(String(err?.message ?? err)); teardown(); process.exit(1); });

--- a/e2e/llm/run.ts
+++ b/e2e/llm/run.ts
@@ -114,7 +114,9 @@ async function listenUi(signal: AbortSignal): Promise<void> {
             const p = JSON.parse(data) as { id: string; text: string };
             replies.push({ id: p.id, text: p.text });
             log(`◀ reply received: ${JSON.stringify(p.text).slice(0, 120)}`);
-          } catch {}
+          } catch (e) {
+            log(`SSE reply frame parse error (ignored): ${String(e)} — raw: ${data.slice(0, 120)}`);
+          }
         }
         event = ""; data = "";
       }
@@ -246,6 +248,11 @@ async function main(): Promise<void> {
   log(`✓ LLM judge: PASS — ${verdict.reason}`);
 
   console.log(`\n✅ PASS — full wake→act→reply loop verified end to end (deterministic + LLM-judged).\n`);
+}
+
+// Ctrl-C / kill during a long poll must still clean up the tmux session + daemon.
+for (const sig of ["SIGINT", "SIGTERM"] as const) {
+  process.on(sig, () => { log(`${sig} — tearing down`); teardown(); process.exit(130); });
 }
 
 main()

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "daemon": "bun src/daemon.ts",
     "bridge": "bun src/bridge.ts",
     "test": "bun test src/",
+    "test:e2e": "bun e2e/llm/run.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -92,11 +92,10 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
   tools: [
     {
       name: "reply",
-      description: "Send a message to a Telegram chat. Supports text, file attachments (images sent as photos, .ogg as voice, others as documents), and quote-reply threading.",
+      description: "Send a message back through the channel to the sender. Supports text, file attachments, and quote-reply threading. The daemon routes it out whichever transport the channel uses.",
       inputSchema: {
         type: "object" as const,
         properties: {
-          chat_id: { type: "string", description: "Telegram chat ID to send to" },
           text: { type: "string", description: "Message text (optional if files provided)" },
           reply_to: { type: "string", description: "Message ID to quote-reply (optional)" },
           files: {
@@ -104,34 +103,39 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
             items: { type: "string" },
             description: "Absolute file paths to attach (optional)",
           },
+          chat_id: {
+            type: "string",
+            description:
+              "Addressing field some transports need (e.g. a Telegram chat ID). Include it ONLY if the inbound message tag carried one; omit it otherwise (e.g. for a web/UI channel).",
+          },
         },
-        required: ["chat_id"],
+        required: [],
       },
     },
     {
       name: "react",
-      description: "Add an emoji reaction to a Telegram message. Only Telegram's fixed emoji whitelist is accepted (👍 👎 ❤ 🔥 👀 etc).",
+      description: "Add an emoji reaction to a message, on transports that support reactions (e.g. Telegram's fixed emoji whitelist 👍 👎 ❤ 🔥 👀). Not all channels support this.",
       inputSchema: {
         type: "object" as const,
         properties: {
-          chat_id: { type: "string", description: "Telegram chat ID" },
           message_id: { type: "string", description: "Message ID to react to" },
           emoji: { type: "string", description: "Emoji reaction" },
+          chat_id: { type: "string", description: "Addressing field for transports that need it (e.g. Telegram chat ID); omit otherwise." },
         },
-        required: ["chat_id", "message_id", "emoji"],
+        required: ["message_id", "emoji"],
       },
     },
     {
       name: "edit_message",
-      description: "Edit a message the bot previously sent. Useful for progress updates. Edits don't trigger push notifications.",
+      description: "Edit a message you previously sent. Useful for progress updates. On most transports edits don't push a notification.",
       inputSchema: {
         type: "object" as const,
         properties: {
-          chat_id: { type: "string", description: "Telegram chat ID" },
           message_id: { type: "string", description: "Message ID to edit" },
           text: { type: "string", description: "New text" },
+          chat_id: { type: "string", description: "Addressing field for transports that need it (e.g. Telegram chat ID); omit otherwise." },
         },
-        required: ["chat_id", "message_id", "text"],
+        required: ["message_id", "text"],
       },
     },
     {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -42,6 +42,9 @@ const PORT = parseInt(process.env.PARACHUTE_CHANNEL_PORT ?? "1941", 10);
 /** Channel a bridge subscribes to when `?channel=` is omitted (back-compat). */
 const DEFAULT_CHANNEL = "telegram";
 
+/** Absolute path to the bridge a Claude Code session spawns — shown in /ui setup. */
+const BRIDGE_PATH = join(import.meta.dir, "bridge.ts");
+
 mkdirSync(STATE_DIR, { recursive: true });
 mkdirSync(INBOX_DIR, { recursive: true });
 
@@ -153,6 +156,21 @@ const CHAT_UI_HTML = `<!doctype html>
     padding: 0 18px; font: inherit; font-weight: 600; cursor: pointer;
   }
   button:disabled { opacity: .4; cursor: default; }
+  details.setup { border-bottom: 1px solid var(--line); background: var(--panel); }
+  details.setup > summary {
+    cursor: pointer; padding: 8px 16px; color: var(--accent); font-size: 13px; user-select: none;
+  }
+  details.setup .body { padding: 4px 16px 14px; font-size: 13px; color: var(--muted); }
+  details.setup .body p { margin: 8px 0 4px; }
+  details.setup pre {
+    margin: 4px 0; padding: 10px 12px; background: var(--bg); border: 1px solid var(--line);
+    border-radius: 8px; overflow-x: auto; color: var(--fg); font-size: 12px; line-height: 1.45;
+  }
+  details.setup code { color: var(--fg); }
+  details.setup .copy {
+    float: right; padding: 1px 8px; font-size: 11px; font-weight: 500; background: var(--them);
+    border: 1px solid var(--line); border-radius: 6px;
+  }
 </style>
 </head>
 <body>
@@ -161,6 +179,16 @@ const CHAT_UI_HTML = `<!doctype html>
     <span id="status">connecting…</span>
     <select id="channel" title="channel"></select>
   </header>
+  <details class="setup">
+    <summary>Connect a Claude Code session ▾</summary>
+    <div class="body">
+      <p>1. In the working directory you'll run Claude Code from, create <code>.mcp.json</code>:</p>
+      <pre><button class="copy" data-copy="mcp">copy</button><code id="snippet-mcp"></code></pre>
+      <p>2. Launch Claude Code from that directory:</p>
+      <pre><button class="copy" data-copy="launch">copy</button><code id="snippet-launch"></code></pre>
+      <p id="setup-note"></p>
+    </div>
+  </details>
   <div id="transcript"></div>
   <form id="composer">
     <textarea id="input" rows="1" placeholder="Type a message… (Enter to send, Shift+Enter for newline)" autocomplete="off"></textarea>
@@ -175,6 +203,36 @@ const CHAT_UI_HTML = `<!doctype html>
   var statusEl = document.getElementById("status");
   var form = document.getElementById("composer");
   var es = null;
+  var BRIDGE_PATH = ${JSON.stringify(BRIDGE_PATH)};
+
+  function updateSetup(ch) {
+    if (!ch) return;
+    var mcp = {
+      mcpServers: {
+        "parachute-channel": {
+          command: "bun",
+          args: [BRIDGE_PATH],
+          env: { PARACHUTE_CHANNEL_URL: window.location.origin, PARACHUTE_CHANNEL_NAME: ch },
+        },
+      },
+    };
+    document.getElementById("snippet-mcp").textContent = JSON.stringify(mcp, null, 2);
+    document.getElementById("snippet-launch").textContent =
+      "claude --dangerously-load-development-channels=server:parachute-channel";
+    document.getElementById("setup-note").textContent =
+      "On first launch, confirm the dev-channels prompt (\\"I am using this for local development\\"). " +
+      "After that, messages you send here inject directly into that idle session, and its replies appear here.";
+  }
+
+  document.querySelectorAll(".copy").forEach(function (btn) {
+    btn.addEventListener("click", function (e) {
+      e.preventDefault();
+      var id = btn.getAttribute("data-copy") === "mcp" ? "snippet-mcp" : "snippet-launch";
+      var txt = document.getElementById(id).textContent;
+      if (navigator.clipboard) navigator.clipboard.writeText(txt);
+      var prev = btn.textContent; btn.textContent = "copied"; setTimeout(function () { btn.textContent = prev; }, 1200);
+    });
+  });
 
   function add(kind, text, files) {
     var el = document.createElement("div");
@@ -201,6 +259,7 @@ const CHAT_UI_HTML = `<!doctype html>
     if (es) { es.close(); es = null; }
     var ch = currentChannel();
     if (!ch) { setStatus("no channel", false); sendBtn.disabled = true; return; }
+    updateSetup(ch);
     setStatus("connecting…", false);
     es = new EventSource("/ui/events?channel=" + encodeURIComponent(ch));
     es.onopen = function () { setStatus("● live · " + ch, true); sendBtn.disabled = false; };

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -90,6 +90,194 @@ function contextFor(channel: string): TransportContext {
 }
 
 // ---------------------------------------------------------------------------
+// Built-in chat UI
+// ---------------------------------------------------------------------------
+
+/**
+ * The built-in chat page — a single self-contained HTML document (no framework,
+ * no build step). On load it fetches /.parachute/config, lists the http-ui
+ * channels as a picker, opens an EventSource on /ui/events?channel=<sel>, and
+ * POSTs sends to /api/channels/<sel>/send. This is the surface for verifying
+ * messaging works end to end with no Telegram and no vault.
+ */
+const CHAT_UI_HTML = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>parachute-channel · chat</title>
+<style>
+  :root {
+    --bg: #0f1115; --panel: #171a21; --line: #262b36; --fg: #e6e9ef;
+    --muted: #8b93a3; --you: #2b5cff; --them: #232936; --accent: #4cc2a0;
+  }
+  * { box-sizing: border-box; }
+  html, body { height: 100%; margin: 0; }
+  body {
+    background: var(--bg); color: var(--fg);
+    font: 15px/1.5 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    display: flex; flex-direction: column; height: 100vh;
+  }
+  header {
+    display: flex; align-items: center; gap: 12px;
+    padding: 10px 16px; border-bottom: 1px solid var(--line); background: var(--panel);
+  }
+  header .brand { font-weight: 600; }
+  header .brand small { color: var(--muted); font-weight: 400; }
+  header select {
+    margin-left: auto; background: var(--bg); color: var(--fg);
+    border: 1px solid var(--line); border-radius: 6px; padding: 6px 10px; font: inherit;
+  }
+  #status { font-size: 12px; color: var(--muted); }
+  #status.live { color: var(--accent); }
+  #transcript {
+    flex: 1; overflow-y: auto; padding: 16px;
+    display: flex; flex-direction: column; gap: 8px;
+  }
+  .msg { max-width: 78%; padding: 8px 12px; border-radius: 12px; white-space: pre-wrap; word-wrap: break-word; }
+  .msg.you { align-self: flex-end; background: var(--you); color: #fff; border-bottom-right-radius: 4px; }
+  .msg.them { align-self: flex-start; background: var(--them); border-bottom-left-radius: 4px; }
+  .msg.sys { align-self: center; background: transparent; color: var(--muted); font-size: 12px; font-style: italic; max-width: 90%; }
+  .msg.perm { align-self: flex-start; background: #3a2f1a; border: 1px solid #6b5320; color: #ffd98a; max-width: 90%; }
+  .files { margin-top: 4px; font-size: 12px; opacity: .85; }
+  form {
+    display: flex; gap: 8px; padding: 12px 16px;
+    border-top: 1px solid var(--line); background: var(--panel);
+  }
+  #input {
+    flex: 1; resize: none; background: var(--bg); color: var(--fg);
+    border: 1px solid var(--line); border-radius: 8px; padding: 10px 12px; font: inherit; max-height: 120px;
+  }
+  button {
+    background: var(--you); color: #fff; border: 0; border-radius: 8px;
+    padding: 0 18px; font: inherit; font-weight: 600; cursor: pointer;
+  }
+  button:disabled { opacity: .4; cursor: default; }
+</style>
+</head>
+<body>
+  <header>
+    <div class="brand">parachute-channel <small>· chat</small></div>
+    <span id="status">connecting…</span>
+    <select id="channel" title="channel"></select>
+  </header>
+  <div id="transcript"></div>
+  <form id="composer">
+    <textarea id="input" rows="1" placeholder="Type a message… (Enter to send, Shift+Enter for newline)" autocomplete="off"></textarea>
+    <button id="send" type="submit" disabled>Send</button>
+  </form>
+<script>
+(function () {
+  var transcript = document.getElementById("transcript");
+  var sel = document.getElementById("channel");
+  var input = document.getElementById("input");
+  var sendBtn = document.getElementById("send");
+  var statusEl = document.getElementById("status");
+  var form = document.getElementById("composer");
+  var es = null;
+
+  function add(kind, text, files) {
+    var el = document.createElement("div");
+    el.className = "msg " + kind;
+    el.textContent = text;
+    if (files && files.length) {
+      var f = document.createElement("div");
+      f.className = "files";
+      f.textContent = "📎 " + files.join(", ");
+      el.appendChild(f);
+    }
+    transcript.appendChild(el);
+    transcript.scrollTop = transcript.scrollHeight;
+  }
+
+  function setStatus(text, live) {
+    statusEl.textContent = text;
+    statusEl.className = live ? "live" : "";
+  }
+
+  function currentChannel() { return sel.value; }
+
+  function connect() {
+    if (es) { es.close(); es = null; }
+    var ch = currentChannel();
+    if (!ch) { setStatus("no channel", false); sendBtn.disabled = true; return; }
+    setStatus("connecting…", false);
+    es = new EventSource("/ui/events?channel=" + encodeURIComponent(ch));
+    es.onopen = function () { setStatus("● live · " + ch, true); sendBtn.disabled = false; };
+    es.addEventListener("reply", function (e) {
+      try { var d = JSON.parse(e.data); add("them", d.text || "", d.files); }
+      catch (_) { add("them", e.data); }
+    });
+    es.addEventListener("edit", function (e) {
+      try { var d = JSON.parse(e.data); add("sys", "(edited) " + (d.text || "")); } catch (_) {}
+    });
+    es.addEventListener("permission", function (e) {
+      try {
+        var d = JSON.parse(e.data);
+        add("perm", "🔐 permission: " + d.tool_name + "\\n" + (d.description || "") + "\\n" + (d.input_preview || ""));
+      } catch (_) {}
+    });
+    es.addEventListener("close", function () { setStatus("closed", false); });
+    es.onerror = function () {
+      // EventSource auto-reconnects; reflect the transient state.
+      setStatus("reconnecting…", false);
+    };
+  }
+
+  function send() {
+    var text = input.value.trim();
+    var ch = currentChannel();
+    if (!text || !ch) return;
+    add("you", text);
+    input.value = "";
+    autosize();
+    fetch("/api/channels/" + encodeURIComponent(ch) + "/send", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ text: text }),
+    }).then(function (r) {
+      if (!r.ok) return r.json().catch(function(){return {};}).then(function (j) {
+        add("sys", "send failed: " + (j.error || r.status));
+      });
+    }).catch(function (err) { add("sys", "send failed: " + err); });
+  }
+
+  function autosize() {
+    input.style.height = "auto";
+    input.style.height = Math.min(input.scrollHeight, 120) + "px";
+  }
+
+  form.addEventListener("submit", function (e) { e.preventDefault(); send(); });
+  input.addEventListener("keydown", function (e) {
+    if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); send(); }
+  });
+  input.addEventListener("input", autosize);
+  sel.addEventListener("change", function () {
+    transcript.innerHTML = "";
+    var url = new URL(window.location.href);
+    url.searchParams.set("channel", sel.value);
+    history.replaceState(null, "", url);
+    connect();
+  });
+
+  fetch("/.parachute/config").then(function (r) { return r.json(); }).then(function (cfg) {
+    var chans = (cfg.channels || []).filter(function (c) { return c.transport === "http-ui"; });
+    if (!chans.length) { setStatus("no http-ui channels configured", false); return; }
+    var preselect = new URL(window.location.href).searchParams.get("channel");
+    chans.forEach(function (c) {
+      var opt = document.createElement("option");
+      opt.value = c.name; opt.textContent = c.name;
+      if (c.name === preselect) opt.selected = true;
+      sel.appendChild(opt);
+    });
+    connect();
+  }).catch(function (err) { setStatus("config load failed: " + err, false); });
+})();
+</script>
+</body>
+</html>`;
+
+// ---------------------------------------------------------------------------
 // HTTP server
 // ---------------------------------------------------------------------------
 
@@ -151,7 +339,7 @@ const server = Bun.serve({
                 name: { type: "string", description: "Unique channel name bridges subscribe to." },
                 transport: {
                   type: "string",
-                  enum: ["telegram"],
+                  enum: ["telegram", "http-ui"],
                   description: "Transport kind backing this channel.",
                 },
                 config: {
@@ -312,6 +500,23 @@ const server = Bun.serve({
       } catch (err) {
         return errResponse(err);
       }
+    }
+
+    // Built-in chat UI — a global channel-picker page across all http-ui
+    // channels. Served by the daemon (not a transport) because it spans every
+    // http-ui channel; the per-channel send + SSE routes live in the transport.
+    if (req.method === "GET" && url.pathname === "/ui") {
+      return new Response(CHAT_UI_HTML, {
+        headers: { "content-type": "text/html; charset=utf-8" },
+      });
+    }
+
+    // Give each transport a chance to handle a route the daemon didn't. Runs
+    // after the daemon's own built-in routes and before the final 404. A
+    // transport returns a Response if it owns the path, or null to pass.
+    for (const ch of channels.values()) {
+      const res = await ch.transport.ingestHttp?.(req, url);
+      if (res) return res;
     }
 
     return json({ error: "not found" }, 404);

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -203,7 +203,7 @@ const CHAT_UI_HTML = `<!doctype html>
   var statusEl = document.getElementById("status");
   var form = document.getElementById("composer");
   var es = null;
-  var BRIDGE_PATH = ${JSON.stringify(BRIDGE_PATH)};
+  var BRIDGE_PATH = ${JSON.stringify(BRIDGE_PATH).replace(/</g, "\\u003c")};
 
   function updateSetup(ch) {
     if (!ch) return;

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -16,6 +16,7 @@ import { join } from "path";
 import { homedir } from "os";
 import type { Transport } from "./transport.ts";
 import { TelegramTransport, type TelegramTransportConfig } from "./transports/telegram.ts";
+import { HttpUiTransport, type HttpUiTransportConfig } from "./transports/http-ui.ts";
 
 export interface ChannelEntry {
   name: string;
@@ -62,10 +63,13 @@ export function instantiateTransport(entry: ChannelEntry): Transport {
   switch (entry.transport) {
     case "telegram":
       return new TelegramTransport((entry.config ?? {}) as TelegramTransportConfig);
+    case "http-ui":
+      // http-ui needs no secret — just a channel name (taken from ctx at start).
+      return new HttpUiTransport((entry.config ?? {}) as HttpUiTransportConfig);
     default:
       throw new Error(
         `registry: unknown transport kind "${entry.transport}" for channel "${entry.name}" ` +
-          `(known: telegram)`,
+          `(known: telegram, http-ui)`,
       );
   }
 }

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -95,4 +95,12 @@ export interface Transport {
   sendPermission?(args: PermissionArgs): Promise<{ sent: string[] }>;
   /** Optional: fetch an attachment, returning a local path. */
   download?(args: DownloadArgs): Promise<{ path: string }>;
+  /**
+   * Optional: handle an HTTP request the daemon didn't handle itself. The
+   * daemon owns `Bun.serve`; a transport that needs to contribute routes (e.g.
+   * http-ui's per-channel send + SSE endpoints) implements this. Return a
+   * Response if this transport owns the path, or null to pass it on. Called
+   * after the daemon's built-in routes and before the final 404.
+   */
+  ingestHttp?(req: Request, url: URL): Promise<Response | null>;
 }

--- a/src/transports/http-ui.test.ts
+++ b/src/transports/http-ui.test.ts
@@ -309,24 +309,30 @@ describe("HttpUiTransport — through a daemon-shaped server", () => {
     }
   });
 
-  test("channel isolation: a send on A does NOT reach a UI client on B", async () => {
+  test("channel isolation: a send on A reaches A's bridge but NOT a UI client on B", async () => {
     const { server, base } = buildServer([{ name: "A" }, { name: "B" }]);
     try {
+      const bridgeA = await openSse(base, "/events?channel=A");
       const uiB = await openSse(base, "/ui/events?channel=B");
 
-      // Send on channel A, then reply on A — neither should hit B's UI stream.
+      // Send on channel A, then reply on A.
       await fetch(`${base}/api/channels/A/send`, {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ text: "for-A" }),
       });
+      // Close the loop: A's bridge MUST receive the inbound (not just "B didn't").
+      const bridgeFrame = await bridgeA.read();
+      expect(bridgeFrame).toContain("for-A");
+
       await fetch(`${base}/api/reply`, {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ channel: "A", text: "reply-to-A" }),
       });
 
-      // Now reply on B so B's stream definitely has a frame, and assert it's B's.
+      // Now reply on B so B's stream definitely has a frame, and assert it's B's
+      // only — none of A's traffic leaked across.
       await fetch(`${base}/api/reply`, {
         method: "POST",
         headers: { "content-type": "application/json" },
@@ -337,6 +343,7 @@ describe("HttpUiTransport — through a daemon-shaped server", () => {
       expect(frame).toContain("reply-to-B");
       expect(frame).not.toContain("reply-to-A");
       expect(frame).not.toContain("for-A");
+      bridgeA.cancel();
       uiB.cancel();
     } finally {
       server.stop(true);

--- a/src/transports/http-ui.test.ts
+++ b/src/transports/http-ui.test.ts
@@ -1,0 +1,345 @@
+/**
+ * Tier 1 unit + integration tests for the http-ui transport.
+ *
+ * These exercise the transport (and a daemon-shaped Bun.serve harness) WITHOUT a
+ * live Claude session. They cover:
+ *   - inbound routing: a UI `send` reaches the bridge subscribed to that channel;
+ *   - outbound to UI: `transport.reply()` pushes a `reply` event to a connected
+ *     /ui/events SSE client;
+ *   - round-trip through the daemon HTTP server (UI send → bridge, bridge reply
+ *     → UI) with no Claude;
+ *   - channel isolation (a send on A never reaches a UI client on B);
+ *   - registry: an http-ui channel instantiates without a token;
+ *   - reply() with no connected UI client does not throw.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { HttpUiTransport } from "./http-ui.ts";
+import type { TransportContext, InboundMessage } from "../transport.ts";
+import { ClientRegistry } from "../routing.ts";
+import { instantiateTransport } from "../registry.ts";
+
+/** A test context that records emitted inbound messages + permission verdicts. */
+function fakeCtx(channel: string): TransportContext & {
+  emitted: InboundMessage[];
+  verdicts: { request_id: string; behavior: string }[];
+} {
+  const emitted: InboundMessage[] = [];
+  const verdicts: { request_id: string; behavior: string }[] = [];
+  return {
+    channel,
+    emitted,
+    verdicts,
+    emit(msg) {
+      emitted.push(msg);
+    },
+    emitPermissionVerdict(v) {
+      verdicts.push(v);
+    },
+  };
+}
+
+/**
+ * Read the next non-comment SSE frame from a reader. Handles both the bytes a
+ * `fetch` response body yields and the raw string chunks a directly-read
+ * in-process ReadableStream<string> yields (the transport enqueues strings).
+ */
+async function readFrame(
+  reader: ReadableStreamDefaultReader<Uint8Array | string>,
+  decoder = new TextDecoder(),
+): Promise<string> {
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) return "";
+    const chunk = typeof value === "string" ? value : decoder.decode(value, { stream: true });
+    if (chunk.includes("event:")) return chunk;
+  }
+}
+
+describe("HttpUiTransport — direct", () => {
+  test("ingestHttp send → ctx.emit on its own channel", async () => {
+    const t = new HttpUiTransport();
+    const ctx = fakeCtx("dev");
+    await t.start(ctx);
+
+    const req = new Request("http://x/api/channels/dev/send", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ text: "hello session" }),
+    });
+    const res = await t.ingestHttp(req, new URL(req.url));
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(200);
+    expect(await res!.json()).toEqual({ ok: true });
+
+    expect(ctx.emitted).toHaveLength(1);
+    expect(ctx.emitted[0]!.content).toBe("hello session");
+    expect(ctx.emitted[0]!.channel).toBe("dev");
+    expect(ctx.emitted[0]!.source).toBe("http-ui");
+  });
+
+  test("ingestHttp ignores a send for a DIFFERENT channel's path", async () => {
+    const t = new HttpUiTransport();
+    await t.start(fakeCtx("dev"));
+    const req = new Request("http://x/api/channels/other/send", {
+      method: "POST",
+      body: JSON.stringify({ text: "nope" }),
+    });
+    const res = await t.ingestHttp(req, new URL(req.url));
+    expect(res).toBeNull();
+  });
+
+  test("send with empty/missing text → 400, no emit", async () => {
+    const t = new HttpUiTransport();
+    const ctx = fakeCtx("dev");
+    await t.start(ctx);
+    const req = new Request("http://x/api/channels/dev/send", {
+      method: "POST",
+      body: JSON.stringify({ text: "" }),
+    });
+    const res = await t.ingestHttp(req, new URL(req.url));
+    expect(res!.status).toBe(400);
+    expect(ctx.emitted).toHaveLength(0);
+  });
+
+  test("reply() with no connected UI client does not throw and returns sent:[]", async () => {
+    const t = new HttpUiTransport();
+    await t.start(fakeCtx("dev"));
+    const result = await t.reply({ channel: "dev", text: "ping" });
+    expect(result.sent).toEqual([]);
+  });
+
+  test("reply() pushes a `reply` event to a connected /ui/events SSE client", async () => {
+    const t = new HttpUiTransport();
+    await t.start(fakeCtx("dev"));
+
+    // Open the UI SSE stream via ingestHttp.
+    const sseReq = new Request("http://x/ui/events?channel=dev");
+    const sseRes = await t.ingestHttp(sseReq, new URL(sseReq.url));
+    expect(sseRes).not.toBeNull();
+    const reader = sseRes!.body!.getReader();
+
+    // Drain the ": connected" comment, then reply.
+    const result = await t.reply({ channel: "dev", text: "from session", files: ["/tmp/a.png"] });
+    expect(result.sent).toHaveLength(1);
+
+    const frame = await readFrame(reader);
+    expect(frame).toContain("event: reply");
+    expect(frame).toContain("from session");
+    expect(frame).toContain("/tmp/a.png");
+    reader.cancel().catch(() => {});
+  });
+
+  test("stop() clears UI clients", async () => {
+    const t = new HttpUiTransport();
+    await t.start(fakeCtx("dev"));
+    const sseReq = new Request("http://x/ui/events?channel=dev");
+    const sseRes = await t.ingestHttp(sseReq, new URL(sseReq.url));
+    sseRes!.body!.getReader();
+    await t.stop();
+    // After stop, a reply reaches nobody.
+    const result = await t.reply({ channel: "dev", text: "x" });
+    expect(result.sent).toEqual([]);
+  });
+});
+
+describe("registry — http-ui", () => {
+  test("an http-ui channel instantiates without a token", () => {
+    const transport = instantiateTransport({ name: "dev", transport: "http-ui" });
+    expect(transport.kind).toBe("http-ui");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Daemon-shaped integration: a Bun.serve harness wiring routing + ingestHttp,
+// mirroring daemon.ts. No Claude.
+// ---------------------------------------------------------------------------
+
+describe("HttpUiTransport — through a daemon-shaped server", () => {
+  /** Build a minimal daemon-shaped server over the given channels. */
+  function buildServer(channelDefs: { name: string }[]) {
+    const registry = new ClientRegistry();
+    const channels = new Map<string, { name: string; transport: HttpUiTransport }>();
+    for (const def of channelDefs) {
+      const transport = new HttpUiTransport();
+      channels.set(def.name, { name: def.name, transport });
+    }
+
+    // Start each transport with a ctx that routes into the bridge registry,
+    // exactly like daemon.ts's contextFor.
+    for (const ch of channels.values()) {
+      const name = ch.name;
+      const ctx: TransportContext = {
+        channel: name,
+        emit(msg) {
+          registry.routeToChannel(name, "message", {
+            content: msg.content,
+            meta: msg.meta,
+            source: msg.source,
+          });
+        },
+        emitPermissionVerdict(v) {
+          registry.routeToChannel(name, "permission_verdict", v);
+        },
+      };
+      ch.transport.start(ctx);
+    }
+
+    const server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      idleTimeout: 0,
+      async fetch(req) {
+        const url = new URL(req.url);
+
+        // Bridge SSE subscription (mirrors daemon /events).
+        if (req.method === "GET" && url.pathname === "/events") {
+          const channel = url.searchParams.get("channel") ?? "default";
+          const id = crypto.randomUUID();
+          const stream = new ReadableStream<string>({
+            start(controller) {
+              registry.add(id, { channel, enqueue: (p) => controller.enqueue(p) });
+              controller.enqueue(": connected\n\n");
+            },
+            cancel() {
+              registry.remove(id);
+            },
+          });
+          return new Response(stream, { headers: { "content-type": "text/event-stream" } });
+        }
+
+        // Bridge reply (mirrors daemon /api/reply dispatch).
+        if (req.method === "POST" && url.pathname === "/api/reply") {
+          const body = (await req.json()) as { channel: string; text?: string };
+          const ch = channels.get(body.channel);
+          if (!ch) return new Response(JSON.stringify({ error: "unknown channel" }), { status: 400 });
+          const r = await ch.transport.reply({ channel: body.channel, text: body.text });
+          return new Response(JSON.stringify({ sent: r.sent }), {
+            headers: { "content-type": "application/json" },
+          });
+        }
+
+        // Transport-owned routes (send + /ui/events).
+        for (const ch of channels.values()) {
+          const res = await ch.transport.ingestHttp(req, url);
+          if (res) return res;
+        }
+        return new Response(JSON.stringify({ error: "not found" }), { status: 404 });
+      },
+    });
+
+    return { server, base: `http://127.0.0.1:${server.port}`, registry };
+  }
+
+  /** Open an SSE stream and return a reader + helpers. */
+  async function openSse(base: string, path: string) {
+    const res = await fetch(`${base}${path}`);
+    const reader = res.body!.getReader();
+    return {
+      read: () => readFrame(reader),
+      cancel: () => reader.cancel().catch(() => {}),
+    };
+  }
+
+  test("inbound routing: UI send reaches the subscribed bridge", async () => {
+    const { server, base, registry } = buildServer([{ name: "dev" }]);
+    try {
+      // A bridge subscribes to channel "dev".
+      const bridge = await openSse(base, "/events?channel=dev");
+      // Wait for registration.
+      const start = Date.now();
+      while (registry.size < 1 && Date.now() - start < 1000) {
+        await new Promise((r) => setTimeout(r, 5));
+      }
+      expect(registry.size).toBe(1);
+
+      // UI POSTs a send.
+      const res = await fetch(`${base}/api/channels/dev/send`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ text: "hi from UI" }),
+      });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ ok: true });
+
+      const frame = await bridge.read();
+      expect(frame).toContain("event: message");
+      expect(frame).toContain("hi from UI");
+      bridge.cancel();
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("round-trip: UI send → bridge AND bridge /api/reply → UI SSE, end to end", async () => {
+    const { server, base, registry } = buildServer([{ name: "dev" }]);
+    try {
+      const bridge = await openSse(base, "/events?channel=dev");
+      const ui = await openSse(base, "/ui/events?channel=dev");
+      const start = Date.now();
+      while (registry.size < 1 && Date.now() - start < 1000) {
+        await new Promise((r) => setTimeout(r, 5));
+      }
+
+      // UI → bridge.
+      await fetch(`${base}/api/channels/dev/send`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ text: "wake up" }),
+      });
+      const bridgeFrame = await bridge.read();
+      expect(bridgeFrame).toContain("wake up");
+
+      // bridge → UI (the session replied via the reply tool).
+      const replyRes = await fetch(`${base}/api/reply`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ channel: "dev", text: "I am awake" }),
+      });
+      expect((await replyRes.json()).sent).toHaveLength(1);
+
+      const uiFrame = await ui.read();
+      expect(uiFrame).toContain("event: reply");
+      expect(uiFrame).toContain("I am awake");
+
+      bridge.cancel();
+      ui.cancel();
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("channel isolation: a send on A does NOT reach a UI client on B", async () => {
+    const { server, base } = buildServer([{ name: "A" }, { name: "B" }]);
+    try {
+      const uiB = await openSse(base, "/ui/events?channel=B");
+
+      // Send on channel A, then reply on A — neither should hit B's UI stream.
+      await fetch(`${base}/api/channels/A/send`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ text: "for-A" }),
+      });
+      await fetch(`${base}/api/reply`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ channel: "A", text: "reply-to-A" }),
+      });
+
+      // Now reply on B so B's stream definitely has a frame, and assert it's B's.
+      await fetch(`${base}/api/reply`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ channel: "B", text: "reply-to-B" }),
+      });
+
+      const frame = await uiB.read();
+      expect(frame).toContain("reply-to-B");
+      expect(frame).not.toContain("reply-to-A");
+      expect(frame).not.toContain("for-A");
+      uiB.cancel();
+    } finally {
+      server.stop(true);
+    }
+  });
+});

--- a/src/transports/http-ui.ts
+++ b/src/transports/http-ui.ts
@@ -129,7 +129,8 @@ export class HttpUiTransport implements Transport {
   // -------------------------------------------------------------------------
 
   async ingestHttp(req: Request, url: URL): Promise<Response | null> {
-    const channel = this.channel;
+    const channel = this.channel; // getter throws a clear error if not started
+    const ctx = this.ctx!; // safe: the getter above guarantees ctx is set
 
     // 1. Inbound: POST /api/channels/<channel>/send  body {text}
     if (
@@ -146,7 +147,7 @@ export class HttpUiTransport implements Transport {
       } catch {
         return json({ error: "invalid JSON body" }, 400);
       }
-      this.ctx!.emit({
+      ctx.emit({
         channel,
         content: text,
         meta: { source: "http-ui", ts: new Date().toISOString() },

--- a/src/transports/http-ui.ts
+++ b/src/transports/http-ui.ts
@@ -1,0 +1,195 @@
+/**
+ * http-ui transport for parachute-channel.
+ *
+ * The freestanding "make sure message sending works" surface: a human talks to
+ * a Claude Code session through a browser, with NO Telegram and NO vault.
+ *
+ * How it differs from telegram — the "external party" is a browser:
+ *  - Inbound (human → session): the UI POSTs to
+ *    `/api/channels/<name>/send {text}`; this transport calls `ctx.emit(...)`,
+ *    which routes to the bridge subscribed to that channel and wakes the
+ *    session.
+ *  - Outbound (session → human): when the session calls the `reply` tool, the
+ *    bridge POSTs `/api/reply {channel,...}`; the daemon dispatches to this
+ *    transport's `reply()`. Since the browser can't be POSTed to, this transport
+ *    holds its own set of **UI SSE clients** per channel and `reply()` enqueues
+ *    to them (mirroring the daemon's `/events` SSE pattern for bridges).
+ *
+ * It owns two HTTP surfaces via `ingestHttp` (scoped to ITS OWN channel name):
+ *   1. POST /api/channels/<name>/send   — body {text} → ctx.emit(...) → {ok:true}
+ *   2. GET  /ui/events?channel=<name>    — SSE stream the browser subscribes to
+ * The static `/ui` chat page itself is global and served by the daemon, since
+ * it's a channel picker across all http-ui channels.
+ */
+
+import type {
+  Transport,
+  TransportContext,
+  ReplyArgs,
+  EditArgs,
+  PermissionArgs,
+} from "../transport.ts";
+import { sseFrame } from "../routing.ts";
+
+/** A connected browser SSE client (one per open chat page on this channel). */
+interface UiClient {
+  enqueue(payload: string): void;
+}
+
+/** Config for an http-ui transport instance (no secret needed — just a name). */
+export interface HttpUiTransportConfig {
+  /** Optional override for the channel name; normally taken from ctx.channel. */
+  channel?: string;
+}
+
+export class HttpUiTransport implements Transport {
+  readonly kind = "http-ui";
+
+  /** Captured in start() — the channel this instance is bound to. */
+  private ctx: TransportContext | undefined;
+  /** Connected browser SSE clients for this channel, keyed by client id. */
+  private uiClients = new Map<string, UiClient>();
+
+  constructor(_config: HttpUiTransportConfig = {}) {
+    // http-ui needs no secret. Config is accepted for forward-compat.
+  }
+
+  async start(ctx: TransportContext): Promise<void> {
+    this.ctx = ctx;
+  }
+
+  async stop(): Promise<void> {
+    // Close all browser SSE streams. Enqueue can throw on an already-closed
+    // stream; swallow per-client so one bad client doesn't block the rest.
+    for (const client of this.uiClients.values()) {
+      try {
+        client.enqueue(sseFrame("close", {}));
+      } catch {}
+    }
+    this.uiClients.clear();
+  }
+
+  /** The channel name this transport is bound to (after start). */
+  private get channel(): string {
+    if (!this.ctx) throw new Error("http-ui transport: not started");
+    return this.ctx.channel;
+  }
+
+  /** Push an SSE frame to every connected browser client. Returns delivery count. */
+  private pushToUi(event: string, data: unknown): number {
+    const payload = sseFrame(event, data);
+    let delivered = 0;
+    for (const [id, client] of this.uiClients) {
+      try {
+        client.enqueue(payload);
+        delivered++;
+      } catch {
+        this.uiClients.delete(id);
+      }
+    }
+    return delivered;
+  }
+
+  // -------------------------------------------------------------------------
+  // Outbound — the session → browser direction
+  // -------------------------------------------------------------------------
+
+  async reply(args: ReplyArgs): Promise<{ sent: string[] }> {
+    // The browser can't be POSTed to, so we push the reply over the UI SSE
+    // stream(s). A message with no connected UI client still succeeds — it just
+    // has no listener (return an empty sent list).
+    const id = crypto.randomUUID();
+    const delivered = this.pushToUi("reply", {
+      id,
+      text: args.text ?? "",
+      files: args.files ?? [],
+    });
+    return { sent: delivered > 0 ? [id] : [] };
+  }
+
+  async edit(args: EditArgs): Promise<void> {
+    this.pushToUi("edit", { id: args.message_id, text: args.text });
+  }
+
+  async sendPermission(args: PermissionArgs): Promise<{ sent: string[] }> {
+    // Surface the permission prompt in the chat so the human sees it. There's no
+    // verdict affordance wired in the minimal UI yet (Stage 1), but the prompt
+    // is visible — better than the daemon's methodMissing 400.
+    const delivered = this.pushToUi("permission", {
+      request_id: args.request_id,
+      tool_name: args.tool_name,
+      description: args.description,
+      input_preview: args.input_preview,
+    });
+    return { sent: delivered > 0 ? [args.request_id] : [] };
+  }
+
+  // -------------------------------------------------------------------------
+  // HTTP routes this transport owns (only for ITS OWN channel name)
+  // -------------------------------------------------------------------------
+
+  async ingestHttp(req: Request, url: URL): Promise<Response | null> {
+    const channel = this.channel;
+
+    // 1. Inbound: POST /api/channels/<channel>/send  body {text}
+    if (
+      req.method === "POST" &&
+      url.pathname === `/api/channels/${channel}/send`
+    ) {
+      let text: string;
+      try {
+        const body = (await req.json()) as { text?: unknown };
+        if (typeof body.text !== "string" || body.text.length === 0) {
+          return json({ error: "body must be { text: <non-empty string> }" }, 400);
+        }
+        text = body.text;
+      } catch {
+        return json({ error: "invalid JSON body" }, 400);
+      }
+      this.ctx!.emit({
+        channel,
+        content: text,
+        meta: { source: "http-ui", ts: new Date().toISOString() },
+        source: "http-ui",
+      });
+      return json({ ok: true });
+    }
+
+    // 2. Outbound stream: GET /ui/events?channel=<channel>
+    if (
+      req.method === "GET" &&
+      url.pathname === "/ui/events" &&
+      url.searchParams.get("channel") === channel
+    ) {
+      const clientId = crypto.randomUUID();
+      const clients = this.uiClients;
+      const stream = new ReadableStream<string>({
+        start(controller) {
+          clients.set(clientId, {
+            enqueue: (payload) => controller.enqueue(payload),
+          });
+          controller.enqueue(": connected\n\n");
+        },
+        cancel() {
+          clients.delete(clientId);
+        },
+      });
+      return new Response(stream, {
+        headers: {
+          "content-type": "text/event-stream",
+          "cache-control": "no-cache",
+          connection: "keep-alive",
+        },
+      });
+    }
+
+    return null;
+  }
+}
+
+function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}


### PR DESCRIPTION
## PR 1.2 of the channel-fabric arc

Adds the first non-Telegram transport and the headline test infrastructure. With this, a human can talk to a Claude Code session through the channel with **no Telegram and no vault** — the freestanding "make sure messaging works" surface.

### What's in it
- **`http-ui` transport** (`src/transports/http-ui.ts`) — inbound via `POST /api/channels/<name>/send`; outbound pushed to the browser over per-channel UI SSE (`/ui/events?channel=<name>`). Daemon gained an optional `Transport.ingestHttp` so transports contribute routes without owning `Bun.serve` (Telegram untouched).
- **Built-in chat UI** (`GET /ui`, daemon-served) — vanilla single-file: channel picker + transcript + composer.
- **Transport-neutral bridge tools** — `reply` no longer requires a Telegram `chat_id` (the gap that blocked http-ui replies; addressing fields are now optional, included only when the inbound carried them). `react`/`edit` descriptions de-Telegram'd. `download` left Telegram-specific (`file_id`) as a noted follow-up.
- **Tier 2 LLM-run e2e harness** (`e2e/llm/`) — boots the daemon + a **real interactive Claude session in tmux**, sends a message through the channel, and verifies the reply **deterministically** (positive control that the bridge connected + sentinel echo + expected content) **and via an LLM judge**. Realizes the Tier 2 the hub e2e README deferred. `bun run test:e2e`.

### Testing
- `bun run typecheck`: clean.
- `bun test src/`: **45 pass / 0 fail** (4 files) — http-ui routing isolation, UI round-trip, registry, plus the existing telegram/routing suites.
- `bun run test:e2e`: **PASS** — real session woke on the channel message and replied through it; deterministic checks + LLM judge both green.

### Notes
- Loopback-only, no auth in Stage 1 (per plan Decision 3; hub-JWT when exposed).
- Stage 0 (idle-wake) + this e2e both confirm the `notifications/claude/channel` wake mechanism on Claude Code 2.1.166.

🤖 Generated with [Claude Code](https://claude.com/claude-code)