### PR TITLE
fix(channel): consistent channel-<name> MCP naming + two-step setup UI

### DIFF
--- a/scripts/launch-session.sh
+++ b/scripts/launch-session.sh
@@ -80,11 +80,15 @@ fi
 # headless/local launch path); a human adding the channel by hand uses
 # `claude mcp add --transport http` and gets prompted for OAuth instead.
 MCP_URL="$DAEMON_URL/mcp/$CHANNEL"
+# MCP server name — `channel-<channel>` so the .mcp.json key, the
+# `--dangerously-load-development-channels=server:<name>` flag, and the daemon's
+# self-reported name all match (no `server:aaron` vs `server:channel` surprise).
+MCP_NAME="channel-$CHANNEL"
 if [ -n "$TOKEN" ]; then
   cat > "$WORKDIR/.mcp.json" <<EOF
 {
   "mcpServers": {
-    "parachute-channel": {
+    "$MCP_NAME": {
       "type": "http",
       "url": "$MCP_URL",
       "headers": {
@@ -98,7 +102,7 @@ else
   cat > "$WORKDIR/.mcp.json" <<EOF
 {
   "mcpServers": {
-    "parachute-channel": {
+    "$MCP_NAME": {
       "type": "http",
       "url": "$MCP_URL"
     }
@@ -124,7 +128,7 @@ EOF
 
 echo "launching session '$SESSION' on channel '$CHANNEL' (daemon $DAEMON_URL)…"
 tmux new-session -d -s "$SESSION" -x 220 -y 50 \
-  "cd '$WORKDIR' && exec claude --dangerously-load-development-channels=server:parachute-channel --dangerously-skip-permissions"
+  "cd '$WORKDIR' && exec claude --dangerously-load-development-channels=server:$MCP_NAME --dangerously-skip-permissions"
 
 # First-launch prompts render a beat after start; accept them, then wait for the
 # channel to attach. The order can vary, so poll for either.

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -191,8 +191,11 @@ const CHAT_UI_HTML = `<!doctype html>
   <details class="setup">
     <summary>Connect a Claude Code session ▾</summary>
     <div class="body">
-      <p>Add this channel as an HTTP MCP server — by URL, exactly like adding the vault. Run:</p>
-      <pre><button class="copy" data-copy="add">copy</button><code id="snippet-add"></code></pre>
+      <p>Two steps — add the channel by URL (like the vault), then open a session on it:</p>
+      <p><b>1.</b> Add it (once — prompts for OAuth the first time):</p>
+      <pre><button class="copy" data-copy="snippet-add">copy</button><code id="snippet-add"></code></pre>
+      <p><b>2.</b> Open a session on it (run in any directory):</p>
+      <pre><button class="copy" data-copy="snippet-launch">copy</button><code id="snippet-launch"></code></pre>
       <p id="setup-note"></p>
     </div>
   </details>
@@ -247,20 +250,23 @@ const CHAT_UI_HTML = `<!doctype html>
     // expose, location.origin IS the hub origin and the channel mounts under
     // /channel; served directly off the daemon, it's the loopback origin with
     // no mount prefix. MOUNT (derived from the page path) captures that prefix.
-    var addCmd =
-      "claude mcp add --transport http channel " +
-      window.location.origin + MOUNT + "/mcp/" + ch;
-    document.getElementById("snippet-add").textContent = addCmd;
+    var name = "channel-" + ch;
+    var url = window.location.origin + MOUNT + "/mcp/" + ch;
+    document.getElementById("snippet-add").textContent =
+      "claude mcp add --transport http --scope user " + name + " " + url;
+    document.getElementById("snippet-launch").textContent =
+      "claude --dangerously-load-development-channels=server:" + name + " --dangerously-skip-permissions";
     document.getElementById("setup-note").textContent =
-      "It will prompt for OAuth the first time (just like adding the vault) — no local file, " +
-      "works on any machine that can reach this URL. After it connects, messages you send here " +
-      "inject directly into that idle session, and its replies appear here.";
+      "Step 1 prompts for OAuth the first time (like adding the vault) — no local file, any machine. " +
+      "Step 2 makes that session a live responder for this channel; the flag's name MUST match step 1. " +
+      "--scope user makes it available in any directory — drop it to scope to the current project. " +
+      "Then messages you send here inject into that idle session and its replies appear here.";
   }
 
   document.querySelectorAll(".copy").forEach(function (btn) {
     btn.addEventListener("click", function (e) {
       e.preventDefault();
-      var txt = document.getElementById("snippet-add").textContent;
+      var txt = document.getElementById(btn.getAttribute("data-copy")).textContent;
       if (navigator.clipboard) navigator.clipboard.writeText(txt);
       var prev = btn.textContent; btn.textContent = "copied"; setTimeout(function () { btn.textContent = prev; }, 1200);
     });

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -266,7 +266,9 @@ const CHAT_UI_HTML = `<!doctype html>
   document.querySelectorAll(".copy").forEach(function (btn) {
     btn.addEventListener("click", function (e) {
       e.preventDefault();
-      var txt = document.getElementById(btn.getAttribute("data-copy")).textContent;
+      var el = document.getElementById(btn.getAttribute("data-copy") || "");
+      if (!el) return;
+      var txt = el.textContent;
       if (navigator.clipboard) navigator.clipboard.writeText(txt);
       var prev = btn.textContent; btn.textContent = "copied"; setTimeout(function () { btn.textContent = prev; }, 1200);
     });

--- a/src/mcp-http.ts
+++ b/src/mcp-http.ts
@@ -291,7 +291,10 @@ function mergeMeta(args: Record<string, unknown>): Record<string, string> {
  */
 function buildServer(channel: string, transport: Transport, session: McpSession): Server {
   const server = new Server(
-    { name: "parachute-channel", version: "0.1.0" },
+    // Per-channel name (`channel-<name>`) so it reads clearly in `/mcp` and lines
+    // up with the `--dangerously-load-development-channels=server:channel-<name>`
+    // flag + the `claude mcp add channel-<name>` name the setup UI/launcher use.
+    { name: `channel-${channel}`, version: "0.1.0" },
     {
       capabilities: {
         experimental: {


### PR DESCRIPTION
Addresses Aaron's live feedback: the manual add flow had a naming mismatch (UI said 'channel', the launch flag needed a different name) and the UI only showed step 1. Now one convention — `channel-<channelname>` — across the daemon's MCP serverInfo.name, the launcher (.mcp.json key + the `--dangerously-load-development-channels=server:<name>` flag), and the setup UI (which now shows BOTH the add and launch commands with matching names + copy buttons + a --scope note). 91 tests; UI two-step render smoke-verified; live-verified by relaunching the aaron/ops sessions on the new naming.