### PR TITLE
feat(channel): Layer 1 auth — hub-issued JWTs on the session↔channel connection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,8 @@ SSE takes a `?token=` query param since EventSource can't set headers).
 | `PARACHUTE_CHANNEL_PORT` | `1941` | Daemon HTTP port |
 | `PARACHUTE_CHANNEL_URL` | `http://127.0.0.1:1941` | Bridge → daemon URL |
 | `PARACHUTE_CHANNEL_STATE_DIR` | `~/.parachute/channel` | Token, access config, inbox |
+| `PARACHUTE_HUB_ORIGIN` | `http://127.0.0.1:1939` | **Daemon:** hub's public origin for JWT `iss` validation. Required on an exposed deployment (the loopback default is dev-only); hub-as-supervisor sets it. |
+| `PARACHUTE_CHANNEL_TOKEN` | (none) | **Bridge:** hub-issued channel JWT presented as Bearer. The launcher mints + injects it; unset = no auth header (dev only). Default mint TTL is the hub's non-ephemeral default (~90d); re-launch re-mints. |
 
 ## State directory
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,8 +93,26 @@ Channel self-registers into `~/.parachute/services.json` at boot and ships
 `.parachute/module.json`, so hub lists it in the portal and reverse-proxies
 `<expose>/channel/*` → the loopback daemon (`stripPrefix:true`; SSE survives the proxy).
 The built-in chat UI is reachable at `<hub-origin>/channel/ui` over the expose, and at
-`http://127.0.0.1:1941/ui` locally. **Note:** the UI is currently unauthenticated
-(loopback / trusted-network only) — hub-scoped JWT auth is the next priority.
+`http://127.0.0.1:1941/ui` locally.
+
+## Auth
+
+**Layer 1 — session↔channel (done).** The bridge-facing daemon endpoints (`GET /events`,
+`POST /api/{reply,react,edit,permission,download}`) require a hub-issued JWT (`aud: channel`,
+scope `channel:read`/`channel:write`), validated via `@openparachute/scope-guard` against the
+hub's JWKS — exactly like a vault MCP client. The launcher mints the token
+(`parachute auth mint-token --scope "channel:read channel:write"`) and injects it as
+`PARACHUTE_CHANNEL_TOKEN`; the bridge presents it as a Bearer. Any session on any machine
+connects this way — no loopback trust.
+
+The daemon **must** have `PARACHUTE_HUB_ORIGIN` set to the hub's *public* origin (the hub stamps
+that as the token `iss`); the loopback fallback is dev-only. Hub-as-supervisor sets this when it
+starts the module; a manually-run daemon on an exposed box needs it in the environment.
+
+**Layer 2 — human↔UI (next).** The UI-facing endpoints (`/ui`, `/.parachute/config`,
+`/api/channels/<name>/send`, `/ui/events`) are still open. They'll authenticate the
+hub-management way (like scribe config — hub mints a short-lived token from the portal session;
+SSE takes a `?token=` query param since EventSource can't set headers).
 
 ## Environment variables
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "parachute-channel",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
+        "@openparachute/scope-guard": "^0.4.0",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -19,6 +20,8 @@
     "@hono/node-server": ["@hono/node-server@1.19.13", "", { "peerDependencies": { "hono": "^4" } }, "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
+    "@openparachute/scope-guard": ["@openparachute/scope-guard@0.4.0", "", { "dependencies": { "jose": "^6.2.2" }, "peerDependencies": { "typescript": "^5" } }, "sha512-Atzc2TcEAdZvOK+BBN7iNEYzllO3svn63Rmn5+ZnJZkRo2jBWfent9J6nazS/uVrvoP6eGj2F1kuHKe93JkwsQ=="],
 
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.0.0"
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "@openparachute/scope-guard": "^0.4.0"
   },
   "peerDependencies": {
     "typescript": "^5"

--- a/scripts/launch-session.sh
+++ b/scripts/launch-session.sh
@@ -60,8 +60,41 @@ fi
 
 mkdir -p "$WORKDIR"
 
-# Bridge MCP config — the session's only wiring to the channel.
-cat > "$WORKDIR/.mcp.json" <<EOF
+# Mint a hub-issued JWT so the session authenticates to the channel daemon
+# (aud: "channel", scopes channel:read + channel:write). The daemon validates it
+# against the hub's JWKS — the bridge connection is authenticated like a vault
+# MCP client, NOT trusted by loopback. If minting fails (no hub running, or not
+# logged in), warn but continue: a dev daemon may be running unguarded, in which
+# case it accepts an unauthenticated bridge.
+TOKEN="$(parachute auth mint-token --scope "channel:read channel:write" 2>/dev/null || true)"
+if [ -z "$TOKEN" ]; then
+  echo "warning: could not mint a channel token (parachute auth mint-token failed)." >&2
+  echo "         the session will connect WITHOUT auth — fine for an unguarded dev daemon," >&2
+  echo "         but an auth-enabled daemon will reject it (HTTP 401). Ensure the hub is" >&2
+  echo "         running and you're logged in (parachute login) to authenticate the session." >&2
+fi
+
+# Bridge MCP config — the session's only wiring to the channel. The token, when
+# present, is injected into the env block so the bridge presents it on every
+# daemon request.
+if [ -n "$TOKEN" ]; then
+  cat > "$WORKDIR/.mcp.json" <<EOF
+{
+  "mcpServers": {
+    "parachute-channel": {
+      "command": "bun",
+      "args": ["$BRIDGE"],
+      "env": {
+        "PARACHUTE_CHANNEL_URL": "$DAEMON_URL",
+        "PARACHUTE_CHANNEL_NAME": "$CHANNEL",
+        "PARACHUTE_CHANNEL_TOKEN": "$TOKEN"
+      }
+    }
+  }
+}
+EOF
+else
+  cat > "$WORKDIR/.mcp.json" <<EOF
 {
   "mcpServers": {
     "parachute-channel": {
@@ -75,6 +108,7 @@ cat > "$WORKDIR/.mcp.json" <<EOF
   }
 }
 EOF
+fi
 
 # Reinforce the channel contract so the session always answers via the reply tool.
 cat > "$WORKDIR/CLAUDE.md" <<'EOF'
@@ -123,6 +157,8 @@ for _ in $(seq 1 20); do
 done
 
 echo "✓ session '$SESSION' ready on channel '$CHANNEL'."
+[ -n "$TOKEN" ] && echo "  authenticated with a hub-issued channel token (channel:read + channel:write)." \
+                || echo "  NOT authenticated (no token minted) — only an unguarded dev daemon will accept it."
 [ "$connected" = 1 ] && echo "  bridge connected to the daemon." || echo "  (bridge connection not yet confirmed via /health — usually a moment behind.)"
 echo "  chat:    open the channel UI and pick channel '$CHANNEL'"
 echo "  watch:   tmux attach -t $SESSION   (detach: Ctrl-b then d)"

--- a/scripts/launch-session.sh
+++ b/scripts/launch-session.sh
@@ -109,6 +109,8 @@ else
 }
 EOF
 fi
+# .mcp.json holds the channel token — keep it owner-only.
+chmod 600 "$WORKDIR/.mcp.json"
 
 # Reinforce the channel contract so the session always answers via the reply tool.
 cat > "$WORKDIR/CLAUDE.md" <<'EOF'

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -21,6 +21,18 @@ import { z } from "zod";
 
 const DAEMON_URL = process.env.PARACHUTE_CHANNEL_URL ?? "http://127.0.0.1:1941";
 
+// Hub-issued JWT (aud: "channel", scopes channel:read + channel:write) the
+// session presents to the daemon on every request. Minted by launch-session.sh
+// via `parachute auth mint-token` and passed through .mcp.json. When unset, the
+// bridge sends no Authorization header — back-compat for an unguarded/dev daemon
+// (a daemon with auth on will then 401, surfaced below).
+const TOKEN = process.env.PARACHUTE_CHANNEL_TOKEN;
+
+/** Headers for an outbound daemon request, adding the bearer when a token is set. */
+function daemonHeaders(extra: Record<string, string> = {}): Record<string, string> {
+  return TOKEN ? { ...extra, authorization: `Bearer ${TOKEN}` } : { ...extra };
+}
+
 // The named channel this bridge subscribes to. Defaults to "telegram" for
 // backwards-compat with single-bot installs. The daemon routes inbound on this
 // channel only to bridges subscribed to it, and every outbound tool call below
@@ -76,7 +88,7 @@ mcp.setNotificationHandler(
     try {
       await fetch(`${DAEMON_URL}/api/permission`, {
         method: "POST",
-        headers: { "content-type": "application/json" },
+        headers: daemonHeaders({ "content-type": "application/json" }),
         body: JSON.stringify({ channel: CHANNEL, ...params }),
       });
     } catch (err) {
@@ -163,7 +175,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
     case "reply": {
       const res = await fetch(`${DAEMON_URL}/api/reply`, {
         method: "POST",
-        headers: { "content-type": "application/json" },
+        headers: daemonHeaders({ "content-type": "application/json" }),
         body: JSON.stringify(body),
       });
       if (!res.ok) {
@@ -179,7 +191,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
     case "react": {
       const res = await fetch(`${DAEMON_URL}/api/react`, {
         method: "POST",
-        headers: { "content-type": "application/json" },
+        headers: daemonHeaders({ "content-type": "application/json" }),
         body: JSON.stringify(body),
       });
       if (!res.ok) {
@@ -192,7 +204,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
     case "edit_message": {
       const res = await fetch(`${DAEMON_URL}/api/edit`, {
         method: "POST",
-        headers: { "content-type": "application/json" },
+        headers: daemonHeaders({ "content-type": "application/json" }),
         body: JSON.stringify(body),
       });
       if (!res.ok) {
@@ -205,7 +217,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
     case "download_attachment": {
       const res = await fetch(`${DAEMON_URL}/api/download`, {
         method: "POST",
-        headers: { "content-type": "application/json" },
+        headers: daemonHeaders({ "content-type": "application/json" }),
         body: JSON.stringify(body),
       });
       if (!res.ok) {
@@ -228,7 +240,23 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
 async function connectToEvents(): Promise<void> {
   while (true) {
     try {
-      const res = await fetch(`${DAEMON_URL}/events?channel=${encodeURIComponent(CHANNEL)}`);
+      const res = await fetch(`${DAEMON_URL}/events?channel=${encodeURIComponent(CHANNEL)}`, {
+        headers: daemonHeaders(),
+      });
+      if (res.status === 401 || res.status === 403) {
+        // The daemon has auth on and rejected our token (or we sent none).
+        // Surface the operator-facing cause clearly before the reconnect loop
+        // retries — otherwise this looks like a generic connectivity failure.
+        process.stderr.write(
+          `parachute-channel bridge: daemon rejected the channel connection (HTTP ${res.status}). ` +
+            (TOKEN
+              ? "The PARACHUTE_CHANNEL_TOKEN is invalid/expired or lacks channel:read — re-mint it " +
+                "(parachute auth mint-token --scope \"channel:read channel:write\") and relaunch the session.\n"
+              : "No PARACHUTE_CHANNEL_TOKEN was provided but the daemon requires one — relaunch the " +
+                "session via launch-session.sh so it mints + passes a hub token.\n"),
+        );
+        throw new Error(`SSE connect rejected: ${res.status}`);
+      }
       if (!res.ok || !res.body) {
         throw new Error(`SSE connect failed: ${res.status}`);
       }

--- a/src/daemon.test.ts
+++ b/src/daemon.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Daemon auth-gate tests (Layer 1, bridge-facing).
+ *
+ * Spins the real daemon fetch handler (`createFetchHandler`) on an ephemeral
+ * `Bun.serve` with one http-ui channel, and asserts the bridge-facing endpoints
+ * reject a request with no Authorization header (401) while the UI-facing /
+ * discovery endpoints stay open (200).
+ *
+ * Crucially this needs NO live hub / JWKS: the no-token path in `requireScope`
+ * short-circuits before any JWKS fetch. We deliberately do NOT mint or validate
+ * a real JWT here — that's scope-guard's own tested surface. What we own is the
+ * routing layer: which endpoints are guarded, which are exempt, and that the
+ * no-token reject is wired in front of the guarded handlers.
+ */
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { createFetchHandler } from "./daemon.ts";
+import { ClientRegistry } from "./routing.ts";
+import { HttpUiTransport } from "./transports/http-ui.ts";
+import type { Channel } from "./registry.ts";
+
+let server: ReturnType<typeof Bun.serve>;
+let base: string;
+
+beforeAll(async () => {
+  const registry = new ClientRegistry();
+  const transport = new HttpUiTransport({ channel: "ui1" });
+  const channels = new Map<string, Channel>([
+    ["ui1", { name: "ui1", transport, entry: { name: "ui1", transport: "http-ui" } }],
+  ]);
+  // Wire the transport's ctx so its ingestHttp routes (open) work.
+  await transport.start({
+    channel: "ui1",
+    emit: () => {},
+    emitPermissionVerdict: () => {},
+  });
+
+  server = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    idleTimeout: 0,
+    fetch: createFetchHandler(channels, registry),
+  });
+  base = `http://127.0.0.1:${server.port}`;
+});
+
+afterAll(() => {
+  server.stop(true);
+});
+
+describe("bridge-facing endpoints require a bearer token (401 with none)", () => {
+  test("GET /events with no Authorization → 401", async () => {
+    const res = await fetch(`${base}/events?channel=ui1`);
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("unauthorized");
+    // Make sure the SSE stream did NOT open — a 401 must short-circuit.
+    expect(res.headers.get("content-type")).toContain("application/json");
+  });
+
+  test("POST /api/reply with no Authorization → 401", async () => {
+    const res = await fetch(`${base}/api/reply`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ channel: "ui1", text: "hi" }),
+    });
+    expect(res.status).toBe(401);
+    expect(((await res.json()) as { error: string }).error).toBe("unauthorized");
+  });
+
+  test("POST /api/react with no Authorization → 401", async () => {
+    const res = await fetch(`${base}/api/react`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ channel: "ui1", message_id: "1", emoji: "👍" }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test("POST /api/edit with no Authorization → 401", async () => {
+    const res = await fetch(`${base}/api/edit`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ channel: "ui1", message_id: "1", text: "x" }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test("POST /api/permission with no Authorization → 401", async () => {
+    const res = await fetch(`${base}/api/permission`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        channel: "ui1",
+        request_id: "r1",
+        tool_name: "Bash",
+        description: "",
+        input_preview: "",
+      }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test("POST /api/download with no Authorization → 401", async () => {
+    const res = await fetch(`${base}/api/download`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ channel: "ui1", file_id: "f1" }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test("an invalid bearer is also rejected (401, no JWKS needed for a non-JWT)", async () => {
+    // A non-JWT bearer can't reach the JWKS — looksLikeJwt is false so the lib
+    // rejects shape-first. Still no network.
+    const res = await fetch(`${base}/api/reply`, {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: "Bearer not-a-jwt" },
+      body: JSON.stringify({ channel: "ui1", text: "hi" }),
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("UI-facing + discovery endpoints stay open (no token, 200)", () => {
+  test("GET /health → 200", async () => {
+    const res = await fetch(`${base}/health`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { status: string };
+    expect(body.status).toBe("ok");
+  });
+
+  test("GET /.parachute/config → 200", async () => {
+    const res = await fetch(`${base}/.parachute/config`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { channels: unknown[] };
+    expect(Array.isArray(body.channels)).toBe(true);
+  });
+
+  test("GET /.parachute/config/schema → 200", async () => {
+    const res = await fetch(`${base}/.parachute/config/schema`);
+    expect(res.status).toBe(200);
+  });
+
+  test("GET /ui → 200 (html)", async () => {
+    const res = await fetch(`${base}/ui`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+  });
+
+  test("POST /api/channels/ui1/send (http-ui ingestHttp) → open, not 401", async () => {
+    const res = await fetch(`${base}/api/channels/ui1/send`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ text: "from-ui" }),
+    });
+    // Open route (UI-facing) — must NOT be gated. Accept any non-401/403.
+    expect(res.status).not.toBe(401);
+    expect(res.status).not.toBe(403);
+  });
+});

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -31,6 +31,8 @@ import type {
 import { ChannelConfigError } from "./transport.ts";
 import { loadRegistry, defaultStateDir, type Channel } from "./registry.ts";
 import { ClientRegistry } from "./routing.ts";
+import { validateHubJwt, HubJwtError } from "./hub-jwt.ts";
+import { extractBearer } from "@openparachute/scope-guard";
 
 // ---------------------------------------------------------------------------
 // Config
@@ -60,34 +62,12 @@ const PKG_VERSION = ((): string => {
 })();
 const INSTALL_DIR = join(import.meta.dir, "..");
 
-mkdirSync(STATE_DIR, { recursive: true });
-mkdirSync(INBOX_DIR, { recursive: true });
-
 // ---------------------------------------------------------------------------
 // Registry + routing
 // ---------------------------------------------------------------------------
 
-let channels: Map<string, Channel>;
-try {
-  channels = loadRegistry({ stateDir: STATE_DIR });
-} catch (err) {
-  console.error(`parachute-channel: failed to load channel registry: ${err}`);
-  process.exit(1);
-}
-
-if (channels.size === 0) {
-  console.error(
-    `parachute-channel: no channels configured.\n` +
-      `  Add ${join(STATE_DIR, "channels.json")} or set TELEGRAM_BOT_TOKEN\n` +
-      `  (env or ${join(STATE_DIR, ".env")}) for a default telegram channel.`,
-  );
-  process.exit(1);
-}
-
-const registry = new ClientRegistry();
-
 /** Build the per-channel context a transport routes through. */
-function contextFor(channel: string): TransportContext {
+function contextFor(registry: ClientRegistry, channel: string): TransportContext {
   return {
     channel,
     emit(msg: InboundMessage): void {
@@ -367,18 +347,94 @@ function json(data: unknown, status = 200): Response {
   });
 }
 
-/** Resolve the transport for a channel from a request body, or null on miss. */
-function transportFor(channel: string | undefined): Transport | null {
-  if (!channel) return null;
-  return channels.get(channel)?.transport ?? null;
+// ---------------------------------------------------------------------------
+// Bridge-facing auth (Layer 1)
+//
+// The session↔channel connection (the bridge) is authenticated with hub-issued
+// JWTs, exactly like a vault MCP client. A launched session has full machine
+// access, so we do NOT rely on loopback trust — any session on any machine
+// presents a hub token (`aud: "channel"`, scopes `channel:read`/`channel:write`)
+// and the daemon validates it against the hub's JWKS via scope-guard.
+//
+// Scope split: subscribing to inbound events is `channel:read`; sending
+// anything out (reply/react/edit/permission/download) is `channel:write`.
+//
+// UI-facing + discovery routes (/health, /.parachute/config[/schema], /ui, and
+// the http-ui transport's ingestHttp send/SSE routes) are deliberately left
+// OPEN here — UI auth is a separate, later PR.
+// ---------------------------------------------------------------------------
+
+export const SCOPE_READ = "channel:read" as const;
+export const SCOPE_WRITE = "channel:write" as const;
+
+/**
+ * Guard a bridge-facing endpoint on a hub-issued JWT carrying `scope`.
+ * Returns `null` when the request is authorized (caller proceeds), or a
+ * `Response` (401/403) the caller must return as-is.
+ *
+ * The no-token path short-circuits before any JWKS fetch, so it's unit-testable
+ * without a live hub. Real signature/issuer/audience validation is scope-guard's
+ * own tested surface.
+ */
+export async function requireScope(req: Request, scope: string): Promise<Response | null> {
+  const token = extractBearer(req.headers.get("authorization"));
+  if (!token) {
+    return json({ error: "unauthorized", message: "Bearer token required" }, 401);
+  }
+  try {
+    const claims = await validateHubJwt(token);
+    if (!claims.scopes.includes(scope)) {
+      return json(
+        { error: "insufficient_scope", message: `requires ${scope}`, granted: claims.scopes },
+        403,
+      );
+    }
+    return null;
+  } catch (err) {
+    return json(
+      { error: "unauthorized", message: err instanceof HubJwtError ? err.message : "invalid token" },
+      401,
+    );
+  }
 }
 
-const server = Bun.serve({
-  port: PORT,
-  hostname: "127.0.0.1",
-  idleTimeout: 0,
+/**
+ * Build the daemon's HTTP fetch handler over a channel registry + client
+ * registry. Extracted as a factory so tests can exercise routing + the auth
+ * gate on an ephemeral `Bun.serve` without booting the real daemon (and without
+ * a live hub — the no-token 401 path short-circuits before JWKS).
+ */
+export function createFetchHandler(
+  channels: Map<string, Channel>,
+  registry: ClientRegistry,
+): (req: Request) => Promise<Response> {
+  /** Resolve the transport for a channel name, or null on miss. */
+  function transportFor(channel: string | undefined): Transport | null {
+    if (!channel) return null;
+    return channels.get(channel)?.transport ?? null;
+  }
 
-  async fetch(req) {
+  function channelError(channel: string | undefined): Response {
+    if (!channel) {
+      return json({ error: "missing 'channel' field in request body" }, 400);
+    }
+    return json(
+      {
+        error: `unknown channel "${channel}" — known channels: ${[...channels.keys()].join(", ") || "(none)"}`,
+      },
+      400,
+    );
+  }
+
+  function methodMissing(channel: string, method: string): Response {
+    const kind = channels.get(channel)?.transport.kind ?? "unknown";
+    return json(
+      { error: `transport "${kind}" for channel "${channel}" does not support ${method}` },
+      400,
+    );
+  }
+
+  return async function fetch(req) {
     const url = new URL(req.url);
 
     // Health check — per-channel client counts.
@@ -434,8 +490,11 @@ const server = Bun.serve({
       });
     }
 
-    // SSE event stream — bridges subscribe by channel.
+    // SSE event stream — bridges subscribe by channel. Bridge-facing: requires
+    // a hub JWT with `channel:read`.
     if (req.method === "GET" && url.pathname === "/events") {
+      const denied = await requireScope(req, SCOPE_READ);
+      if (denied) return denied;
       let channel = url.searchParams.get("channel") ?? undefined;
       if (!channel) {
         channel = DEFAULT_CHANNEL;
@@ -467,8 +526,10 @@ const server = Bun.serve({
       });
     }
 
-    // Reply
+    // Reply — bridge-facing: requires `channel:write`.
     if (req.method === "POST" && url.pathname === "/api/reply") {
+      const denied = await requireScope(req, SCOPE_WRITE);
+      if (denied) return denied;
       try {
         const body = (await req.json()) as {
           channel?: string;
@@ -487,8 +548,10 @@ const server = Bun.serve({
       }
     }
 
-    // React
+    // React — bridge-facing: requires `channel:write`.
     if (req.method === "POST" && url.pathname === "/api/react") {
+      const denied = await requireScope(req, SCOPE_WRITE);
+      if (denied) return denied;
       try {
         const body = (await req.json()) as {
           channel?: string;
@@ -513,8 +576,10 @@ const server = Bun.serve({
       }
     }
 
-    // Edit message
+    // Edit message — bridge-facing: requires `channel:write`.
     if (req.method === "POST" && url.pathname === "/api/edit") {
+      const denied = await requireScope(req, SCOPE_WRITE);
+      if (denied) return denied;
       try {
         const body = (await req.json()) as {
           channel?: string;
@@ -540,7 +605,10 @@ const server = Bun.serve({
     }
 
     // Permission prompt — bridge forwards permission_request here.
+    // Bridge-facing: requires `channel:write`.
     if (req.method === "POST" && url.pathname === "/api/permission") {
+      const denied = await requireScope(req, SCOPE_WRITE);
+      if (denied) return denied;
       try {
         const body = (await req.json()) as {
           channel?: string;
@@ -566,8 +634,10 @@ const server = Bun.serve({
       }
     }
 
-    // Download attachment
+    // Download attachment — bridge-facing: requires `channel:write`.
     if (req.method === "POST" && url.pathname === "/api/download") {
+      const denied = await requireScope(req, SCOPE_WRITE);
+      if (denied) return denied;
       try {
         const body = (await req.json()) as { channel?: string; file_id: string };
         const transport = transportFor(body.channel);
@@ -599,11 +669,11 @@ const server = Bun.serve({
     }
 
     return json({ error: "not found" }, 404);
-  },
-});
+  };
+}
 
 // ---------------------------------------------------------------------------
-// Request helpers
+// Request helpers (module-scope; hoisted, referenced from inside the factory)
 // ---------------------------------------------------------------------------
 
 /**
@@ -613,26 +683,6 @@ const server = Bun.serve({
 function errResponse(err: unknown): Response {
   if (err instanceof ChannelConfigError) return json({ error: err.message }, 400);
   return json({ error: String(err) }, 500);
-}
-
-function channelError(channel: string | undefined): Response {
-  if (!channel) {
-    return json({ error: "missing 'channel' field in request body" }, 400);
-  }
-  return json(
-    {
-      error: `unknown channel "${channel}" — known channels: ${[...channels.keys()].join(", ") || "(none)"}`,
-    },
-    400,
-  );
-}
-
-function methodMissing(channel: string, method: string): Response {
-  const kind = channels.get(channel)?.transport.kind ?? "unknown";
-  return json(
-    { error: `transport "${kind}" for channel "${channel}" does not support ${method}` },
-    400,
-  );
 }
 
 /**
@@ -664,50 +714,87 @@ function toReplyArgs(body: {
 }
 
 // ---------------------------------------------------------------------------
-// Startup — start every transport
+// Boot — load the registry, bind Bun.serve, start every transport.
+//
+// Gated on `import.meta.main` so importing this module (e.g. from a test that
+// only wants `createFetchHandler` / `requireScope`) does NOT load the registry,
+// bind a port, or `process.exit` on a missing config.
 // ---------------------------------------------------------------------------
 
-console.log(`parachute-channel: daemon listening on http://127.0.0.1:${PORT}`);
-console.log(`parachute-channel: state dir: ${STATE_DIR}`);
-console.log(
-  `parachute-channel: ${channels.size} channel(s): ${[...channels.values()]
-    .map((c) => `${c.name}→${c.transport.kind}`)
-    .join(", ")}`,
-);
+function main(): void {
+  mkdirSync(STATE_DIR, { recursive: true });
+  mkdirSync(INBOX_DIR, { recursive: true });
 
-// Self-register into ~/.parachute/services.json so hub lists this module in the
-// portal and reverse-proxies `<expose>/channel/*` → this loopback daemon.
-// Best-effort: a failure must not stop the daemon from serving locally. Honors
-// PARACHUTE_HOME, so sandboxed/e2e daemons never touch the real services.json.
-try {
-  upsertService({
-    name: "parachute-channel",
+  let channels: Map<string, Channel>;
+  try {
+    channels = loadRegistry({ stateDir: STATE_DIR });
+  } catch (err) {
+    console.error(`parachute-channel: failed to load channel registry: ${err}`);
+    process.exit(1);
+  }
+
+  if (channels.size === 0) {
+    console.error(
+      `parachute-channel: no channels configured.\n` +
+        `  Add ${join(STATE_DIR, "channels.json")} or set TELEGRAM_BOT_TOKEN\n` +
+        `  (env or ${join(STATE_DIR, ".env")}) for a default telegram channel.`,
+    );
+    process.exit(1);
+  }
+
+  const registry = new ClientRegistry();
+
+  const server = Bun.serve({
     port: PORT,
-    paths: ["/channel"],
-    health: "/health",
-    version: PKG_VERSION,
-    displayName: "Channel",
-    tagline: "Chat with your Claude Code sessions — a channel per session.",
-    installDir: INSTALL_DIR,
-    stripPrefix: true,
-    uiUrl: "/channel/ui", // portal "Open UI" link (also in module.json; written here in case hub reads it from services.json)
+    hostname: "127.0.0.1",
+    idleTimeout: 0,
+    fetch: createFetchHandler(channels, registry),
   });
-  console.log(`parachute-channel: self-registered into services.json (port ${PORT}, mount /channel)`);
-} catch (err) {
-  console.error(`parachute-channel: services.json self-registration failed (continuing): ${err}`);
+
+  console.log(`parachute-channel: daemon listening on http://127.0.0.1:${PORT}`);
+  console.log(`parachute-channel: state dir: ${STATE_DIR}`);
+  console.log(
+    `parachute-channel: ${channels.size} channel(s): ${[...channels.values()]
+      .map((c) => `${c.name}→${c.transport.kind}`)
+      .join(", ")}`,
+  );
+
+  // Self-register into ~/.parachute/services.json so hub lists this module in the
+  // portal and reverse-proxies `<expose>/channel/*` → this loopback daemon.
+  // Best-effort: a failure must not stop the daemon from serving locally. Honors
+  // PARACHUTE_HOME, so sandboxed/e2e daemons never touch the real services.json.
+  try {
+    upsertService({
+      name: "parachute-channel",
+      port: PORT,
+      paths: ["/channel"],
+      health: "/health",
+      version: PKG_VERSION,
+      displayName: "Channel",
+      tagline: "Chat with your Claude Code sessions — a channel per session.",
+      installDir: INSTALL_DIR,
+      stripPrefix: true,
+      uiUrl: "/channel/ui", // portal "Open UI" link (also in module.json; written here in case hub reads it from services.json)
+    });
+    console.log(`parachute-channel: self-registered into services.json (port ${PORT}, mount /channel)`);
+  } catch (err) {
+    console.error(`parachute-channel: services.json self-registration failed (continuing): ${err}`);
+  }
+
+  for (const channel of channels.values()) {
+    channel.transport.start(contextFor(registry, channel.name)).catch((err) => {
+      console.error(`parachute-channel: transport "${channel.name}" start failed:`, err);
+    });
+  }
+
+  // Graceful shutdown — stop all transports.
+  async function shutdown(): Promise<void> {
+    await Promise.allSettled([...channels.values()].map((c) => c.transport.stop()));
+    server.stop();
+    process.exit(0);
+  }
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
 }
 
-for (const channel of channels.values()) {
-  channel.transport.start(contextFor(channel.name)).catch((err) => {
-    console.error(`parachute-channel: transport "${channel.name}" start failed:`, err);
-  });
-}
-
-// Graceful shutdown — stop all transports.
-async function shutdown(): Promise<void> {
-  await Promise.allSettled([...channels.values()].map((c) => c.transport.stop()));
-  server.stop();
-  process.exit(0);
-}
-process.on("SIGINT", shutdown);
-process.on("SIGTERM", shutdown);
+if (import.meta.main) main();

--- a/src/hub-jwt.test.ts
+++ b/src/hub-jwt.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Tests for the channel-side hub-JWT adapter. These exercise the parts that
+ * DON'T need a live hub / JWKS endpoint: hub-origin resolution (env precedence +
+ * loopback fallback), the audience constant, and the re-exported pure helpers
+ * (`looksLikeJwt`). Real signature/issuer/audience validation is scope-guard's
+ * own tested surface — we don't re-test it here and we never need a real JWKS.
+ */
+import { describe, test, expect, afterEach } from "bun:test";
+import {
+  getHubOrigin,
+  CHANNEL_AUDIENCE,
+  looksLikeJwt,
+  HubJwtError,
+} from "./hub-jwt.ts";
+
+const savedOrigin = process.env.PARACHUTE_HUB_ORIGIN;
+
+afterEach(() => {
+  if (savedOrigin === undefined) delete process.env.PARACHUTE_HUB_ORIGIN;
+  else process.env.PARACHUTE_HUB_ORIGIN = savedOrigin;
+});
+
+describe("getHubOrigin", () => {
+  test("falls back to loopback when PARACHUTE_HUB_ORIGIN is unset", () => {
+    delete process.env.PARACHUTE_HUB_ORIGIN;
+    expect(getHubOrigin()).toBe("http://127.0.0.1:1939");
+  });
+
+  test("falls back to loopback when PARACHUTE_HUB_ORIGIN is empty", () => {
+    process.env.PARACHUTE_HUB_ORIGIN = "";
+    expect(getHubOrigin()).toBe("http://127.0.0.1:1939");
+  });
+
+  test("uses the env value when set", () => {
+    process.env.PARACHUTE_HUB_ORIGIN = "https://hub.example.com";
+    expect(getHubOrigin()).toBe("https://hub.example.com");
+  });
+
+  test("strips a single trailing slash for a canonical form", () => {
+    process.env.PARACHUTE_HUB_ORIGIN = "https://hub.example.com/";
+    expect(getHubOrigin()).toBe("https://hub.example.com");
+  });
+});
+
+describe("CHANNEL_AUDIENCE", () => {
+  test("is the literal 'channel' (what the hub mints aud as)", () => {
+    expect(CHANNEL_AUDIENCE).toBe("channel");
+  });
+});
+
+describe("re-exported helpers", () => {
+  test("looksLikeJwt recognizes the eyJ prefix", () => {
+    expect(looksLikeJwt("eyJhbGciOiJSUzI1NiJ9.payload.sig")).toBe(true);
+    expect(looksLikeJwt("opaque-shared-secret")).toBe(false);
+  });
+
+  test("HubJwtError is the scope-guard error class", () => {
+    const err = new HubJwtError("issuer", "bad iss");
+    expect(err).toBeInstanceOf(Error);
+    expect(err.code).toBe("issuer");
+  });
+});

--- a/src/hub-jwt.ts
+++ b/src/hub-jwt.ts
@@ -1,0 +1,88 @@
+/**
+ * Hub-issued JWT validation. parachute-channel as a resource server: it trusts
+ * tokens the hub signs against keys fetched from the hub's
+ * `/.well-known/jwks.json`.
+ *
+ * The trust kernel — JWKS fetch + verify, issuer pin, RFC 7519 string-or-array
+ * `aud` handling, revocation — lives in the shared `@openparachute/scope-guard`
+ * library so vault, scribe, and channel can't silently drift on the worst place
+ * to drift. This file is the channel-side adapter: hub-origin resolution
+ * (env-var precedence + loopback fallback), a process-wide guard instance, and
+ * re-exports preserving the surface the daemon imports.
+ *
+ * Audience pin: channel tokens carry `aud: "channel"`. We pass
+ * `expectedAudience: "channel"` so a token minted for some other resource
+ * (e.g. a vault) can't be replayed against the channel even if it happens to
+ * carry channel-shaped scopes. The hub mints `iss: <hub public origin>`, so
+ * `PARACHUTE_HUB_ORIGIN` MUST be set to the hub's *public* origin for `iss`
+ * validation to succeed on an exposed deployment — the loopback fallback is for
+ * a co-located, never-exposed dev daemon only.
+ */
+import {
+  createScopeGuard,
+  HubJwtError,
+  type HubJwtClaims,
+  looksLikeJwt,
+} from "@openparachute/scope-guard";
+
+const DEFAULT_HUB_LOOPBACK = "http://127.0.0.1:1939";
+
+/** The audience channel tokens are minted with; strict-checked on every validate. */
+export const CHANNEL_AUDIENCE = "channel" as const;
+
+/**
+ * Resolve the hub origin used to fetch JWKS and validate `iss`. Strips a
+ * trailing slash so we get a single canonical form.
+ *
+ * Order: env var → loopback fallback. We deliberately don't read
+ * `~/.parachute/services.json` — the hub is the dispatcher, not a registered
+ * service in that file. If a deployment exposes the hub on a non-default
+ * origin (the normal case once channel is reachable off-box), the env var is
+ * the contract — and it MUST be the hub's public origin, because the hub stamps
+ * that origin as the token `iss`.
+ */
+export function getHubOrigin(): string {
+  const env = process.env.PARACHUTE_HUB_ORIGIN?.replace(/\/$/, "");
+  if (env && env.length > 0) return env;
+  return DEFAULT_HUB_LOOPBACK;
+}
+
+// Process-wide guard. The resolver form lets tests flip `PARACHUTE_HUB_ORIGIN`
+// between cases — the lib re-resolves on every `validateHubJwt` and
+// `resetJwksCache` call so the env-var change picks up without a restart. The
+// JWKS cache (5min/30s defaults) lives inside the guard, shared across requests.
+const guard = createScopeGuard({ hubOrigin: () => getHubOrigin() });
+
+/**
+ * Verify a presented JWT against the hub's JWKS, pinned to `aud: "channel"`.
+ * Throws `HubJwtError` on any failure (bad signature, wrong issuer, wrong
+ * audience, expired, missing kid, JWKS unreachable, revoked). On success
+ * returns the surfaced claims plus the parsed scope list.
+ *
+ * Trust pins: `iss` MUST equal the configured hub origin AND `aud` MUST equal
+ * `"channel"`. Without those, a token signed by any RSA key — or one minted for
+ * another resource — would pass verification.
+ */
+export async function validateHubJwt(token: string): Promise<HubJwtClaims> {
+  return guard.validateHubJwt(token, { expectedAudience: CHANNEL_AUDIENCE });
+}
+
+/**
+ * Reset the cached JWKS getter. Tests use this to switch origins between cases;
+ * production callers shouldn't need it (origin is process-stable).
+ */
+export function resetJwksCache(): void {
+  guard.resetJwksCache();
+}
+
+/**
+ * Reset the cached revocation list. Tests use this to start from a clean
+ * fail-closed state between cases; production callers shouldn't need it (the
+ * cache refreshes itself on TTL expiry).
+ */
+export function resetRevocationCache(): void {
+  guard.resetRevocationCache();
+}
+
+export { HubJwtError, looksLikeJwt };
+export type { HubJwtClaims };


### PR DESCRIPTION
## Authenticate the session↔channel connection like a vault MCP client

Per Aaron: the channel is a hub-fronted authenticated service — any Claude Code session on any machine connects by presenting a hub token, **not** by loopback trust. This is the scariest boundary (a connected session has full machine access), so it lands first; UI auth (Layer 2) follows.

### What's in it
- **`@openparachute/scope-guard`** dependency + **`src/hub-jwt.ts`** (mirrors scribe's adapter): process-wide guard, `validateHubJwt` pinned to `aud: "channel"`, hub-origin from `PARACHUTE_HUB_ORIGIN` → loopback fallback.
- **`daemon.ts`** — `requireScope()` gates the **bridge-facing** endpoints: `GET /events` → `channel:read`; `POST /api/{reply,react,edit,permission,download}` → `channel:write`. Open (Layer 2): `/health`, `/.parachute/config[/schema]`, `/ui`, and the http-ui `ingestHttp` routes. (Boot was refactored behind `import.meta.main` + a `createFetchHandler` factory so the handler is unit-testable — mirrors scribe; real boot path unchanged.)
- **`bridge.ts`** — presents `PARACHUTE_CHANNEL_TOKEN` as a Bearer on the `/events` fetch and every `/api/*` POST (it uses `fetch`, so the header works); clear stderr error on 401/403; no header when unset (dev back-compat).
- **`launch-session.sh`** — mints `parachute auth mint-token --scope "channel:read channel:write"` and injects it; warns + continues if minting fails.

### Tested — unit + live
- `bun run typecheck` clean; `bun test src/` **71 pass / 0 fail** (new `hub-jwt.test.ts` + `daemon.test.ts`; the no-token→401 + exempt-paths→200 routing layer is covered without needing a live JWKS).
- **Live against the running hub (0.6.4):** with `PARACHUTE_HUB_ORIGIN` set to the expose FQDN — unauthed `/api/reply` → **401**, invalid token → **401**, valid hub-minted token → **passes** (real signature + `iss` + `aud:channel` + scope check against the live JWKS); `/health` + `/.parachute/config` stay **200**. The launcher minted+injected a token, the **authed bridge connected**, and a full round-trip succeeded ("8×7?" → "56 ✅") with the session replying over the authed `/api/reply`.

### Note
`PARACHUTE_HUB_ORIGIN` must be the hub's public origin on an exposed box (the hub stamps it as the token `iss`); hub-as-supervisor sets this. A follow-up could self-resolve it from expose-state (like the hub issuer-determinism fix) so manual runs don't need the env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)