### PR TITLE
feat(channel): config-management API + hub-JWT inbound auth (retire shared secret) + prescribed trigger template

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -23,6 +23,8 @@ import { extractBearer } from "@openparachute/scope-guard";
 export const SCOPE_READ = "channel:read" as const;
 export const SCOPE_WRITE = "channel:write" as const;
 export const SCOPE_SEND = "channel:send" as const;
+/** Config-management scope: create/list/delete channels (hub-orchestrated setup). */
+export const SCOPE_ADMIN = "channel:admin" as const;
 
 /** JSON Response helper (shared spelling for the auth error bodies). */
 export function json(data: unknown, status = 200): Response {

--- a/src/daemon-config-api.test.ts
+++ b/src/daemon-config-api.test.ts
@@ -1,0 +1,513 @@
+/**
+ * PR 2 of the frictionless-channel-setup arc — config-management API + webhook
+ * JWT auth + the prescribed trigger template.
+ *
+ * These cover the THREE new surfaces, all on the real daemon fetch handler:
+ *
+ *  A. Webhook JWT auth on POST /api/vault/inbound — a hub JWT (aud:channel,
+ *     scope channel:send) is accepted and routes the note; the DEPRECATED
+ *     ?secret= fallback still works; neither → 401; an insufficient scope → 401.
+ *  B. Config-management API (channel:admin) — POST writes channels.json (600
+ *     perms) + hot-adds the channel live (a subsequent inbound routes without a
+ *     restart); GET never leaks token/secret; DELETE removes from file + stops
+ *     routing; other scopes → 403.
+ *  C. CHANNEL_VAULT_TRIGGER_TEMPLATE is exposed via /.parachute/config.
+ *
+ * The hub JWT validator is stubbed (sentinel tokens → fixed scope sets) so the
+ * accept paths run without a live hub/JWKS. The no-token reject still hits the
+ * real short-circuit. This mirrors the http-ui Layer-2 test's approach.
+ */
+import { describe, test, expect, mock, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, existsSync, readFileSync, statSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+// Re-export the REAL error class + shape helper from scope-guard in the mock
+// below, so this `mock.module` (which Bun applies process-wide) doesn't break
+// hub-jwt.test.ts's assertions on the genuine HubJwtError(code, message) shape.
+import { HubJwtError, looksLikeJwt } from "@openparachute/scope-guard";
+
+const SEND_TOKEN = "test-send-token"; // channel:send (the trigger token)
+const ADMIN_TOKEN = "test-admin-token"; // channel:admin (config-mgmt)
+const READ_TOKEN = "test-read-token"; // channel:read only (insufficient)
+mock.module("./hub-jwt.ts", () => ({
+  CHANNEL_AUDIENCE: "channel",
+  async validateHubJwt(token: string) {
+    const base = { sub: "test", aud: "channel", jti: undefined, clientId: undefined, vaultScope: undefined };
+    if (token === SEND_TOKEN) return { ...base, scopes: ["channel:send"] };
+    if (token === ADMIN_TOKEN) return { ...base, scopes: ["channel:admin"] };
+    if (token === READ_TOKEN) return { ...base, scopes: ["channel:read"] };
+    throw new HubJwtError("issuer", "invalid token");
+  },
+  HubJwtError,
+  looksLikeJwt,
+  resetJwksCache() {},
+  resetRevocationCache() {},
+}));
+
+import { createFetchHandler } from "./daemon.ts";
+import { ClientRegistry } from "./routing.ts";
+import { VaultTransport, CHANNEL_VAULT_TRIGGER_TEMPLATE } from "./transports/vault.ts";
+import { channelsFilePath } from "./registry.ts";
+import type { Channel } from "./registry.ts";
+import type { TransportContext, InboundMessage } from "./transport.ts";
+
+const sendAuth = { authorization: "Bearer " + SEND_TOKEN } as const;
+const adminAuth = { authorization: "Bearer " + ADMIN_TOKEN } as const;
+const readAuth = { authorization: "Bearer " + READ_TOKEN } as const;
+
+let stateDir: string;
+
+beforeEach(() => {
+  // Sandbox channels.json under a throwaway state dir — the config API resolves
+  // STATE_DIR from PARACHUTE_CHANNEL_STATE_DIR (read once at daemon module load),
+  // so set it BEFORE importing... but the module is already imported. Instead the
+  // daemon's STATE_DIR is captured at module init; we set the env to a temp dir
+  // and the tests that touch the file assert under that path. Re-resolve per test.
+  stateDir = mkdtempSync(join(tmpdir(), "channel-cfg-"));
+  process.env.PARACHUTE_CHANNEL_STATE_DIR = stateDir;
+});
+
+afterEach(() => {
+  try {
+    rmSync(stateDir, { recursive: true, force: true });
+  } catch {}
+});
+
+// ---------------------------------------------------------------------------
+// A vault channel + a recording ctx, wired through the real fetch handler.
+// ---------------------------------------------------------------------------
+// `secret`: a string → that shared secret; `null` → a JWT-only channel with NO
+// webhookSecret configured; omitted → defaults to "s3cret".
+function buildServer(initial: Array<{ name: string; secret?: string | null }> = [{ name: "eng", secret: "s3cret" }]) {
+  const registry = new ClientRegistry();
+  const channels = new Map<string, Channel>();
+  const emitted: InboundMessage[] = [];
+  for (const { name, secret } of initial) {
+    const transport = new VaultTransport({
+      vault: "default",
+      vaultUrl: "http://127.0.0.1:1940",
+      token: "x",
+      // null → omit (JWT-only channel); undefined → default "s3cret".
+      ...(secret === null ? {} : { webhookSecret: secret ?? "s3cret" }),
+    });
+    const ctx: TransportContext = {
+      channel: name,
+      emit(msg) {
+        emitted.push(msg);
+      },
+      emitPermissionVerdict() {},
+    };
+    void transport.start(ctx);
+    channels.set(name, { name, transport, entry: { name, transport: "vault", config: { vault: "default" } } });
+  }
+  const srv = Bun.serve({ port: 0, hostname: "127.0.0.1", idleTimeout: 0, fetch: createFetchHandler(channels, registry) });
+  return { srv, base: `http://127.0.0.1:${srv.port}`, emitted, channels };
+}
+
+function inboundBody(noteId: string, channel = "eng") {
+  return JSON.stringify({
+    trigger: "channel-inbound",
+    event: "created",
+    note: {
+      id: noteId,
+      path: `channel/${channel}/${noteId}`,
+      content: "wake up session",
+      tags: ["#channel-message", "#channel-message/inbound"],
+      metadata: { channel, direction: "inbound", sender: "aaron" },
+    },
+  });
+}
+
+// ===========================================================================
+// A. Webhook JWT auth on POST /api/vault/inbound
+// ===========================================================================
+describe("A — webhook hub-JWT auth (channel:send), secret fallback retained", () => {
+  test("valid channel:send JWT → 200 + routes the note (emits)", async () => {
+    const { srv, base, emitted } = buildServer();
+    try {
+      const res = await fetch(`${base}/api/vault/inbound`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...sendAuth },
+        body: inboundBody("jwt-1"),
+      });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ ok: true });
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]!.channel).toBe("eng");
+      expect(emitted[0]!.meta.note_id).toBe("jwt-1");
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("a channel:read-only JWT → 401 (uniform on the webhook — no scope/channel probing), no emit", async () => {
+    // The webhook collapses insufficient-scope to a uniform 401 (unlike the
+    // operator-facing config API, which returns 403). This tailnet-reachable
+    // endpoint stays opaque to scope/channel enumeration.
+    const { srv, base, emitted } = buildServer();
+    try {
+      const res = await fetch(`${base}/api/vault/inbound`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...readAuth },
+        body: inboundBody("jwt-ro"),
+      });
+      expect(res.status).toBe(401);
+      expect(emitted).toHaveLength(0);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("a bad/garbage Bearer → 401, no emit", async () => {
+    const { srv, base, emitted } = buildServer();
+    try {
+      const res = await fetch(`${base}/api/vault/inbound`, {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: "Bearer nope" },
+        body: inboundBody("jwt-bad"),
+      });
+      expect(res.status).toBe(401);
+      expect(emitted).toHaveLength(0);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("no Bearer AND no secret → 401, no emit", async () => {
+    const { srv, base, emitted } = buildServer();
+    try {
+      const res = await fetch(`${base}/api/vault/inbound`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: inboundBody("none"),
+      });
+      expect(res.status).toBe(401);
+      expect(emitted).toHaveLength(0);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("M1 — whitespace-only `Authorization: Bearer ` + a VALID ?secret= → 401 (no fallthrough to the secret path)", async () => {
+    // An Authorization header present-but-empty must take the JWT path and fail
+    // hard — it must NOT fall through to the deprecated ?secret= path even though
+    // the secret is correct. Branching on header PRESENCE (not token truthiness)
+    // is what closes this auth-confusion.
+    const { srv, base, emitted } = buildServer([{ name: "eng", secret: "s3cret" }]);
+    try {
+      const res = await fetch(`${base}/api/vault/inbound?secret=s3cret`, {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: "Bearer    " },
+        body: inboundBody("ws-1"),
+      });
+      expect(res.status).toBe(401);
+      expect(emitted).toHaveLength(0);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("M2 — a JWT-only channel (NO webhookSecret) accepts a valid channel:send JWT → 200 + emits", async () => {
+    const { srv, base, emitted } = buildServer([{ name: "eng", secret: null }]);
+    try {
+      const res = await fetch(`${base}/api/vault/inbound`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...sendAuth },
+        body: inboundBody("jwtonly-1"),
+      });
+      expect(res.status).toBe(200);
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]!.channel).toBe("eng");
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("M2 — a JWT-only channel (NO webhookSecret) 401s a no-auth request (nothing to validate against)", async () => {
+    const { srv, base, emitted } = buildServer([{ name: "eng", secret: null }]);
+    try {
+      // No Authorization header → ?secret= fallback. The channel has no configured
+      // secret, so an empty/any `?secret=` can never match → 401 (no "undefined ===
+      // undefined" passing). Also assert an explicit empty ?secret= stays 401.
+      const noAuth = await fetch(`${base}/api/vault/inbound`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: inboundBody("jwtonly-noauth"),
+      });
+      expect(noAuth.status).toBe(401);
+      const emptySecret = await fetch(`${base}/api/vault/inbound?secret=`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: inboundBody("jwtonly-emptysecret"),
+      });
+      expect(emptySecret.status).toBe(401);
+      expect(emitted).toHaveLength(0);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("DEPRECATED ?secret= fallback still works (200 + emits + logs a warning)", async () => {
+    const warnings: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "));
+    };
+    const { srv, base, emitted } = buildServer();
+    try {
+      const res = await fetch(`${base}/api/vault/inbound?secret=s3cret`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: inboundBody("sec-1"),
+      });
+      expect(res.status).toBe(200);
+      expect(emitted).toHaveLength(1);
+      expect(warnings.some((w) => w.includes("DEPRECATED") && w.includes("eng"))).toBe(true);
+    } finally {
+      console.warn = origWarn;
+      srv.stop(true);
+    }
+  });
+
+  test("valid JWT but unknown channel → uniform 401 (no enumeration), no emit", async () => {
+    const { srv, base, emitted } = buildServer();
+    try {
+      const res = await fetch(`${base}/api/vault/inbound`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...sendAuth },
+        body: inboundBody("ghost", "nope"),
+      });
+      expect(res.status).toBe(401);
+      expect(emitted).toHaveLength(0);
+    } finally {
+      srv.stop(true);
+    }
+  });
+});
+
+// ===========================================================================
+// B. Config-management API (channel:admin)
+// ===========================================================================
+describe("B — config-management API (channel:admin)", () => {
+  test("POST without channel:admin → 403 (other scope) / 401 (none)", async () => {
+    const { srv, base } = buildServer([]);
+    try {
+      const none = await fetch(`${base}/api/channels`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "x", transport: "http-ui" }),
+      });
+      expect(none.status).toBe(401);
+
+      const wrong = await fetch(`${base}/api/channels`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...sendAuth },
+        body: JSON.stringify({ name: "x", transport: "http-ui" }),
+      });
+      expect(wrong.status).toBe(403);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("POST writes channels.json (600 perms) + hot-adds the channel LIVE (inbound routes, no restart)", async () => {
+    const { srv, base } = buildServer([]); // start with NO channels
+    try {
+      const create = await fetch(`${base}/api/channels`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({
+          name: "eng",
+          transport: "vault",
+          config: { vault: "default", vaultUrl: "http://127.0.0.1:1940", token: "vault-jwt", webhookSecret: "sek" },
+        }),
+      });
+      expect(create.status).toBe(200);
+      expect(await create.json()).toMatchObject({ ok: true, name: "eng", transport: "vault", live: true });
+
+      // channels.json written, with the token, at 0600.
+      const file = channelsFilePath(stateDir);
+      expect(existsSync(file)).toBe(true);
+      const onDisk = JSON.parse(readFileSync(file, "utf8")) as { channels: Array<{ name: string; config?: Record<string, unknown> }> };
+      expect(onDisk.channels.map((c) => c.name)).toContain("eng");
+      const engEntry = onDisk.channels.find((c) => c.name === "eng")!;
+      expect(engEntry.config!.token).toBe("vault-jwt"); // the file DOES hold the token
+      const mode = statSync(file).mode & 0o777;
+      expect(mode).toBe(0o600);
+
+      // HOT-ADD proof #1: the new channel is in the LIVE registry — /health lists it.
+      const health = (await (await fetch(`${base}/health`)).json()) as { channels: Array<{ name: string; kind: string }> };
+      expect(health.channels.map((c) => c.name)).toContain("eng");
+      expect(health.channels.find((c) => c.name === "eng")!.kind).toBe("vault");
+
+      // HOT-ADD proof #2: a subsequent inbound for the new channel ROUTES (200 →
+      // the channel is live + the secret authorizes) WITHOUT a restart. An unknown
+      // channel would 401; routing to its transport's ingestInbound is what makes
+      // this 200. (The hot-added transport emits into the real ClientRegistry, not
+      // this test's recorder, so we assert on the routed 200 + health, not `emitted`.)
+      const inbound = await fetch(`${base}/api/vault/inbound?secret=sek`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: inboundBody("hot-1", "eng"),
+      });
+      expect(inbound.status).toBe(200);
+
+      // HOT-ADD proof #3 (nit): a JWT-authenticated inbound (channel:send) also
+      // routes on the freshly hot-added channel — the JWT path is live too, not
+      // just the secret fallback.
+      const jwtInbound = await fetch(`${base}/api/vault/inbound`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...sendAuth },
+        body: inboundBody("hot-jwt-1", "eng"),
+      });
+      expect(jwtInbound.status).toBe(200);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("POST replaces an existing channel (stops the old transport, new config wins)", async () => {
+    const { srv, base } = buildServer([{ name: "eng", secret: "old" }]);
+    try {
+      const res = await fetch(`${base}/api/channels`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({
+          name: "eng",
+          transport: "vault",
+          config: { vault: "default", token: "x", webhookSecret: "new" },
+        }),
+      });
+      expect(res.status).toBe(200);
+      // New secret takes effect; old one no longer authorizes.
+      const oldSecret = await fetch(`${base}/api/vault/inbound?secret=old`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: inboundBody("r-old", "eng"),
+      });
+      expect(oldSecret.status).toBe(401);
+      const newSecret = await fetch(`${base}/api/vault/inbound?secret=new`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: inboundBody("r-new", "eng"),
+      });
+      expect(newSecret.status).toBe(200);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("POST with an invalid config (vault channel, no token) → 400, nothing persisted", async () => {
+    const { srv, base } = buildServer([]);
+    try {
+      const res = await fetch(`${base}/api/channels`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ name: "bad", transport: "vault", config: { vault: "default" } }),
+      });
+      expect(res.status).toBe(400);
+      // channels.json must not have been created with the broken entry.
+      const file = channelsFilePath(stateDir);
+      if (existsSync(file)) {
+        const onDisk = JSON.parse(readFileSync(file, "utf8")) as { channels: Array<{ name: string }> };
+        expect(onDisk.channels.map((c) => c.name)).not.toContain("bad");
+      }
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("GET lists channels (name + transport + vault) — NEVER token/secret", async () => {
+    const { srv, base } = buildServer([{ name: "eng", secret: "s3cret" }]);
+    try {
+      const res = await fetch(`${base}/api/channels`, { headers: { ...adminAuth } });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { channels: Array<Record<string, unknown>> };
+      expect(body.channels).toHaveLength(1);
+      const eng = body.channels[0]!;
+      expect(eng.name).toBe("eng");
+      expect(eng.transport).toBe("vault");
+      expect(eng.vault).toBe("default");
+      // No credential fields leak.
+      const serialized = JSON.stringify(body);
+      expect(serialized).not.toContain("s3cret");
+      expect(serialized).not.toContain("token");
+      expect(serialized).not.toContain("webhookSecret");
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("GET without channel:admin → 401 (none) / 403 (wrong scope)", async () => {
+    const { srv, base } = buildServer([]);
+    try {
+      expect((await fetch(`${base}/api/channels`)).status).toBe(401);
+      expect((await fetch(`${base}/api/channels`, { headers: { ...readAuth } })).status).toBe(403);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("DELETE removes the channel from channels.json + stops routing", async () => {
+    const { srv, base, emitted } = buildServer([]);
+    try {
+      // Add it via the API so it's both on disk and live.
+      await fetch(`${base}/api/channels`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ name: "eng", transport: "vault", config: { vault: "default", token: "x", webhookSecret: "sek" } }),
+      });
+      const file = channelsFilePath(stateDir);
+      expect((JSON.parse(readFileSync(file, "utf8")) as { channels: unknown[] }).channels).toHaveLength(1);
+
+      const del = await fetch(`${base}/api/channels/eng`, { method: "DELETE", headers: { ...adminAuth } });
+      expect(del.status).toBe(200);
+      expect(await del.json()).toMatchObject({ ok: true, name: "eng", removed: true });
+
+      // Gone from disk.
+      expect((JSON.parse(readFileSync(file, "utf8")) as { channels: unknown[] }).channels).toHaveLength(0);
+      // Routing stopped — an inbound for the deleted channel is now an unknown
+      // channel → uniform 401, no emit.
+      const inbound = await fetch(`${base}/api/vault/inbound?secret=sek`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: inboundBody("after-del", "eng"),
+      });
+      expect(inbound.status).toBe(401);
+      expect(emitted).toHaveLength(0);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("DELETE without channel:admin → 401/403", async () => {
+    const { srv, base } = buildServer([{ name: "eng" }]);
+    try {
+      expect((await fetch(`${base}/api/channels/eng`, { method: "DELETE" })).status).toBe(401);
+      expect((await fetch(`${base}/api/channels/eng`, { method: "DELETE", headers: { ...readAuth } })).status).toBe(403);
+    } finally {
+      srv.stop(true);
+    }
+  });
+});
+
+// ===========================================================================
+// C. Prescribed trigger template exposed via /.parachute/config
+// ===========================================================================
+describe("C — CHANNEL_VAULT_TRIGGER_TEMPLATE exposed via /.parachute/config", () => {
+  test("GET /.parachute/config carries triggerTemplate (the module-owned trigger shape)", async () => {
+    const { srv, base } = buildServer([{ name: "eng" }]);
+    try {
+      const res = await fetch(`${base}/.parachute/config`);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { channels: unknown[]; triggerTemplate: typeof CHANNEL_VAULT_TRIGGER_TEMPLATE };
+      expect(body.triggerTemplate).toEqual(CHANNEL_VAULT_TRIGGER_TEMPLATE);
+      // Sanity on the shape the hub depends on (placeholders + webhook path).
+      expect(body.triggerTemplate.name).toBe("channel_inbound_<channel>");
+      expect(body.triggerTemplate.when.tags).toEqual(["#channel-message/inbound"]);
+      expect(body.triggerTemplate.action.webhook).toBe("<hub-origin>/channel/api/vault/inbound");
+    } finally {
+      srv.stop(true);
+    }
+  });
+});

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -38,10 +38,25 @@ import type {
   DownloadArgs,
 } from "./transport.ts";
 import { ChannelConfigError } from "./transport.ts";
-import { loadRegistry, defaultStateDir, type Channel } from "./registry.ts";
-import { VaultTransport } from "./transports/vault.ts";
+import {
+  loadRegistry,
+  instantiateTransport,
+  upsertChannelEntry,
+  removeChannelEntry,
+  defaultStateDir,
+  type Channel,
+  type ChannelEntry,
+} from "./registry.ts";
+import { VaultTransport, CHANNEL_VAULT_TRIGGER_TEMPLATE } from "./transports/vault.ts";
 import { ClientRegistry } from "./routing.ts";
-import { requireScope, extractToken, SCOPE_READ, SCOPE_WRITE } from "./auth.ts";
+import {
+  requireScope,
+  extractToken,
+  SCOPE_READ,
+  SCOPE_WRITE,
+  SCOPE_SEND,
+  SCOPE_ADMIN,
+} from "./auth.ts";
 import { validateHubJwt } from "./hub-jwt.ts";
 import {
   handleProtectedResource,
@@ -109,6 +124,61 @@ function contextFor(registry: ClientRegistry, channel: string): TransportContext
       mcpPushPermissionVerdict(channel, v);
     },
   };
+}
+
+/**
+ * Instantiate one channel entry, start its transport, and register it in the
+ * LIVE channels map — the single per-channel "bring a channel up" path. Boot
+ * (`main`) and the config-management hot-add both go through here so they can't
+ * drift. If a channel with the same name is already live, its old transport is
+ * stopped first (config-API replace semantics).
+ *
+ * `start()` is awaited so a hot-add only reports success once the transport is
+ * actually receiving (e.g. the vault transport has fired its schema upsert). At
+ * boot a throw is logged per-channel and doesn't abort the others; the config
+ * API surfaces the throw to the caller as a 500.
+ */
+async function addChannelLive(
+  channels: Map<string, Channel>,
+  registry: ClientRegistry,
+  entry: ChannelEntry,
+): Promise<Channel> {
+  const existing = channels.get(entry.name);
+  if (existing) {
+    // Replace: stop the old transport before swapping it out so it releases any
+    // resources (pollers, SSE clients) before the new one starts.
+    try {
+      await existing.transport.stop();
+    } catch (err) {
+      console.error(`parachute-channel: stopping old transport for "${entry.name}" failed (continuing):`, err);
+    }
+    channels.delete(entry.name);
+  }
+  const transport = instantiateTransport(entry);
+  const channel: Channel = { name: entry.name, transport, entry };
+  channels.set(entry.name, channel);
+  await transport.start(contextFor(registry, entry.name));
+  return channel;
+}
+
+/**
+ * Stop a live channel's transport and remove it from the map. Idempotent — a
+ * missing name is a no-op returning false. The transport's `stop()` is awaited
+ * so it releases resources before we drop the reference.
+ */
+async function removeChannelLive(
+  channels: Map<string, Channel>,
+  name: string,
+): Promise<boolean> {
+  const channel = channels.get(name);
+  if (!channel) return false;
+  try {
+    await channel.transport.stop();
+  } catch (err) {
+    console.error(`parachute-channel: stopping transport for "${name}" failed (continuing):`, err);
+  }
+  channels.delete(name);
+  return true;
 }
 
 // ---------------------------------------------------------------------------
@@ -530,12 +600,20 @@ export function createFetchHandler(
     }
 
     // Self-describing config (runner pattern) — read-only, no secrets.
+    //
+    // `triggerTemplate` is MODULE-OWNED DATA: the prescribed vault trigger this
+    // channel needs the hub to register on its behalf (PR 3). The hub GETs this,
+    // substitutes the channel name into the `<channel>` placeholders, fills the
+    // `<hub-origin>` in `action.webhook`, and injects `action.auth.bearer` (a
+    // minted channel:send JWT) — so the channel owns its own trigger shape rather
+    // than the hub hardcoding it.
     if (req.method === "GET" && url.pathname === "/.parachute/config") {
       return json({
         channels: [...channels.values()].map((c) => ({
           name: c.name,
           transport: c.transport.kind,
         })),
+        triggerTemplate: CHANNEL_VAULT_TRIGGER_TEMPLATE,
       });
     }
 
@@ -567,6 +645,117 @@ export function createFetchHandler(
         },
         required: ["channels"],
       });
+    }
+
+    // ---------------------------------------------------------------------
+    // Channel config-management API — the hub writes channels.json + hot-adds
+    // the channel to the LIVE daemon, so a frictionless setup never hand-edits a
+    // file or restarts the daemon. Gated on a hub JWT with `channel:admin`.
+    //
+    //   POST   /api/channels        { name, transport, config } → write + hot-add
+    //   GET    /api/channels        → list (name + transport + vault; NO secrets)
+    //   DELETE /api/channels/:name  → stop + unregister + remove from channels.json
+    //
+    // Externally hub strips `/channel`, so these are `<hub>/channel/api/channels`.
+    // ---------------------------------------------------------------------
+    if (url.pathname === "/api/channels" && (req.method === "GET" || req.method === "POST")) {
+      const denied = await requireScope(req, url, SCOPE_ADMIN);
+      if (denied) return denied;
+
+      if (req.method === "GET") {
+        // List configured channels — surface ONLY name + transport + vault (for a
+        // vault transport). NEVER the token/secret: this is an admin read, but the
+        // file holds credentials we don't echo back.
+        return json({
+          channels: [...channels.values()].map((c) => {
+            const out: { name: string; transport: string; vault?: string } = {
+              name: c.name,
+              transport: c.transport.kind,
+            };
+            const v = (c.entry.config as { vault?: unknown } | undefined)?.vault;
+            if (typeof v === "string") out.vault = v;
+            return out;
+          }),
+        });
+      }
+
+      // POST — create/replace a channel.
+      let cfgBody: { name?: unknown; transport?: unknown; config?: unknown };
+      try {
+        cfgBody = (await req.json()) as typeof cfgBody;
+      } catch {
+        return json({ error: "invalid JSON body" }, 400);
+      }
+      if (typeof cfgBody.name !== "string" || cfgBody.name.length === 0) {
+        return json({ error: "body.name (string) is required" }, 400);
+      }
+      if (typeof cfgBody.transport !== "string" || cfgBody.transport.length === 0) {
+        return json({ error: "body.transport (string) is required" }, 400);
+      }
+      const entry: ChannelEntry = {
+        name: cfgBody.name,
+        transport: cfgBody.transport,
+        config:
+          cfgBody.config && typeof cfgBody.config === "object"
+            ? (cfgBody.config as Record<string, unknown>)
+            : undefined,
+      };
+      // Validate the entry by instantiating it FIRST (constructor throws on a
+      // missing required field — e.g. a vault channel with no token). We do this
+      // before writing channels.json so a bad request never persists a broken
+      // entry. `addChannelLive` re-instantiates; the throwaway here is the gate.
+      try {
+        instantiateTransport(entry);
+      } catch (err) {
+        return json({ error: `invalid channel config: ${(err as Error).message}` }, 400);
+      }
+      // Persist FIRST (chmod 600 — holds a token), then hot-add to the live
+      // daemon. If the hot-add throws, the file is already written, so a daemon
+      // restart would still pick it up; we surface the error AND a restart hint.
+      try {
+        // Resolve the state dir at request time (defaultStateDir reads the env)
+        // so the persisted file always lands where the daemon would next read it,
+        // even if the env was set after module load (and so it's testable).
+        upsertChannelEntry(entry, defaultStateDir());
+      } catch (err) {
+        return json({ error: `failed to write channels.json: ${(err as Error).message}` }, 500);
+      }
+      try {
+        await addChannelLive(channels, registry, entry);
+      } catch (err) {
+        return json(
+          {
+            ok: true,
+            name: entry.name,
+            transport: entry.transport,
+            live: false,
+            restart_needed: true,
+            error: `channel persisted but hot-add failed: ${(err as Error).message}`,
+          },
+          200,
+        );
+      }
+      return json({ ok: true, name: entry.name, transport: entry.transport, live: true });
+    }
+
+    const delMatch = url.pathname.match(/^\/api\/channels\/([^/]+)$/);
+    if (delMatch && req.method === "DELETE") {
+      const denied = await requireScope(req, url, SCOPE_ADMIN);
+      if (denied) return denied;
+      const name = decodeURIComponent(delMatch[1]!);
+      const wasLive = await removeChannelLive(channels, name);
+      // Always rewrite channels.json (idempotent) so the file matches the live
+      // state even if the channel was only on disk (added before a restart).
+      try {
+        removeChannelEntry(name, defaultStateDir());
+      } catch (err) {
+        return json({ error: `failed to update channels.json: ${(err as Error).message}` }, 500);
+      }
+      if (!wasLive) {
+        // Not in the live map. Either never live, or removed from disk only.
+        return json({ ok: true, name, removed: false }, 200);
+      }
+      return json({ ok: true, name, removed: true });
     }
 
     // ---------------------------------------------------------------------
@@ -757,12 +946,18 @@ export function createFetchHandler(
     // the note to that transport's `ingestInbound`, which `ctx.emit`s it →
     // wakes the subscribed bridge / MCP session.
     //
-    // Auth: a shared secret presented as `?secret=` OR `X-Channel-Webhook-Secret`,
-    // validated against the target channel's vault-transport `webhookSecret`.
-    // (Vault's trigger webhook is unauthenticated by default, so the secret rides
-    // in the configured webhook URL; a hub-JWT auth block on the vault trigger is
-    // a follow-up.) The secret is per-channel, so we resolve the channel from the
-    // body FIRST, then check the secret against that channel's transport.
+    // Auth — two paths, in order:
+    //   1. PREFERRED: `Authorization: Bearer <hub JWT>` (aud:channel, scope
+    //      `channel:send` — the trigger is effectively "posting an inbound
+    //      message"). The hub registers the trigger with `action.auth.bearer`
+    //      set to a minted channel:send token, so a fresh setup never touches a
+    //      shared secret. Validated via the same scope-guard path as the bridge.
+    //   2. DEPRECATED back-compat: a shared `?secret=` (or `X-Channel-Webhook-Secret`)
+    //      validated against the target channel's vault-transport `webhookSecret`,
+    //      for existing manual setups whose triggers still ride the secret in the
+    //      URL. Logs a one-line deprecation warning when used.
+    // A request with NEITHER → 401. We keep the uniform-401 (no channel
+    // enumeration) behavior on both paths.
     if (req.method === "POST" && url.pathname === "/api/vault/inbound") {
       let body: {
         trigger?: string;
@@ -783,16 +978,47 @@ export function createFetchHandler(
       if (!channelName) {
         return json({ error: "note.metadata.channel is required to route the message" }, 400);
       }
-      const presented =
-        url.searchParams.get("secret") ?? req.headers.get("x-channel-webhook-secret") ?? "";
       const ch = channels.get(channelName);
       const vt = ch?.transport instanceof VaultTransport ? ch.transport : undefined;
-      // Uniform 401 for an unknown vault channel OR a bad secret — never reveal
-      // which, so this (tailnet-reachable) endpoint can't be used to enumerate
-      // channel names. The secret is per-channel, so the lookup happens first,
-      // but both failure modes return the identical response. Constant-time compare.
-      if (!vt || !webhookSecretMatches(presented, vt.webhookSecret)) {
-        return json({ error: "unauthorized" }, 401);
+
+      // Branch on Authorization-header PRESENCE, not token truthiness. A
+      // whitespace-only `Authorization: Bearer   ` (which extractBearer trims to
+      // empty/falsy) must NOT fall through to the `?secret=` path — that would let
+      // a caller who knows the secret but lacks a valid JWT force the secret path.
+      // Any Authorization header at all → JWT path, full stop; a malformed/empty
+      // token fails hard via requireScope's 401. The deprecated `?secret=`
+      // fallback runs ONLY when there is no Authorization header.
+      const authHeader = req.headers.get("authorization");
+      if (authHeader !== null) {
+        // JWT path — validate the hub token, require channel:send. This is a
+        // tailnet-reachable webhook, so we keep it uniform-401: any auth failure
+        // (missing/malformed/expired token OR insufficient scope OR unknown
+        // channel) collapses to the SAME 401, so it can't be probed for valid
+        // scopes or channel names. (requireScope would otherwise distinguish 401
+        // vs 403 — fine for the operator-facing config API, but this endpoint
+        // stays opaque.)
+        const denied = await requireScope(req, url, SCOPE_SEND);
+        if (denied || !vt) {
+          return json({ error: "unauthorized" }, 401);
+        }
+      } else {
+        // DEPRECATED shared-secret fallback — only reachable with NO Authorization
+        // header. The secret is per-channel, so resolve the channel first, then
+        // constant-time compare. Uniform 401 for an unknown vault channel, a
+        // channel with no configured secret (nothing to validate against), OR a
+        // bad secret — never reveal which (no channel enumeration on this
+        // tailnet-reachable endpoint). webhookSecretMatches treats an empty/absent
+        // configured secret as never-matching, so a JWT-only channel (no secret)
+        // can't be opened by a `?secret=` request.
+        const presented =
+          url.searchParams.get("secret") ?? req.headers.get("x-channel-webhook-secret") ?? "";
+        if (!vt || !webhookSecretMatches(presented, vt.webhookSecret ?? "")) {
+          return json({ error: "unauthorized" }, 401);
+        }
+        console.warn(
+          `parachute-channel: /api/vault/inbound authenticated via DEPRECATED ?secret= shared secret ` +
+            `for channel "${channelName}". Migrate to a hub-JWT trigger (action.auth.bearer, scope channel:send).`,
+        );
       }
       // Idempotency: a duplicate trigger delivery for the same note must not
       // double-wake. First-seen → process; already-seen → ack without emitting.
@@ -985,8 +1211,14 @@ function main(): void {
     console.error(`parachute-channel: services.json self-registration failed (continuing): ${err}`);
   }
 
-  for (const channel of channels.values()) {
-    channel.transport.start(contextFor(registry, channel.name)).catch((err) => {
+  // Start each channel via the same single-channel add path the config API uses
+  // (`addChannelLive`), so boot and hot-add can't drift. The map already holds
+  // the channels (from `loadRegistry`); addChannelLive replaces-in-place, which
+  // for a freshly-instantiated boot transport means stop()→re-instantiate→start.
+  // Per-channel failures are logged and don't abort the others; the daemon must
+  // still serve the channels that did come up.
+  for (const channel of [...channels.values()]) {
+    addChannelLive(channels, registry, channel.entry).catch((err) => {
       console.error(`parachute-channel: transport "${channel.name}" start failed:`, err);
     });
   }

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -11,7 +11,7 @@
  * is synthesized so existing single-bot installs keep working with zero config.
  */
 
-import { readFileSync, existsSync, chmodSync } from "fs";
+import { readFileSync, writeFileSync, existsSync, chmodSync, mkdirSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 import type { Transport } from "./transport.ts";
@@ -115,6 +115,65 @@ export function resolveChannelEntries(opts: {
   }
 
   return [];
+}
+
+/** Absolute path to the channels.json registry file in a state dir. */
+export function channelsFilePath(stateDir?: string): string {
+  return join(stateDir ?? defaultStateDir(), "channels.json");
+}
+
+/**
+ * Read the channels.json registry as a plain `ChannelsFile`, WITHOUT
+ * instantiating transports or synthesizing the telegram fallback. Returns an
+ * empty `{ channels: [] }` if the file is absent. Used by the config-management
+ * API to read-modify-write the file while the daemon holds the live channels.
+ */
+export function readChannelsFile(stateDir?: string): ChannelsFile {
+  const file = channelsFilePath(stateDir);
+  if (!existsSync(file)) return { channels: [] };
+  const parsed = JSON.parse(readFileSync(file, "utf8")) as ChannelsFile;
+  if (!parsed || !Array.isArray(parsed.channels)) {
+    throw new Error(`registry: ${file} must have a "channels" array`);
+  }
+  return parsed;
+}
+
+/**
+ * Upsert a channel entry into channels.json (preserving every other entry) and
+ * write it back with 0600 perms — the file holds transport tokens/secrets. If an
+ * entry with the same name exists it's REPLACED in place (same position);
+ * otherwise the new entry is appended. Creates the state dir if needed. Returns
+ * the persisted file contents.
+ */
+export function upsertChannelEntry(entry: ChannelEntry, stateDir?: string): ChannelsFile {
+  const dir = stateDir ?? defaultStateDir();
+  mkdirSync(dir, { recursive: true });
+  const file = channelsFilePath(dir);
+  const current = readChannelsFile(dir);
+  const idx = current.channels.findIndex((c) => c.name === entry.name);
+  if (idx >= 0) current.channels[idx] = entry;
+  else current.channels.push(entry);
+  writeFileSync(file, JSON.stringify(current, null, 2) + "\n", { mode: 0o600 });
+  // writeFileSync's mode only applies on CREATE; chmod unconditionally so an
+  // existing file (created before this code, or with a looser umask) is tightened.
+  chmodSync(file, 0o600);
+  return current;
+}
+
+/**
+ * Remove a channel entry from channels.json by name, preserving the rest. Returns
+ * the persisted file contents, or null if the file didn't exist. A no-op (name
+ * absent) still rewrites the file (idempotent) when the file exists.
+ */
+export function removeChannelEntry(name: string, stateDir?: string): ChannelsFile | null {
+  const dir = stateDir ?? defaultStateDir();
+  const file = channelsFilePath(dir);
+  if (!existsSync(file)) return null;
+  const current = readChannelsFile(dir);
+  current.channels = current.channels.filter((c) => c.name !== name);
+  writeFileSync(file, JSON.stringify(current, null, 2) + "\n", { mode: 0o600 });
+  chmodSync(file, 0o600);
+  return current;
 }
 
 /**

--- a/src/transports/vault.ts
+++ b/src/transports/vault.ts
@@ -55,8 +55,15 @@ export interface VaultTransportConfig {
   vaultUrl?: string;
   /** A `vault:<name>:write` hub JWT, presented as Bearer when writing replies. */
   token: string;
-  /** Shared secret the inbound webhook must present (validated by the daemon). */
-  webhookSecret: string;
+  /**
+   * Shared secret the inbound webhook must present (validated by the daemon),
+   * for the DEPRECATED `?secret=` back-compat path. OPTIONAL — a JWT-only channel
+   * (the frictionless-setup default, provisioned by the hub with NO shared
+   * secret) configures none, and the webhook handler authenticates it via the
+   * hub-JWT path instead. When absent, the `?secret=` fallback can never succeed
+   * for this channel (nothing to validate against → 401).
+   */
+  webhookSecret?: string;
   /** Optional path prefix for written notes. Default `channel`. */
   notePathPrefix?: string;
 }
@@ -122,6 +129,41 @@ export const CHANNEL_VAULT_TAG_SCHEMA: ReadonlyArray<{
   },
 ];
 
+/**
+ * The vault trigger the hub registers to wake this channel on inbound notes.
+ *
+ * This is MODULE-OWNED DATA: the channel owns the shape of the trigger it needs,
+ * rather than the hub hardcoding it. The hub fetches this template (via
+ * `GET /.parachute/config` → `triggerTemplate`), substitutes the channel name
+ * into the placeholders, fills the webhook origin + the `action.auth.bearer`
+ * (a `channel:send` hub JWT, per the keystone vault PR's `action.auth.bearer`
+ * support), and registers it through the vault's runtime trigger-registration API.
+ *
+ * Placeholders the hub substitutes:
+ *  - `<channel>` in `name` → the channel name (e.g. `channel_inbound_eng`);
+ *  - `<hub-origin>` in `action.webhook` → the hub's public origin.
+ * The hub also injects `action.auth.bearer` (not in the template — it's a secret
+ * the hub mints).
+ *
+ * The predicate matches a NEW inbound note (`#channel-message/inbound`) that
+ * carries a `channel` metadata field and hasn't been rendered yet. Loop avoidance
+ * is by the inbound CHILD tag: an outbound (reply) note carries
+ * `#channel-message/outbound`, never the inbound child, so it never fires this.
+ */
+export const CHANNEL_VAULT_TRIGGER_TEMPLATE = {
+  name: "channel_inbound_<channel>", // hub substitutes the channel name
+  events: ["created"],
+  when: {
+    tags: ["#channel-message/inbound"],
+    has_metadata: ["channel"],
+    missing_metadata: ["channel_inbound_rendered_at"],
+  },
+  action: {
+    webhook: "<hub-origin>/channel/api/vault/inbound", // hub fills origin + the auth.bearer
+    send: "json",
+  },
+} as const;
+
 export class VaultTransport implements Transport {
   readonly kind = "vault";
 
@@ -129,8 +171,14 @@ export class VaultTransport implements Transport {
   private readonly vault: string;
   private readonly vaultUrl: string;
   private readonly token: string;
-  /** Shared secret the daemon validates on the inbound webhook (read by the daemon). */
-  readonly webhookSecret: string;
+  /**
+   * Shared secret the daemon validates on the inbound webhook (read by the
+   * daemon), for the DEPRECATED `?secret=` path only. Optional — absent on a
+   * JWT-only channel, in which case the `?secret=` fallback can never authorize
+   * this channel (the daemon treats an absent/empty configured secret as
+   * never-matching). The hub-JWT path doesn't read it at all.
+   */
+  readonly webhookSecret?: string;
   private readonly pathPrefix: string;
 
   constructor(config: VaultTransportConfig) {
@@ -140,9 +188,9 @@ export class VaultTransport implements Transport {
     if (!config.token) {
       throw new Error("VaultTransport: config.token (vault:<name>:write JWT) is required");
     }
-    if (!config.webhookSecret) {
-      throw new Error("VaultTransport: config.webhookSecret is required");
-    }
+    // webhookSecret is OPTIONAL — a JWT-only channel (the frictionless-setup
+    // default) needs none. The webhook is authenticated via the hub-JWT path;
+    // the `?secret=` fallback simply can't succeed for a channel with no secret.
     this.vault = config.vault;
     this.vaultUrl = (config.vaultUrl ?? DEFAULT_VAULT_URL).replace(/\/$/, "");
     this.token = config.token;


### PR DESCRIPTION
## What (PR 2 of frictionless-channel-setup)

Stops the channel needing a hand-edited config + a shared webhook secret.

- **Webhook hub-JWT auth** — `POST /api/vault/inbound` validates a hub JWT (`aud:channel`, scope `channel:send`) via scope-guard. Branches on **Authorization-header presence** (any header → JWT path, fail-hard 401 — no fall-through), with `?secret=` as a deprecated fallback ONLY when no Authorization header is present. Uniform 401 (no channel/scope enumeration).
- **Config-management API** — `POST/GET/DELETE /api/channels`, gated on `channel:admin`. Writes `channels.json` (600 perms; never echoes token/secret on GET) and **hot-adds/removes** channels in the live daemon with NO restart (boot + hot-add share one `addChannelLive` path; bad config validated-before-persist → 400, nothing written).
- **`webhookSecret` now optional** — a JWT-only channel needs no shared secret.
- **`CHANNEL_VAULT_TRIGGER_TEMPLATE`** — module-owned data exposed via `GET /.parachute/config` so the hub (PR 3) reads the prescribed inbound-trigger shape rather than hardcoding it.

## Review
Reviewer caught an auth-confusion edge (whitespace `Bearer` forcing the secret path) → fixed (header-presence branch) + tested; relaxed `webhookSecret` per the same review. 132 pass / 0 fail, typecheck clean, no binary files. Additive; version untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)