### PR TITLE
fix(vault-transport): tag #channel-message notes with parent + child (slash is namespace, not query inheritance)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,20 +161,33 @@ A `vault` transport backs a channel with notes in a Parachute vault, so messages
 are durable, queryable, and a vault surface can render them. Multiple channels per
 vault: the note's `channel` metadata routes it.
 
-**Note shape** — hierarchical tags off the `#channel-message` parent:
-`#channel-message/inbound` (human→session) and `#channel-message/outbound` (session reply).
+**Note shape** — TWO tags per note, carried literally (two orthogonal axes):
+- the parent `#channel-message` — the QUERYABLE membership tag. A UI lists a channel's
+  whole transcript (both directions) with one `tag: "#channel-message"` + `metadata.channel`
+  query, because the parent is literally on every note.
+- a directional child — the trigger DISCRIMINATOR: `#channel-message/inbound` (human→session)
+  or `#channel-message/outbound` (session reply).
+
+**The slash is a namespace, NOT query inheritance.** In a Parachute vault a slash in a tag
+NAME is a namespace convention only — `query-notes { tag: "#channel-message" }` matches
+descendants by the `tags.parent_names` graph (declared via `update-tag`), NOT by name-prefix.
+A note tagged ONLY `#channel-message/inbound` is INVISIBLE to a `tag: "#channel-message"`
+query unless that inheritance was separately declared — so we tag BOTH the parent and the
+child and don't depend on per-vault schema setup.
+
 Content = the message text; metadata: `{ channel, direction: "inbound"|"outbound", sender,
 in_reply_to (outbound), ts }`. Loop avoidance lives in the TAG, not metadata: the trigger
-fires on the inbound child tag only (exact match — no descendant expansion), so a reply never
-wakes its own session. A UI querying the parent `#channel-message` still sees BOTH directions,
-because the query engine DOES inherit descendants. Inbound notes MUST be written with the
-`#channel-message/inbound` tag and the channel name in `metadata.channel`.
+fires on the inbound child tag only (exact match), which an outbound note never carries, so a
+reply never wakes its own session. **Inbound notes MUST carry BOTH `#channel-message` (parent,
+makes it queryable) AND `#channel-message/inbound` (child, fires the trigger), with the channel
+name in `metadata.channel`.** Outbound notes carry `#channel-message` + `#channel-message/outbound`.
 
-**Flow.** INBOUND (human→session): a new `#channel-message/inbound` note → a vault **trigger**
-POSTs a webhook → the channel daemon's `POST /api/vault/inbound` → routes by `note.metadata.channel`
-→ `ctx.emit` wakes the session (fans to SSE bridges + HTTP-MCP sessions alike).
-OUTBOUND (session→human): the session's `reply` writes a `#channel-message/outbound` note via the
-vault REST API (`POST <vaultUrl>/vault/<vault>/api/notes`, Bearer `vault:<name>:write`).
+**Flow.** INBOUND (human→session): a new `#channel-message` + `#channel-message/inbound` note →
+a vault **trigger** POSTs a webhook → the channel daemon's `POST /api/vault/inbound` → routes by
+`note.metadata.channel` → `ctx.emit` wakes the session (fans to SSE bridges + HTTP-MCP sessions
+alike). OUTBOUND (session→human): the session's `reply` writes a `#channel-message` +
+`#channel-message/outbound` note via the vault REST API (`POST <vaultUrl>/vault/<vault>/api/notes`,
+Bearer `vault:<name>:write`).
 
 **channels.json** (the channel side):
 ```json
@@ -187,10 +200,11 @@ vault REST API (`POST <vaultUrl>/vault/<vault>/api/notes`, Bearer `vault:<name>:
 1. (Optional, for indexed queries) declare the `#channel-message` tag schema with
    indexed `channel`/`direction`/`sender` fields (`update-tag`).
 2. Add a trigger to the vault's `config.yaml` that fires on new inbound notes and
-   webhooks the channel daemon. Loop avoidance is by hierarchical tag: the vault
-   predicate does EXACT tag membership (no descendant expansion), so firing on the
-   inbound child tag never matches an outbound (reply) note — no `missing_metadata`
-   clause needed:
+   webhooks the channel daemon. Loop avoidance is by tag: the vault predicate does
+   EXACT tag membership, so firing on the inbound CHILD tag (`#channel-message/inbound`)
+   never matches an outbound (reply) note — which carries `#channel-message/outbound`,
+   not the inbound child — so no `missing_metadata` clause is needed. (Both directions
+   also carry the parent `#channel-message`, but the trigger keys on the child only.)
    ```yaml
    triggers:
      - name: channel_inbound

--- a/src/daemon.test.ts
+++ b/src/daemon.test.ts
@@ -331,7 +331,7 @@ describe("Vault inbound webhook — POST /api/vault/inbound", () => {
   function body(
     noteId: string,
     extraMeta: Record<string, unknown> = {},
-    tags: string[] = ["#channel-message/inbound"],
+    tags: string[] = ["#channel-message", "#channel-message/inbound"],
   ) {
     return JSON.stringify({
       trigger: "channel-inbound",
@@ -492,7 +492,7 @@ describe("Vault inbound webhook — POST /api/vault/inbound", () => {
       const res = await fetch(`${base}/api/vault/inbound?secret=${SECRET}`, {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: body("ob-1", { direction: "outbound" }, ["#channel-message/outbound"]),
+        body: body("ob-1", { direction: "outbound" }, ["#channel-message", "#channel-message/outbound"]),
       });
       expect(res.status).toBe(200);
       expect(emitted).toHaveLength(0);

--- a/src/transports/vault.test.ts
+++ b/src/transports/vault.test.ts
@@ -4,9 +4,9 @@
  * These exercise the transport WITHOUT a live vault — `fetch` is stubbed to
  * capture the outbound note write, and `ctx.emit` is recorded to assert inbound
  * delivery. They cover:
- *   - reply(): writes the right POST .../api/notes tagged
- *     `#channel-message/outbound` (no `outbound` metadata key), with direction,
- *     channel, Bearer token; returns the created note id;
+ *   - reply(): writes the right POST .../api/notes tagged BOTH the queryable parent
+ *     `#channel-message` AND the directional child `#channel-message/outbound` (no
+ *     `outbound` metadata key), with direction, channel, Bearer token; returns the id;
  *   - reply(): threads in_reply_to when the bridge passes it;
  *   - ingestInbound(): emits the inbound content + meta onto its channel;
  *   - ingestInbound(): IGNORES a `#channel-message/outbound`-tagged note (loop avoidance);
@@ -75,8 +75,14 @@ describe("VaultTransport — reply (outbound note write)", () => {
       metadata: Record<string, string>;
     };
     expect(sent.content).toBe("the reply text");
-    // Loop avoidance is now the hierarchical TAG, not a metadata marker.
-    expect(sent.tags).toEqual(["#channel-message/outbound"]);
+    // Two orthogonal tags: the parent `#channel-message` is carried LITERALLY so
+    // the note is queryable under it (a slash is namespace, NOT query inheritance —
+    // a child-only-tagged note is invisible to a `tag:#channel-message` query), and
+    // the directional child `#channel-message/outbound` is the trigger discriminator.
+    expect(sent.tags).toEqual(["#channel-message", "#channel-message/outbound"]);
+    // Regression guard: the queryable parent tag MUST be present literally.
+    expect(sent.tags).toContain("#channel-message");
+    expect(sent.tags).toContain("#channel-message/outbound");
     expect(sent.path.startsWith("channel/eng/")).toBe(true);
     expect(sent.metadata.channel).toBe("eng");
     expect(sent.metadata.direction).toBe("outbound");
@@ -128,7 +134,7 @@ describe("VaultTransport — ingestInbound", () => {
     t.ingestInbound({
       id: "note-in-1",
       content: "hello session",
-      tags: ["#channel-message/inbound"],
+      tags: ["#channel-message", "#channel-message/inbound"],
       metadata: { channel: "eng", direction: "inbound", sender: "aaron", ts: "2026-06-08T00:00:00Z" },
     });
     expect(ctx.emitted).toHaveLength(1);
@@ -149,7 +155,7 @@ describe("VaultTransport — ingestInbound", () => {
     t.ingestInbound({
       id: "our-own-reply",
       content: "I am awake",
-      tags: ["#channel-message/outbound"],
+      tags: ["#channel-message", "#channel-message/outbound"],
       metadata: { channel: "eng", direction: "outbound", sender: "session" },
     });
     expect(ctx.emitted).toHaveLength(0);

--- a/src/transports/vault.ts
+++ b/src/transports/vault.ts
@@ -17,18 +17,26 @@
  *    transport's `reply()`, which writes a `#channel-message/outbound` note via
  *    the vault REST API (`POST <vaultUrl>/vault/<vault>/api/notes`).
  *
- * Loop avoidance (load-bearing) — via hierarchical tags. An outbound reply is
- * itself a `#channel-message` note; if the trigger fired on it, the session would
- * wake on its own reply forever. The vault trigger predicate does EXACT tag
- * membership (no descendant expansion), so we split the parent tag into two
- * children and key the trigger off the inbound child only:
- *  - inbound notes carry `#channel-message/inbound`;
- *  - outbound (reply) notes carry `#channel-message/outbound`;
- *  - the trigger fires on `tags: ["#channel-message/inbound"]` — an exact match
- *    that never matches an outbound note, so a reply can't wake its own session.
- * A UI querying the parent `#channel-message` still sees BOTH directions, because
- * the query engine DOES inherit descendants. As belt-and-suspenders over the
- * trigger predicate, `ingestInbound` also drops any note tagged
+ * Tagging model — two ORTHOGONAL axes (this was a footgun; read carefully).
+ * In a Parachute vault a slash in a tag NAME is a namespace convention only —
+ * it implies NOTHING about query inheritance. `query-notes { tag: "X" }` matches
+ * descendants by the `tags.parent_names` graph, which is declared explicitly via
+ * `update-tag`, NOT inferred from the name. So a note tagged ONLY
+ * `#channel-message/inbound` is INVISIBLE to a `tag: "#channel-message"` query
+ * unless that inheritance was separately declared. We don't want to depend on
+ * per-vault schema setup, so every note carries BOTH tags literally:
+ *  - the parent `#channel-message` — the QUERYABLE membership tag (a UI lists a
+ *    channel's whole transcript, both directions, with one `tag: "#channel-message"`
+ *    + `metadata.channel` query, because the parent is literally present);
+ *  - a directional child — the trigger DISCRIMINATOR (`#channel-message/inbound`
+ *    on inbound, `#channel-message/outbound` on outbound).
+ *
+ * Loop avoidance (load-bearing). An outbound reply is itself a `#channel-message`
+ * note; if the trigger fired on it the session would wake on its own reply forever.
+ * The vault trigger predicate does EXACT tag membership, so it's keyed on the
+ * inbound child only — `tags: ["#channel-message/inbound"]` — which an outbound
+ * note (parent + `/outbound`) never carries, so a reply can't wake its own session.
+ * As belt-and-suspenders, `ingestInbound` also drops any note tagged
  * `#channel-message/outbound` (or `direction: "outbound"`) — so even a mis-wired
  * trigger can never wake us on our own reply.
  */
@@ -64,7 +72,8 @@ export interface InboundNote {
 
 const DEFAULT_VAULT_URL = "http://127.0.0.1:1940";
 const DEFAULT_PATH_PREFIX = "channel";
-/** Parent tag — query this (descendants inherit) to see BOTH directions of a channel. */
+/** Parent tag — carried LITERALLY on every note; query this + metadata.channel to
+ *  see BOTH directions of a channel (the slash children are namespace, not inheritance). */
 const CHANNEL_MESSAGE_TAG = "#channel-message";
 /** Inbound child — the vault trigger fires on this exact tag (never matches outbound → no loop). */
 const CHANNEL_MESSAGE_INBOUND_TAG = "#channel-message/inbound";
@@ -149,7 +158,9 @@ export class VaultTransport implements Transport {
       body: JSON.stringify({
         content: args.text ?? "",
         path,
-        tags: [CHANNEL_MESSAGE_OUTBOUND_TAG],
+        // Parent (queryable membership) + directional child (trigger discriminator).
+        // Both literal — the slash child is NOT queryable under the parent on its own.
+        tags: [CHANNEL_MESSAGE_TAG, CHANNEL_MESSAGE_OUTBOUND_TAG],
         metadata,
       }),
     });


### PR DESCRIPTION
## The bug (regression from #29)

#29 switched vault-backed channel notes to **child-only** tags (`#channel-message/inbound` / `/outbound`) and assumed a `tag:#channel-message` query would union them "via inheritance." It won't.

In a Parachute vault, **a slash in a tag name is a namespace convention — it does NOT imply query inheritance.** `query-notes { tag: "X" }` matches descendants by the `tags.parent_names` graph (declared explicitly via `update-tag`), never by name-prefix (verified in `core/src/tag-hierarchy.ts` — `parent_names` is only ever set explicitly). So a note tagged *only* `#channel-message/inbound` is invisible to a `tag:#channel-message` query — the transcript query returned nothing.

## The fix

Every note carries **both** tags literally — two orthogonal axes:
- **`#channel-message`** (parent) — the **queryable membership** tag. A UI lists a channel's whole transcript (both directions) with one `tag:#channel-message` + `metadata.channel` query because the parent is literally present.
- **directional child** (`#channel-message/inbound` / `/outbound`) — the **trigger discriminator**.

Loop avoidance is unchanged: the trigger keys on the exact inbound child (`tags:["#channel-message/inbound"]`), which an outbound note (parent + `/outbound`) never carries. `ingestInbound`'s defensive drop still keys on `#channel-message/outbound`.

This is the fail-safe choice (vs. declaring `parent_names` inheritance) because channel writes into arbitrary user vaults whose tag schema it doesn't control — tag-both needs no per-vault setup.

## Changes
- `src/transports/vault.ts` — `reply()` tags `[#channel-message, #channel-message/outbound]`; header rewritten to explain the namespace-vs-inheritance axes.
- tests — `reply()` asserts both tags present; inbound/outbound fixtures carry both.
- `CLAUDE.md` — inbound notes carry both tags; explicit "slash is namespace, not inheritance" note.

Gates: 109 pass / 0 fail, typecheck clean. Version untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)