### PR TITLE
feat(channel): Layer 2 auth — hub-issued JWTs on the chat-UI endpoints

### DIFF
--- a/.parachute/module.json
+++ b/.parachute/module.json
@@ -10,6 +10,6 @@
   "uiUrl": "/channel/ui",
   "startCmd": ["parachute-channel"],
   "scopes": {
-    "defines": ["channel:read", "channel:write", "channel:admin"]
+    "defines": ["channel:read", "channel:write", "channel:send", "channel:admin"]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,10 +109,16 @@ The daemon **must** have `PARACHUTE_HUB_ORIGIN` set to the hub's *public* origin
 that as the token `iss`); the loopback fallback is dev-only. Hub-as-supervisor sets this when it
 starts the module; a manually-run daemon on an exposed box needs it in the environment.
 
-**Layer 2 — human↔UI (next).** The UI-facing endpoints (`/ui`, `/.parachute/config`,
-`/api/channels/<name>/send`, `/ui/events`) are still open. They'll authenticate the
-hub-management way (like scribe config — hub mints a short-lived token from the portal session;
-SSE takes a `?token=` query param since EventSource can't set headers).
+**Layer 2 — human↔UI (done).** The chat-UI traffic endpoints (`POST /api/channels/<name>/send`
+→ scope `channel:send`; `GET /ui/events` → scope `channel:read`) require a hub-issued JWT,
+validated the same way as Layer 1 (shared `requireScope` in `src/auth.ts`). The token comes from
+a hub endpoint — `GET <hub-origin>/admin/channel-token` (cookie-gated to the logged-in portal
+operator), returning `{ token, expires_at, scopes }` with `aud:channel` + `channel:read channel:send`,
+~10min TTL. The chat page fetches it on load (`credentials: "include"`) and attaches it: a Bearer
+header on the send POST, and a `?token=` query param on the `/ui/events` EventSource (which can't
+set headers). On a 401/SSE-error it re-fetches once and retries. `/ui`, `/health`, and
+`/.parachute/config[/schema]` stay OPEN — the page must load to bootstrap its token fetch, and the
+config listing is non-sensitive.
 
 ## Environment variables
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -38,17 +38,25 @@ export function json(data: unknown, status = 200): Response {
  * (the SSE case — `EventSource` can't set headers). Returns null if neither is
  * present.
  */
-export function extractToken(req: Request, url: URL): string | null {
+export function extractToken(req: Request, url: URL, allowQueryParam = false): string | null {
   const bearer = extractBearer(req.headers.get("authorization"));
   if (bearer) return bearer;
-  const q = url.searchParams.get("token");
-  if (q && q.length > 0) return q;
+  // `?token=` is opt-in (the SSE case only). The bridge + the UI POST present a
+  // Bearer header, so they never enable it — keeps query-param tokens off every
+  // endpoint that doesn't strictly need them (and out of those access logs).
+  if (allowQueryParam) {
+    const q = url.searchParams.get("token");
+    if (q && q.length > 0) return q;
+  }
   return null;
 }
 
 /**
- * Guard an HTTP endpoint on a hub-issued JWT carrying `scope`. The token may
- * arrive in the `Authorization: Bearer` header OR a `?token=` query param.
+ * Guard an HTTP endpoint on a hub-issued JWT carrying `scope`. The token arrives
+ * as an `Authorization: Bearer` header; pass `allowQueryParam: true` to also
+ * accept a `?token=` query param (the SSE case only — `EventSource` can't set
+ * headers). Bridge + UI-POST callers leave it false, so query-param tokens are
+ * confined to the one endpoint that needs them.
  *
  * Returns `null` when the request is authorized (caller proceeds), or a
  * `Response` (401/403) the caller must return as-is.
@@ -61,8 +69,9 @@ export async function requireScope(
   req: Request,
   url: URL,
   scope: string,
+  allowQueryParam = false,
 ): Promise<Response | null> {
-  const token = extractToken(req, url);
+  const token = extractToken(req, url, allowQueryParam);
   if (!token) {
     return json({ error: "unauthorized", message: "Bearer token required" }, 401);
   }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,84 @@
+/**
+ * Shared hub-JWT auth gate for parachute-channel's HTTP surfaces.
+ *
+ * Both auth layers run the same check — validate a hub-issued JWT against the
+ * hub's JWKS (via `hub-jwt.ts` → scope-guard) and assert a required scope:
+ *
+ *   - Layer 1 (bridge / session↔channel): the bridge presents the token as an
+ *     `Authorization: Bearer` header on `/events` + `/api/*`.
+ *   - Layer 2 (human / chat UI): the page fetches a short-lived token from the
+ *     hub (`/admin/channel-token`) and attaches it — as a Bearer header on the
+ *     `send` POST, and as a `?token=` query param on the `/ui/events` SSE
+ *     (EventSource can't set headers).
+ *
+ * `requireScope` accepts the token from EITHER source so one helper guards both
+ * layers. The no-token path short-circuits before any JWKS fetch, keeping it
+ * unit-testable without a live hub (same approach Layer 1 used).
+ */
+
+import { validateHubJwt, HubJwtError } from "./hub-jwt.ts";
+import { extractBearer } from "@openparachute/scope-guard";
+
+/** Channel scopes, declared here so callers share one spelling. */
+export const SCOPE_READ = "channel:read" as const;
+export const SCOPE_WRITE = "channel:write" as const;
+export const SCOPE_SEND = "channel:send" as const;
+
+/** JSON Response helper (shared spelling for the auth error bodies). */
+export function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/**
+ * Extract a presented token from a request: the `Authorization: Bearer` header
+ * first (the bridge + the UI's POST), falling back to a `?token=` query param
+ * (the SSE case — `EventSource` can't set headers). Returns null if neither is
+ * present.
+ */
+export function extractToken(req: Request, url: URL): string | null {
+  const bearer = extractBearer(req.headers.get("authorization"));
+  if (bearer) return bearer;
+  const q = url.searchParams.get("token");
+  if (q && q.length > 0) return q;
+  return null;
+}
+
+/**
+ * Guard an HTTP endpoint on a hub-issued JWT carrying `scope`. The token may
+ * arrive in the `Authorization: Bearer` header OR a `?token=` query param.
+ *
+ * Returns `null` when the request is authorized (caller proceeds), or a
+ * `Response` (401/403) the caller must return as-is.
+ *
+ * The no-token path short-circuits before any JWKS fetch, so it's unit-testable
+ * without a live hub. Real signature/issuer/audience validation is scope-guard's
+ * own tested surface.
+ */
+export async function requireScope(
+  req: Request,
+  url: URL,
+  scope: string,
+): Promise<Response | null> {
+  const token = extractToken(req, url);
+  if (!token) {
+    return json({ error: "unauthorized", message: "Bearer token required" }, 401);
+  }
+  try {
+    const claims = await validateHubJwt(token);
+    if (!claims.scopes.includes(scope)) {
+      return json(
+        { error: "insufficient_scope", message: `requires ${scope}`, granted: claims.scopes },
+        403,
+      );
+    }
+    return null;
+  } catch (err) {
+    return json(
+      { error: "unauthorized", message: err instanceof HubJwtError ? err.message : "invalid token" },
+      401,
+    );
+  }
+}

--- a/src/daemon.test.ts
+++ b/src/daemon.test.ts
@@ -147,14 +147,30 @@ describe("UI-facing + discovery endpoints stay open (no token, 200)", () => {
     expect(res.headers.get("content-type")).toContain("text/html");
   });
 
-  test("POST /api/channels/ui1/send (http-ui ingestHttp) → open, not 401", async () => {
+});
+
+// ---------------------------------------------------------------------------
+// Layer 2 (human↔UI): the http-ui transport's send + SSE routes are gated the
+// same way — a hub JWT (no-token → 401, short-circuits pre-JWKS). The token may
+// arrive as a Bearer header (send) or a ?token= query param (SSE). Asserted here
+// through the REAL daemon fetch handler so we cover the daemon → ingestHttp →
+// requireScope wiring, not just the transport in isolation.
+// ---------------------------------------------------------------------------
+describe("Layer 2 — http-ui UI endpoints require a token (401 with none)", () => {
+  test("POST /api/channels/ui1/send with no token → 401", async () => {
     const res = await fetch(`${base}/api/channels/ui1/send`, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ text: "from-ui" }),
     });
-    // Open route (UI-facing) — must NOT be gated. Accept any non-401/403.
-    expect(res.status).not.toBe(401);
-    expect(res.status).not.toBe(403);
+    expect(res.status).toBe(401);
+    expect(((await res.json()) as { error: string }).error).toBe("unauthorized");
+  });
+
+  test("GET /ui/events with no ?token= → 401", async () => {
+    const res = await fetch(`${base}/ui/events?channel=ui1`);
+    expect(res.status).toBe(401);
+    // Must short-circuit before the SSE stream opens.
+    expect(res.headers.get("content-type")).toContain("application/json");
   });
 });

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -35,7 +35,7 @@ import { requireScope, SCOPE_READ, SCOPE_WRITE } from "./auth.ts";
 
 // Re-export the shared auth surface so existing importers of the daemon module
 // keep working; the canonical home is now `auth.ts` (shared with http-ui.ts).
-export { requireScope, SCOPE_READ, SCOPE_WRITE } from "./auth.ts";
+export { requireScope, SCOPE_READ, SCOPE_WRITE, SCOPE_SEND } from "./auth.ts";
 
 // ---------------------------------------------------------------------------
 // Config

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -31,8 +31,11 @@ import type {
 import { ChannelConfigError } from "./transport.ts";
 import { loadRegistry, defaultStateDir, type Channel } from "./registry.ts";
 import { ClientRegistry } from "./routing.ts";
-import { validateHubJwt, HubJwtError } from "./hub-jwt.ts";
-import { extractBearer } from "@openparachute/scope-guard";
+import { requireScope, SCOPE_READ, SCOPE_WRITE } from "./auth.ts";
+
+// Re-export the shared auth surface so existing importers of the daemon module
+// keep working; the canonical home is now `auth.ts` (shared with http-ui.ts).
+export { requireScope, SCOPE_READ, SCOPE_WRITE } from "./auth.ts";
 
 // ---------------------------------------------------------------------------
 // Config
@@ -205,6 +208,33 @@ const CHAT_UI_HTML = `<!doctype html>
   // mount prefix so every API/SSE call resolves under the same prefix.
   var MOUNT = location.pathname.replace(/\\/ui\\/?$/, "");
 
+  // ----- Layer 2 auth -----------------------------------------------------
+  // The daemon's send + SSE endpoints require a hub-issued channel JWT
+  // (aud:channel, scopes channel:read channel:send). The hub mints one for the
+  // logged-in portal operator at <hub-origin>/admin/channel-token (cookie-gated,
+  // ~10min TTL). We fetch it from the page origin (same origin as the hub when
+  // served through the expose) and attach it: Bearer header on POST, ?token= on
+  // the EventSource (which can't set headers). A direct-to-daemon / not-logged-in
+  // load just leaves the token unset and surfaces a notice — an unguarded dev
+  // daemon may still accept the calls, so we don't hard-crash.
+  window.__token = null;
+  function fetchToken() {
+    return fetch(window.location.origin + "/admin/channel-token", { credentials: "include" })
+      .then(function (r) {
+        if (!r.ok) throw new Error("token " + r.status);
+        return r.json();
+      })
+      .then(function (j) {
+        window.__token = j && j.token ? j.token : null;
+        return window.__token;
+      })
+      .catch(function (err) {
+        window.__token = null;
+        add("sys", "Not authenticated — open this UI through the hub portal (" + err + ")");
+        return null;
+      });
+  }
+
   function updateSetup(ch) {
     if (!ch) return;
     var mcp = {
@@ -255,14 +285,20 @@ const CHAT_UI_HTML = `<!doctype html>
 
   function currentChannel() { return sel.value; }
 
+  // Guard so an SSE error triggers at most one token-refresh+reconnect per
+  // connect cycle (the token is short-lived; a stale one 401s the stream).
+  var sseRetried = false;
+
   function connect() {
     if (es) { es.close(); es = null; }
     var ch = currentChannel();
     if (!ch) { setStatus("no channel", false); sendBtn.disabled = true; return; }
     updateSetup(ch);
     setStatus("connecting…", false);
-    es = new EventSource(MOUNT + "/ui/events?channel=" + encodeURIComponent(ch));
-    es.onopen = function () { setStatus("● live · " + ch, true); sendBtn.disabled = false; };
+    var url = MOUNT + "/ui/events?channel=" + encodeURIComponent(ch);
+    if (window.__token) url += "&token=" + encodeURIComponent(window.__token);
+    es = new EventSource(url);
+    es.onopen = function () { sseRetried = false; setStatus("● live · " + ch, true); sendBtn.disabled = false; };
     es.addEventListener("reply", function (e) {
       try { var d = JSON.parse(e.data); add("them", d.text || "", d.files); }
       catch (_) { add("them", e.data); }
@@ -278,9 +314,27 @@ const CHAT_UI_HTML = `<!doctype html>
     });
     es.addEventListener("close", function () { setStatus("closed", false); });
     es.onerror = function () {
-      // EventSource auto-reconnects; reflect the transient state.
+      // A stale/short-lived token 401s the stream. Refresh the token once and
+      // reconnect; otherwise let EventSource auto-reconnect (transient network).
+      if (!sseRetried && window.__token) {
+        sseRetried = true;
+        setStatus("re-authenticating…", false);
+        if (es) { es.close(); es = null; }
+        fetchToken().then(function () { connect(); });
+        return;
+      }
       setStatus("reconnecting…", false);
     };
+  }
+
+  function postSend(ch, text) {
+    var headers = { "content-type": "application/json" };
+    if (window.__token) headers.authorization = "Bearer " + window.__token;
+    return fetch(MOUNT + "/api/channels/" + encodeURIComponent(ch) + "/send", {
+      method: "POST",
+      headers: headers,
+      body: JSON.stringify({ text: text }),
+    });
   }
 
   function send() {
@@ -290,12 +344,20 @@ const CHAT_UI_HTML = `<!doctype html>
     add("you", text);
     input.value = "";
     autosize();
-    fetch(MOUNT + "/api/channels/" + encodeURIComponent(ch) + "/send", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ text: text }),
-    }).then(function (r) {
-      if (!r.ok) return r.json().catch(function(){return {};}).then(function (j) {
+    postSend(ch, text).then(function (r) {
+      if (r.ok) return;
+      // The token is short-lived; on a 401 refresh it once and retry the send.
+      if (r.status === 401) {
+        return fetchToken().then(function (tok) {
+          if (!tok) { add("sys", "send failed: not authenticated"); return; }
+          return postSend(ch, text).then(function (r2) {
+            if (!r2.ok) return r2.json().catch(function(){return {};}).then(function (j) {
+              add("sys", "send failed: " + (j.error || r2.status));
+            });
+          });
+        });
+      }
+      return r.json().catch(function(){return {};}).then(function (j) {
         add("sys", "send failed: " + (j.error || r.status));
       });
     }).catch(function (err) { add("sys", "send failed: " + err); });
@@ -319,18 +381,25 @@ const CHAT_UI_HTML = `<!doctype html>
     connect();
   });
 
-  fetch(MOUNT + "/.parachute/config").then(function (r) { return r.json(); }).then(function (cfg) {
-    var chans = (cfg.channels || []).filter(function (c) { return c.transport === "http-ui"; });
-    if (!chans.length) { setStatus("no http-ui channels configured", false); return; }
-    var preselect = new URL(window.location.href).searchParams.get("channel");
-    chans.forEach(function (c) {
-      var opt = document.createElement("option");
-      opt.value = c.name; opt.textContent = c.name;
-      if (c.name === preselect) opt.selected = true;
-      sel.appendChild(opt);
-    });
-    connect();
-  }).catch(function (err) { setStatus("config load failed: " + err, false); });
+  function loadChannelsAndConnect() {
+    return fetch(MOUNT + "/.parachute/config").then(function (r) { return r.json(); }).then(function (cfg) {
+      var chans = (cfg.channels || []).filter(function (c) { return c.transport === "http-ui"; });
+      if (!chans.length) { setStatus("no http-ui channels configured", false); return; }
+      var preselect = new URL(window.location.href).searchParams.get("channel");
+      chans.forEach(function (c) {
+        var opt = document.createElement("option");
+        opt.value = c.name; opt.textContent = c.name;
+        if (c.name === preselect) opt.selected = true;
+        sel.appendChild(opt);
+      });
+      connect();
+    }).catch(function (err) { setStatus("config load failed: " + err, false); });
+  }
+
+  // Fetch a hub token first (so SSE + send go out authenticated), then list the
+  // channels and connect. A token failure still proceeds — an unguarded dev
+  // daemon may accept the calls, and the failure already surfaced a notice.
+  fetchToken().then(loadChannelsAndConnect);
 })();
 </script>
 </body>
@@ -348,55 +417,28 @@ function json(data: unknown, status = 200): Response {
 }
 
 // ---------------------------------------------------------------------------
-// Bridge-facing auth (Layer 1)
+// Auth gates
 //
-// The session↔channel connection (the bridge) is authenticated with hub-issued
-// JWTs, exactly like a vault MCP client. A launched session has full machine
-// access, so we do NOT rely on loopback trust — any session on any machine
-// presents a hub token (`aud: "channel"`, scopes `channel:read`/`channel:write`)
-// and the daemon validates it against the hub's JWKS via scope-guard.
+// Both layers share `requireScope` from `auth.ts` (validate a hub-issued JWT
+// against the hub's JWKS via scope-guard, assert a scope). It accepts the token
+// from an `Authorization: Bearer` header OR a `?token=` query param.
 //
-// Scope split: subscribing to inbound events is `channel:read`; sending
-// anything out (reply/react/edit/permission/download) is `channel:write`.
+// Layer 1 — bridge / session↔channel. The session↔channel connection is
+// authenticated with hub-issued JWTs, exactly like a vault MCP client. A
+// launched session has full machine access, so we do NOT rely on loopback trust
+// — any session on any machine presents a hub token (`aud: "channel"`, scopes
+// `channel:read`/`channel:write`) as a Bearer header and the daemon validates
+// it against the hub's JWKS. Scope split: subscribing to inbound events is
+// `channel:read`; sending anything out (reply/react/edit/permission/download)
+// is `channel:write`.
 //
-// UI-facing + discovery routes (/health, /.parachute/config[/schema], /ui, and
-// the http-ui transport's ingestHttp send/SSE routes) are deliberately left
-// OPEN here — UI auth is a separate, later PR.
+// Layer 2 — human / chat UI — gates the http-ui transport's `send` (POST,
+// `channel:send`) + `/ui/events` SSE (`?token=` query, `channel:read`) inside
+// `http-ui.ts`'s ingestHttp using the same `requireScope`.
+//
+// Discovery + the page itself (/health, /.parachute/config[/schema], /ui) stay
+// OPEN — non-sensitive, and /ui must load to bootstrap its token fetch.
 // ---------------------------------------------------------------------------
-
-export const SCOPE_READ = "channel:read" as const;
-export const SCOPE_WRITE = "channel:write" as const;
-
-/**
- * Guard a bridge-facing endpoint on a hub-issued JWT carrying `scope`.
- * Returns `null` when the request is authorized (caller proceeds), or a
- * `Response` (401/403) the caller must return as-is.
- *
- * The no-token path short-circuits before any JWKS fetch, so it's unit-testable
- * without a live hub. Real signature/issuer/audience validation is scope-guard's
- * own tested surface.
- */
-export async function requireScope(req: Request, scope: string): Promise<Response | null> {
-  const token = extractBearer(req.headers.get("authorization"));
-  if (!token) {
-    return json({ error: "unauthorized", message: "Bearer token required" }, 401);
-  }
-  try {
-    const claims = await validateHubJwt(token);
-    if (!claims.scopes.includes(scope)) {
-      return json(
-        { error: "insufficient_scope", message: `requires ${scope}`, granted: claims.scopes },
-        403,
-      );
-    }
-    return null;
-  } catch (err) {
-    return json(
-      { error: "unauthorized", message: err instanceof HubJwtError ? err.message : "invalid token" },
-      401,
-    );
-  }
-}
 
 /**
  * Build the daemon's HTTP fetch handler over a channel registry + client
@@ -493,7 +535,7 @@ export function createFetchHandler(
     // SSE event stream — bridges subscribe by channel. Bridge-facing: requires
     // a hub JWT with `channel:read`.
     if (req.method === "GET" && url.pathname === "/events") {
-      const denied = await requireScope(req, SCOPE_READ);
+      const denied = await requireScope(req, url, SCOPE_READ);
       if (denied) return denied;
       let channel = url.searchParams.get("channel") ?? undefined;
       if (!channel) {
@@ -528,7 +570,7 @@ export function createFetchHandler(
 
     // Reply — bridge-facing: requires `channel:write`.
     if (req.method === "POST" && url.pathname === "/api/reply") {
-      const denied = await requireScope(req, SCOPE_WRITE);
+      const denied = await requireScope(req, url, SCOPE_WRITE);
       if (denied) return denied;
       try {
         const body = (await req.json()) as {
@@ -550,7 +592,7 @@ export function createFetchHandler(
 
     // React — bridge-facing: requires `channel:write`.
     if (req.method === "POST" && url.pathname === "/api/react") {
-      const denied = await requireScope(req, SCOPE_WRITE);
+      const denied = await requireScope(req, url, SCOPE_WRITE);
       if (denied) return denied;
       try {
         const body = (await req.json()) as {
@@ -578,7 +620,7 @@ export function createFetchHandler(
 
     // Edit message — bridge-facing: requires `channel:write`.
     if (req.method === "POST" && url.pathname === "/api/edit") {
-      const denied = await requireScope(req, SCOPE_WRITE);
+      const denied = await requireScope(req, url, SCOPE_WRITE);
       if (denied) return denied;
       try {
         const body = (await req.json()) as {
@@ -607,7 +649,7 @@ export function createFetchHandler(
     // Permission prompt — bridge forwards permission_request here.
     // Bridge-facing: requires `channel:write`.
     if (req.method === "POST" && url.pathname === "/api/permission") {
-      const denied = await requireScope(req, SCOPE_WRITE);
+      const denied = await requireScope(req, url, SCOPE_WRITE);
       if (denied) return denied;
       try {
         const body = (await req.json()) as {
@@ -636,7 +678,7 @@ export function createFetchHandler(
 
     // Download attachment — bridge-facing: requires `channel:write`.
     if (req.method === "POST" && url.pathname === "/api/download") {
-      const denied = await requireScope(req, SCOPE_WRITE);
+      const denied = await requireScope(req, url, SCOPE_WRITE);
       if (denied) return denied;
       try {
         const body = (await req.json()) as { channel?: string; file_id: string };

--- a/src/transports/http-ui.test.ts
+++ b/src/transports/http-ui.test.ts
@@ -23,18 +23,34 @@ import { describe, test, expect, mock } from "bun:test";
 // any other token) still hits the real no-token / shape-first reject. This keeps
 // the round-trip coverage genuine while staying hub-free.
 const VALID_TOKEN = "test-valid-token";
+// A token carrying ONLY channel:write (a session/bridge token) — must be
+// REJECTED on the UI send endpoint, which requires channel:send. Locks the
+// privilege separation (a session token can't post as a human).
+const WRITE_ONLY_TOKEN = "test-write-only-token";
 mock.module("../hub-jwt.ts", () => ({
   CHANNEL_AUDIENCE: "channel",
   async validateHubJwt(token: string) {
-    if (token !== VALID_TOKEN) throw new HubJwtError("invalid token");
-    return {
-      sub: "test",
-      scopes: ["channel:read", "channel:send", "channel:write"],
-      aud: "channel",
-      jti: undefined,
-      clientId: undefined,
-      vaultScope: undefined,
-    };
+    if (token === VALID_TOKEN) {
+      return {
+        sub: "test",
+        scopes: ["channel:read", "channel:send", "channel:write"],
+        aud: "channel",
+        jti: undefined,
+        clientId: undefined,
+        vaultScope: undefined,
+      };
+    }
+    if (token === WRITE_ONLY_TOKEN) {
+      return {
+        sub: "test",
+        scopes: ["channel:write"],
+        aud: "channel",
+        jti: undefined,
+        clientId: undefined,
+        vaultScope: undefined,
+      };
+    }
+    throw new HubJwtError("invalid token");
   },
   HubJwtError: class HubJwtError extends Error {},
   looksLikeJwt: (t: string) => t.split(".").length === 3,
@@ -126,6 +142,23 @@ describe("HttpUiTransport — direct", () => {
     const res = await t.ingestHttp(req, new URL(req.url));
     expect(res).not.toBeNull();
     expect(res!.status).toBe(401);
+    expect(ctx.emitted).toHaveLength(0);
+  });
+
+  test("ingestHttp send with a channel:write-only (session) token → 403, no emit", async () => {
+    // Privilege separation: a session/bridge token (channel:write) must NOT be
+    // usable to post a human message through the UI send endpoint (channel:send).
+    const t = new HttpUiTransport();
+    const ctx = fakeCtx("dev");
+    await t.start(ctx);
+    const req = new Request("http://x/api/channels/dev/send", {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: "Bearer " + WRITE_ONLY_TOKEN },
+      body: JSON.stringify({ text: "trying to send as a session" }),
+    });
+    const res = await t.ingestHttp(req, new URL(req.url));
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(403);
     expect(ctx.emitted).toHaveLength(0);
   });
 

--- a/src/transports/http-ui.test.ts
+++ b/src/transports/http-ui.test.ts
@@ -13,11 +13,47 @@
  *   - reply() with no connected UI client does not throw.
  */
 
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, mock } from "bun:test";
+
+// Layer 2 gates the http-ui send + SSE routes on `requireScope`, which validates
+// a hub JWT against the hub's JWKS. The no-token path short-circuits to 401
+// before any JWKS fetch (asserted below). To exercise the *delivery* paths
+// (routing, SSE fan-out) without a live hub, stub the JWT validator so a single
+// sentinel token validates with the channel scopes. A request with no token (or
+// any other token) still hits the real no-token / shape-first reject. This keeps
+// the round-trip coverage genuine while staying hub-free.
+const VALID_TOKEN = "test-valid-token";
+mock.module("../hub-jwt.ts", () => ({
+  CHANNEL_AUDIENCE: "channel",
+  async validateHubJwt(token: string) {
+    if (token !== VALID_TOKEN) throw new HubJwtError("invalid token");
+    return {
+      sub: "test",
+      scopes: ["channel:read", "channel:send", "channel:write"],
+      aud: "channel",
+      jti: undefined,
+      clientId: undefined,
+      vaultScope: undefined,
+    };
+  },
+  HubJwtError: class HubJwtError extends Error {},
+  looksLikeJwt: (t: string) => t.split(".").length === 3,
+  resetJwksCache() {},
+  resetRevocationCache() {},
+}));
+class HubJwtError extends Error {}
+
 import { HttpUiTransport } from "./http-ui.ts";
 import type { TransportContext, InboundMessage } from "../transport.ts";
 import { ClientRegistry } from "../routing.ts";
 import { instantiateTransport } from "../registry.ts";
+
+/** Authorization header carrying the sentinel valid token. */
+const AUTH = { authorization: "Bearer " + VALID_TOKEN } as const;
+/** Append the sentinel token as a `?token=` query param (the SSE auth path). */
+function withToken(path: string): string {
+  return path + (path.includes("?") ? "&" : "?") + "token=" + encodeURIComponent(VALID_TOKEN);
+}
 
 /** A test context that records emitted inbound messages + permission verdicts. */
 function fakeCtx(channel: string): TransportContext & {
@@ -57,14 +93,14 @@ async function readFrame(
 }
 
 describe("HttpUiTransport — direct", () => {
-  test("ingestHttp send → ctx.emit on its own channel", async () => {
+  test("ingestHttp send (authed) → ctx.emit on its own channel", async () => {
     const t = new HttpUiTransport();
     const ctx = fakeCtx("dev");
     await t.start(ctx);
 
     const req = new Request("http://x/api/channels/dev/send", {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: { "content-type": "application/json", ...AUTH },
       body: JSON.stringify({ text: "hello session" }),
     });
     const res = await t.ingestHttp(req, new URL(req.url));
@@ -78,6 +114,31 @@ describe("HttpUiTransport — direct", () => {
     expect(ctx.emitted[0]!.source).toBe("http-ui");
   });
 
+  test("ingestHttp send WITHOUT a token → 401, no emit (Layer 2)", async () => {
+    const t = new HttpUiTransport();
+    const ctx = fakeCtx("dev");
+    await t.start(ctx);
+    const req = new Request("http://x/api/channels/dev/send", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ text: "no token" }),
+    });
+    const res = await t.ingestHttp(req, new URL(req.url));
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(401);
+    expect(ctx.emitted).toHaveLength(0);
+  });
+
+  test("ingestHttp SSE WITHOUT a ?token= → 401 (Layer 2)", async () => {
+    const t = new HttpUiTransport();
+    await t.start(fakeCtx("dev"));
+    const req = new Request("http://x/ui/events?channel=dev");
+    const res = await t.ingestHttp(req, new URL(req.url));
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(401);
+    expect(res!.headers.get("content-type")).toContain("application/json");
+  });
+
   test("ingestHttp ignores a send for a DIFFERENT channel's path", async () => {
     const t = new HttpUiTransport();
     await t.start(fakeCtx("dev"));
@@ -89,12 +150,13 @@ describe("HttpUiTransport — direct", () => {
     expect(res).toBeNull();
   });
 
-  test("send with empty/missing text → 400, no emit", async () => {
+  test("send (authed) with empty/missing text → 400, no emit", async () => {
     const t = new HttpUiTransport();
     const ctx = fakeCtx("dev");
     await t.start(ctx);
     const req = new Request("http://x/api/channels/dev/send", {
       method: "POST",
+      headers: { ...AUTH },
       body: JSON.stringify({ text: "" }),
     });
     const res = await t.ingestHttp(req, new URL(req.url));
@@ -113,8 +175,8 @@ describe("HttpUiTransport — direct", () => {
     const t = new HttpUiTransport();
     await t.start(fakeCtx("dev"));
 
-    // Open the UI SSE stream via ingestHttp.
-    const sseReq = new Request("http://x/ui/events?channel=dev");
+    // Open the UI SSE stream via ingestHttp (authed via ?token=).
+    const sseReq = new Request("http://x" + withToken("/ui/events?channel=dev"));
     const sseRes = await t.ingestHttp(sseReq, new URL(sseReq.url));
     expect(sseRes).not.toBeNull();
     const reader = sseRes!.body!.getReader();
@@ -133,7 +195,7 @@ describe("HttpUiTransport — direct", () => {
   test("stop() clears UI clients", async () => {
     const t = new HttpUiTransport();
     await t.start(fakeCtx("dev"));
-    const sseReq = new Request("http://x/ui/events?channel=dev");
+    const sseReq = new Request("http://x" + withToken("/ui/events?channel=dev"));
     const sseRes = await t.ingestHttp(sseReq, new URL(sseReq.url));
     sseRes!.body!.getReader();
     await t.stop();
@@ -231,9 +293,12 @@ describe("HttpUiTransport — through a daemon-shaped server", () => {
     return { server, base: `http://127.0.0.1:${server.port}`, registry };
   }
 
-  /** Open an SSE stream and return a reader + helpers. */
+  /** Open an SSE stream and return a reader + helpers. The http-ui `/ui/events`
+   *  route is Layer-2-gated, so append the sentinel `?token=` for those; the
+   *  bridge `/events` route in this harness is ungated (pass through as-is). */
   async function openSse(base: string, path: string) {
-    const res = await fetch(`${base}${path}`);
+    const url = path.startsWith("/ui/events") ? withToken(path) : path;
+    const res = await fetch(`${base}${url}`);
     const reader = res.body!.getReader();
     return {
       read: () => readFrame(reader),
@@ -253,10 +318,10 @@ describe("HttpUiTransport — through a daemon-shaped server", () => {
       }
       expect(registry.size).toBe(1);
 
-      // UI POSTs a send.
+      // UI POSTs a send (authed — Layer 2).
       const res = await fetch(`${base}/api/channels/dev/send`, {
         method: "POST",
-        headers: { "content-type": "application/json" },
+        headers: { "content-type": "application/json", ...AUTH },
         body: JSON.stringify({ text: "hi from UI" }),
       });
       expect(res.status).toBe(200);
@@ -281,10 +346,10 @@ describe("HttpUiTransport — through a daemon-shaped server", () => {
         await new Promise((r) => setTimeout(r, 5));
       }
 
-      // UI → bridge.
+      // UI → bridge (authed — Layer 2).
       await fetch(`${base}/api/channels/dev/send`, {
         method: "POST",
-        headers: { "content-type": "application/json" },
+        headers: { "content-type": "application/json", ...AUTH },
         body: JSON.stringify({ text: "wake up" }),
       });
       const bridgeFrame = await bridge.read();
@@ -315,10 +380,10 @@ describe("HttpUiTransport — through a daemon-shaped server", () => {
       const bridgeA = await openSse(base, "/events?channel=A");
       const uiB = await openSse(base, "/ui/events?channel=B");
 
-      // Send on channel A, then reply on A.
+      // Send on channel A, then reply on A (authed — Layer 2).
       await fetch(`${base}/api/channels/A/send`, {
         method: "POST",
-        headers: { "content-type": "application/json" },
+        headers: { "content-type": "application/json", ...AUTH },
         body: JSON.stringify({ text: "for-A" }),
       });
       // Close the loop: A's bridge MUST receive the inbound (not just "B didn't").

--- a/src/transports/http-ui.ts
+++ b/src/transports/http-ui.ts
@@ -169,9 +169,10 @@ export class HttpUiTransport implements Transport {
       url.searchParams.get("channel") === channel
     ) {
       // Layer 2: gate on `channel:read`. EventSource can't set headers, so the
-      // token rides in as a `?token=` query param (requireScope falls back to
-      // it). No-token → 401 before the stream opens.
-      const denied = await requireScope(req, url, SCOPE_READ);
+      // token rides in as a `?token=` query param — the ONLY endpoint that opts
+      // into the query-param fallback (allowQueryParam: true). No-token → 401
+      // before the stream opens.
+      const denied = await requireScope(req, url, SCOPE_READ, true);
       if (denied) return denied;
       const clientId = crypto.randomUUID();
       const clients = this.uiClients;

--- a/src/transports/http-ui.ts
+++ b/src/transports/http-ui.ts
@@ -30,6 +30,7 @@ import type {
   PermissionArgs,
 } from "../transport.ts";
 import { sseFrame } from "../routing.ts";
+import { requireScope, json, SCOPE_SEND, SCOPE_READ } from "../auth.ts";
 
 /** A connected browser SSE client (one per open chat page on this channel). */
 interface UiClient {
@@ -137,6 +138,11 @@ export class HttpUiTransport implements Transport {
       req.method === "POST" &&
       url.pathname === `/api/channels/${channel}/send`
     ) {
+      // Layer 2 (human→UI): a hub-issued token with `channel:send`. The UI
+      // fetches it from the hub's /admin/channel-token (portal-cookie-gated) and
+      // attaches it as a Bearer header. No-token → 401 (short-circuits pre-JWKS).
+      const denied = await requireScope(req, url, SCOPE_SEND);
+      if (denied) return denied;
       let text: string;
       try {
         const body = (await req.json()) as { text?: unknown };
@@ -162,6 +168,11 @@ export class HttpUiTransport implements Transport {
       url.pathname === "/ui/events" &&
       url.searchParams.get("channel") === channel
     ) {
+      // Layer 2: gate on `channel:read`. EventSource can't set headers, so the
+      // token rides in as a `?token=` query param (requireScope falls back to
+      // it). No-token → 401 before the stream opens.
+      const denied = await requireScope(req, url, SCOPE_READ);
+      if (denied) return denied;
       const clientId = crypto.randomUUID();
       const clients = this.uiClients;
       const stream = new ReadableStream<string>({
@@ -186,11 +197,4 @@ export class HttpUiTransport implements Transport {
 
     return null;
   }
-}
-
-function json(data: unknown, status = 200): Response {
-  return new Response(JSON.stringify(data), {
-    status,
-    headers: { "content-type": "application/json" },
-  });
 }


### PR DESCRIPTION
## Authenticate the chat-UI endpoints (pairs with hub PR for /admin/channel-token)

Completes channel auth. The UI-facing endpoints now require a hub JWT, the **scribe-config way**: the logged-in portal operator's session yields a short-lived token (from hub's new `/admin/channel-token`) that the proxied UI attaches.

**⚠️ Coordinated with the hub PR adding `/admin/channel-token`. Do not redeploy the live channel daemon to this until the hub change is live (restarted), or the chat UI can't fetch a token. The live daemon stays on Layer 1 until then.**

### What's in it
- **`src/auth.ts`** (new) — shared `requireScope(req, url, scope)` (token from `Authorization: Bearer` OR `?token=` query param, for the EventSource SSE case). Layer 1's inline gate moved here verbatim; daemon re-exports for back-compat. **Layer 1 behavior unchanged** (bridge still hits the header path).
- **`http-ui.ts`** — gates `POST /api/channels/<name>/send` → `channel:send`, `GET /ui/events` → `channel:read` (`?token=`).
- **Chat UI JS** — fetches the token from `<hub-origin>/admin/channel-token` (credentials: include), attaches it (Bearer on send, `?token=` on SSE), refreshes once on 401, shows a notice if unauthenticated.
- **`module.json`** — adds `channel:send` to `scopes.defines`.
- Left open: `/health`, `/.parachute/config[/schema]`, `/ui` (the page bootstraps the token fetch).

### Scope separation (verified live)
`channel:send` (human posts a message) ≠ `channel:write` (session replies) ≠ `channel:read` (receive). Verified against the real hub JWKS: a `channel:write`-only (session) token → **403** on the UI send endpoint; a `channel:read+send` (UI) token → 200; no token → 401; SSE `?token=` → 200.

### Testing
`bun run typecheck` clean; `bun test src/` **74 pass / 0 fail**. Sandbox smoke: send/SSE no-token → 401, `/ui` + config → 200, Layer-1 `/events` → 401. The full browser token-fetch flow gets live-verified after the hub endpoint is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)