### PR TITLE
refactor(vault-transport): replace outbound:"1" marker with #channel-message/inbound|outbound tags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,14 +161,20 @@ A `vault` transport backs a channel with notes in a Parachute vault, so messages
 are durable, queryable, and a vault surface can render them. Multiple channels per
 vault: the note's `channel` metadata routes it.
 
-**Note shape** — tag `#channel-message`, content = the message text, metadata:
-`{ channel, direction: "inbound"|"outbound", sender, outbound: "1" (outbound only — the loop-avoidance marker), in_reply_to (outbound), ts }`.
+**Note shape** — hierarchical tags off the `#channel-message` parent:
+`#channel-message/inbound` (human→session) and `#channel-message/outbound` (session reply).
+Content = the message text; metadata: `{ channel, direction: "inbound"|"outbound", sender,
+in_reply_to (outbound), ts }`. Loop avoidance lives in the TAG, not metadata: the trigger
+fires on the inbound child tag only (exact match — no descendant expansion), so a reply never
+wakes its own session. A UI querying the parent `#channel-message` still sees BOTH directions,
+because the query engine DOES inherit descendants. Inbound notes MUST be written with the
+`#channel-message/inbound` tag and the channel name in `metadata.channel`.
 
-**Flow.** INBOUND (human→session): a new inbound note → a vault **trigger** POSTs a
-webhook → the channel daemon's `POST /api/vault/inbound` → routes by `note.metadata.channel`
+**Flow.** INBOUND (human→session): a new `#channel-message/inbound` note → a vault **trigger**
+POSTs a webhook → the channel daemon's `POST /api/vault/inbound` → routes by `note.metadata.channel`
 → `ctx.emit` wakes the session (fans to SSE bridges + HTTP-MCP sessions alike).
-OUTBOUND (session→human): the session's `reply` writes an outbound note via the vault
-REST API (`POST <vaultUrl>/vault/<vault>/api/notes`, Bearer `vault:<name>:write`).
+OUTBOUND (session→human): the session's `reply` writes a `#channel-message/outbound` note via the
+vault REST API (`POST <vaultUrl>/vault/<vault>/api/notes`, Bearer `vault:<name>:write`).
 
 **channels.json** (the channel side):
 ```json
@@ -181,25 +187,26 @@ REST API (`POST <vaultUrl>/vault/<vault>/api/notes`, Bearer `vault:<name>:write`
 1. (Optional, for indexed queries) declare the `#channel-message` tag schema with
    indexed `channel`/`direction`/`sender` fields (`update-tag`).
 2. Add a trigger to the vault's `config.yaml` that fires on new inbound notes and
-   webhooks the channel daemon. Loop avoidance: the vault predicate can only match
-   key *presence* (not `direction == "inbound"`), so it excludes the `outbound`
-   marker via `missing_metadata`:
+   webhooks the channel daemon. Loop avoidance is by hierarchical tag: the vault
+   predicate does EXACT tag membership (no descendant expansion), so firing on the
+   inbound child tag never matches an outbound (reply) note — no `missing_metadata`
+   clause needed:
    ```yaml
    triggers:
      - name: channel_inbound
        events: ["created"]
        when:
-         tags: ["#channel-message"]
+         tags: ["#channel-message/inbound"]
          has_metadata: ["channel"]
-         missing_metadata: ["outbound", "channel_inbound_rendered_at"]
+         missing_metadata: ["channel_inbound_rendered_at"]
        action:
          webhook: "http://127.0.0.1:1941/api/vault/inbound?secret=<shared secret>"
          send: "json"
    ```
    The shared secret rides in the URL — vault doesn't sign webhooks yet; a hub-JWT
    auth block on the trigger is a follow-up. The daemon defends in depth too:
-   `ingestInbound` drops any note marked `outbound`, so a reply can never wake its
-   own session.
+   `ingestInbound` drops any note tagged `#channel-message/outbound`, so a reply can
+   never wake its own session.
 
 ## Environment variables
 

--- a/src/daemon.test.ts
+++ b/src/daemon.test.ts
@@ -328,7 +328,11 @@ describe("Vault inbound webhook — POST /api/vault/inbound", () => {
     return { srv, base: `http://127.0.0.1:${srv.port}`, emitted };
   }
 
-  function body(noteId: string, extraMeta: Record<string, unknown> = {}) {
+  function body(
+    noteId: string,
+    extraMeta: Record<string, unknown> = {},
+    tags: string[] = ["#channel-message/inbound"],
+  ) {
     return JSON.stringify({
       trigger: "channel-inbound",
       event: "created",
@@ -336,7 +340,7 @@ describe("Vault inbound webhook — POST /api/vault/inbound", () => {
         id: noteId,
         path: `channel/eng/${noteId}`,
         content: "wake up session",
-        tags: ["#channel-message"],
+        tags,
         metadata: { channel: "eng", direction: "inbound", sender: "aaron", ...extraMeta },
       },
     });
@@ -482,13 +486,13 @@ describe("Vault inbound webhook — POST /api/vault/inbound", () => {
     }
   });
 
-  test("outbound-marked note is ack'd 200 but NOT emitted (belt-and-suspenders)", async () => {
+  test("#channel-message/outbound-tagged note is ack'd 200 but NOT emitted (belt-and-suspenders)", async () => {
     const { srv, base, emitted } = buildVaultServer();
     try {
       const res = await fetch(`${base}/api/vault/inbound?secret=${SECRET}`, {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: body("ob-1", { direction: "outbound", outbound: "1" }),
+        body: body("ob-1", { direction: "outbound" }, ["#channel-message/outbound"]),
       });
       expect(res.status).toBe(200);
       expect(emitted).toHaveLength(0);

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -751,8 +751,8 @@ export function createFetchHandler(
       }
     }
 
-    // Vault inbound webhook — a vault trigger POSTs here when a new inbound
-    // `#channel-message` note appears. Resolves the target channel from
+    // Vault inbound webhook — a vault trigger POSTs here when a new
+    // `#channel-message/inbound` note appears. Resolves the target channel from
     // `note.metadata.channel`, asserts it's a vault-transport channel, and hands
     // the note to that transport's `ingestInbound`, which `ctx.emit`s it →
     // wakes the subscribed bridge / MCP session.
@@ -797,7 +797,7 @@ export function createFetchHandler(
       // Idempotency: a duplicate trigger delivery for the same note must not
       // double-wake. First-seen → process; already-seen → ack without emitting.
       if (markSeen(note.id)) {
-        vt.ingestInbound({ id: note.id, content: note.content, metadata: note.metadata });
+        vt.ingestInbound({ id: note.id, content: note.content, tags: note.tags, metadata: note.metadata });
       }
       // Never write back to the note — the v1 trigger handles its own
       // created/rendered_at markers vault-side.

--- a/src/transports/vault.test.ts
+++ b/src/transports/vault.test.ts
@@ -4,11 +4,12 @@
  * These exercise the transport WITHOUT a live vault — `fetch` is stubbed to
  * capture the outbound note write, and `ctx.emit` is recorded to assert inbound
  * delivery. They cover:
- *   - reply(): writes the right POST .../api/notes with the outbound marker,
- *     direction, channel, Bearer token; returns the created note id;
+ *   - reply(): writes the right POST .../api/notes tagged
+ *     `#channel-message/outbound` (no `outbound` metadata key), with direction,
+ *     channel, Bearer token; returns the created note id;
  *   - reply(): threads in_reply_to when the bridge passes it;
  *   - ingestInbound(): emits the inbound content + meta onto its channel;
- *   - ingestInbound(): IGNORES an outbound-marked note (loop avoidance);
+ *   - ingestInbound(): IGNORES a `#channel-message/outbound`-tagged note (loop avoidance);
  *   - registry: a vault channel instantiates from config.
  */
 
@@ -45,7 +46,7 @@ function baseConfig() {
 }
 
 describe("VaultTransport — reply (outbound note write)", () => {
-  test("reply() POSTs .../api/notes with outbound marker + direction + channel + Bearer", async () => {
+  test("reply() POSTs .../api/notes tagged #channel-message/outbound + direction + channel + Bearer", async () => {
     const calls: { url: string; init: RequestInit }[] = [];
     globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
       calls.push({ url: String(url), init: init ?? {} });
@@ -74,13 +75,14 @@ describe("VaultTransport — reply (outbound note write)", () => {
       metadata: Record<string, string>;
     };
     expect(sent.content).toBe("the reply text");
-    expect(sent.tags).toEqual(["#channel-message"]);
+    // Loop avoidance is now the hierarchical TAG, not a metadata marker.
+    expect(sent.tags).toEqual(["#channel-message/outbound"]);
     expect(sent.path.startsWith("channel/eng/")).toBe(true);
     expect(sent.metadata.channel).toBe("eng");
     expect(sent.metadata.direction).toBe("outbound");
     expect(sent.metadata.sender).toBe("session");
-    // The load-bearing loop-avoidance presence marker.
-    expect(sent.metadata.outbound).toBe("1");
+    // The old `outbound:"1"` presence marker is gone — no such metadata key.
+    expect("outbound" in sent.metadata).toBe(false);
     expect(typeof sent.metadata.ts).toBe("string");
   });
 
@@ -126,6 +128,7 @@ describe("VaultTransport — ingestInbound", () => {
     t.ingestInbound({
       id: "note-in-1",
       content: "hello session",
+      tags: ["#channel-message/inbound"],
       metadata: { channel: "eng", direction: "inbound", sender: "aaron", ts: "2026-06-08T00:00:00Z" },
     });
     expect(ctx.emitted).toHaveLength(1);
@@ -139,19 +142,20 @@ describe("VaultTransport — ingestInbound", () => {
     expect(m.meta.direction).toBe("inbound");
   });
 
-  test("IGNORES an outbound-marked note (loop avoidance)", () => {
+  test("IGNORES a #channel-message/outbound-tagged note (loop avoidance)", () => {
     const t = new VaultTransport(baseConfig());
     const ctx = fakeCtx("eng");
     void t.start(ctx);
     t.ingestInbound({
       id: "our-own-reply",
       content: "I am awake",
-      metadata: { channel: "eng", direction: "outbound", sender: "session", outbound: "1" },
+      tags: ["#channel-message/outbound"],
+      metadata: { channel: "eng", direction: "outbound", sender: "session" },
     });
     expect(ctx.emitted).toHaveLength(0);
   });
 
-  test("IGNORES a note with direction:outbound even if outbound marker is absent", () => {
+  test("IGNORES a note with direction:outbound even if the outbound tag is absent", () => {
     const t = new VaultTransport(baseConfig());
     const ctx = fakeCtx("eng");
     void t.start(ctx);

--- a/src/transports/vault.ts
+++ b/src/transports/vault.ts
@@ -8,24 +8,29 @@
  *
  * How it differs from telegram / http-ui — the "external party" is the vault:
  *  - Inbound (human → session): a vault trigger POSTs the daemon's
- *    `/api/vault/inbound` webhook when a new inbound `#channel-message` note
+ *    `/api/vault/inbound` webhook when a new `#channel-message/inbound` note
  *    appears; the daemon resolves the channel from `note.metadata.channel` and
  *    calls this transport's `ingestInbound(note)`, which `ctx.emit(...)`s →
  *    routes to the bridge / MCP session subscribed to that channel and wakes it.
  *  - Outbound (session → human): when the session calls the `reply` tool, the
  *    bridge POSTs `/api/reply {channel,...}`; the daemon dispatches to this
- *    transport's `reply()`, which writes an OUTBOUND `#channel-message` note via
+ *    transport's `reply()`, which writes a `#channel-message/outbound` note via
  *    the vault REST API (`POST <vaultUrl>/vault/<vault>/api/notes`).
  *
- * Loop avoidance (load-bearing). An outbound reply is itself a new
- * `#channel-message` note — if the trigger fired on it, the session would wake
- * on its own reply forever. The vault trigger predicate can only match on
- * key-PRESENCE (`has_metadata`/`missing_metadata`), NOT on a value
- * (`direction == "inbound"`). So every outbound note carries a presence marker
- * `outbound: "1"`, and the trigger is configured to EXCLUDE notes that have it.
- * As belt-and-suspenders over the trigger predicate, `ingestInbound` also drops
- * any note that is outbound-marked (or `direction: "outbound"`) — so even a
- * mis-wired trigger can never wake us on our own reply.
+ * Loop avoidance (load-bearing) — via hierarchical tags. An outbound reply is
+ * itself a `#channel-message` note; if the trigger fired on it, the session would
+ * wake on its own reply forever. The vault trigger predicate does EXACT tag
+ * membership (no descendant expansion), so we split the parent tag into two
+ * children and key the trigger off the inbound child only:
+ *  - inbound notes carry `#channel-message/inbound`;
+ *  - outbound (reply) notes carry `#channel-message/outbound`;
+ *  - the trigger fires on `tags: ["#channel-message/inbound"]` — an exact match
+ *    that never matches an outbound note, so a reply can't wake its own session.
+ * A UI querying the parent `#channel-message` still sees BOTH directions, because
+ * the query engine DOES inherit descendants. As belt-and-suspenders over the
+ * trigger predicate, `ingestInbound` also drops any note tagged
+ * `#channel-message/outbound` (or `direction: "outbound"`) — so even a mis-wired
+ * trigger can never wake us on our own reply.
  */
 
 import type {
@@ -52,12 +57,19 @@ export interface VaultTransportConfig {
 export interface InboundNote {
   id: string;
   content?: string;
+  /** The note's tags — carries `#channel-message/{inbound,outbound}` for loop avoidance. */
+  tags?: string[];
   metadata?: Record<string, unknown>;
 }
 
 const DEFAULT_VAULT_URL = "http://127.0.0.1:1940";
 const DEFAULT_PATH_PREFIX = "channel";
+/** Parent tag — query this (descendants inherit) to see BOTH directions of a channel. */
 const CHANNEL_MESSAGE_TAG = "#channel-message";
+/** Inbound child — the vault trigger fires on this exact tag (never matches outbound → no loop). */
+const CHANNEL_MESSAGE_INBOUND_TAG = "#channel-message/inbound";
+/** Outbound child — replies carry this; the trigger's exact-match predicate excludes it. */
+const CHANNEL_MESSAGE_OUTBOUND_TAG = "#channel-message/outbound";
 
 export class VaultTransport implements Transport {
   readonly kind = "vault";
@@ -117,11 +129,11 @@ export class VaultTransport implements Transport {
 
     const metadata: Record<string, string> = {
       channel,
+      // `direction` stays as a human/UI convenience field. The loop-avoidance
+      // source of truth is now the `#channel-message/outbound` TAG below — the
+      // trigger fires on the inbound child tag only, so this note never wakes us.
       direction: "outbound",
       sender: "session",
-      // PRESENCE MARKER — the trigger excludes notes that have this key, so an
-      // outbound reply never wakes the session (loop avoidance). Load-bearing.
-      outbound: "1",
       ts,
     };
     // Thread the reply to the inbound note id when the bridge passes it through.
@@ -137,7 +149,7 @@ export class VaultTransport implements Transport {
       body: JSON.stringify({
         content: args.text ?? "",
         path,
-        tags: [CHANNEL_MESSAGE_TAG],
+        tags: [CHANNEL_MESSAGE_OUTBOUND_TAG],
         metadata,
       }),
     });
@@ -168,19 +180,19 @@ export class VaultTransport implements Transport {
   // -------------------------------------------------------------------------
 
   /**
-   * Deliver an inbound `#channel-message` note onto this channel: emit it so the
-   * subscribed bridge / MCP session wakes. Called by the daemon's
+   * Deliver an inbound `#channel-message/inbound` note onto this channel: emit it
+   * so the subscribed bridge / MCP session wakes. Called by the daemon's
    * `/api/vault/inbound` webhook after it has resolved the channel.
    *
-   * Belt-and-suspenders over the trigger predicate: a note that is
-   * outbound-marked (`metadata.outbound` present) OR explicitly
-   * `direction: "outbound"` is IGNORED — we never wake on our own reply, even if
-   * a mis-wired trigger delivers one.
+   * Belt-and-suspenders over the trigger predicate: a note tagged
+   * `#channel-message/outbound` OR explicitly `direction: "outbound"` is IGNORED
+   * — we never wake on our own reply, even if a mis-wired trigger delivers one.
    */
   ingestInbound(note: InboundNote): void {
     if (!this.ctx) throw new Error("vault transport: not started");
     const meta = note.metadata ?? {};
-    if (meta.outbound !== undefined || meta.direction === "outbound") {
+    const tags = note.tags ?? [];
+    if (tags.includes(CHANNEL_MESSAGE_OUTBOUND_TAG) || meta.direction === "outbound") {
       return; // our own reply — never wake on it.
     }
     // Flatten the note's metadata into the inbound meta (string-valued), then


### PR DESCRIPTION
## What

Replaces the value-less `outbound: "1"` metadata presence-marker — a workaround for the vault trigger only matching key-*presence* — with **hierarchical tags**:

- Inbound `#channel-message` notes carry **`#channel-message/inbound`**
- Outbound (session reply) notes carry **`#channel-message/outbound`**

The vault trigger fires on `tags: ["#channel-message/inbound"]`. The trigger predicate does **exact** tag membership (`when.tags.every(t => note.tags?.includes(t))`, verified in vault `src/triggers.ts`), so it never matches the `/outbound` child → no reply loop. A UI querying the parent `#channel-message` still gets **both** directions via the query engine's descendant inheritance.

## Why

`outbound: "1"` was a code smell — a meaningless field duplicating `direction`, existing only to paper over the trigger predicate's lack of value-matching. The tag hierarchy is idiomatic to the vault (tags are the natural discriminator), needs no engine change, and gives both the discriminator (child tag → trigger) and the union (parent tag → render the thread) at once.

## Changes
- `src/transports/vault.ts` — `reply()` tags `#channel-message/outbound`, drops the `outbound` metadata key entirely; `ingestInbound()` drops notes tagged `#channel-message/outbound` (belt-and-suspenders over the trigger); `InboundNote` gains `tags?`; loop-avoidance docs rewritten for the tag mechanism.
- `src/daemon.ts` — threads `note.tags` through the `/api/vault/inbound` webhook into `ingestInbound`.
- `CLAUDE.md` — Stage-2 trigger config now `tags: ["#channel-message/inbound"]`, drops the `outbound` missing_metadata clause.
- tests — `reply()` tags `/outbound` + carries no `outbound` key; `ingestInbound` drops `/outbound`, forwards `/inbound`; asserted at both the transport layer and the full HTTP daemon path.

## Notes
- **Operator migration:** an existing vault trigger on the old `tags:[#channel-message]` + `missing_metadata:[outbound]` pattern must update to `tags:[#channel-message/inbound]`. Fail-closed (a mis-updated trigger stops routing rather than loops), documented in CLAUDE.md. No live vault-backed channel is deployed today, so no standing config to migrate.
- Reviewed (LGTM, no must-fixes). 109 pass / 0 fail, typecheck clean. Additive to the data model; version untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)