### PR TITLE
feat(channel): vault transport — channels backed by #channel-message notes (Stage 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,52 @@ set headers). On a 401/SSE-error it re-fetches once and retries. `/ui`, `/health
 `/.parachute/config[/schema]` stay OPEN — the page must load to bootstrap its token fetch, and the
 config listing is non-sensitive.
 
+## Vault integration (Stage 2) — channels backed by `#channel-message` notes
+
+A `vault` transport backs a channel with notes in a Parachute vault, so messages
+are durable, queryable, and a vault surface can render them. Multiple channels per
+vault: the note's `channel` metadata routes it.
+
+**Note shape** — tag `#channel-message`, content = the message text, metadata:
+`{ channel, direction: "inbound"|"outbound", sender, outbound: "1" (outbound only — the loop-avoidance marker), in_reply_to (outbound), ts }`.
+
+**Flow.** INBOUND (human→session): a new inbound note → a vault **trigger** POSTs a
+webhook → the channel daemon's `POST /api/vault/inbound` → routes by `note.metadata.channel`
+→ `ctx.emit` wakes the session (fans to SSE bridges + HTTP-MCP sessions alike).
+OUTBOUND (session→human): the session's `reply` writes an outbound note via the vault
+REST API (`POST <vaultUrl>/vault/<vault>/api/notes`, Bearer `vault:<name>:write`).
+
+**channels.json** (the channel side):
+```json
+{ "name": "eng", "transport": "vault",
+  "config": { "vault": "default", "vaultUrl": "http://127.0.0.1:1940",
+              "token": "<vault:default:write JWT>", "webhookSecret": "<shared secret>" } }
+```
+
+**Vault side** (operator config — activates the inbound trigger):
+1. (Optional, for indexed queries) declare the `#channel-message` tag schema with
+   indexed `channel`/`direction`/`sender` fields (`update-tag`).
+2. Add a trigger to the vault's `config.yaml` that fires on new inbound notes and
+   webhooks the channel daemon. Loop avoidance: the vault predicate can only match
+   key *presence* (not `direction == "inbound"`), so it excludes the `outbound`
+   marker via `missing_metadata`:
+   ```yaml
+   triggers:
+     - name: channel_inbound
+       events: ["created"]
+       when:
+         tags: ["#channel-message"]
+         has_metadata: ["channel"]
+         missing_metadata: ["outbound", "channel_inbound_rendered_at"]
+       action:
+         webhook: "http://127.0.0.1:1941/api/vault/inbound?secret=<shared secret>"
+         send: "json"
+   ```
+   The shared secret rides in the URL — vault doesn't sign webhooks yet; a hub-JWT
+   auth block on the trigger is a follow-up. The daemon defends in depth too:
+   `ingestInbound` drops any note marked `outbound`, so a reply can never wake its
+   own session.
+
 ## Environment variables
 
 | Variable | Default | Description |

--- a/src/daemon.test.ts
+++ b/src/daemon.test.ts
@@ -16,7 +16,9 @@ import { describe, test, expect, beforeAll, afterAll } from "bun:test";
 import { createFetchHandler } from "./daemon.ts";
 import { ClientRegistry } from "./routing.ts";
 import { HttpUiTransport } from "./transports/http-ui.ts";
+import { VaultTransport } from "./transports/vault.ts";
 import type { Channel } from "./registry.ts";
+import type { TransportContext, InboundMessage } from "./transport.ts";
 
 let server: ReturnType<typeof Bun.serve>;
 let base: string;
@@ -283,5 +285,188 @@ describe("Layer 2 — http-ui UI endpoints require a token (401 with none)", () 
     expect(res.status).toBe(401);
     // Must short-circuit before the SSE stream opens.
     expect(res.headers.get("content-type")).toContain("application/json");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Vault inbound webhook: POST /api/vault/inbound. A vault trigger POSTs here on
+// a new inbound #channel-message note; the daemon validates the per-channel
+// shared secret, resolves the channel from note.metadata.channel, and hands the
+// note to the channel's VaultTransport.ingestInbound (which emits → wakes the
+// session). Secret auth, unknown-channel 404, idempotency by note id.
+// ---------------------------------------------------------------------------
+describe("Vault inbound webhook — POST /api/vault/inbound", () => {
+  const SECRET = "s3cret";
+
+  /** Build a daemon over one vault channel + a fake transport ctx recording emits. */
+  function buildVaultServer() {
+    const registry = new ClientRegistry();
+    const transport = new VaultTransport({
+      vault: "default",
+      vaultUrl: "http://127.0.0.1:1940",
+      token: "x",
+      webhookSecret: SECRET,
+    });
+    const emitted: InboundMessage[] = [];
+    const ctx: TransportContext = {
+      channel: "eng",
+      emit(msg) {
+        emitted.push(msg);
+      },
+      emitPermissionVerdict() {},
+    };
+    void transport.start(ctx);
+    const channels = new Map<string, Channel>([
+      ["eng", { name: "eng", transport, entry: { name: "eng", transport: "vault" } }],
+    ]);
+    const srv = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      idleTimeout: 0,
+      fetch: createFetchHandler(channels, registry),
+    });
+    return { srv, base: `http://127.0.0.1:${srv.port}`, emitted };
+  }
+
+  function body(noteId: string, extraMeta: Record<string, unknown> = {}) {
+    return JSON.stringify({
+      trigger: "channel-inbound",
+      event: "created",
+      note: {
+        id: noteId,
+        path: `channel/eng/${noteId}`,
+        content: "wake up session",
+        tags: ["#channel-message"],
+        metadata: { channel: "eng", direction: "inbound", sender: "aaron", ...extraMeta },
+      },
+    });
+  }
+
+  test("wrong secret → 401, no emit", async () => {
+    const { srv, base, emitted } = buildVaultServer();
+    try {
+      const res = await fetch(`${base}/api/vault/inbound?secret=wrong`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: body("n1"),
+      });
+      expect(res.status).toBe(401);
+      expect(emitted).toHaveLength(0);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("missing secret → 401", async () => {
+    const { srv, base, emitted } = buildVaultServer();
+    try {
+      const res = await fetch(`${base}/api/vault/inbound`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: body("n1"),
+      });
+      expect(res.status).toBe(401);
+      expect(emitted).toHaveLength(0);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("unknown channel → 404, no emit", async () => {
+    const { srv, base, emitted } = buildVaultServer();
+    try {
+      const res = await fetch(`${base}/api/vault/inbound?secret=${SECRET}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          note: { id: "n1", content: "x", metadata: { channel: "nope", direction: "inbound" } },
+        }),
+      });
+      expect(res.status).toBe(404);
+      expect(emitted).toHaveLength(0);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("missing note.metadata.channel → 400", async () => {
+    const { srv, base } = buildVaultServer();
+    try {
+      const res = await fetch(`${base}/api/vault/inbound?secret=${SECRET}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ note: { id: "n1", content: "x", metadata: {} } }),
+      });
+      expect(res.status).toBe(400);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("valid (query secret) → 200 + routes to the channel's transport + emits", async () => {
+    const { srv, base, emitted } = buildVaultServer();
+    try {
+      const res = await fetch(`${base}/api/vault/inbound?secret=${SECRET}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: body("n-ok"),
+      });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ ok: true });
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]!.channel).toBe("eng");
+      expect(emitted[0]!.content).toBe("wake up session");
+      expect(emitted[0]!.meta.note_id).toBe("n-ok");
+      expect(emitted[0]!.meta.source).toBe("vault");
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("valid via X-Channel-Webhook-Secret header → 200 + emits", async () => {
+    const { srv, base, emitted } = buildVaultServer();
+    try {
+      const res = await fetch(`${base}/api/vault/inbound`, {
+        method: "POST",
+        headers: { "content-type": "application/json", "x-channel-webhook-secret": SECRET },
+        body: body("n-hdr"),
+      });
+      expect(res.status).toBe(200);
+      expect(emitted).toHaveLength(1);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("duplicate note id → no double-emit (idempotency)", async () => {
+    const { srv, base, emitted } = buildVaultServer();
+    try {
+      for (let i = 0; i < 2; i++) {
+        const res = await fetch(`${base}/api/vault/inbound?secret=${SECRET}`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: body("dup-1"),
+        });
+        expect(res.status).toBe(200); // both ack
+      }
+      expect(emitted).toHaveLength(1); // but only one wake
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("outbound-marked note is ack'd 200 but NOT emitted (belt-and-suspenders)", async () => {
+    const { srv, base, emitted } = buildVaultServer();
+    try {
+      const res = await fetch(`${base}/api/vault/inbound?secret=${SECRET}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: body("ob-1", { direction: "outbound", outbound: "1" }),
+      });
+      expect(res.status).toBe(200);
+      expect(emitted).toHaveLength(0);
+    } finally {
+      srv.stop(true);
+    }
   });
 });

--- a/src/daemon.test.ts
+++ b/src/daemon.test.ts
@@ -372,7 +372,7 @@ describe("Vault inbound webhook — POST /api/vault/inbound", () => {
     }
   });
 
-  test("unknown channel → 404, no emit", async () => {
+  test("unknown channel → 401 (uniform with bad-secret, no channel enumeration), no emit", async () => {
     const { srv, base, emitted } = buildVaultServer();
     try {
       const res = await fetch(`${base}/api/vault/inbound?secret=${SECRET}`, {
@@ -382,8 +382,35 @@ describe("Vault inbound webhook — POST /api/vault/inbound", () => {
           note: { id: "n1", content: "x", metadata: { channel: "nope", direction: "inbound" } },
         }),
       });
-      expect(res.status).toBe(404);
+      expect(res.status).toBe(401);
       expect(emitted).toHaveLength(0);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("channel-spoofing: a webhook for channel B presenting channel A's secret → 401, no emit", async () => {
+    const registry = new ClientRegistry();
+    const eng = new VaultTransport({ vault: "default", vaultUrl: "http://127.0.0.1:1940", token: "x", webhookSecret: "eng-secret" });
+    const ops = new VaultTransport({ vault: "default", vaultUrl: "http://127.0.0.1:1940", token: "x", webhookSecret: "ops-secret" });
+    const engEmits: InboundMessage[] = [];
+    const opsEmits: InboundMessage[] = [];
+    void eng.start({ channel: "eng", emit: (m) => engEmits.push(m), emitPermissionVerdict() {} });
+    void ops.start({ channel: "ops", emit: (m) => opsEmits.push(m), emitPermissionVerdict() {} });
+    const channels = new Map<string, Channel>([
+      ["eng", { name: "eng", transport: eng, entry: { name: "eng", transport: "vault" } }],
+      ["ops", { name: "ops", transport: ops, entry: { name: "ops", transport: "vault" } }],
+    ]);
+    const srv = Bun.serve({ port: 0, hostname: "127.0.0.1", idleTimeout: 0, fetch: createFetchHandler(channels, registry) });
+    try {
+      const res = await fetch(`http://127.0.0.1:${srv.port}/api/vault/inbound?secret=eng-secret`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ note: { id: "spoof1", content: "x", metadata: { channel: "ops", direction: "inbound" } } }),
+      });
+      expect(res.status).toBe(401); // eng's secret can't authorize a write to ops
+      expect(opsEmits).toHaveLength(0);
+      expect(engEmits).toHaveLength(0);
     } finally {
       srv.stop(true);
     }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -17,7 +17,16 @@
 import { mkdirSync, readFileSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
+import { timingSafeEqual } from "node:crypto";
 import { upsertService } from "./services-manifest.ts";
+
+/** Constant-time webhook-secret compare. Length check first (a length mismatch
+ *  is never equal); timingSafeEqual on equal-length buffers avoids the
+ *  short-circuit timing leak of `===`. Empty configured/presented → never match. */
+function webhookSecretMatches(presented: string, configured: string): boolean {
+  if (!presented || !configured || presented.length !== configured.length) return false;
+  return timingSafeEqual(Buffer.from(presented), Buffer.from(configured));
+}
 import type {
   Transport,
   TransportContext,
@@ -774,24 +783,16 @@ export function createFetchHandler(
       if (!channelName) {
         return json({ error: "note.metadata.channel is required to route the message" }, 400);
       }
-      const channel = channels.get(channelName);
-      if (!channel || !(channel.transport instanceof VaultTransport)) {
-        return json(
-          {
-            error: `no vault channel "${channelName}" — vault channels: ${[...channels.values()]
-              .filter((c) => c.transport instanceof VaultTransport)
-              .map((c) => c.name)
-              .join(", ") || "(none)"}`,
-          },
-          404,
-        );
-      }
-      const vt = channel.transport;
-      // Validate the shared secret against THIS channel's configured secret.
       const presented =
         url.searchParams.get("secret") ?? req.headers.get("x-channel-webhook-secret") ?? "";
-      if (!presented || presented !== vt.webhookSecret) {
-        return json({ error: "unauthorized", message: "bad or missing webhook secret" }, 401);
+      const ch = channels.get(channelName);
+      const vt = ch?.transport instanceof VaultTransport ? ch.transport : undefined;
+      // Uniform 401 for an unknown vault channel OR a bad secret — never reveal
+      // which, so this (tailnet-reachable) endpoint can't be used to enumerate
+      // channel names. The secret is per-channel, so the lookup happens first,
+      // but both failure modes return the identical response. Constant-time compare.
+      if (!vt || !webhookSecretMatches(presented, vt.webhookSecret)) {
+        return json({ error: "unauthorized" }, 401);
       }
       // Idempotency: a duplicate trigger delivery for the same note must not
       // double-wake. First-seen → process; already-seen → ack without emitting.

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -30,6 +30,7 @@ import type {
 } from "./transport.ts";
 import { ChannelConfigError } from "./transport.ts";
 import { loadRegistry, defaultStateDir, type Channel } from "./registry.ts";
+import { VaultTransport } from "./transports/vault.ts";
 import { ClientRegistry } from "./routing.ts";
 import { requireScope, extractToken, SCOPE_READ, SCOPE_WRITE } from "./auth.ts";
 import { validateHubJwt } from "./hub-jwt.ts";
@@ -486,6 +487,22 @@ export function createFetchHandler(
     );
   }
 
+  // Idempotency for the vault inbound webhook: a small bounded set of recently-
+  // seen note ids so a duplicate trigger delivery doesn't double-wake the
+  // session. Bounded by eviction (oldest-out) so it can't grow unbounded.
+  const seenInboundNoteIds = new Set<string>();
+  const SEEN_INBOUND_CAP = 2048;
+  function markSeen(noteId: string): boolean {
+    if (seenInboundNoteIds.has(noteId)) return false; // already processed
+    seenInboundNoteIds.add(noteId);
+    if (seenInboundNoteIds.size > SEEN_INBOUND_CAP) {
+      // Evict the oldest insertion (Set preserves insertion order).
+      const oldest = seenInboundNoteIds.values().next().value;
+      if (oldest !== undefined) seenInboundNoteIds.delete(oldest);
+    }
+    return true;
+  }
+
   return async function fetch(req) {
     const url = new URL(req.url);
 
@@ -527,7 +544,7 @@ export function createFetchHandler(
                 name: { type: "string", description: "Unique channel name bridges subscribe to." },
                 transport: {
                   type: "string",
-                  enum: ["telegram", "http-ui"],
+                  enum: ["telegram", "http-ui", "vault"],
                   description: "Transport kind backing this channel.",
                 },
                 config: {
@@ -723,6 +740,67 @@ export function createFetchHandler(
       } catch (err) {
         return errResponse(err);
       }
+    }
+
+    // Vault inbound webhook — a vault trigger POSTs here when a new inbound
+    // `#channel-message` note appears. Resolves the target channel from
+    // `note.metadata.channel`, asserts it's a vault-transport channel, and hands
+    // the note to that transport's `ingestInbound`, which `ctx.emit`s it →
+    // wakes the subscribed bridge / MCP session.
+    //
+    // Auth: a shared secret presented as `?secret=` OR `X-Channel-Webhook-Secret`,
+    // validated against the target channel's vault-transport `webhookSecret`.
+    // (Vault's trigger webhook is unauthenticated by default, so the secret rides
+    // in the configured webhook URL; a hub-JWT auth block on the vault trigger is
+    // a follow-up.) The secret is per-channel, so we resolve the channel from the
+    // body FIRST, then check the secret against that channel's transport.
+    if (req.method === "POST" && url.pathname === "/api/vault/inbound") {
+      let body: {
+        trigger?: string;
+        event?: string;
+        note?: { id?: string; path?: string; content?: string; tags?: string[]; metadata?: Record<string, unknown> };
+      };
+      try {
+        body = (await req.json()) as typeof body;
+      } catch {
+        return json({ error: "invalid JSON body" }, 400);
+      }
+      const note = body.note;
+      if (!note || typeof note.id !== "string" || !note.id) {
+        return json({ error: "body must include note.id" }, 400);
+      }
+      const channelName =
+        typeof note.metadata?.channel === "string" ? note.metadata.channel : undefined;
+      if (!channelName) {
+        return json({ error: "note.metadata.channel is required to route the message" }, 400);
+      }
+      const channel = channels.get(channelName);
+      if (!channel || !(channel.transport instanceof VaultTransport)) {
+        return json(
+          {
+            error: `no vault channel "${channelName}" — vault channels: ${[...channels.values()]
+              .filter((c) => c.transport instanceof VaultTransport)
+              .map((c) => c.name)
+              .join(", ") || "(none)"}`,
+          },
+          404,
+        );
+      }
+      const vt = channel.transport;
+      // Validate the shared secret against THIS channel's configured secret.
+      const presented =
+        url.searchParams.get("secret") ?? req.headers.get("x-channel-webhook-secret") ?? "";
+      if (!presented || presented !== vt.webhookSecret) {
+        return json({ error: "unauthorized", message: "bad or missing webhook secret" }, 401);
+      }
+      // Idempotency: a duplicate trigger delivery for the same note must not
+      // double-wake. First-seen → process; already-seen → ack without emitting.
+      if (markSeen(note.id)) {
+        vt.ingestInbound({ id: note.id, content: note.content, metadata: note.metadata });
+      }
+      // Never write back to the note — the v1 trigger handles its own
+      // created/rendered_at markers vault-side.
+      return json({ ok: true });
     }
 
     // Built-in chat UI — a global channel-picker page across all http-ui

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -17,6 +17,7 @@ import { homedir } from "os";
 import type { Transport } from "./transport.ts";
 import { TelegramTransport, type TelegramTransportConfig } from "./transports/telegram.ts";
 import { HttpUiTransport, type HttpUiTransportConfig } from "./transports/http-ui.ts";
+import { VaultTransport, type VaultTransportConfig } from "./transports/vault.ts";
 
 export interface ChannelEntry {
   name: string;
@@ -66,10 +67,13 @@ export function instantiateTransport(entry: ChannelEntry): Transport {
     case "http-ui":
       // http-ui needs no secret — just a channel name (taken from ctx at start).
       return new HttpUiTransport((entry.config ?? {}) as HttpUiTransportConfig);
+    case "vault":
+      // vault needs vault name + a write token + the inbound-webhook secret.
+      return new VaultTransport((entry.config ?? {}) as unknown as VaultTransportConfig);
     default:
       throw new Error(
         `registry: unknown transport kind "${entry.transport}" for channel "${entry.name}" ` +
-          `(known: telegram, http-ui)`,
+          `(known: telegram, http-ui, vault)`,
       );
   }
 }

--- a/src/transports/vault.test.ts
+++ b/src/transports/vault.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Tier 1 unit tests for the vault transport.
+ *
+ * These exercise the transport WITHOUT a live vault — `fetch` is stubbed to
+ * capture the outbound note write, and `ctx.emit` is recorded to assert inbound
+ * delivery. They cover:
+ *   - reply(): writes the right POST .../api/notes with the outbound marker,
+ *     direction, channel, Bearer token; returns the created note id;
+ *   - reply(): threads in_reply_to when the bridge passes it;
+ *   - ingestInbound(): emits the inbound content + meta onto its channel;
+ *   - ingestInbound(): IGNORES an outbound-marked note (loop avoidance);
+ *   - registry: a vault channel instantiates from config.
+ */
+
+import { describe, test, expect, afterEach } from "bun:test";
+import { VaultTransport } from "./vault.ts";
+import type { TransportContext, InboundMessage } from "../transport.ts";
+import { instantiateTransport } from "../registry.ts";
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+/** A test context that records emitted inbound messages. */
+function fakeCtx(channel: string): TransportContext & { emitted: InboundMessage[] } {
+  const emitted: InboundMessage[] = [];
+  return {
+    channel,
+    emitted,
+    emit(msg) {
+      emitted.push(msg);
+    },
+    emitPermissionVerdict() {},
+  };
+}
+
+function baseConfig() {
+  return {
+    vault: "default",
+    vaultUrl: "http://127.0.0.1:1940",
+    token: "write-token-xyz",
+    webhookSecret: "s3cret",
+  };
+}
+
+describe("VaultTransport — reply (outbound note write)", () => {
+  test("reply() POSTs .../api/notes with outbound marker + direction + channel + Bearer", async () => {
+    const calls: { url: string; init: RequestInit }[] = [];
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      calls.push({ url: String(url), init: init ?? {} });
+      return new Response(JSON.stringify({ id: "note-created-1" }), {
+        status: 201,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+    const result = await t.reply({ channel: "eng", text: "the reply text" });
+
+    expect(result.sent).toEqual(["note-created-1"]);
+    expect(calls).toHaveLength(1);
+    const call = calls[0]!;
+    expect(call.url).toBe("http://127.0.0.1:1940/vault/default/api/notes");
+    expect(call.init.method).toBe("POST");
+    const headers = call.init.headers as Record<string, string>;
+    expect(headers.authorization).toBe("Bearer write-token-xyz");
+
+    const sent = JSON.parse(String(call.init.body)) as {
+      content: string;
+      path: string;
+      tags: string[];
+      metadata: Record<string, string>;
+    };
+    expect(sent.content).toBe("the reply text");
+    expect(sent.tags).toEqual(["#channel-message"]);
+    expect(sent.path.startsWith("channel/eng/")).toBe(true);
+    expect(sent.metadata.channel).toBe("eng");
+    expect(sent.metadata.direction).toBe("outbound");
+    expect(sent.metadata.sender).toBe("session");
+    // The load-bearing loop-avoidance presence marker.
+    expect(sent.metadata.outbound).toBe("1");
+    expect(typeof sent.metadata.ts).toBe("string");
+  });
+
+  test("reply() threads in_reply_to from args.meta", async () => {
+    let captured: Record<string, string> | undefined;
+    globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as { metadata: Record<string, string> };
+      captured = body.metadata;
+      return new Response(JSON.stringify({ id: "n2" }), { status: 201 });
+    }) as typeof fetch;
+
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+    await t.reply({ channel: "eng", text: "re", meta: { in_reply_to: "inbound-99" } });
+    expect(captured!.in_reply_to).toBe("inbound-99");
+  });
+
+  test("reply() falls back to the proposed id when the response has no id", async () => {
+    globalThis.fetch = (async () =>
+      new Response("", { status: 201 })) as unknown as typeof fetch;
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+    const result = await t.reply({ channel: "eng", text: "x" });
+    expect(result.sent).toHaveLength(1);
+    expect(typeof result.sent[0]).toBe("string");
+  });
+
+  test("reply() throws on a non-ok vault response", async () => {
+    globalThis.fetch = (async () =>
+      new Response("boom", { status: 500 })) as unknown as typeof fetch;
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+    await expect(t.reply({ channel: "eng", text: "x" })).rejects.toThrow(/write reply failed/);
+  });
+});
+
+describe("VaultTransport — ingestInbound", () => {
+  test("emits the inbound content + meta onto its channel", () => {
+    const t = new VaultTransport(baseConfig());
+    const ctx = fakeCtx("eng");
+    // start synchronously enough for the test (start just stores ctx).
+    void t.start(ctx);
+    t.ingestInbound({
+      id: "note-in-1",
+      content: "hello session",
+      metadata: { channel: "eng", direction: "inbound", sender: "aaron", ts: "2026-06-08T00:00:00Z" },
+    });
+    expect(ctx.emitted).toHaveLength(1);
+    const m = ctx.emitted[0]!;
+    expect(m.channel).toBe("eng");
+    expect(m.content).toBe("hello session");
+    expect(m.source).toBe("vault");
+    expect(m.meta.source).toBe("vault");
+    expect(m.meta.note_id).toBe("note-in-1");
+    expect(m.meta.sender).toBe("aaron");
+    expect(m.meta.direction).toBe("inbound");
+  });
+
+  test("IGNORES an outbound-marked note (loop avoidance)", () => {
+    const t = new VaultTransport(baseConfig());
+    const ctx = fakeCtx("eng");
+    void t.start(ctx);
+    t.ingestInbound({
+      id: "our-own-reply",
+      content: "I am awake",
+      metadata: { channel: "eng", direction: "outbound", sender: "session", outbound: "1" },
+    });
+    expect(ctx.emitted).toHaveLength(0);
+  });
+
+  test("IGNORES a note with direction:outbound even if outbound marker is absent", () => {
+    const t = new VaultTransport(baseConfig());
+    const ctx = fakeCtx("eng");
+    void t.start(ctx);
+    t.ingestInbound({
+      id: "x",
+      content: "y",
+      metadata: { channel: "eng", direction: "outbound" },
+    });
+    expect(ctx.emitted).toHaveLength(0);
+  });
+});
+
+describe("registry — vault", () => {
+  test("a vault channel instantiates from config", () => {
+    const transport = instantiateTransport({
+      name: "eng",
+      transport: "vault",
+      config: baseConfig(),
+    });
+    expect(transport.kind).toBe("vault");
+    expect(transport).toBeInstanceOf(VaultTransport);
+  });
+
+  test("a vault channel without a token throws", () => {
+    expect(() =>
+      instantiateTransport({
+        name: "eng",
+        transport: "vault",
+        config: { vault: "default", webhookSecret: "s" },
+      }),
+    ).toThrow(/token/);
+  });
+});

--- a/src/transports/vault.ts
+++ b/src/transports/vault.ts
@@ -1,0 +1,202 @@
+/**
+ * vault transport for parachute-channel.
+ *
+ * A channel backed by `#channel-message` notes in a Parachute vault. The vault
+ * becomes the persistence layer + the inter-module event bus; the channel is the
+ * adapter that wakes a session on a new note and writes the session's reply back
+ * as a note.
+ *
+ * How it differs from telegram / http-ui — the "external party" is the vault:
+ *  - Inbound (human → session): a vault trigger POSTs the daemon's
+ *    `/api/vault/inbound` webhook when a new inbound `#channel-message` note
+ *    appears; the daemon resolves the channel from `note.metadata.channel` and
+ *    calls this transport's `ingestInbound(note)`, which `ctx.emit(...)`s →
+ *    routes to the bridge / MCP session subscribed to that channel and wakes it.
+ *  - Outbound (session → human): when the session calls the `reply` tool, the
+ *    bridge POSTs `/api/reply {channel,...}`; the daemon dispatches to this
+ *    transport's `reply()`, which writes an OUTBOUND `#channel-message` note via
+ *    the vault REST API (`POST <vaultUrl>/vault/<vault>/api/notes`).
+ *
+ * Loop avoidance (load-bearing). An outbound reply is itself a new
+ * `#channel-message` note — if the trigger fired on it, the session would wake
+ * on its own reply forever. The vault trigger predicate can only match on
+ * key-PRESENCE (`has_metadata`/`missing_metadata`), NOT on a value
+ * (`direction == "inbound"`). So every outbound note carries a presence marker
+ * `outbound: "1"`, and the trigger is configured to EXCLUDE notes that have it.
+ * As belt-and-suspenders over the trigger predicate, `ingestInbound` also drops
+ * any note that is outbound-marked (or `direction: "outbound"`) — so even a
+ * mis-wired trigger can never wake us on our own reply.
+ */
+
+import type {
+  Transport,
+  TransportContext,
+  ReplyArgs,
+} from "../transport.ts";
+
+/** Config for a vault transport instance (from the channel registry entry). */
+export interface VaultTransportConfig {
+  /** Vault name (the `<vault>` path segment in the REST URL). */
+  vault: string;
+  /** REST base origin. Default `http://127.0.0.1:1940`. */
+  vaultUrl?: string;
+  /** A `vault:<name>:write` hub JWT, presented as Bearer when writing replies. */
+  token: string;
+  /** Shared secret the inbound webhook must present (validated by the daemon). */
+  webhookSecret: string;
+  /** Optional path prefix for written notes. Default `channel`. */
+  notePathPrefix?: string;
+}
+
+/** The note shape the daemon hands `ingestInbound` (a subset of the trigger payload). */
+export interface InboundNote {
+  id: string;
+  content?: string;
+  metadata?: Record<string, unknown>;
+}
+
+const DEFAULT_VAULT_URL = "http://127.0.0.1:1940";
+const DEFAULT_PATH_PREFIX = "channel";
+const CHANNEL_MESSAGE_TAG = "#channel-message";
+
+export class VaultTransport implements Transport {
+  readonly kind = "vault";
+
+  private ctx: TransportContext | undefined;
+  private readonly vault: string;
+  private readonly vaultUrl: string;
+  private readonly token: string;
+  /** Shared secret the daemon validates on the inbound webhook (read by the daemon). */
+  readonly webhookSecret: string;
+  private readonly pathPrefix: string;
+
+  constructor(config: VaultTransportConfig) {
+    if (!config.vault) {
+      throw new Error("VaultTransport: config.vault (vault name) is required");
+    }
+    if (!config.token) {
+      throw new Error("VaultTransport: config.token (vault:<name>:write JWT) is required");
+    }
+    if (!config.webhookSecret) {
+      throw new Error("VaultTransport: config.webhookSecret is required");
+    }
+    this.vault = config.vault;
+    this.vaultUrl = (config.vaultUrl ?? DEFAULT_VAULT_URL).replace(/\/$/, "");
+    this.token = config.token;
+    this.webhookSecret = config.webhookSecret;
+    this.pathPrefix = (config.notePathPrefix ?? DEFAULT_PATH_PREFIX).replace(/\/$/, "");
+  }
+
+  async start(ctx: TransportContext): Promise<void> {
+    this.ctx = ctx;
+  }
+
+  async stop(): Promise<void> {
+    // Nothing to release — inbound arrives via the daemon's webhook, not a poll.
+  }
+
+  /** The channel name this transport is bound to (after start). */
+  private get channel(): string {
+    if (!this.ctx) throw new Error("vault transport: not started");
+    return this.ctx.channel;
+  }
+
+  // -------------------------------------------------------------------------
+  // Outbound — the session → vault direction. Write an OUTBOUND note.
+  // -------------------------------------------------------------------------
+
+  async reply(args: ReplyArgs): Promise<{ sent: string[] }> {
+    const channel = this.channel;
+    const ts = new Date().toISOString();
+    const id = crypto.randomUUID();
+    const path = `${this.pathPrefix}/${channel}/${id}`;
+
+    const metadata: Record<string, string> = {
+      channel,
+      direction: "outbound",
+      sender: "session",
+      // PRESENCE MARKER — the trigger excludes notes that have this key, so an
+      // outbound reply never wakes the session (loop avoidance). Load-bearing.
+      outbound: "1",
+      ts,
+    };
+    // Thread the reply to the inbound note id when the bridge passes it through.
+    const inReplyTo = args.meta?.in_reply_to;
+    if (inReplyTo) metadata.in_reply_to = inReplyTo;
+
+    const res = await fetch(`${this.vaultUrl}/vault/${this.vault}/api/notes`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${this.token}`,
+      },
+      body: JSON.stringify({
+        content: args.text ?? "",
+        path,
+        tags: [CHANNEL_MESSAGE_TAG],
+        metadata,
+      }),
+    });
+
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "");
+      throw new Error(
+        `vault transport: write reply failed (${res.status}) ${detail}`.trim(),
+      );
+    }
+
+    // The vault returns the created note; surface its id. Fall back to the id we
+    // proposed in the path if the response shape is unexpected.
+    let noteId: string = id;
+    try {
+      const created = (await res.json()) as { id?: string; note?: { id?: string } };
+      noteId = created?.id ?? created?.note?.id ?? id;
+    } catch {
+      // Non-JSON / empty body — keep the proposed id.
+    }
+    return { sent: [noteId] };
+  }
+
+  // react / edit / download: vault has no reactions; v1 is reply-only. Omitted.
+
+  // -------------------------------------------------------------------------
+  // Inbound — the daemon's webhook hands us a new inbound note to deliver.
+  // -------------------------------------------------------------------------
+
+  /**
+   * Deliver an inbound `#channel-message` note onto this channel: emit it so the
+   * subscribed bridge / MCP session wakes. Called by the daemon's
+   * `/api/vault/inbound` webhook after it has resolved the channel.
+   *
+   * Belt-and-suspenders over the trigger predicate: a note that is
+   * outbound-marked (`metadata.outbound` present) OR explicitly
+   * `direction: "outbound"` is IGNORED — we never wake on our own reply, even if
+   * a mis-wired trigger delivers one.
+   */
+  ingestInbound(note: InboundNote): void {
+    if (!this.ctx) throw new Error("vault transport: not started");
+    const meta = note.metadata ?? {};
+    if (meta.outbound !== undefined || meta.direction === "outbound") {
+      return; // our own reply — never wake on it.
+    }
+    // Flatten the note's metadata into the inbound meta (string-valued), then
+    // stamp our own provenance fields. `source`/`note_id`/`direction` are set
+    // explicitly so they win over anything in the note's metadata.
+    const flatMeta: Record<string, string> = {};
+    for (const [k, v] of Object.entries(meta)) {
+      flatMeta[k] = typeof v === "string" ? v : String(v);
+    }
+    this.ctx.emit({
+      channel: this.ctx.channel,
+      content: note.content ?? "",
+      meta: {
+        ...flatMeta,
+        source: "vault",
+        note_id: note.id,
+        sender: typeof meta.sender === "string" ? meta.sender : "",
+        direction: "inbound",
+      },
+      source: "vault",
+    });
+  }
+}

--- a/src/transports/vault.ts
+++ b/src/transports/vault.ts
@@ -109,7 +109,11 @@ export class VaultTransport implements Transport {
     const channel = this.channel;
     const ts = new Date().toISOString();
     const id = crypto.randomUUID();
-    const path = `${this.pathPrefix}/${channel}/${id}`;
+    // Sanitize the channel segment so an operator-configured name with a slash
+    // can't reshape the vault path hierarchy (the channel/prefix are operator
+    // config, not external input, but keep the path a flat, predictable slug).
+    const safeChannel = channel.replace(/[^a-zA-Z0-9_-]/g, "-");
+    const path = `${this.pathPrefix}/${safeChannel}/${id}`;
 
     const metadata: Record<string, string> = {
       channel,


### PR DESCRIPTION
## Stage 2 — vault integration (channel side)

A `vault` transport backs a channel with `#channel-message` notes. INBOUND: a vault trigger webhooks `POST /api/vault/inbound` → routes by `note.metadata.channel` → wakes the session (fans to SSE bridges + HTTP-MCP sessions). OUTBOUND: the session's `reply` writes an outbound note via the vault REST API. Multiple channels per vault via the `channel` field. Per Aaron's requirements: multi-channel ✓, direction (inbound/outbound) nailed ✓, solid webhook ✓.

### Loop avoidance (two layers)
The vault predicate can't match `direction == "inbound"` (vault only supports key-presence), so: outbound notes carry an `outbound: "1"` marker the trigger excludes via `missing_metadata`; AND the daemon's `ingestInbound` defensively drops any `outbound`-marked note — a reply can never wake its own session.

### Verified live, end-to-end
Set up a vault channel pointing at the real vault, connected an HTTP-MCP session, POSTed a simulated inbound trigger webhook → the session woke → replied → **an outbound `#channel-message` note appeared in the vault** with content "5 plus 5 is 10. Round-trip confirmed ✅" and correct metadata (direction outbound, channel, the loop-avoidance marker). Outbound write path independently confirmed against the live vault (create → read → delete).

### Security (reviewer nits folded)
Constant-time webhook-secret compare; uniform 401 for unknown-channel-or-bad-secret (no channel enumeration over the tailnet); path-segment sanitization; channel-spoofing test (channel B + channel A's secret → 401).

### Testing
`bun run typecheck` clean; `bun test src/` **109 pass / 0 fail**. Reviewer LGTM (zero must-fix). Vault-side setup (tag schema + trigger config) documented in CLAUDE.md.

### Remaining for full activation
The vault-side **trigger config** + tag schema are operator config (documented) — applying them + verifying the actual trigger *fires* (note created → webhook) is the one leg I simulated here (the trigger is vault's tested mechanism). The current chat UI stays a thin client; folding it into a scoped vault surface is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)