### PR TITLE
feat(vault-transport): declare #channel-message tag schema on connect (idempotent, best-effort)

### DIFF
--- a/src/transports/vault.test.ts
+++ b/src/transports/vault.test.ts
@@ -14,7 +14,7 @@
  */
 
 import { describe, test, expect, afterEach } from "bun:test";
-import { VaultTransport } from "./vault.ts";
+import { VaultTransport, CHANNEL_VAULT_TAG_SCHEMA } from "./vault.ts";
 import type { TransportContext, InboundMessage } from "../transport.ts";
 import { instantiateTransport } from "../registry.ts";
 
@@ -61,8 +61,10 @@ describe("VaultTransport — reply (outbound note write)", () => {
     const result = await t.reply({ channel: "eng", text: "the reply text" });
 
     expect(result.sent).toEqual(["note-created-1"]);
-    expect(calls).toHaveLength(1);
-    const call = calls[0]!;
+    // start() also fires ensureSchema() (PUT .../api/tags/*); isolate the note POST.
+    const noteCalls = calls.filter((c) => c.url.endsWith("/api/notes"));
+    expect(noteCalls).toHaveLength(1);
+    const call = noteCalls[0]!;
     expect(call.url).toBe("http://127.0.0.1:1940/vault/default/api/notes");
     expect(call.init.method).toBe("POST");
     const headers = call.init.headers as Record<string, string>;
@@ -94,9 +96,12 @@ describe("VaultTransport — reply (outbound note write)", () => {
 
   test("reply() threads in_reply_to from args.meta", async () => {
     let captured: Record<string, string> | undefined;
-    globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
-      const body = JSON.parse(String(init?.body)) as { metadata: Record<string, string> };
-      captured = body.metadata;
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      // Ignore the ensureSchema PUTs fired by start(); only the note POST carries metadata.
+      if (String(url).endsWith("/api/notes")) {
+        const body = JSON.parse(String(init?.body)) as { metadata: Record<string, string> };
+        captured = body.metadata;
+      }
       return new Response(JSON.stringify({ id: "n2" }), { status: 201 });
     }) as typeof fetch;
 
@@ -171,6 +176,127 @@ describe("VaultTransport — ingestInbound", () => {
       metadata: { channel: "eng", direction: "outbound" },
     });
     expect(ctx.emitted).toHaveLength(0);
+  });
+});
+
+describe("VaultTransport — ensureSchema (tag-schema declaration on connect)", () => {
+  /** Drain microtasks so a fire-and-forget `void this.ensureSchema()` from
+   *  start() has issued its fetches before we assert. */
+  const flush = () => new Promise<void>((r) => setTimeout(r, 0));
+
+  test("PUTs each CHANNEL_VAULT_TAG_SCHEMA entry with the right URL encoding, Bearer, and body", async () => {
+    const calls: { url: string; init: RequestInit }[] = [];
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      calls.push({ url: String(url), init: init ?? {} });
+      return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
+    }) as typeof fetch;
+
+    const t = new VaultTransport(baseConfig());
+    await t.ensureSchema();
+
+    expect(calls).toHaveLength(CHANNEL_VAULT_TAG_SCHEMA.length);
+
+    // Parent — no parent_names, just a description. Plain `#` → `%23`.
+    const parent = calls[0]!;
+    expect(parent.url).toBe(
+      "http://127.0.0.1:1940/vault/default/api/tags/%23channel-message",
+    );
+    expect(parent.init.method).toBe("PUT");
+    expect((parent.init.headers as Record<string, string>).authorization).toBe(
+      "Bearer write-token-xyz",
+    );
+    const parentBody = JSON.parse(String(parent.init.body)) as {
+      description?: string;
+      parent_names?: string[];
+    };
+    expect(parentBody.description).toBe(
+      "A message in a Parachute channel (parent of /inbound + /outbound).",
+    );
+    expect("parent_names" in parentBody).toBe(false);
+
+    // Inbound child — name carries BOTH `#` and `/`. The vault route matches a
+    // single path segment (`[^/]+`) then decodeURIComponent's it, so the `/` MUST
+    // be encoded as `%2F` (a bare slash would fail the single-segment match → 404).
+    const inbound = calls[1]!;
+    expect(inbound.url).toBe(
+      "http://127.0.0.1:1940/vault/default/api/tags/%23channel-message%2Finbound",
+    );
+    // Confirm the encoding decodes back to the literal tag name the vault stores.
+    const encodedSegment = inbound.url.split("/api/tags/")[1]!;
+    expect(decodeURIComponent(encodedSegment)).toBe("#channel-message/inbound");
+    const inboundBody = JSON.parse(String(inbound.init.body)) as {
+      description?: string;
+      parent_names?: string[];
+    };
+    expect(inboundBody.parent_names).toEqual(["#channel-message"]);
+    expect(inboundBody.description).toBe(
+      "Human→session message; the vault trigger fires on this.",
+    );
+
+    // Outbound child — same encoding, parent declared.
+    const outbound = calls[2]!;
+    expect(outbound.url).toBe(
+      "http://127.0.0.1:1940/vault/default/api/tags/%23channel-message%2Foutbound",
+    );
+    expect(decodeURIComponent(outbound.url.split("/api/tags/")[1]!)).toBe(
+      "#channel-message/outbound",
+    );
+    const outboundBody = JSON.parse(String(outbound.init.body)) as { parent_names?: string[] };
+    expect(outboundBody.parent_names).toEqual(["#channel-message"]);
+  });
+
+  test("schema is sourced from CHANNEL_VAULT_TAG_SCHEMA — declares exactly its entries", async () => {
+    const declared: string[] = [];
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      declared.push(decodeURIComponent(String(url).split("/api/tags/")[1]!));
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+
+    const t = new VaultTransport(baseConfig());
+    await t.ensureSchema();
+
+    expect(declared).toEqual(CHANNEL_VAULT_TAG_SCHEMA.map((e) => e.name));
+  });
+
+  test("best-effort: a rejecting fetch does NOT throw out of ensureSchema", async () => {
+    globalThis.fetch = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+
+    const t = new VaultTransport(baseConfig());
+    // Must resolve, not reject.
+    await expect(t.ensureSchema()).resolves.toBeUndefined();
+  });
+
+  test("best-effort: a 500 response does NOT throw out of ensureSchema", async () => {
+    globalThis.fetch = (async () =>
+      new Response("boom", { status: 500 })) as unknown as typeof fetch;
+
+    const t = new VaultTransport(baseConfig());
+    await expect(t.ensureSchema()).resolves.toBeUndefined();
+  });
+
+  test("start() stays non-fatal + the transport still works when schema-ensure fails", async () => {
+    // A fetch that fails the PUT (schema) but the test asserts start() resolves
+    // and ingestInbound still emits — the transport is fully functional regardless.
+    globalThis.fetch = (async () => {
+      throw new Error("vault unreachable");
+    }) as unknown as typeof fetch;
+
+    const t = new VaultTransport(baseConfig());
+    const ctx = fakeCtx("eng");
+    await expect(t.start(ctx)).resolves.toBeUndefined();
+    await flush(); // let the fire-and-forget ensureSchema settle (it must not reject globally)
+
+    // Transport still delivers inbound after a failed schema declaration.
+    t.ingestInbound({
+      id: "n1",
+      content: "still works",
+      tags: ["#channel-message", "#channel-message/inbound"],
+      metadata: { channel: "eng", direction: "inbound", sender: "aaron" },
+    });
+    expect(ctx.emitted).toHaveLength(1);
+    expect(ctx.emitted[0]!.content).toBe("still works");
   });
 });
 

--- a/src/transports/vault.ts
+++ b/src/transports/vault.ts
@@ -80,6 +80,48 @@ const CHANNEL_MESSAGE_INBOUND_TAG = "#channel-message/inbound";
 /** Outbound child — replies carry this; the trigger's exact-match predicate excludes it. */
 const CHANNEL_MESSAGE_OUTBOUND_TAG = "#channel-message/outbound";
 
+/**
+ * The tag schema this module manages in any vault it's connected to.
+ *
+ * This is the declarative complement to the "tag both parent + child" fail-safe
+ * in `reply()` / inbound writes. A slash in a Parachute tag NAME is namespace-only
+ * — it carries NO query inheritance. Inheritance is the `parent_names` graph,
+ * declared via the vault's tag-schema API. By DECLARING that
+ * `#channel-message/{inbound,outbound}` have parent `#channel-message`, a default
+ * `tag:#channel-message` query expands to include the children semantically — so
+ * a UI listing a channel's transcript works off the parent even for notes that
+ * only carry the child tag.
+ *
+ * This matches the vault's "clients bring their own tag schema" principle: the
+ * WRITING module provisions its own tag schema at connect-time. It's MODULE-OWNED
+ * DATA (not inline calls) so it's the seam for a future module-protocol
+ * "tag schemas this module manages" declaration — changing this constant changes
+ * exactly what `ensureSchema()` provisions.
+ *
+ * `ensureSchema()` upserts each entry; the "tag both" floor in the note writes
+ * stays as the fail-safe so the channel works even if this declaration never lands.
+ */
+export const CHANNEL_VAULT_TAG_SCHEMA: ReadonlyArray<{
+  name: string;
+  description?: string;
+  parent_names?: string[];
+}> = [
+  {
+    name: CHANNEL_MESSAGE_TAG,
+    description: "A message in a Parachute channel (parent of /inbound + /outbound).",
+  },
+  {
+    name: CHANNEL_MESSAGE_INBOUND_TAG,
+    parent_names: [CHANNEL_MESSAGE_TAG],
+    description: "Human→session message; the vault trigger fires on this.",
+  },
+  {
+    name: CHANNEL_MESSAGE_OUTBOUND_TAG,
+    parent_names: [CHANNEL_MESSAGE_TAG],
+    description: "Session→human reply.",
+  },
+];
+
 export class VaultTransport implements Transport {
   readonly kind = "vault";
 
@@ -110,6 +152,67 @@ export class VaultTransport implements Transport {
 
   async start(ctx: TransportContext): Promise<void> {
     this.ctx = ctx;
+    // Declare the tag schema this module manages in the connected vault. Strictly
+    // best-effort: `ensureSchema` swallows all of its own errors, so an unreachable
+    // vault or a failing PUT can NEVER block (or reject out of) `start()`. The
+    // "tag both parent + child" floor in the note writes is the fail-safe, so the
+    // channel works even if this declaration never lands. Fire-and-forget — no
+    // reason to delay the channel coming up on a schema upsert.
+    void this.ensureSchema();
+  }
+
+  // -------------------------------------------------------------------------
+  // Schema declaration — provision this module's tag inheritance at connect-time.
+  // -------------------------------------------------------------------------
+
+  /**
+   * Idempotently upsert `CHANNEL_VAULT_TAG_SCHEMA` into the connected vault via
+   * the vault's tag-schema REST API. The vault route is
+   *   PUT /vault/<vault>/api/tags/:name
+   * where `:name` is matched by `subpath.match(/^\/([^/]+)$/)` then
+   * `decodeURIComponent`'d (parachute-vault `src/routes.ts` handleTags, the
+   * "Routes with tag name" block + `routing.ts` `apiPath.startsWith("/tags")`).
+   * Because the route matches a SINGLE path segment (`[^/]+`, no literal slash)
+   * and decodes it, the tag name — which contains BOTH `#` and `/`
+   * (`#channel-message/inbound`) — must be `encodeURIComponent`'d so the `#`
+   * becomes `%23` and the `/` becomes `%2F`; the route then decodes that back to
+   * the literal name. A bare `/` in the URL would fail the `[^/]+` match → 404,
+   * silently dropping the declaration. The PUT body is `{ description?, parent_names? }`.
+   *
+   * Best-effort + non-fatal by contract: every failure is caught and `console.warn`'d,
+   * never thrown — the tag-both write floor is the fallback.
+   */
+  async ensureSchema(): Promise<void> {
+    for (const entry of CHANNEL_VAULT_TAG_SCHEMA) {
+      try {
+        // Single-segment, percent-encoded name: `#channel-message/inbound` →
+        // `%23channel-message%2Finbound`. The vault decodes it back to the literal.
+        const url = `${this.vaultUrl}/vault/${this.vault}/api/tags/${encodeURIComponent(entry.name)}`;
+        const body: { description?: string; parent_names?: string[] } = {};
+        if (entry.description !== undefined) body.description = entry.description;
+        if (entry.parent_names !== undefined) body.parent_names = entry.parent_names;
+
+        const res = await fetch(url, {
+          method: "PUT",
+          headers: {
+            "content-type": "application/json",
+            authorization: `Bearer ${this.token}`,
+          },
+          body: JSON.stringify(body),
+        });
+        if (!res.ok) {
+          const detail = await res.text().catch(() => "");
+          console.warn(
+            `vault transport: tag-schema upsert for ${entry.name} failed (${res.status}) ${detail}`.trim(),
+          );
+        }
+      } catch (err) {
+        // Vault unreachable / fetch rejected — non-fatal, the tag-both floor covers us.
+        console.warn(
+          `vault transport: tag-schema upsert for ${entry.name} errored: ${(err as Error).message}`,
+        );
+      }
+    }
   }
 
   async stop(): Promise<void> {


### PR DESCRIPTION
## What

A vault-backed channel now **declares its own tag schema** in the target vault at connect-time, so the `#channel-message/inbound|outbound` children are real `parent_names` subtypes of `#channel-message` — queryable under the parent by default expansion, not just via tag-both.

- **Schema as module-owned data**: `CHANNEL_VAULT_TAG_SCHEMA` (the parent + two children with `parent_names`). The declarative seam — changing the constant changes what's provisioned. Future module-protocol hook for "tag schemas this module manages."
- **`ensureSchema()`** on `VaultTransport`, fired (fire-and-forget) from `start()`: idempotent `PUT /vault/<v>/api/tags/<encodeURIComponent(name)>` with the existing `vault:<name>:write` token. The vault route matches a single path segment then `decodeURIComponent`s, so `#`/`/` are percent-encoded (`%23…%2F…`) — verified against `handleTags`, round-trip locked by a test.
- **Best-effort / non-fatal**: a failed or unreachable vault never crashes or blocks `start()` or delivery — **tag-both stays the fail-safe floor**. Tested: fetch-throws, 500, start()-resolves, and ingestInbound-still-works-after-failure.

Embodies the principle: *the module that writes a tag namespace provisions its own schema, idempotently, at connect-time* (the vault stays opinion-free; surfaces stay pure consumers). Validated live: declaring the inheritance in a real vault makes a child-only-tagged note come back from a `tag:#channel-message` query.

## Notes
- Reviewed (LGTM, no must-fixes). 114 pass / 0 fail, typecheck clean. Additive; version untouched.
- Follow-up (filed): a few unrelated test suites emit benign 401 warns from `start()` hitting the live local vault — test hygiene, non-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)