### PR TITLE
feat(channel): HTTP MCP refactor — connect a session by URL + OAuth, like the vault

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,41 @@ Channel self-registers into `~/.parachute/services.json` at boot and ships
 The built-in chat UI is reachable at `<hub-origin>/channel/ui` over the expose, and at
 `http://127.0.0.1:1941/ui` locally.
 
+## Connecting a session over HTTP MCP (primary)
+
+A Claude Code session connects to a channel as a **pure HTTP MCP server** — by URL +
+OAuth, exactly like adding the vault. No local `.mcp.json` pointing at `bun src/bridge.ts`,
+no machine-local file: the session adds `<hub-origin>/channel/mcp/<channel>` and the daemon
+serves a stateful Streamable-HTTP MCP endpoint (`src/mcp-http.ts`) that pushes the idle-wake
+`notifications/claude/channel` onto the session's SSE stream.
+
+```bash
+claude mcp add --transport http channel <hub-origin>/channel/mcp/<channel>
+```
+
+It prompts for OAuth the first time (like the vault). Discovery is RFC 9728 + RFC 8414, in
+the **path-insertion** form a Claude Code HTTP-MCP client probes (mirrors vault's
+`src/oauth-discovery.ts`), served PUBLIC (no auth) by the daemon:
+
+- `GET /.well-known/oauth-protected-resource/mcp/<channel>` → `resource` (the public MCP
+  URL, built from `X-Forwarded-Host`), `authorization_servers: [<hub-origin>]`,
+  `scopes_supported: ["channel:read","channel:write"]`, `bearer_methods_supported: ["header"]`.
+- `GET /.well-known/oauth-authorization-server/mcp/<channel>` → forwarder pointing
+  `authorization_endpoint` / `token_endpoint` / `registration_endpoint` / `jwks_uri` at the hub.
+- A no/invalid-bearer `POST /mcp/<channel>` returns **401 + `WWW-Authenticate: Bearer
+  resource_metadata="…/.well-known/oauth-protected-resource/mcp/<channel>"`** — the signal a
+  spec OAuth client follows to start the flow. (Only `/mcp/*` carries the challenge; `/events`
+  + `/api/*` stay plain 401.)
+
+The built-in chat UI's "Connect a session" panel now shows this one-liner (computed from
+`window.location.origin` so it's the hub origin over the expose). `scripts/launch-session.sh`
+writes the session's `.mcp.json` as an HTTP server config (`{ "type": "http", "url": …,
+"headers": { "Authorization": "Bearer <minted-token>" } }`) for the headless/local launch —
+the minted token is the header; remote/manual users go through OAuth.
+
+The stdio `bridge.ts` over `/events` + `/api/*` still works (Layer 1 below) — the HTTP MCP
+endpoint is **additive**, and is now the path the UI + launcher steer toward.
+
 ## Auth
 
 **Layer 1 — session↔channel (done).** The bridge-facing daemon endpoints (`GET /events`,

--- a/scripts/launch-session.sh
+++ b/scripts/launch-session.sh
@@ -147,10 +147,10 @@ if [ "$ready" != 1 ]; then
   exit 1
 fi
 
-# Best-effort confirm the bridge registered with the daemon on this channel.
+# Best-effort confirm the HTTP MCP session registered with the daemon on this channel.
 connected=0
 for _ in $(seq 1 20); do
-  n="$(curl -fsS "$DAEMON_URL/health" 2>/dev/null | grep -o "\"name\":\"$CHANNEL\"[^}]*\"clients\":[0-9]*" | grep -o '"clients":[0-9]*' | grep -o '[0-9]*' || echo 0)"
+  n="$(curl -fsS "$DAEMON_URL/health" 2>/dev/null | grep -o "\"name\":\"$CHANNEL\"[^}]*\"mcp_sessions\":[0-9]*" | grep -o '"mcp_sessions":[0-9]*' | grep -o '[0-9]*' || echo 0)"
   if [ "${n:-0}" -ge 1 ]; then connected=1; break; fi
   sleep 0.5
 done
@@ -159,7 +159,7 @@ echo "✓ session '$SESSION' ready on channel '$CHANNEL'."
 echo "  connected over HTTP MCP at $MCP_URL (no local bridge file)."
 [ -n "$TOKEN" ] && echo "  authenticated with a hub-issued channel token (channel:read + channel:write)." \
                 || echo "  NOT authenticated (no token minted) — only an unguarded dev daemon will accept it."
-[ "$connected" = 1 ] && echo "  bridge connected to the daemon." || echo "  (bridge connection not yet confirmed via /health — usually a moment behind.)"
+[ "$connected" = 1 ] && echo "  HTTP MCP session registered with the daemon." || echo "  (MCP session not yet confirmed via /health — usually a moment behind.)"
 echo "  chat:    open the channel UI and pick channel '$CHANNEL'"
 echo "  watch:   tmux attach -t $SESSION   (detach: Ctrl-b then d)"
 echo "  stop:    ./scripts/stop-session.sh $NAME"

--- a/scripts/launch-session.sh
+++ b/scripts/launch-session.sh
@@ -32,8 +32,6 @@ if printf '%s' "$NAME$CHANNEL" | grep -q '[^a-zA-Z0-9_-]'; then
   exit 2
 fi
 
-REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-BRIDGE="$REPO/src/bridge.ts"
 DAEMON_URL="${PARACHUTE_CHANNEL_URL:-http://127.0.0.1:1941}"
 STATE_DIR="${PARACHUTE_CHANNEL_STATE_DIR:-$HOME/.parachute/channel}"
 WORKDIR="$STATE_DIR/sessions/$NAME"
@@ -74,20 +72,23 @@ if [ -z "$TOKEN" ]; then
   echo "         running and you're logged in (parachute login) to authenticate the session." >&2
 fi
 
-# Bridge MCP config — the session's only wiring to the channel. The token, when
-# present, is injected into the env block so the bridge presents it on every
-# daemon request.
+# MCP config — the session's only wiring to the channel. This is now an HTTP
+# MCP server (URL + Bearer), NOT a stdio bridge spawned from a local file: the
+# session connects to the daemon's `/mcp/<channel>` endpoint exactly like adding
+# the vault MCP. No `bun src/bridge.ts` path — works on any machine that can
+# reach the daemon URL. The minted token rides as the Authorization header (the
+# headless/local launch path); a human adding the channel by hand uses
+# `claude mcp add --transport http` and gets prompted for OAuth instead.
+MCP_URL="$DAEMON_URL/mcp/$CHANNEL"
 if [ -n "$TOKEN" ]; then
   cat > "$WORKDIR/.mcp.json" <<EOF
 {
   "mcpServers": {
     "parachute-channel": {
-      "command": "bun",
-      "args": ["$BRIDGE"],
-      "env": {
-        "PARACHUTE_CHANNEL_URL": "$DAEMON_URL",
-        "PARACHUTE_CHANNEL_NAME": "$CHANNEL",
-        "PARACHUTE_CHANNEL_TOKEN": "$TOKEN"
+      "type": "http",
+      "url": "$MCP_URL",
+      "headers": {
+        "Authorization": "Bearer $TOKEN"
       }
     }
   }
@@ -98,12 +99,8 @@ else
 {
   "mcpServers": {
     "parachute-channel": {
-      "command": "bun",
-      "args": ["$BRIDGE"],
-      "env": {
-        "PARACHUTE_CHANNEL_URL": "$DAEMON_URL",
-        "PARACHUTE_CHANNEL_NAME": "$CHANNEL"
-      }
+      "type": "http",
+      "url": "$MCP_URL"
     }
   }
 }
@@ -159,6 +156,7 @@ for _ in $(seq 1 20); do
 done
 
 echo "✓ session '$SESSION' ready on channel '$CHANNEL'."
+echo "  connected over HTTP MCP at $MCP_URL (no local bridge file)."
 [ -n "$TOKEN" ] && echo "  authenticated with a hub-issued channel token (channel:read + channel:write)." \
                 || echo "  NOT authenticated (no token minted) — only an unguarded dev daemon will accept it."
 [ "$connected" = 1 ] && echo "  bridge connected to the daemon." || echo "  (bridge connection not yet confirmed via /health — usually a moment behind.)"

--- a/src/daemon.test.ts
+++ b/src/daemon.test.ts
@@ -150,6 +150,117 @@ describe("UI-facing + discovery endpoints stay open (no token, 200)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// OAuth discovery for the HTTP MCP surface (RFC 9728 + RFC 8414). These are the
+// endpoints a Claude Code HTTP-MCP client probes when adding the channel by URL.
+// Path-insertion form (`.well-known` ABOVE the resource path), mirroring vault.
+// PUBLIC — no token needed (they must be reachable before the client has one).
+// ---------------------------------------------------------------------------
+describe("OAuth discovery (RFC 9728 / RFC 8414) — public, points at the hub", () => {
+  // The hub origin the daemon advertises as the authorization server. Set on the
+  // module's getHubOrigin via PARACHUTE_HUB_ORIGIN; default loopback otherwise.
+  const HUB = process.env.PARACHUTE_HUB_ORIGIN?.replace(/\/$/, "") || "http://127.0.0.1:1939";
+
+  test("GET /.well-known/oauth-protected-resource/mcp/ui1 → 200, names hub + channel scopes", async () => {
+    const res = await fetch(`${base}/.well-known/oauth-protected-resource/mcp/ui1`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      resource: string;
+      authorization_servers: string[];
+      scopes_supported: string[];
+      bearer_methods_supported: string[];
+    };
+    expect(body.authorization_servers).toEqual([HUB]);
+    expect(body.scopes_supported).toEqual(["channel:read", "channel:write"]);
+    expect(body.bearer_methods_supported).toEqual(["header"]);
+    // No forwarded host → loopback resource URL at /mcp/<channel> (no /channel prefix).
+    expect(body.resource).toBe(`${base}/mcp/ui1`);
+  });
+
+  test("X-Forwarded-Host builds the PUBLIC resource URL (with /channel mount prefix)", async () => {
+    const res = await fetch(`${base}/.well-known/oauth-protected-resource/mcp/ui1`, {
+      headers: { "x-forwarded-host": "parachute.taildf9ce2.ts.net", "x-forwarded-proto": "https" },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { resource: string };
+    expect(body.resource).toBe("https://parachute.taildf9ce2.ts.net/channel/mcp/ui1");
+  });
+
+  test("GET /.well-known/oauth-authorization-server/mcp/ui1 → 200, forwards every endpoint to the hub", async () => {
+    const res = await fetch(`${base}/.well-known/oauth-authorization-server/mcp/ui1`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      issuer: string;
+      authorization_endpoint: string;
+      token_endpoint: string;
+      registration_endpoint: string;
+      jwks_uri: string;
+      scopes_supported: string[];
+    };
+    expect(body.issuer).toBe(HUB);
+    expect(body.authorization_endpoint).toBe(`${HUB}/oauth/authorize`);
+    expect(body.token_endpoint).toBe(`${HUB}/oauth/token`);
+    expect(body.registration_endpoint).toBe(`${HUB}/oauth/register`);
+    expect(body.jwks_uri).toBe(`${HUB}/.well-known/jwks.json`);
+    expect(body.scopes_supported).toEqual(["channel:read", "channel:write"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RFC 9728 WWW-Authenticate challenge on the /mcp/<channel> 401. A plain 401
+// gives a spec OAuth client no way to find the authorization server; the header
+// names the protected-resource metadata document so the client can discover
+// OAuth and start the flow. Only the /mcp path carries it (it's the one that
+// drives a spec client); /events + /api/* stay plain 401.
+// ---------------------------------------------------------------------------
+describe("MCP 401 carries the WWW-Authenticate challenge (RFC 9728)", () => {
+  test("POST /mcp/ui1 with no bearer → 401 + WWW-Authenticate naming the PRM URL", async () => {
+    const res = await fetch(`${base}/mcp/ui1`, {
+      method: "POST",
+      headers: { "content-type": "application/json", accept: "application/json, text/event-stream" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} }),
+    });
+    expect(res.status).toBe(401);
+    const header = res.headers.get("WWW-Authenticate");
+    expect(header).toBe(
+      `Bearer resource_metadata="${base}/.well-known/oauth-protected-resource/mcp/ui1"`,
+    );
+    // And the URL the header names is a route the daemon actually serves.
+    const prmUrl = header!.match(/resource_metadata="([^"]+)"/)![1]!;
+    const prm = await fetch(prmUrl);
+    expect(prm.status).toBe(200);
+  });
+
+  test("behind the hub (x-forwarded-host) the challenge names the PUBLIC PRM URL", async () => {
+    const res = await fetch(`${base}/mcp/ui1`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-forwarded-host": "parachute.taildf9ce2.ts.net",
+        "x-forwarded-proto": "https",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} }),
+    });
+    expect(res.status).toBe(401);
+    expect(res.headers.get("WWW-Authenticate")).toBe(
+      'Bearer resource_metadata="https://parachute.taildf9ce2.ts.net/channel/.well-known/oauth-protected-resource/mcp/ui1"',
+    );
+  });
+
+  test("the other bridge endpoints stay plain 401 (no challenge)", async () => {
+    const events = await fetch(`${base}/events?channel=ui1`);
+    expect(events.status).toBe(401);
+    expect(events.headers.get("WWW-Authenticate")).toBeNull();
+    const reply = await fetch(`${base}/api/reply`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ channel: "ui1", text: "hi" }),
+    });
+    expect(reply.status).toBe(401);
+    expect(reply.headers.get("WWW-Authenticate")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Layer 2 (human↔UI): the http-ui transport's send + SSE routes are gated the
 // same way — a hub JWT (no-token → 401, short-circuits pre-JWKS). The token may
 // arrive as a Bearer header (send) or a ?token= query param (SSE). Asserted here

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -31,7 +31,14 @@ import type {
 import { ChannelConfigError } from "./transport.ts";
 import { loadRegistry, defaultStateDir, type Channel } from "./registry.ts";
 import { ClientRegistry } from "./routing.ts";
-import { requireScope, SCOPE_READ, SCOPE_WRITE } from "./auth.ts";
+import { requireScope, extractToken, SCOPE_READ, SCOPE_WRITE } from "./auth.ts";
+import { validateHubJwt } from "./hub-jwt.ts";
+import {
+  handleMcp,
+  pushToChannel as mcpPushToChannel,
+  pushPermissionVerdict as mcpPushPermissionVerdict,
+  mcpSessionCount,
+} from "./mcp-http.ts";
 
 // Re-export the shared auth surface so existing importers of the daemon module
 // keep working; the canonical home is now `auth.ts` (shared with http-ui.ts).
@@ -83,9 +90,15 @@ function contextFor(registry: ClientRegistry, channel: string): TransportContext
         meta: msg.meta,
         source: msg.source,
       });
+      // ALSO wake any HTTP MCP sessions on this channel — a session connected
+      // over /mcp/<channel> (vs. the stdio bridge over /events) receives the
+      // same inbound as a server-pushed notifications/claude/channel. Additive:
+      // the SSE path above is untouched.
+      mcpPushToChannel(channel, msg.content, msg.meta);
     },
     emitPermissionVerdict(v): void {
       registry.routeToChannel(channel, "permission_verdict", v);
+      mcpPushPermissionVerdict(channel, v);
     },
   };
 }
@@ -487,6 +500,7 @@ export function createFetchHandler(
           name: c.name,
           kind: c.transport.kind,
           clients: registry.countForChannel(c.name),
+          mcp_sessions: mcpSessionCount(c.name),
         })),
         total_clients: registry.size,
       });
@@ -700,6 +714,45 @@ export function createFetchHandler(
       return new Response(CHAT_UI_HTML, {
         headers: { "content-type": "text/html; charset=utf-8" },
       });
+    }
+
+    // Stateful HTTP MCP — a session connects directly over HTTP (URL + OAuth,
+    // no stdio bridge): POST/GET/DELETE /mcp/<channel>. Externally this is
+    // `<hub>/channel/mcp/<channel>`; hub's stripPrefix removes `/channel`, so the
+    // daemon sees `/mcp/<channel>`. A session needs `channel:read` to connect +
+    // receive the wake; the reply/react/edit tools additionally require
+    // `channel:write`, enforced inside the tool handlers from the connection's
+    // own scopes. This endpoint is ADDITIVE — the stdio bridge over /events is
+    // unchanged.
+    const mcpMatch = url.pathname.match(/^\/mcp\/([^/]+)$/);
+    if (mcpMatch) {
+      const channel = decodeURIComponent(mcpMatch[1]!);
+      const transport = transportFor(channel);
+      if (!transport) {
+        return json(
+          {
+            error: `unknown channel "${channel}" — known channels: ${[...channels.keys()].join(", ") || "(none)"}`,
+          },
+          404,
+        );
+      }
+      // Gate on channel:read — short-circuits to 401 pre-JWKS when no token is
+      // presented (testable without a live hub, same as the other endpoints).
+      const denied = await requireScope(req, url, SCOPE_READ);
+      if (denied) return denied;
+      // Re-validate to surface the caller's scopes for the write-tool checks.
+      // (requireScope already proved the token valid + carrying channel:read;
+      // this second pass hits the warm JWKS cache.) A token present but missing
+      // here would have been rejected above, so claims must resolve.
+      let scopes: string[] = [];
+      try {
+        const token = extractToken(req, url);
+        if (token) scopes = (await validateHubJwt(token)).scopes;
+      } catch {
+        // Unreachable in practice (requireScope passed); fall back to read-only.
+        scopes = [SCOPE_READ];
+      }
+      return handleMcp(req, channel, transport, scopes);
     }
 
     // Give each transport a chance to handle a route the daemon didn't. Runs

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -34,6 +34,11 @@ import { ClientRegistry } from "./routing.ts";
 import { requireScope, extractToken, SCOPE_READ, SCOPE_WRITE } from "./auth.ts";
 import { validateHubJwt } from "./hub-jwt.ts";
 import {
+  handleProtectedResource,
+  handleAuthorizationServer,
+  mcpWwwAuthenticate,
+} from "./oauth-discovery.ts";
+import {
   handleMcp,
   pushToChannel as mcpPushToChannel,
   pushPermissionVerdict as mcpPushPermissionVerdict,
@@ -54,13 +59,6 @@ const PORT = parseInt(process.env.PARACHUTE_CHANNEL_PORT ?? "1941", 10);
 
 /** Channel a bridge subscribes to when `?channel=` is omitted (back-compat). */
 const DEFAULT_CHANNEL = "telegram";
-
-/** Absolute path to the bridge a Claude Code session spawns — shown in /ui setup. */
-const BRIDGE_PATH = join(import.meta.dir, "bridge.ts");
-
-/** Loopback origin a co-located bridge connects to (shown in /ui setup — the
- *  bridge talks to this daemon directly, NOT through hub/the expose). */
-const DAEMON_ORIGIN = `http://127.0.0.1:${PORT}`;
 
 /** Package version + install dir, for services.json self-registration. */
 const PKG_VERSION = ((): string => {
@@ -193,10 +191,8 @@ const CHAT_UI_HTML = `<!doctype html>
   <details class="setup">
     <summary>Connect a Claude Code session ▾</summary>
     <div class="body">
-      <p>1. In the working directory you'll run Claude Code from, create <code>.mcp.json</code>:</p>
-      <pre><button class="copy" data-copy="mcp">copy</button><code id="snippet-mcp"></code></pre>
-      <p>2. Launch Claude Code from that directory:</p>
-      <pre><button class="copy" data-copy="launch">copy</button><code id="snippet-launch"></code></pre>
+      <p>Add this channel as an HTTP MCP server — by URL, exactly like adding the vault. Run:</p>
+      <pre><button class="copy" data-copy="add">copy</button><code id="snippet-add"></code></pre>
       <p id="setup-note"></p>
     </div>
   </details>
@@ -214,9 +210,6 @@ const CHAT_UI_HTML = `<!doctype html>
   var statusEl = document.getElementById("status");
   var form = document.getElementById("composer");
   var es = null;
-  var BRIDGE_PATH = ${JSON.stringify(BRIDGE_PATH).replace(/</g, "\\u003c")};
-  // The bridge talks to the daemon directly on loopback (not through hub).
-  var DAEMON_ORIGIN = ${JSON.stringify(DAEMON_ORIGIN)};
   // Served through hub the page is /channel/ui; locally it's /ui. Derive the
   // mount prefix so every API/SSE call resolves under the same prefix.
   var MOUNT = location.pathname.replace(/\\/ui\\/?$/, "");
@@ -250,28 +243,24 @@ const CHAT_UI_HTML = `<!doctype html>
 
   function updateSetup(ch) {
     if (!ch) return;
-    var mcp = {
-      mcpServers: {
-        "parachute-channel": {
-          command: "bun",
-          args: [BRIDGE_PATH],
-          env: { PARACHUTE_CHANNEL_URL: DAEMON_ORIGIN, PARACHUTE_CHANNEL_NAME: ch },
-        },
-      },
-    };
-    document.getElementById("snippet-mcp").textContent = JSON.stringify(mcp, null, 2);
-    document.getElementById("snippet-launch").textContent =
-      "claude --dangerously-load-development-channels=server:parachute-channel";
+    // The public origin this channel is reachable at. Served through the hub
+    // expose, location.origin IS the hub origin and the channel mounts under
+    // /channel; served directly off the daemon, it's the loopback origin with
+    // no mount prefix. MOUNT (derived from the page path) captures that prefix.
+    var addCmd =
+      "claude mcp add --transport http channel " +
+      window.location.origin + MOUNT + "/mcp/" + ch;
+    document.getElementById("snippet-add").textContent = addCmd;
     document.getElementById("setup-note").textContent =
-      "On first launch, confirm the dev-channels prompt (\\"I am using this for local development\\"). " +
-      "After that, messages you send here inject directly into that idle session, and its replies appear here.";
+      "It will prompt for OAuth the first time (just like adding the vault) — no local file, " +
+      "works on any machine that can reach this URL. After it connects, messages you send here " +
+      "inject directly into that idle session, and its replies appear here.";
   }
 
   document.querySelectorAll(".copy").forEach(function (btn) {
     btn.addEventListener("click", function (e) {
       e.preventDefault();
-      var id = btn.getAttribute("data-copy") === "mcp" ? "snippet-mcp" : "snippet-launch";
-      var txt = document.getElementById(id).textContent;
+      var txt = document.getElementById("snippet-add").textContent;
       if (navigator.clipboard) navigator.clipboard.writeText(txt);
       var prev = btn.textContent; btn.textContent = "copied"; setTimeout(function () { btn.textContent = prev; }, 1200);
     });
@@ -546,6 +535,27 @@ export function createFetchHandler(
       });
     }
 
+    // ---------------------------------------------------------------------
+    // OAuth discovery for the HTTP MCP surface — RFC 9728 + RFC 8414, in the
+    // PATH-INSERTION form (`.well-known` ABOVE the resource path). This is the
+    // shape a Claude Code HTTP-MCP client probes when adding the channel by URL
+    // (the same shape vault serves). For the resource at `/mcp/<channel>`:
+    //
+    //   /.well-known/oauth-protected-resource/mcp/<channel>
+    //   /.well-known/oauth-authorization-server/mcp/<channel>
+    //
+    // Both are PUBLIC (no auth) — they have to be reachable before the client
+    // holds a token. Externally they're `<hub>/channel/.well-known/...`; hub's
+    // stripPrefix removes `/channel`, so the daemon matches the bare path and
+    // re-adds the prefix in the advertised URLs via x-forwarded-host.
+    // ---------------------------------------------------------------------
+    if (req.method === "GET") {
+      const prm = url.pathname.match(/^\/\.well-known\/oauth-protected-resource\/mcp\/([^/]+)$/);
+      if (prm) return handleProtectedResource(req, decodeURIComponent(prm[1]!));
+      const asm = url.pathname.match(/^\/\.well-known\/oauth-authorization-server\/mcp\/([^/]+)$/);
+      if (asm) return handleAuthorizationServer(req, decodeURIComponent(asm[1]!));
+    }
+
     // SSE event stream — bridges subscribe by channel. Bridge-facing: requires
     // a hub JWT with `channel:read`.
     if (req.method === "GET" && url.pathname === "/events") {
@@ -738,8 +748,20 @@ export function createFetchHandler(
       }
       // Gate on channel:read — short-circuits to 401 pre-JWKS when no token is
       // presented (testable without a live hub, same as the other endpoints).
+      // On a 401 (no/invalid bearer), decorate with the RFC 9728
+      // `WWW-Authenticate` challenge so a Claude Code HTTP-MCP client knows
+      // where to discover OAuth (mirrors vault's withMcpChallenge). The other
+      // endpoints (/events, /api/*) stay plain 401 — only the /mcp path drives
+      // a spec OAuth client, so only it carries the challenge.
       const denied = await requireScope(req, url, SCOPE_READ);
-      if (denied) return denied;
+      if (denied) {
+        if (denied.status === 401) {
+          const headers = new Headers(denied.headers);
+          headers.set("WWW-Authenticate", mcpWwwAuthenticate(req, channel));
+          return new Response(await denied.text(), { status: 401, headers });
+        }
+        return denied;
+      }
       // Re-validate to surface the caller's scopes for the write-tool checks.
       // (requireScope already proved the token valid + carrying channel:read;
       // this second pass hits the warm JWKS cache.) A token present but missing

--- a/src/mcp-http.test.ts
+++ b/src/mcp-http.test.ts
@@ -32,7 +32,7 @@ import type { Transport, ReplyArgs } from "./transport.ts";
 // server.notification. We use the exported _registerForTest below.
 // ---------------------------------------------------------------------------
 
-import { _registerSessionForTest } from "./mcp-http.ts";
+import { _registerSessionForTest, _unregisterSessionForTest } from "./mcp-http.ts";
 
 interface FakeServer {
   notes: Array<{ method: string; params: unknown }>;
@@ -106,6 +106,18 @@ describe("per-channel MCP session registry + wake push", () => {
     expect(mcpSessionCount("A")).toBe(1);
     _resetSessionsForTest();
     expect(mcpSessionCount("A")).toBe(0);
+  });
+
+  test("unregister cleans up the session and drops the empty channel set (no leak)", () => {
+    _registerSessionForTest("A", "sid-a1", fakeSession().server as never, ["channel:read"]);
+    _registerSessionForTest("A", "sid-a2", fakeSession().server as never, ["channel:read"]);
+    expect(mcpSessionCount("A")).toBe(2);
+    _unregisterSessionForTest("A", "sid-a1");
+    expect(mcpSessionCount("A")).toBe(1); // the other session survives
+    _unregisterSessionForTest("A", "sid-a2");
+    expect(mcpSessionCount("A")).toBe(0); // empty set removed — no orphaned channel entry
+    // a push to the now-cleaned channel reaches nobody
+    expect(pushToChannel("A", "hi", {})).toBe(0);
   });
 });
 

--- a/src/mcp-http.test.ts
+++ b/src/mcp-http.test.ts
@@ -1,0 +1,204 @@
+/**
+ * HTTP MCP tests — the per-channel session registry, the wake push, write-scope
+ * enforcement on tool dispatch, and the daemon's /mcp/<channel> auth gate.
+ *
+ * Like daemon.test.ts these need NO live hub: the no-token path in requireScope
+ * short-circuits before any JWKS fetch, and the registry/push/tool tests drive
+ * the in-memory session set directly with fake servers + a fake transport.
+ */
+import { describe, test, expect, afterEach, beforeAll, afterAll } from "bun:test";
+import {
+  pushToChannel,
+  pushPermissionVerdict,
+  mcpSessionCount,
+  _resetSessionsForTest,
+} from "./mcp-http.ts";
+import { createFetchHandler } from "./daemon.ts";
+import { ClientRegistry } from "./routing.ts";
+import { HttpUiTransport } from "./transports/http-ui.ts";
+import type { Channel } from "./registry.ts";
+import type { Transport, ReplyArgs } from "./transport.ts";
+
+// ---------------------------------------------------------------------------
+// Registry + wake — drive the session set directly via a registration shim.
+//
+// pushToChannel iterates the channel's session set and calls
+// server.notification. We register fake sessions by reaching the same internal
+// maps the way handleMcp's onsessioninitialized would. Since those maps are
+// module-private, we exercise them through the public surface: register via a
+// tiny test-only re-entry that mirrors registerSession. To keep this hermetic
+// without exporting internals, we register by spinning handleMcp is overkill;
+// instead we assert push reaches a registered session through a captured
+// server.notification. We use the exported _registerForTest below.
+// ---------------------------------------------------------------------------
+
+import { _registerSessionForTest } from "./mcp-http.ts";
+
+interface FakeServer {
+  notes: Array<{ method: string; params: unknown }>;
+}
+
+function fakeSession(): { server: { notification: (n: unknown) => void }; captured: FakeServer } {
+  const captured: FakeServer = { notes: [] };
+  const server = {
+    notification(n: unknown) {
+      captured.notes.push(n as { method: string; params: unknown });
+    },
+  };
+  return { server, captured };
+}
+
+afterEach(() => {
+  _resetSessionsForTest();
+});
+
+describe("per-channel MCP session registry + wake push", () => {
+  test("pushToChannel reaches a session on A and NOT one on B", () => {
+    const a = fakeSession();
+    const b = fakeSession();
+    _registerSessionForTest("A", "sid-a", a.server as never, ["channel:read", "channel:write"]);
+    _registerSessionForTest("B", "sid-b", b.server as never, ["channel:read"]);
+
+    const delivered = pushToChannel("A", "hello A", { foo: "bar" });
+    expect(delivered).toBe(1);
+    expect(a.captured.notes).toHaveLength(1);
+    expect(a.captured.notes[0]!.method).toBe("notifications/claude/channel");
+    expect((a.captured.notes[0]!.params as { content: string }).content).toBe("hello A");
+    // Source is stamped + caller meta merged.
+    expect((a.captured.notes[0]!.params as { meta: Record<string, string> }).meta).toMatchObject({
+      source: "parachute-channel",
+      foo: "bar",
+    });
+    // B got nothing.
+    expect(b.captured.notes).toHaveLength(0);
+  });
+
+  test("two sessions on the same channel both get the wake", () => {
+    const a1 = fakeSession();
+    const a2 = fakeSession();
+    _registerSessionForTest("A", "sid-a1", a1.server as never, ["channel:read"]);
+    _registerSessionForTest("A", "sid-a2", a2.server as never, ["channel:read"]);
+    expect(mcpSessionCount("A")).toBe(2);
+    const delivered = pushToChannel("A", "broadcast", {});
+    expect(delivered).toBe(2);
+    expect(a1.captured.notes).toHaveLength(1);
+    expect(a2.captured.notes).toHaveLength(1);
+  });
+
+  test("pushPermissionVerdict pushes the permission method", () => {
+    const a = fakeSession();
+    _registerSessionForTest("A", "sid-a", a.server as never, ["channel:read"]);
+    const delivered = pushPermissionVerdict("A", { request_id: "r1", behavior: "allow" });
+    expect(delivered).toBe(1);
+    expect(a.captured.notes[0]!.method).toBe("notifications/claude/channel/permission");
+    expect(a.captured.notes[0]!.params).toMatchObject({ request_id: "r1", behavior: "allow" });
+  });
+
+  test("push to an unknown channel delivers to nobody (0)", () => {
+    expect(pushToChannel("nope", "x", {})).toBe(0);
+    expect(pushPermissionVerdict("nope", { request_id: "r", behavior: "deny" })).toBe(0);
+  });
+
+  test("mcpSessionCount tracks registration + reset", () => {
+    expect(mcpSessionCount("A")).toBe(0);
+    const a = fakeSession();
+    _registerSessionForTest("A", "sid-a", a.server as never, ["channel:read"]);
+    expect(mcpSessionCount("A")).toBe(1);
+    _resetSessionsForTest();
+    expect(mcpSessionCount("A")).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tool dispatch — a reply tool call routes to the channel's transport.
+// ---------------------------------------------------------------------------
+
+describe("tool dispatch routes to the channel's transport + enforces write scope", () => {
+  function fakeTransport(): { transport: Transport; replies: ReplyArgs[] } {
+    const replies: ReplyArgs[] = [];
+    const transport: Transport = {
+      kind: "fake",
+      async start() {},
+      async stop() {},
+      async reply(args: ReplyArgs) {
+        replies.push(args);
+        return { sent: ["msg-1"] };
+      },
+    };
+    return { transport, replies };
+  }
+
+  test("a write-scoped reply call reaches transport.reply with the channel + args", async () => {
+    const { transport, replies } = fakeTransport();
+    const { callReplyTool } = await import("./mcp-http.ts");
+    const result = await callReplyTool("A", transport, ["channel:read", "channel:write"], {
+      text: "hi there",
+      chat_id: "42",
+    });
+    expect(result.isError).toBeUndefined();
+    expect(replies).toHaveLength(1);
+    expect(replies[0]).toMatchObject({ channel: "A", text: "hi there", meta: { chat_id: "42" } });
+  });
+
+  test("a read-only token cannot call reply (write scope enforced)", async () => {
+    const { transport, replies } = fakeTransport();
+    const { callReplyTool } = await import("./mcp-http.ts");
+    const result = await callReplyTool("A", transport, ["channel:read"], { text: "blocked" });
+    expect(result.isError).toBe(true);
+    expect(replies).toHaveLength(0);
+    expect((result.content[0] as { text: string }).text).toContain("channel:write");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Daemon auth gate — POST /mcp/<channel> with no bearer → 401 (pre-JWKS).
+// ---------------------------------------------------------------------------
+
+describe("daemon /mcp/<channel> auth gate", () => {
+  let server: ReturnType<typeof Bun.serve>;
+  let base: string;
+
+  beforeAll(async () => {
+    const registry = new ClientRegistry();
+    const transport = new HttpUiTransport({ channel: "ui1" });
+    await transport.start({ channel: "ui1", emit: () => {}, emitPermissionVerdict: () => {} });
+    const channels = new Map<string, Channel>([
+      ["ui1", { name: "ui1", transport, entry: { name: "ui1", transport: "http-ui" } }],
+    ]);
+    server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      idleTimeout: 0,
+      fetch: createFetchHandler(channels, registry),
+    });
+    base = `http://127.0.0.1:${server.port}`;
+  });
+
+  afterAll(() => {
+    server.stop(true);
+  });
+
+  test("POST /mcp/ui1 with an initialize body and no bearer → 401", async () => {
+    const res = await fetch(`${base}/mcp/ui1`, {
+      method: "POST",
+      headers: { "content-type": "application/json", accept: "application/json, text/event-stream" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "t", version: "0" } },
+      }),
+    });
+    expect(res.status).toBe(401);
+    expect(((await res.json()) as { error: string }).error).toBe("unauthorized");
+  });
+
+  test("POST /mcp/unknown-channel → 404 (channel miss, before auth body)", async () => {
+    const res = await fetch(`${base}/mcp/does-not-exist`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} }),
+    });
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/mcp-http.ts
+++ b/src/mcp-http.ts
@@ -1,0 +1,503 @@
+/**
+ * Stateful HTTP MCP endpoint for parachute-channel.
+ *
+ * A second, additive way for a Claude Code session to connect to a channel:
+ * instead of spawning the stdio `bridge.ts` and consuming the daemon's SSE
+ * `/events`, the session adds the channel as a *pure HTTP MCP server* (URL +
+ * OAuth) — exactly like the vault. No local file, works on any machine.
+ *
+ * Why STATEFUL (not stateless like vault's mcp-http.ts): the channel's headline
+ * feature is the IDLE WAKE — Claude Code's `notifications/claude/channel` must
+ * fire on an idle session when an inbound message arrives. That requires the
+ * server to PUSH a notification to a *persistent* connection. Stateful
+ * Streamable HTTP (a `sessionIdGenerator` + `enableJsonResponse:false`) gives
+ * each session an SSE GET stream the server can push onto. The probe at
+ * /tmp/http-mcp-probe/probe-server.ts proved CC opens that GET stream and acts
+ * on server-pushed `notifications/claude/channel` while idle. This file is that
+ * probe's structure, productionized: per-channel session registry, the real
+ * tool surface ported from bridge.ts, and read-vs-write scope enforcement.
+ *
+ * Lifecycle:
+ *   - POST /mcp/<channel> with no mcp-session-id → a NEW session: build a
+ *     Server + stateful transport, connect, register under <channel> on
+ *     onsessioninitialized.
+ *   - POST/GET /mcp/<channel> with a known mcp-session-id → route to that
+ *     session's transport (GET opens the SSE push stream).
+ *   - DELETE /mcp/<channel> (or transport.onclose) → tear the session down and
+ *     drop it from the channel's set.
+ *
+ * Auth: the daemon validates `channel:read` BEFORE calling handleMcp (a session
+ * needs read to connect + receive the wake). The validated scopes are threaded
+ * in and stored ON the session, so the reply/react/edit/download tool handlers
+ * can additionally require `channel:write` — a read-only token connects and is
+ * woken but cannot send.
+ */
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import {
+  ListToolsRequestSchema,
+  CallToolRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import type {
+  Transport,
+  ReplyArgs,
+  ReactArgs,
+  EditArgs,
+  DownloadArgs,
+} from "./transport.ts";
+import { SCOPE_WRITE } from "./auth.ts";
+
+// ---------------------------------------------------------------------------
+// Per-channel session registry
+// ---------------------------------------------------------------------------
+
+/** A live HTTP MCP session = a Server + its stateful transport + caller scopes. */
+interface McpSession {
+  server: Server;
+  transport: WebStandardStreamableHTTPServerTransport;
+  /** The scopes the connecting token carried — write-tools check these. */
+  scopes: string[];
+}
+
+/**
+ * channel name → its set of live MCP sessions. A push on channel A reaches only
+ * the sessions registered under A. Distinct from the SSE ClientRegistry (which
+ * serves stdio bridges over `/events`); the two run side by side.
+ */
+const sessionsByChannel = new Map<string, Set<McpSession>>();
+
+/** mcp-session-id → session, so a follow-up POST/GET/DELETE finds its transport. */
+const sessionsById = new Map<string, McpSession>();
+
+function registerSession(channel: string, id: string, session: McpSession): void {
+  let set = sessionsByChannel.get(channel);
+  if (!set) {
+    set = new Set();
+    sessionsByChannel.set(channel, set);
+  }
+  set.add(session);
+  sessionsById.set(id, session);
+}
+
+function unregisterSession(channel: string, id: string): void {
+  const session = sessionsById.get(id);
+  sessionsById.delete(id);
+  const set = sessionsByChannel.get(channel);
+  if (set && session) {
+    set.delete(session);
+    if (set.size === 0) sessionsByChannel.delete(channel);
+  }
+}
+
+/** Count of live MCP sessions on a channel (for /health). */
+export function mcpSessionCount(channel: string): number {
+  return sessionsByChannel.get(channel)?.size ?? 0;
+}
+
+/** Test/teardown helper — drop every registered session without touching transports. */
+export function _resetSessionsForTest(): void {
+  sessionsByChannel.clear();
+  sessionsById.clear();
+}
+
+/**
+ * Test-only: register a fake session under a channel without booting a real
+ * transport. The `server` only needs a `.notification` method for the push
+ * tests; pass scopes to model a connection's grant.
+ */
+export function _registerSessionForTest(
+  channel: string,
+  id: string,
+  server: Server,
+  scopes: string[],
+): void {
+  registerSession(channel, id, { server, transport: undefined as never, scopes });
+}
+
+// ---------------------------------------------------------------------------
+// The wake — push to a channel's MCP sessions
+// ---------------------------------------------------------------------------
+
+/**
+ * Push an inbound message to every MCP session on `channel` as a
+ * `notifications/claude/channel` — the wake that pulls an idle session in to
+ * answer. The daemon calls this alongside the existing SSE `routeToChannel`, so
+ * both stdio bridges and HTTP MCP sessions receive the same inbound traffic.
+ */
+export function pushToChannel(
+  channel: string,
+  content: string,
+  meta: Record<string, string>,
+): number {
+  const set = sessionsByChannel.get(channel);
+  if (!set) return 0;
+  let delivered = 0;
+  for (const session of set) {
+    try {
+      void session.server.notification({
+        method: "notifications/claude/channel",
+        params: { content, meta: { source: "parachute-channel", ...meta } },
+      });
+      delivered++;
+    } catch {
+      // A dead session throws; the transport's onclose handler removes it.
+    }
+  }
+  return delivered;
+}
+
+/**
+ * Push a permission verdict to a channel's MCP sessions (mirrors the SSE
+ * `permission_verdict` route → bridge's `notifications/claude/channel/permission`).
+ */
+export function pushPermissionVerdict(
+  channel: string,
+  verdict: { request_id: string; behavior: string },
+): number {
+  const set = sessionsByChannel.get(channel);
+  if (!set) return 0;
+  let delivered = 0;
+  for (const session of set) {
+    try {
+      void session.server.notification({
+        method: "notifications/claude/channel/permission",
+        params: { request_id: verdict.request_id, behavior: verdict.behavior },
+      });
+      delivered++;
+    } catch {}
+  }
+  return delivered;
+}
+
+// ---------------------------------------------------------------------------
+// Tool surface — ported from bridge.ts, dispatched to the channel's transport
+// ---------------------------------------------------------------------------
+
+const INSTRUCTIONS = [
+  "You are connected to a live chat channel over HTTP MCP. A human is messaging you through it.",
+  "",
+  "CRITICAL — HOW THE HUMAN SEES YOU: they read ONLY what you send via the `reply` tool. Your normal assistant/transcript text is INVISIBLE to them. So for EVERY message that arrives on this channel you MUST call the `reply` tool to answer — even a one-word reply. Never answer only in your transcript: if you don't call `reply`, the human sees nothing at all.",
+  "",
+  'Inbound messages arrive as <channel source="parachute-channel" ...> with metadata attributes describing the sender. Treat each as a chat message from the human and respond by calling the reply tool — the daemon routes it back out the same channel. Pass back any addressing fields the inbound tag carried (e.g. chat_id) if present; omit them otherwise. Use reply_to (message_id) to thread a specific message; omit it for normal responses.',
+  "",
+  "If the tag has an image_path attribute, Read that file — it is an attachment the sender sent.",
+  "If the tag has attachment_file_id, call download_attachment with that file_id to fetch the file, then Read the returned path.",
+  "",
+  "Use react to add emoji reactions. Use edit_message for interim progress updates (edits do not push notifications — send a new reply when a long task completes so the user's device pings).",
+  "",
+  'reply accepts file paths (files: ["/abs/path.png"]) for attachments.',
+].join("\n");
+
+/** The tool list — identical schema to bridge.ts (transport-neutral: no chat_id required on reply). */
+const TOOL_DEFS = [
+  {
+    name: "reply",
+    description:
+      "Send a message back through the channel to the sender. Supports text, file attachments, and quote-reply threading. The daemon routes it out whichever transport the channel uses.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        text: { type: "string", description: "Message text (optional if files provided)" },
+        reply_to: { type: "string", description: "Message ID to quote-reply (optional)" },
+        files: {
+          type: "array",
+          items: { type: "string" },
+          description: "Absolute file paths to attach (optional)",
+        },
+        chat_id: {
+          type: "string",
+          description:
+            "Addressing field some transports need (e.g. a Telegram chat ID). Include it ONLY if the inbound message tag carried one; omit it otherwise (e.g. for a web/UI channel).",
+        },
+      },
+      required: [] as string[],
+    },
+  },
+  {
+    name: "react",
+    description:
+      "Add an emoji reaction to a message, on transports that support reactions (e.g. Telegram's fixed emoji whitelist 👍 👎 ❤ 🔥 👀). Not all channels support this.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        message_id: { type: "string", description: "Message ID to react to" },
+        emoji: { type: "string", description: "Emoji reaction" },
+        chat_id: {
+          type: "string",
+          description: "Addressing field for transports that need it (e.g. Telegram chat ID); omit otherwise.",
+        },
+      },
+      required: ["message_id", "emoji"],
+    },
+  },
+  {
+    name: "edit_message",
+    description:
+      "Edit a message you previously sent. Useful for progress updates. On most transports edits don't push a notification.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        message_id: { type: "string", description: "Message ID to edit" },
+        text: { type: "string", description: "New text" },
+        chat_id: {
+          type: "string",
+          description: "Addressing field for transports that need it (e.g. Telegram chat ID); omit otherwise.",
+        },
+      },
+      required: ["message_id", "text"],
+    },
+  },
+  {
+    name: "download_attachment",
+    description: "Download a Telegram file attachment by file_id. Returns the local path.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        file_id: { type: "string", description: "Telegram file_id from the attachment_file_id attribute" },
+      },
+      required: ["file_id"],
+    },
+  },
+];
+
+const WRITE_TOOLS = new Set(["reply", "react", "edit_message"]);
+
+/** Fold a top-level chat_id into meta, mirroring the daemon's mergeMeta. */
+function mergeMeta(args: Record<string, unknown>): Record<string, string> {
+  const meta: Record<string, string> = {};
+  if (typeof args.chat_id === "string") meta.chat_id = args.chat_id;
+  return meta;
+}
+
+/**
+ * Build the per-session MCP Server. Tool handlers dispatch to `transport` — the
+ * SAME transport methods the daemon's `/api/*` handlers call — and check write
+ * scope against `session.scopes` (mutated by the caller after construction so
+ * the closure reads the live value). `channel` is threaded so outbound args
+ * carry the right channel context.
+ */
+function buildServer(channel: string, transport: Transport, session: McpSession): Server {
+  const server = new Server(
+    { name: "parachute-channel", version: "0.1.0" },
+    {
+      capabilities: {
+        experimental: {
+          "claude/channel": {},
+          "claude/channel/permission": {},
+        },
+        tools: {},
+      },
+      instructions: INSTRUCTIONS,
+    },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOL_DEFS }));
+
+  // Dispatch reads `session.scopes` live (the daemon refreshes it per request),
+  // so a re-auth with a narrower token takes effect on the next tool call.
+  server.setRequestHandler(CallToolRequestSchema, async (req) => {
+    const result = await dispatchTool(
+      channel,
+      transport,
+      session.scopes,
+      req.params.name,
+      (req.params.arguments ?? {}) as Record<string, unknown>,
+    );
+    // Our ToolResult is the content/isError subset of the SDK's CallToolResult
+    // (which also has a task-variant we never emit); return it as that shape.
+    return result as { content: Array<{ type: "text"; text: string }>; isError?: boolean };
+  });
+
+  return server;
+}
+
+/** A tool-call result in the MCP content shape. */
+export interface ToolResult {
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+}
+
+/**
+ * Dispatch one tool call to the channel's transport, enforcing write scope on
+ * the mutating tools (reply/react/edit) from the connection's `scopes`. Pure
+ * over its inputs — the daemon's per-session handler and the unit tests both
+ * call it, so tool behavior is asserted without standing up an MCP transport.
+ */
+export async function dispatchTool(
+  channel: string,
+  transport: Transport,
+  scopes: string[],
+  name: string,
+  args: Record<string, unknown>,
+): Promise<ToolResult> {
+  // Read-only tokens connect + receive the wake, but cannot send. Enforce
+  // channel:write on the mutating tools using the connection's own scopes.
+  if (WRITE_TOOLS.has(name) && !scopes.includes(SCOPE_WRITE)) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: `tool "${name}" requires the ${SCOPE_WRITE} scope, which this connection's token lacks`,
+        },
+      ],
+      isError: true,
+    };
+  }
+
+  try {
+    switch (name) {
+      case "reply": {
+        const replyArgs: ReplyArgs = {
+          channel,
+          text: typeof args.text === "string" ? args.text : undefined,
+          files: Array.isArray(args.files) ? (args.files as string[]) : undefined,
+          reply_to: typeof args.reply_to === "string" ? args.reply_to : undefined,
+          meta: mergeMeta(args),
+        };
+        const result = await transport.reply(replyArgs);
+        const ids = result.sent;
+        const parts = ids.length === 1 ? `(id: ${ids[0]})` : `(ids: ${ids.join(", ")})`;
+        return {
+          content: [{ type: "text", text: `sent ${ids.length} part${ids.length === 1 ? "" : "s"} ${parts}` }],
+        };
+      }
+
+      case "react": {
+        if (!transport.react) return methodMissing(channel, transport, "react");
+        const reactArgs: ReactArgs = {
+          channel,
+          message_id: String(args.message_id ?? ""),
+          emoji: String(args.emoji ?? ""),
+          meta: mergeMeta(args),
+        };
+        await transport.react(reactArgs);
+        return { content: [{ type: "text", text: "reacted" }] };
+      }
+
+      case "edit_message": {
+        if (!transport.edit) return methodMissing(channel, transport, "edit");
+        const editArgs: EditArgs = {
+          channel,
+          message_id: String(args.message_id ?? ""),
+          text: String(args.text ?? ""),
+          meta: mergeMeta(args),
+        };
+        await transport.edit(editArgs);
+        return { content: [{ type: "text", text: "edited" }] };
+      }
+
+      case "download_attachment": {
+        if (!transport.download) return methodMissing(channel, transport, "download");
+        const dlArgs: DownloadArgs = { channel, file_id: String(args.file_id ?? "") };
+        const result = await transport.download(dlArgs);
+        return { content: [{ type: "text", text: result.path }] };
+      }
+
+      default:
+        return { content: [{ type: "text", text: `unknown tool: ${name}` }], isError: true };
+    }
+  } catch (err) {
+    return {
+      content: [{ type: "text", text: `${name} failed: ${err instanceof Error ? err.message : String(err)}` }],
+      isError: true,
+    };
+  }
+}
+
+/** Thin alias the reply-dispatch tests read against. */
+export function callReplyTool(
+  channel: string,
+  transport: Transport,
+  scopes: string[],
+  args: Record<string, unknown>,
+): Promise<ToolResult> {
+  return dispatchTool(channel, transport, scopes, "reply", args);
+}
+
+function methodMissing(channel: string, transport: Transport, method: string): ToolResult {
+  return {
+    content: [
+      {
+        type: "text",
+        text: `transport "${transport.kind}" for channel "${channel}" does not support ${method}`,
+      },
+    ],
+    isError: true,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// HTTP entry — the daemon routes POST/GET/DELETE /mcp/<channel> here
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle a stateful Streamable HTTP MCP request for `channel`, dispatching tool
+ * calls to `transport`. The daemon has ALREADY validated `channel:read` and
+ * passes the caller's scopes in (threaded onto the session for write-tool
+ * checks). Returns the transport's Response (JSON or an SSE stream).
+ *
+ * Session resolution mirrors the probe:
+ *   - existing mcp-session-id → reuse its transport.
+ *   - POST with no session id → a NEW session (initialize handshake).
+ *   - anything else with no/unknown session id → 400 (no session to attach to).
+ */
+export async function handleMcp(
+  req: Request,
+  channel: string,
+  transport: Transport,
+  scopes: string[],
+): Promise<Response> {
+  const sid = req.headers.get("mcp-session-id");
+
+  if (sid && sessionsById.has(sid)) {
+    const existing = sessionsById.get(sid)!;
+    // Refresh the connection's scopes from the presented token each request, so
+    // a re-auth with a narrower/wider token takes effect (the daemon re-validates
+    // channel:read on every call before reaching here).
+    existing.scopes = scopes;
+    return existing.transport.handleRequest(req);
+  }
+
+  if (req.method === "DELETE") {
+    // No session to delete — treat as a no-op success.
+    return new Response(null, { status: 204 });
+  }
+
+  if (req.method !== "POST") {
+    return new Response(
+      JSON.stringify({ jsonrpc: "2.0", error: { code: -32000, message: "No valid session" }, id: null }),
+      { status: 400, headers: { "content-type": "application/json" } },
+    );
+  }
+
+  // New session — build the transport + server, register on init.
+  const session: McpSession = {
+    // Placeholders replaced immediately below; the object identity is what the
+    // registry + tool closures capture.
+    server: undefined as unknown as Server,
+    transport: undefined as unknown as WebStandardStreamableHTTPServerTransport,
+    scopes,
+  };
+
+  const httpTransport = new WebStandardStreamableHTTPServerTransport({
+    sessionIdGenerator: () => crypto.randomUUID(),
+    enableJsonResponse: false,
+    onsessioninitialized: (id: string) => {
+      registerSession(channel, id, session);
+    },
+  });
+
+  const server = buildServer(channel, transport, session);
+  session.server = server;
+  session.transport = httpTransport;
+
+  // Clean up on transport close (client disconnect / DELETE / stream end).
+  httpTransport.onclose = () => {
+    const id = httpTransport.sessionId;
+    if (id) unregisterSession(channel, id);
+  };
+
+  await server.connect(httpTransport);
+  return httpTransport.handleRequest(req);
+}

--- a/src/mcp-http.ts
+++ b/src/mcp-http.ts
@@ -115,6 +115,11 @@ export function _registerSessionForTest(
   registerSession(channel, id, { server, transport: undefined as never, scopes });
 }
 
+/** Test-only: remove a registered session — exercises the empty-set cleanup path. */
+export function _unregisterSessionForTest(channel: string, id: string): void {
+  unregisterSession(channel, id);
+}
+
 // ---------------------------------------------------------------------------
 // The wake — push to a channel's MCP sessions
 // ---------------------------------------------------------------------------
@@ -141,7 +146,9 @@ export function pushToChannel(
       });
       delivered++;
     } catch {
-      // A dead session throws; the transport's onclose handler removes it.
+      // A dead session throws SYNCHRONOUSLY on a closed transport (SDK `send`), so
+      // this catch runs and the count stays honest; the transport's onclose handler
+      // removes the session from the set.
     }
   }
   return delivered;
@@ -261,6 +268,11 @@ const TOOL_DEFS = [
   },
 ];
 
+// Tools that send/mutate on the channel require channel:write. download_attachment
+// is deliberately NOT here: fetching an attachment that was sent *to* this session is
+// read-access — a channel:read session can receive and read its own messages,
+// attachments included. (The legacy stdio-bridge /api/download gates it as write; the
+// MCP path is the principled read. If they ever need to match, relax the bridge, not this.)
 const WRITE_TOOLS = new Set(["reply", "react", "edit_message"]);
 
 /** Fold a top-level chat_id into meta, mirroring the daemon's mergeMeta. */

--- a/src/oauth-discovery.ts
+++ b/src/oauth-discovery.ts
@@ -1,0 +1,134 @@
+/**
+ * OAuth discovery endpoints for parachute-channel's HTTP MCP surface — the
+ * *resource server* side of the authorization story.
+ *
+ * Mirrors `parachute-vault/src/oauth-discovery.ts` exactly. The channel is a
+ * resource server, not an authorization server: the hub is the OAuth issuer
+ * (see the hub-as-portal-oauth design doc). These endpoints advertise that
+ * contract to clients per RFC 9728 + RFC 8414 so a Claude Code HTTP-MCP client
+ * adding the channel by URL can auto-discover the hub and run the OAuth flow —
+ * the same way it discovers a vault.
+ *
+ *   - `handleProtectedResource` — RFC 9728: "this is the protected resource at
+ *     `<channel>/mcp/<channel>`; the authorization server lives at <hub>".
+ *   - `handleAuthorizationServer` — RFC 8414: "go to <hub>/oauth/* for the
+ *     authorization endpoints" (forwarded shape — issuer + every endpoint name
+ *     the hub).
+ *
+ * The channel resource lives at `/mcp/<channel>` on the daemon, externally
+ * `<hub>/channel/mcp/<channel>` (hub's stripPrefix removes `/channel`). The
+ * metadata `resource` value is built from the request's forwarded host so the
+ * advertised URL is the public one, not loopback.
+ *
+ * `PARACHUTE_HUB_ORIGIN` (via `getHubOrigin()`) is required for these endpoints
+ * to advertise the right issuer URL — the hub stamps that origin as the token
+ * `iss`. The loopback fallback is for a co-located, never-exposed dev daemon.
+ */
+
+import { getHubOrigin } from "./hub-jwt.ts";
+import { SCOPE_READ, SCOPE_WRITE } from "./auth.ts";
+
+/**
+ * OAuth scopes the channel publishes through discovery. These are the channel
+ * session scopes: a session needs `channel:read` to connect + receive the wake,
+ * and `channel:write` to send (reply/react/edit). A spec-following MCP client
+ * reads `scopes_supported` from this PRM and requests exactly these scopes.
+ */
+function scopesSupported(): string[] {
+  return [SCOPE_READ, SCOPE_WRITE];
+}
+
+/**
+ * Public-facing base URL of the daemon. Honors `x-forwarded-*` headers so a
+ * Cloudflare Tunnel / Tailscale Funnel / reverse-proxied (hub) deployment
+ * advertises the right external origin in the `resource` URL. Mirrors vault's
+ * `getBaseUrl`.
+ *
+ * Exported so the daemon can build a `WWW-Authenticate` challenge header that
+ * points at the same origin as the `/.well-known/*` metadata documents.
+ */
+export function getBaseUrl(req: Request): string {
+  const forwardedHost = req.headers.get("x-forwarded-host");
+  const forwardedProto = req.headers.get("x-forwarded-proto");
+  if (forwardedHost) {
+    return `${forwardedProto || "https"}://${forwardedHost}`;
+  }
+  const url = new URL(req.url);
+  return url.origin;
+}
+
+/**
+ * The mount prefix the channel sits under when served through the hub expose.
+ * Hub reverse-proxies `<expose>/channel/*` → the loopback daemon with
+ * `stripPrefix:true`, so the daemon itself never sees `/channel`. But the
+ * PUBLIC resource URL a client must address is `<hub>/channel/mcp/<channel>`.
+ *
+ * When the request carries `x-forwarded-host` (i.e. it came through the hub),
+ * the public URL needs the `/channel` prefix re-added; a direct loopback
+ * request (no forwarded host) addresses `/mcp/<channel>` with no prefix. We key
+ * off the forwarded-host presence to decide.
+ */
+function mountPrefix(req: Request): string {
+  return req.headers.get("x-forwarded-host") ? "/channel" : "";
+}
+
+/**
+ * OAuth 2.0 Protected Resource Metadata (RFC 9728).
+ *
+ * Advertises the channel's `/mcp/<channel>` endpoint as the protected resource
+ * and names the hub as the authorization server. Clients following the spec
+ * fetch this, then fetch the AS metadata at
+ * `<hub>/.well-known/oauth-authorization-server` to drive the full flow.
+ */
+export function handleProtectedResource(req: Request, channel: string): Response {
+  const base = getBaseUrl(req);
+  const prefix = mountPrefix(req);
+  return Response.json({
+    resource: `${base}${prefix}/mcp/${channel}`,
+    authorization_servers: [getHubOrigin()],
+    scopes_supported: scopesSupported(),
+    bearer_methods_supported: ["header"],
+  });
+}
+
+/**
+ * OAuth 2.0 Authorization Server Metadata (RFC 8414).
+ *
+ * The channel is a resource server, not an authorization server — but we serve
+ * this document as a *forwarding* metadata document: issuer + every endpoint
+ * name the hub. Clients that follow the PRM pointer land here and discover the
+ * hub's actual endpoints; conformant clients that probe AS metadata directly at
+ * the channel path get the same answer. Mirrors vault.
+ */
+export function handleAuthorizationServer(_req: Request, _channel: string): Response {
+  const hub = getHubOrigin();
+  return Response.json({
+    issuer: hub,
+    authorization_endpoint: `${hub}/oauth/authorize`,
+    token_endpoint: `${hub}/oauth/token`,
+    registration_endpoint: `${hub}/oauth/register`,
+    jwks_uri: `${hub}/.well-known/jwks.json`,
+    response_types_supported: ["code"],
+    code_challenge_methods_supported: ["S256"],
+    grant_types_supported: ["authorization_code", "refresh_token"],
+    token_endpoint_auth_methods_supported: ["none", "client_secret_post"],
+    scopes_supported: scopesSupported(),
+  });
+}
+
+/**
+ * RFC 9728 `WWW-Authenticate` challenge value pointing at the protected-resource
+ * metadata document for `channel`. When a Claude Code HTTP-MCP client hits
+ * `/mcp/<channel>` with no/invalid bearer and gets a 401 carrying this header,
+ * it knows where to fetch the OAuth discovery metadata and start the flow.
+ *
+ * The advertised metadata URL uses the path-insertion form Claude Code probes
+ * (`/.well-known/oauth-protected-resource/mcp/<channel>`) so the client's first
+ * fetch off this header lands on a route the daemon actually serves. Built from
+ * the same `getBaseUrl` as the metadata document so the origins match.
+ */
+export function mcpWwwAuthenticate(req: Request, channel: string): string {
+  const base = getBaseUrl(req);
+  const prefix = mountPrefix(req);
+  return `Bearer resource_metadata="${base}${prefix}/.well-known/oauth-protected-resource/mcp/${channel}"`;
+}


### PR DESCRIPTION
## The channel is now an HTTP MCP server, like the vault

Per Aaron: a session should connect to the channel **over HTTP by URL + OAuth, no local bridge file, on any machine** — the same way you add the vault MCP. This delivers it.

### The load-bearing finding
The wake (`notifications/claude/channel` pulling an idle session in to answer) needs server→client push. Vault's HTTP MCP is *stateless* (no push), which suggested the wake couldn't survive. So I **probed it**: in **stateful** Streamable HTTP mode, Claude Code opens a server-push SSE stream and **the idle-session wake fires over HTTP MCP**. Then verified the whole loop live — a session added by URL (no bridge file) woke and replied through the daemon (`9 × 9 = 81`).

### What's in it
- **`src/mcp-http.ts`** — stateful Streamable HTTP MCP endpoint at `/mcp/<channel>`. Per-channel session registry; `pushToChannel` fans the wake to a channel's MCP sessions; tools (reply/react/edit/download) dispatch to the channel's transport. `/mcp/<channel>` requires `channel:read`; the mutating tools enforce `channel:write` from the connection's scopes (a read-only token can connect+be woken but not reply — verified live; download is read-accessible by design).
- **`src/oauth-discovery.ts`** — RFC 9728/8414 `.well-known` (path-insertion form, mirroring vault) + a `WWW-Authenticate` 401 challenge on `/mcp/*`, so `claude mcp add --transport http <hub>/channel/mcp/<name>` auto-discovers hub-as-issuer and runs OAuth like the vault.
- **`scripts/launch-session.sh`** — writes a `type:http` `.mcp.json` (no bridge path); polls `mcp_sessions`.
- **Setup UI** — the "Connect a session" panel now shows the `claude mcp add --transport http` one-liner, not a file.
- **Additive**: the stdio bridge, `/events`, `/api/*`, http-ui, and Layer 1/2 auth all stay working.

### Testing
`bun run typecheck` clean; `bun test src/` **91 pass / 0 fail**. Reviewer LGTM (zero must-fix); nits folded (download-scope comment, launcher health field, session-cleanup test). Core verified live end-to-end against the real hub JWKS.

### Note for live verify (your browser)
The token-header path (launcher) is verified. The full **OAuth flow** (`claude mcp add` → browser consent) is the one thing needing your manual confirm on a real add, since it needs an interactive browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)