### PR TITLE
fix(daemon): honor PORT env (supervisor-assigned) so bind == self-register (channel#41)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,7 +227,8 @@ Bearer `vault:<name>:write`).
 | Variable | Default | Description |
 |---|---|---|
 | `TELEGRAM_BOT_TOKEN` | (required) | Telegram bot token from BotFather |
-| `PARACHUTE_CHANNEL_PORT` | `1941` | Daemon HTTP port |
+| `PORT` | (unset) | **Highest-priority port input** — the hub supervisor injects this from the module's services.json `entry.port` (the canonical pattern vault/scribe follow). The daemon binds AND self-registers this port, so the supervisor's readiness probe + `/channel/*` proxy target agree (channel#41). Empty/non-numeric falls through. |
+| `PARACHUTE_CHANNEL_PORT` | `1941` | Daemon HTTP port — back-compat override for a daemon run *outside* the supervisor. Used only when `PORT` is unset. |
 | `PARACHUTE_CHANNEL_URL` | `http://127.0.0.1:1941` | Bridge → daemon URL |
 | `PARACHUTE_CHANNEL_STATE_DIR` | `~/.parachute/channel` | Token, access config, inbox |
 | `PARACHUTE_HUB_ORIGIN` | `http://127.0.0.1:1939` | **Daemon:** hub's public origin for JWT `iss` validation. Required on an exposed deployment (the loopback default is dev-only); hub-as-supervisor sets it. |

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -11,7 +11,11 @@
  * Telegram is one transport behind the registry; the daemon core touches no
  * platform API directly.
  *
- * Default port: 1941 (PARACHUTE_CHANNEL_PORT env).
+ * Port resolution (see `resolvePort`): the hub supervisor's injected `PORT`
+ * wins, then the back-compat `PARACHUTE_CHANNEL_PORT` override, then the
+ * compiled-in canonical default 1941. The daemon binds AND self-registers the
+ * resolved port, so the supervisor's probe/proxy and the bound port never
+ * disagree (channel#41).
  */
 
 import { mkdirSync, readFileSync } from "fs";
@@ -81,7 +85,43 @@ export { requireScope, SCOPE_READ, SCOPE_WRITE, SCOPE_SEND } from "./auth.ts";
 
 const STATE_DIR = defaultStateDir();
 const INBOX_DIR = join(STATE_DIR, "inbox");
-const PORT = parseInt(process.env.PARACHUTE_CHANNEL_PORT ?? "1941", 10);
+
+/**
+ * Resolve the HTTP port the daemon binds (and self-registers in services.json),
+ * honoring sources in priority order:
+ *
+ *   1. `PORT` — the hub supervisor injects this from the module's services.json
+ *      `entry.port` (the canonical pattern vault/scribe follow). It is the port
+ *      the supervisor ALSO probes for readiness and proxies `/channel/*` to, so
+ *      the daemon MUST bind it or the supervisor reports `started_but_unbound`
+ *      and the proxy routes to a dead port (channel#41).
+ *   2. `PARACHUTE_CHANNEL_PORT` — back-compat manual override for a daemon run
+ *      outside the supervisor (the pre-#41 env var; still honored).
+ *   3. `1941` — the compiled-in canonical default.
+ *
+ * Pre-#41 the daemon read only `PARACHUTE_CHANNEL_PORT`, so it ignored the
+ * supervisor's `PORT` and bound 1941 regardless — the supervisor's injected
+ * port and the bound port could disagree, stranding the proxy. Honoring `PORT`
+ * first closes that gap.
+ *
+ * Read at call time (not at import) so tests can drive each tier deterministically.
+ *
+ * Uses `||` (not `??`) for the fall-through so an EMPTY-string env value falls
+ * through rather than being treated as "set": `PORT=""` with `??` would yield
+ * `parseInt("")` = NaN and bind port 0 / garbage. `||` skips the empty string
+ * to the next tier — matches vault's defensive `parseInt(...) || ... || DEFAULT`.
+ * The final `"1941"` literal also guards a non-numeric value (`PORT="abc"` →
+ * `parseInt` NaN → falsy → falls through to the default).
+ */
+export function resolvePort(env: NodeJS.ProcessEnv = process.env): number {
+  return (
+    parseInt(env.PORT ?? "", 10) ||
+    parseInt(env.PARACHUTE_CHANNEL_PORT ?? "", 10) ||
+    1941
+  );
+}
+
+const PORT = resolvePort();
 
 /** Channel a bridge subscribes to when `?channel=` is omitted (back-compat). */
 const DEFAULT_CHANNEL = "telegram";

--- a/src/resolve-port.test.ts
+++ b/src/resolve-port.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Port-resolution tests (channel#41).
+ *
+ * The hub supervisor injects `PORT` from the module's services.json `entry.port`
+ * and PROBES that same port for readiness (and reverse-proxies `/channel/*` to
+ * it). Pre-#41 the daemon read only `PARACHUTE_CHANNEL_PORT` (default 1941), so
+ * it ignored the supervisor's `PORT` and could bind a different port than the
+ * supervisor probed — the supervisor then reported `started_but_unbound` and the
+ * proxy routed to a dead port. `resolvePort` now honors `PORT` first so the bound
+ * port (which is also the self-registered port) matches what the supervisor
+ * assigned.
+ */
+import { describe, test, expect } from "bun:test";
+import { resolvePort } from "./daemon.ts";
+
+describe("resolvePort — PORT > PARACHUTE_CHANNEL_PORT > 1941", () => {
+  test("honors the supervisor-injected PORT first", () => {
+    expect(resolvePort({ PORT: "19415" })).toBe(19415);
+  });
+
+  test("PORT wins even when PARACHUTE_CHANNEL_PORT is also set", () => {
+    expect(resolvePort({ PORT: "1941", PARACHUTE_CHANNEL_PORT: "19415" })).toBe(1941);
+  });
+
+  test("falls back to PARACHUTE_CHANNEL_PORT when PORT is unset (back-compat)", () => {
+    expect(resolvePort({ PARACHUTE_CHANNEL_PORT: "2025" })).toBe(2025);
+  });
+
+  test("falls back to the canonical 1941 default when neither is set", () => {
+    expect(resolvePort({})).toBe(1941);
+  });
+
+  test("an EMPTY PORT='' falls through to PARACHUTE_CHANNEL_PORT (|| not ??)", () => {
+    // With `??` an empty string is "defined" → parseInt("") = NaN → bind port 0.
+    // `||` skips the empty string to the next tier.
+    expect(resolvePort({ PORT: "", PARACHUTE_CHANNEL_PORT: "2000" })).toBe(2000);
+  });
+
+  test("a non-numeric PORT='abc' falls through to the canonical default", () => {
+    // parseInt("abc") = NaN → falsy → falls through past PARACHUTE_CHANNEL_PORT
+    // (also unset here) to 1941. No garbage port.
+    expect(resolvePort({ PORT: "abc" })).toBe(1941);
+  });
+});


### PR DESCRIPTION
Channel daemon now resolves its port PORT → PARACHUTE_CHANNEL_PORT → 1941 (was only PARACHUTE_CHANNEL_PORT), binding + self-registering from a single value so the supervisor's probed port and the daemon's bound port can never disagree (closed the 'failing on wrong port' mismatch). Robust to empty/non-numeric PORT. Part of channel#41. Reviewer: MERGE. 177 tests / typecheck clean. 🤖 Generated with [Claude Code](https://claude.com/claude-code)