### PR TITLE
feat(module.json): enrich message.deliver action with endpoint+scope for hub connection provisioning

### DIFF
--- a/.parachute/module.json
+++ b/.parachute/module.json
@@ -23,6 +23,8 @@
     {
       "key": "message.deliver",
       "title": "Deliver an inbound message (wakes the session)",
+      "endpoint": "/api/vault/inbound",
+      "scope": "channel:send",
       "provision": {
         "type": "vault-trigger",
         "note": "hub registers a vault runtime trigger that webhooks the channel inbound endpoint with a channel:send bearer"

--- a/src/admin-ui.test.ts
+++ b/src/admin-ui.test.ts
@@ -114,6 +114,20 @@ describe("module.json — modular-UI (P4) declaration", () => {
     expect(deliver?.provision?.type).toBe("vault-trigger");
   });
 
+  test("message.deliver declares the hub-connection wiring (endpoint + scope)", async () => {
+    // The hub's general Connections engine (P5) wires a `vault-trigger` action
+    // GENERICALLY: the webhook the vault calls back on is derived from the sink
+    // action's `endpoint` (hub-proxied under the module's mount), and the bearer
+    // the vault re-presents is minted at the action's declared `scope` — NOT a
+    // channel-hardcoded path in hub code. So the deliver action must carry both.
+    const m = JSON.parse(await Bun.file(manifestPath).text()) as {
+      actions?: Array<{ key: string; endpoint?: string; scope?: string }>;
+    };
+    const deliver = (m.actions ?? []).find((a) => a.key === "message.deliver");
+    expect(deliver?.endpoint).toBe("/api/vault/inbound");
+    expect(deliver?.scope).toBe("channel:send");
+  });
+
   test("preserves the existing manifest contract (name, port, scopes)", async () => {
     const m = JSON.parse(await Bun.file(manifestPath).text()) as Record<string, unknown>;
     expect(m.name).toBe("channel");


### PR DESCRIPTION
Adds endpoint:/api/vault/inbound + scope:channel:send to the message.deliver action so the hub's general Connections engine (P5) can wire it without channel-specific hardcoding. Part of the modular-UI arc. 🤖 Generated with [Claude Code](https://claude.com/claude-code)