### PR TITLE
fix(daemon): self-heal hub origin via expose-state + register startCmd for supervision; harden admin-ui escaping (channel#34, #37)

### DIFF
--- a/src/admin-ui.test.ts
+++ b/src/admin-ui.test.ts
@@ -11,7 +11,7 @@
  */
 import { describe, expect, test } from "bun:test";
 import { join } from "node:path";
-import { renderAdminPage } from "./admin-ui.ts";
+import { renderAdminPage, escapeHtml } from "./admin-ui.ts";
 
 describe("renderAdminPage", () => {
   test("renders the channel config chrome", () => {
@@ -79,6 +79,41 @@ describe("renderAdminPage", () => {
   test("renders the same HTML for a given mount (pure function)", () => {
     expect(renderAdminPage("/channel")).toBe(renderAdminPage("/channel"));
     expect(renderAdminPage("")).toBe(renderAdminPage(""));
+  });
+});
+
+describe("escape hardening (channel#37)", () => {
+  test("escapeHtml neutralizes the five HTML metacharacters", () => {
+    expect(escapeHtml(`<script>alert("x&y")</script>'`)).toBe(
+      "&lt;script&gt;alert(&quot;x&amp;y&quot;)&lt;/script&gt;&#39;",
+    );
+  });
+
+  test("the footer configUrl interpolation is escaped, not raw", () => {
+    // A mount carrying HTML metacharacters must render escaped in BOTH the href
+    // attribute and the link text of the footer "live config" link — so it can
+    // never break out into markup at that interpolation site (channel#37).
+    const html = renderAdminPage('"><img src=x onerror=alert(1)>');
+    // Isolate the footer link the interpolation builds.
+    const footer = html.slice(html.indexOf("Live config"), html.indexOf("</a>") + 4);
+    // The raw markup-breakout never appears in the footer link.
+    expect(footer).not.toContain("<img src=x onerror=alert(1)>");
+    expect(footer).not.toContain('"><img');
+    // The escaped form is what lands instead, in both href and text.
+    expect(footer).toContain(escapeHtml('"><img src=x onerror=alert(1)>/.parachute/config'));
+  });
+
+  test("a normal mount still renders a clean, working footer link", () => {
+    const html = renderAdminPage("/channel");
+    expect(html).toContain('href="/channel/.parachute/config"');
+  });
+
+  test("the remove-confirm interpolates the channel name through escapeHtml", () => {
+    // The confirm() string is built from the channel name (a runtime value); the
+    // page-script must route it through escapeHtml so a name with HTML
+    // metacharacters renders escaped rather than as a latent sink.
+    const html = renderAdminPage("");
+    expect(html).toContain('window.confirm("Remove channel \\"" + escapeHtml(name) + "\\"?');
   });
 });
 

--- a/src/admin-ui.ts
+++ b/src/admin-ui.ts
@@ -57,6 +57,26 @@ const FONT_SANS = `-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, san
 const FONT_MONO = `ui-monospace, "SF Mono", Menlo, Monaco, "Cascadia Mono", monospace`;
 
 /**
+ * Server-side HTML escape for values interpolated into the rendered document.
+ * Escapes the five HTML-significant characters so a value is safe in both text
+ * content and a double-quoted attribute value (the two contexts `configUrl`
+ * lands in). Mirrors the in-page client-side `escapeHtml` so the two halves of
+ * the document share one discipline.
+ *
+ * Defensive today: `mount` is server-derived (the proxy prefix), never raw user
+ * input — but this keeps the footer from becoming a latent XSS sink if that
+ * provenance ever changes.
+ */
+export function escapeHtml(s: string): string {
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/**
  * Render the admin page. Pure function — returns the HTML string. The page
  * fetches live state on load (the channel list + per-channel health), so the
  * rendered HTML is the same across requests for a given mount.
@@ -141,7 +161,7 @@ export function renderAdminPage(mount = ""): string {
 
       <footer class="card-footer">
         <p class="footer-hint">
-          Live config (resolved, no secrets): <a href="${configUrl}">${configUrl}</a>.
+          Live config (resolved, no secrets): <a href="${escapeHtml(configUrl)}">${escapeHtml(configUrl)}</a>.
           Channels file on disk: <code>~/.parachute/channel/channels.json</code>.
         </p>
       </footer>
@@ -689,7 +709,7 @@ const PAGE_SCRIPT = String.raw`
 
   // --- Remove -------------------------------------------------------------
   function removeChannel(name, btn) {
-    if (!window.confirm("Remove channel \"" + name + "\"? Sessions on it will stop receiving messages.")) return;
+    if (!window.confirm("Remove channel \"" + escapeHtml(name) + "\"? Sessions on it will stop receiving messages.")) return;
     clearBanner();
     if (btn) { btn.disabled = true; btn.textContent = "Removing..."; }
     fetch(API_URL + "/" + encodeURIComponent(name), {

--- a/src/daemon.test.ts
+++ b/src/daemon.test.ts
@@ -13,7 +13,10 @@
  * no-token reject is wired in front of the guarded handlers.
  */
 import { describe, test, expect, beforeAll, afterAll } from "bun:test";
-import { createFetchHandler } from "./daemon.ts";
+import { createFetchHandler, resolveStartCmd } from "./daemon.ts";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { ClientRegistry } from "./routing.ts";
 import { HttpUiTransport } from "./transports/http-ui.ts";
 import { VaultTransport } from "./transports/vault.ts";
@@ -22,8 +25,23 @@ import type { TransportContext, InboundMessage } from "./transport.ts";
 
 let server: ReturnType<typeof Bun.serve>;
 let base: string;
+let envHome: string | undefined;
+let envHubOrigin: string | undefined;
+let homeDir: string;
 
 beforeAll(async () => {
+  // Pin PARACHUTE_HOME at an empty temp dir + clear PARACHUTE_HUB_ORIGIN so
+  // `getHubOrigin()` resolves deterministically to loopback. Without this the
+  // OAuth-discovery assertions below (which expect the loopback hub origin) flake
+  // on any box that has a real `~/.parachute/expose-state.json` — `getHubOrigin`
+  // now self-heals from expose-state's `hubOrigin` (channel#34), so a tailnet /
+  // public state file would otherwise leak the exposed origin into the doc.
+  envHome = process.env.PARACHUTE_HOME;
+  envHubOrigin = process.env.PARACHUTE_HUB_ORIGIN;
+  homeDir = mkdtempSync(join(tmpdir(), "channel-daemon-home-"));
+  process.env.PARACHUTE_HOME = homeDir;
+  delete process.env.PARACHUTE_HUB_ORIGIN;
+
   const registry = new ClientRegistry();
   const transport = new HttpUiTransport({ channel: "ui1" });
   const channels = new Map<string, Channel>([
@@ -47,6 +65,13 @@ beforeAll(async () => {
 
 afterAll(() => {
   server.stop(true);
+  if (envHome === undefined) delete process.env.PARACHUTE_HOME;
+  else process.env.PARACHUTE_HOME = envHome;
+  if (envHubOrigin === undefined) delete process.env.PARACHUTE_HUB_ORIGIN;
+  else process.env.PARACHUTE_HUB_ORIGIN = envHubOrigin;
+  try {
+    rmSync(homeDir, { recursive: true, force: true });
+  } catch {}
 });
 
 describe("bridge-facing endpoints require a bearer token (401 with none)", () => {
@@ -507,5 +532,73 @@ describe("Vault inbound webhook — POST /api/vault/inbound", () => {
     } finally {
       srv.stop(true);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// startCmd resolution for hub supervision (channel#34)
+// ---------------------------------------------------------------------------
+
+describe("resolveStartCmd (hub-supervisor start command)", () => {
+  function tmpInstallDir(): string {
+    return mkdtempSync(join(tmpdir(), "channel-startcmd-"));
+  }
+
+  test("reads startCmd from <installDir>/.parachute/module.json", () => {
+    const dir = tmpInstallDir();
+    try {
+      mkdirSync(join(dir, ".parachute"), { recursive: true });
+      writeFileSync(
+        join(dir, ".parachute", "module.json"),
+        JSON.stringify({ startCmd: ["parachute-channel"] }),
+      );
+      expect(resolveStartCmd(dir)).toEqual(["parachute-channel"]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("preserves a multi-arg module.json startCmd verbatim", () => {
+    const dir = tmpInstallDir();
+    try {
+      mkdirSync(join(dir, ".parachute"), { recursive: true });
+      writeFileSync(
+        join(dir, ".parachute", "module.json"),
+        JSON.stringify({ startCmd: ["parachute-channel", "daemon"] }),
+      );
+      expect(resolveStartCmd(dir)).toEqual(["parachute-channel", "daemon"]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("falls back to the bin name when module.json is absent", () => {
+    const dir = tmpInstallDir();
+    try {
+      expect(resolveStartCmd(dir)).toEqual(["parachute-channel"]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("falls back to the bin name when module.json startCmd is missing/empty/non-string", () => {
+    const dir = tmpInstallDir();
+    try {
+      mkdirSync(join(dir, ".parachute"), { recursive: true });
+      writeFileSync(join(dir, ".parachute", "module.json"), JSON.stringify({ startCmd: [] }));
+      expect(resolveStartCmd(dir)).toEqual(["parachute-channel"]);
+      writeFileSync(join(dir, ".parachute", "module.json"), JSON.stringify({ name: "channel" }));
+      expect(resolveStartCmd(dir)).toEqual(["parachute-channel"]);
+      writeFileSync(join(dir, ".parachute", "module.json"), JSON.stringify({ startCmd: [123] }));
+      expect(resolveStartCmd(dir)).toEqual(["parachute-channel"]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("the repo's own .parachute/module.json carries a usable startCmd", () => {
+    // INSTALL_DIR at runtime is the repo root; src/.. is that root in this checkout.
+    const repoRoot = join(import.meta.dir, "..");
+    expect(resolveStartCmd(repoRoot)).toEqual(["parachute-channel"]);
   });
 });

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -96,6 +96,40 @@ const PKG_VERSION = ((): string => {
 })();
 const INSTALL_DIR = join(import.meta.dir, "..");
 
+/**
+ * The argv the hub supervisor should spawn to (re)start this module — written
+ * into our services.json row so `parachute restart channel` / reboot-survival /
+ * adopt all have a command to run. Without it the supervisor knows the port but
+ * not how to start the process, so a manually-run `bun src/daemon.ts` daemon
+ * can't be supervised (channel#34).
+ *
+ * Sourced from our own `.parachute/module.json` `startCmd` (the canonical
+ * declaration the hub already prefers when it can read the install dir),
+ * falling back to the package.json `bin` name when the manifest is unreadable.
+ * The bin (`parachute-channel` → `src/daemon.ts`) runs the daemon directly and
+ * ignores extra argv, so the literal command is stable regardless of any
+ * subcommand the hub's first-party fallback might carry.
+ */
+export function resolveStartCmd(installDir: string): string[] {
+  try {
+    const manifest = JSON.parse(
+      readFileSync(join(installDir, ".parachute", "module.json"), "utf8"),
+    ) as { startCmd?: unknown };
+    if (
+      Array.isArray(manifest.startCmd) &&
+      manifest.startCmd.length > 0 &&
+      manifest.startCmd.every((a) => typeof a === "string")
+    ) {
+      return manifest.startCmd as string[];
+    }
+  } catch {
+    // fall through to the bin-name default
+  }
+  return ["parachute-channel"];
+}
+
+const START_CMD: string[] = resolveStartCmd(INSTALL_DIR);
+
 // ---------------------------------------------------------------------------
 // Registry + routing
 // ---------------------------------------------------------------------------
@@ -1217,6 +1251,10 @@ function main(): void {
       displayName: "Channel",
       tagline: "Chat with your Claude Code sessions — a channel per session.",
       installDir: INSTALL_DIR,
+      // The command the hub supervisor spawns to start/restart/adopt us. Without
+      // this the supervisor knows our port but not how to launch the process, so
+      // `parachute restart channel` 404s and we don't survive reboot (channel#34).
+      startCmd: START_CMD,
       stripPrefix: true,
       uiUrl: "/channel/ui", // portal "Open UI" link (also in module.json; written here in case hub reads it from services.json)
       configUiUrl: "/channel/admin", // module-owned config surface (modular-UI P4); hub frames/links it. Also in module.json.

--- a/src/hub-jwt.test.ts
+++ b/src/hub-jwt.test.ts
@@ -1,11 +1,19 @@
 /**
  * Tests for the channel-side hub-JWT adapter. These exercise the parts that
- * DON'T need a live hub / JWKS endpoint: hub-origin resolution (env precedence +
- * loopback fallback), the audience constant, and the re-exported pure helpers
- * (`looksLikeJwt`). Real signature/issuer/audience validation is scope-guard's
- * own tested surface — we don't re-test it here and we never need a real JWKS.
+ * DON'T need a live hub / JWKS endpoint: hub-origin resolution (env precedence →
+ * expose-state self-heal → loopback fallback), the audience constant, and the
+ * re-exported pure helpers (`looksLikeJwt`). Real signature/issuer/audience
+ * validation is scope-guard's own tested surface — we don't re-test it here and
+ * we never need a real JWKS.
+ *
+ * The self-heal reads `<PARACHUTE_HOME>/expose-state.json`. Every case here
+ * points `PARACHUTE_HOME` at a fresh temp dir so the operator's real
+ * `~/.parachute/expose-state.json` can't leak into the loopback assertions.
  */
-import { describe, test, expect, afterEach } from "bun:test";
+import { describe, test, expect, afterEach, beforeEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   getHubOrigin,
   CHANNEL_AUDIENCE,
@@ -14,23 +22,31 @@ import {
 } from "./hub-jwt.ts";
 
 const savedOrigin = process.env.PARACHUTE_HUB_ORIGIN;
+const savedHome = process.env.PARACHUTE_HOME;
+
+let home: string;
+
+beforeEach(() => {
+  // Isolated, empty ecosystem root — no expose-state.json unless a case writes one.
+  home = mkdtempSync(join(tmpdir(), "channel-hubjwt-"));
+  process.env.PARACHUTE_HOME = home;
+});
 
 afterEach(() => {
   if (savedOrigin === undefined) delete process.env.PARACHUTE_HUB_ORIGIN;
   else process.env.PARACHUTE_HUB_ORIGIN = savedOrigin;
+  if (savedHome === undefined) delete process.env.PARACHUTE_HOME;
+  else process.env.PARACHUTE_HOME = savedHome;
+  try {
+    rmSync(home, { recursive: true, force: true });
+  } catch {}
 });
 
-describe("getHubOrigin", () => {
-  test("falls back to loopback when PARACHUTE_HUB_ORIGIN is unset", () => {
-    delete process.env.PARACHUTE_HUB_ORIGIN;
-    expect(getHubOrigin()).toBe("http://127.0.0.1:1939");
-  });
+function writeExposeState(obj: Record<string, unknown>): void {
+  writeFileSync(join(home, "expose-state.json"), JSON.stringify(obj));
+}
 
-  test("falls back to loopback when PARACHUTE_HUB_ORIGIN is empty", () => {
-    process.env.PARACHUTE_HUB_ORIGIN = "";
-    expect(getHubOrigin()).toBe("http://127.0.0.1:1939");
-  });
-
+describe("getHubOrigin — env precedence", () => {
   test("uses the env value when set", () => {
     process.env.PARACHUTE_HUB_ORIGIN = "https://hub.example.com";
     expect(getHubOrigin()).toBe("https://hub.example.com");
@@ -39,6 +55,68 @@ describe("getHubOrigin", () => {
   test("strips a single trailing slash for a canonical form", () => {
     process.env.PARACHUTE_HUB_ORIGIN = "https://hub.example.com/";
     expect(getHubOrigin()).toBe("https://hub.example.com");
+  });
+
+  test("env wins over expose-state (highest precedence)", () => {
+    process.env.PARACHUTE_HUB_ORIGIN = "https://env.example.com";
+    writeExposeState({ hubOrigin: "https://exposed.example.com" });
+    expect(getHubOrigin()).toBe("https://env.example.com");
+  });
+});
+
+describe("getHubOrigin — expose-state self-heal (channel#34)", () => {
+  test("reads expose-state.hubOrigin when env is unset", () => {
+    delete process.env.PARACHUTE_HUB_ORIGIN;
+    writeExposeState({ hubOrigin: "https://exposed.example.com" });
+    expect(getHubOrigin()).toBe("https://exposed.example.com");
+  });
+
+  test("reads expose-state.hubOrigin when env is empty", () => {
+    process.env.PARACHUTE_HUB_ORIGIN = "";
+    writeExposeState({ hubOrigin: "https://exposed.example.com" });
+    expect(getHubOrigin()).toBe("https://exposed.example.com");
+  });
+
+  test("synthesizes https://<canonicalFqdn> for older state files lacking hubOrigin", () => {
+    delete process.env.PARACHUTE_HUB_ORIGIN;
+    writeExposeState({ canonicalFqdn: "box.taildf9ce2.ts.net" });
+    expect(getHubOrigin()).toBe("https://box.taildf9ce2.ts.net");
+  });
+
+  test("strips a trailing slash off the expose-state origin", () => {
+    delete process.env.PARACHUTE_HUB_ORIGIN;
+    writeExposeState({ hubOrigin: "https://exposed.example.com/" });
+    expect(getHubOrigin()).toBe("https://exposed.example.com");
+  });
+
+  test("never self-heals to a loopback expose-state origin", () => {
+    delete process.env.PARACHUTE_HUB_ORIGIN;
+    writeExposeState({ hubOrigin: "http://127.0.0.1:1939" });
+    expect(getHubOrigin()).toBe("http://127.0.0.1:1939"); // loopback default, not a self-heal
+  });
+});
+
+describe("getHubOrigin — loopback fallback", () => {
+  test("falls back to loopback when env unset AND no expose-state file", () => {
+    delete process.env.PARACHUTE_HUB_ORIGIN;
+    expect(getHubOrigin()).toBe("http://127.0.0.1:1939");
+  });
+
+  test("falls back to loopback when env empty AND no expose-state file", () => {
+    process.env.PARACHUTE_HUB_ORIGIN = "";
+    expect(getHubOrigin()).toBe("http://127.0.0.1:1939");
+  });
+
+  test("falls back to loopback when expose-state has no usable origin", () => {
+    delete process.env.PARACHUTE_HUB_ORIGIN;
+    writeExposeState({ layer: "tailnet" }); // neither hubOrigin nor canonicalFqdn
+    expect(getHubOrigin()).toBe("http://127.0.0.1:1939");
+  });
+
+  test("falls back to loopback when expose-state is malformed JSON", () => {
+    delete process.env.PARACHUTE_HUB_ORIGIN;
+    writeFileSync(join(home, "expose-state.json"), "{ not json");
+    expect(getHubOrigin()).toBe("http://127.0.0.1:1939");
   });
 });
 

--- a/src/hub-jwt.ts
+++ b/src/hub-jwt.ts
@@ -7,17 +7,24 @@
  * `aud` handling, revocation — lives in the shared `@openparachute/scope-guard`
  * library so vault, scribe, and channel can't silently drift on the worst place
  * to drift. This file is the channel-side adapter: hub-origin resolution
- * (env-var precedence + loopback fallback), a process-wide guard instance, and
- * re-exports preserving the surface the daemon imports.
+ * (env-var precedence → expose-state self-heal → loopback fallback), a
+ * process-wide guard instance, and re-exports preserving the surface the daemon
+ * imports.
  *
  * Audience pin: channel tokens carry `aud: "channel"`. We pass
  * `expectedAudience: "channel"` so a token minted for some other resource
  * (e.g. a vault) can't be replayed against the channel even if it happens to
- * carry channel-shaped scopes. The hub mints `iss: <hub public origin>`, so
- * `PARACHUTE_HUB_ORIGIN` MUST be set to the hub's *public* origin for `iss`
- * validation to succeed on an exposed deployment — the loopback fallback is for
- * a co-located, never-exposed dev daemon only.
+ * carry channel-shaped scopes. The hub mints `iss: <hub public origin>`, so the
+ * resolved hub origin MUST be that public origin for `iss` validation to
+ * succeed on an exposed deployment. `PARACHUTE_HUB_ORIGIN` is the explicit
+ * contract; when it's unset, `getHubOrigin` self-heals from the hub's persisted
+ * `expose-state.json` `hubOrigin` so a manually-relaunched daemon on an exposed
+ * box doesn't 401 every token — the loopback fallback is for a co-located,
+ * never-exposed dev daemon only.
  */
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
 import {
   createScopeGuard,
   HubJwtError,
@@ -27,6 +34,45 @@ import {
 
 const DEFAULT_HUB_LOOPBACK = "http://127.0.0.1:1939";
 
+/**
+ * Best-effort read of the hub's persisted public origin from
+ * `<root>/expose-state.json` (hub-owned; written by the Tailscale + Cloudflare
+ * expose paths). Returns the canonical public origin — preferring the explicit
+ * `hubOrigin` field (the URL the hub stamps into token `iss` claims), falling
+ * back to synthesizing `https://<canonicalFqdn>` for older state files that
+ * predate `hubOrigin`. Returns undefined on any error, when absent, or when the
+ * only origin available is loopback (there's nothing to self-heal *to*).
+ *
+ * `root` is `$PARACHUTE_HOME` if set, otherwise `~/.parachute` — re-derived
+ * per-call so tests that flip `PARACHUTE_HOME` (and sandboxed/e2e daemons) see
+ * the override rather than a value frozen at import. Mirrors hub's own
+ * `publicOriginFromExposeState` (parachute-hub/src/vault-hub-origin-env.ts) and
+ * vault's `readExposedFqdn` (parachute-vault/src/mcp-install.ts).
+ */
+function readExposeStateHubOrigin(): string | undefined {
+  try {
+    const root = process.env.PARACHUTE_HOME ?? resolve(homedir(), ".parachute");
+    const p = resolve(root, "expose-state.json");
+    if (!existsSync(p)) return undefined;
+    const raw = JSON.parse(readFileSync(p, "utf-8")) as {
+      hubOrigin?: string;
+      canonicalFqdn?: string;
+    };
+    const origin =
+      raw.hubOrigin ?? (raw.canonicalFqdn ? `https://${raw.canonicalFqdn}` : "");
+    const trimmed = origin.replace(/\/$/, "");
+    if (!trimmed) return undefined;
+    // Never self-heal to a loopback origin — that's the last-resort default, not
+    // a public issuer, and persisting it would defeat the env→loopback contract.
+    if (/^https?:\/\/(127\.0\.0\.1|localhost|\[::1\])(:|\/|$)/i.test(trimmed)) {
+      return undefined;
+    }
+    return trimmed;
+  } catch {
+    return undefined;
+  }
+}
+
 /** The audience channel tokens are minted with; strict-checked on every validate. */
 export const CHANNEL_AUDIENCE = "channel" as const;
 
@@ -34,16 +80,26 @@ export const CHANNEL_AUDIENCE = "channel" as const;
  * Resolve the hub origin used to fetch JWKS and validate `iss`. Strips a
  * trailing slash so we get a single canonical form.
  *
- * Order: env var → loopback fallback. We deliberately don't read
- * `~/.parachute/services.json` — the hub is the dispatcher, not a registered
- * service in that file. If a deployment exposes the hub on a non-default
- * origin (the normal case once channel is reachable off-box), the env var is
- * the contract — and it MUST be the hub's public origin, because the hub stamps
- * that origin as the token `iss`.
+ * Order: `PARACHUTE_HUB_ORIGIN` env → `expose-state.json` `hubOrigin`
+ * (self-heal) → loopback fallback. The env var stays highest precedence (the
+ * explicit operator/supervisor contract). The expose-state read is the
+ * self-heal: on an exposed deployment the hub mints `iss: <public origin>` and
+ * persists that origin to `<root>/expose-state.json`, so a channel daemon
+ * started WITHOUT the env (e.g. a manual relaunch) still recovers the hub's
+ * real public issuer and validates JWTs — instead of falling straight to
+ * loopback and 401'ing EVERY token with `unexpected "iss" claim value`. This
+ * mirrors what vault (`chooseHubOrigin`, parachute-vault/src/mcp-install.ts) and
+ * hub (`publicOriginFromExposeState`) already do; we used to deliberately skip
+ * expose-state, and that's exactly the gap this closes (channel#34). Loopback is
+ * the last resort for a co-located, never-exposed dev daemon; we never persist
+ * or self-heal *to* loopback. We still don't read `services.json` — the hub is
+ * the dispatcher, not a registered service there.
  */
 export function getHubOrigin(): string {
   const env = process.env.PARACHUTE_HUB_ORIGIN?.replace(/\/$/, "");
   if (env && env.length > 0) return env;
+  const exposed = readExposeStateHubOrigin();
+  if (exposed) return exposed;
   return DEFAULT_HUB_LOOPBACK;
 }
 

--- a/src/services-manifest.test.ts
+++ b/src/services-manifest.test.ts
@@ -38,6 +38,13 @@ describe("upsertService", () => {
     expect(m.services[0].stripPrefix).toBe(true);
   });
 
+  test("carries startCmd so the hub supervisor can start/restart/adopt the module (channel#34)", () => {
+    const path = tmp();
+    upsertService({ ...CHANNEL, startCmd: ["parachute-channel"] }, path);
+    const m = JSON.parse(readFileSync(path, "utf8"));
+    expect(m.services[0].startCmd).toEqual(["parachute-channel"]);
+  });
+
   test("is idempotent — re-registering the same name does not duplicate", () => {
     const path = tmp();
     upsertService(CHANNEL, path);


### PR DESCRIPTION
Closes channel#34 + #37. **Self-heal:** getHubOrigin now walks env → expose-state.hubOrigin → loopback (was env→loopback), mirroring vault — a channel started without PARACHUTE_HUB_ORIGIN self-heals to the hub's public origin and validates JWTs (fixes the silent iss-rejection that bit the deploy). **Supervision:** self-register now writes startCmd into services.json so the hub supervisor can start/restart channel. **Escaping:** configUrl footer + confirm dialog hardened. Reviewer: MERGE, no must-fixes (iss-trust not widened, loopback can't be pinned as public issuer, no JWKS split-brain). 164 tests / typecheck clean / no binary. 🤖 Generated with [Claude Code](https://claude.com/claude-code)