### PR TITLE
fix(channel): hide telegram token field unless selected; drop daemon-global TELEGRAM_BOT_TOKEN

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ bun src/daemon.ts
 # or via launchd — see below
 ```
 
-Requires `TELEGRAM_BOT_TOKEN` in env or `~/.parachute/channel/.env`.
+Telegram channels carry a per-channel bot token in `channels.json` config — the daemon does NOT read a global `TELEGRAM_BOT_TOKEN`. Define channels via the admin UI at `/channel/admin` (or by writing `~/.parachute/channel/channels.json` directly).
 
 ### Bridge (registered in .mcp.json, Claude Code spawns it)
 
@@ -226,7 +226,6 @@ Bearer `vault:<name>:write`).
 
 | Variable | Default | Description |
 |---|---|---|
-| `TELEGRAM_BOT_TOKEN` | (required) | Telegram bot token from BotFather |
 | `PORT` | (unset) | **Highest-priority port input** — the hub supervisor injects this from the module's services.json `entry.port` (the canonical pattern vault/scribe follow). The daemon binds AND self-registers this port, so the supervisor's readiness probe + `/channel/*` proxy target agree (channel#41). Empty/non-numeric falls through. |
 | `PARACHUTE_CHANNEL_PORT` | `1941` | Daemon HTTP port — back-compat override for a daemon run *outside* the supervisor. Used only when `PORT` is unset. |
 | `PARACHUTE_CHANNEL_URL` | `http://127.0.0.1:1941` | Bridge → daemon URL |
@@ -237,7 +236,8 @@ Bearer `vault:<name>:write`).
 ## State directory
 
 `~/.parachute/channel/`:
-- `.env` — `TELEGRAM_BOT_TOKEN=...`
+- `channels.json` — the channel registry. Each telegram channel carries its own bot token in `config.token` (created via the admin UI or written directly).
+- `.env` — optional generic env vars (e.g. `PARACHUTE_HUB_ORIGIN`). The daemon no longer consumes `TELEGRAM_BOT_TOKEN` here.
 - `access.json` — allowlist (compatible with the official plugin's format)
 - `inbox/` — downloaded attachments
 

--- a/src/admin-ui.test.ts
+++ b/src/admin-ui.test.ts
@@ -131,12 +131,13 @@ describe("unified transport select drives fields + submit path", () => {
     expect(html).toContain("is your approval");
   });
 
-  test("the telegram submit path sends a per-channel bot token in config.token", () => {
+  test("the telegram submit path REQUIRES a per-channel bot token in config.token", () => {
     const html = renderAdminPage("");
-    // The telegram path reads the bot-token field and only sends a config block
-    // when a token was supplied (blank → env fallback).
+    // The telegram path reads the bot-token field; a blank token is now a hard
+    // error (no env fallback), so submit is blocked with a field error.
     expect(html).toContain('el("f-telegram-token").value');
     expect(html).toContain("config = { token: tgToken }");
+    expect(html).toContain('setFieldError("f-telegram-token"');
     // The POST body carries config when present.
     expect(html).toContain("if (config) postBody.config = config;");
     expect(html).toContain('method: "POST"');
@@ -177,15 +178,34 @@ describe("telegram per-channel config copy (Aaron's feedback)", () => {
     expect(html).not.toContain("No extra config needed");
   });
 
-  test("the telegram bot-token field explains the per-channel token + env fallback", () => {
+  test("the telegram bot-token field explains the REQUIRED per-channel token", () => {
     const html = renderAdminPage("");
     expect(html).toContain("Bot token");
-    // Accurate copy: per-channel token, env is the legacy fallback.
-    expect(html).toContain("TELEGRAM_BOT_TOKEN");
-    expect(html).toContain("fallback");
+    // Accurate copy: each telegram channel carries its OWN token; required.
+    expect(html).toContain("each telegram channel carries its");
+    expect(html).toContain("Required");
+    // The misleading env-fallback claim is gone — the daemon no longer reads
+    // a global TELEGRAM_BOT_TOKEN, so the field hint must not advertise one.
+    expect(html).not.toContain("env is used as a fallback");
     // The field is a password input (sensitive) and never echoed back.
     expect(html).toContain('id="f-telegram-token"');
     expect(html).toContain('type="password"');
+  });
+
+  test("per-transport fields hide via .field[hidden] (CSS specificity fix)", () => {
+    const html = renderAdminPage("");
+    // .field declares display:flex, which outranks the UA [hidden] rule — so the
+    // hidden attribute alone wouldn't hide the telegram token field on the
+    // default (vault) selection. This rule re-asserts the hide at matching
+    // specificity. Without it, the bot-token field shows when telegram isn't
+    // selected (Aaron's bug 1).
+    expect(html).toContain(".field[hidden] { display: none; }");
+  });
+
+  test("applyTransportUI gates the bot-token's HTML5 required on visibility", () => {
+    const html = renderAdminPage("");
+    // A hidden-but-required field blocks submit; only require it while shown.
+    expect(html).toContain('tgInput.required = transport === "telegram"');
   });
 });
 

--- a/src/admin-ui.ts
+++ b/src/admin-ui.ts
@@ -188,9 +188,8 @@ export function renderAdminPage(mount = ""): string {
             <span class="field-label">Bot token</span>
             <input type="password" name="telegramToken" id="f-telegram-token" placeholder="123456:ABC-..." autocomplete="off" />
             <span class="field-hint">
-              From BotFather, for this channel's bot. Stored server-side (never echoed back). If left
-              blank, the daemon's <code>TELEGRAM_BOT_TOKEN</code> env is used as a fallback (legacy
-              single-bot setup).
+              From BotFather, for this channel's bot. Required &mdash; each telegram channel carries its
+              own token. Stored server-side (never echoed back).
             </span>
           </label>
 
@@ -414,6 +413,11 @@ const STYLES = `
 
   .add-form { display: flex; flex-direction: column; gap: 1rem; }
   .field { display: flex; flex-direction: column; gap: 0.3rem; }
+  /* The author \`display:flex\` above outranks the UA \`[hidden]{display:none}\`
+     rule, so a per-transport field with the \`hidden\` attribute would still
+     render. Re-assert the hide at matching specificity so applyTransportUI's
+     \`field.hidden = …\` toggling actually shows/hides the field. */
+  .field[hidden] { display: none; }
   .field-label { font-size: 0.85rem; font-weight: 500; color: ${PALETTE.fgMuted}; letter-spacing: 0.01em; }
   .field-hint { font-size: 0.8rem; color: ${PALETTE.fgDim}; }
   .field-error { font-size: 0.8rem; color: ${PALETTE.danger}; font-weight: 500; }
@@ -630,9 +634,18 @@ const PAGE_SCRIPT = String.raw`
     var transport = el("f-transport").value;
     var vaultField = el("field-vault");
     var tgField = el("field-telegram-token");
+    var tgInput = el("f-telegram-token");
     var hint = el("transport-hint");
+    // Reveal exactly the fields the selected transport needs. Each branch is
+    // explicit for ALL THREE transports so no field leaks across a selection:
+    //   vault    → show the vault picker, hide the telegram token field.
+    //   telegram → show the telegram token field, hide the vault picker.
+    //   http-ui  → hide both (no extra config).
     if (vaultField) vaultField.hidden = transport !== "vault";
     if (tgField) tgField.hidden = transport !== "telegram";
+    // Gate HTML5 \`required\` on visibility: a hidden-but-required field can't be
+    // filled and would block submit. Only require the bot token while it's shown.
+    if (tgInput) tgInput.required = transport === "telegram";
     // The connect-a-session result is vault-specific; hide it when switching to
     // a non-vault transport so a prior vault success doesn't linger under an
     // unrelated form.
@@ -816,15 +829,17 @@ const PAGE_SCRIPT = String.raw`
     if (transport === "vault") { return addVaultChannel(name); }
 
     // telegram + http-ui POST straight to the channel daemon. http-ui is fully
-    // self-contained (no config). telegram takes a per-channel bot token in
-    // config.token; when blank, the transport falls back to the daemon's
-    // TELEGRAM_BOT_TOKEN env (legacy single-bot back-compat).
+    // self-contained (no config). telegram REQUIRES a per-channel bot token in
+    // config.token -- there is no daemon-global env fallback anymore, so a blank
+    // token can't succeed. Block the submit with a clear field error.
     var config;
     if (transport === "telegram") {
       var tgToken = el("f-telegram-token").value.trim();
-      // Only send a config block when a token was supplied -- an empty/omitted
-      // config means "use the env fallback", which the transport resolves.
-      if (tgToken) config = { token: tgToken };
+      if (!tgToken) {
+        setFieldError("f-telegram-token", "Required — each telegram channel needs its own bot token.");
+        return;
+      }
+      config = { token: tgToken };
     }
     var btn = el("add-btn");
     btn.disabled = true;

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1254,8 +1254,8 @@ function main(): void {
   if (channels.size === 0) {
     console.error(
       `parachute-channel: no channels configured.\n` +
-        `  Add ${join(STATE_DIR, "channels.json")} or set TELEGRAM_BOT_TOKEN\n` +
-        `  (env or ${join(STATE_DIR, ".env")}) for a default telegram channel.`,
+        `  Add ${join(STATE_DIR, "channels.json")} (or use the admin UI at /channel/admin)\n` +
+        `  to define a channel. Telegram channels carry a per-channel bot token in config.`,
     );
     process.exit(1);
   }

--- a/src/registry.test.ts
+++ b/src/registry.test.ts
@@ -23,18 +23,19 @@ afterEach(() => {
   else process.env.TELEGRAM_BOT_TOKEN = savedToken;
 });
 
-describe("default-channel synthesis (back-compat)", () => {
-  test("no channels.json + TELEGRAM_BOT_TOKEN set → single default telegram channel", () => {
+describe("no env synthesis — channels are always explicit", () => {
+  test("no channels.json + TELEGRAM_BOT_TOKEN set → [] (env is NOT a token source)", () => {
     process.env.TELEGRAM_BOT_TOKEN = "dummy-token";
     const entries = resolveChannelEntries({ stateDir: dir, loadEnv: false });
-    expect(entries).toEqual([{ name: "telegram", transport: "telegram" }]);
+    expect(entries).toEqual([]);
   });
 
-  test("no channels.json + token only in state-dir .env → synthesized after loadEnv", () => {
+  test("no channels.json + token only in state-dir .env → still [] after loadEnv", () => {
+    // .env is still loaded (generic vars may live there), but a TELEGRAM_BOT_TOKEN
+    // there no longer synthesizes a channel — per-channel config is required.
     writeFileSync(join(dir, ".env"), "TELEGRAM_BOT_TOKEN=from-env-file\n");
     const entries = resolveChannelEntries({ stateDir: dir, loadEnv: true });
-    expect(entries).toEqual([{ name: "telegram", transport: "telegram" }]);
-    expect(process.env.TELEGRAM_BOT_TOKEN).toBe("from-env-file");
+    expect(entries).toEqual([]);
   });
 
   test("no channels.json + no token → empty list (caller decides to error)", () => {
@@ -91,9 +92,11 @@ describe("instantiateTransport", () => {
     expect(() => instantiateTransport(entry)).toThrow(/unknown transport kind "carrier-pigeon"/);
   });
 
-  test("telegram entry with no token errors clearly", () => {
+  test("telegram entry with no token errors clearly (names the channel)", () => {
     const entry: ChannelEntry = { name: "t", transport: "telegram" };
-    expect(() => instantiateTransport(entry)).toThrow(/token required/);
+    expect(() => instantiateTransport(entry)).toThrow(
+      /telegram channel t requires a per-channel bot token/,
+    );
   });
 });
 

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -5,10 +5,9 @@
  * instantiates a Transport per entry. A channel is a name bound to a transport
  * kind plus optional transport config.
  *
- * Backwards-compat: if `channels.json` is absent but a Telegram bot token is
- * available (TELEGRAM_BOT_TOKEN env, set directly or loaded from the state-dir
- * `.env`), a single default channel `{ name: "telegram", transport: "telegram" }`
- * is synthesized so existing single-bot installs keep working with zero config.
+ * Every channel is explicit: with no `channels.json` the daemon resolves to
+ * zero channels. There is NO daemon-global TELEGRAM_BOT_TOKEN synthesis — each
+ * telegram channel carries its own per-channel bot token in its config.
  */
 
 import { readFileSync, writeFileSync, existsSync, chmodSync, mkdirSync } from "fs";
@@ -43,8 +42,10 @@ export function defaultStateDir(): string {
 }
 
 /**
- * Load TELEGRAM_BOT_TOKEN (and any other vars) from the state dir's `.env` into
- * process.env if not already set. Mirrors the original daemon's behavior.
+ * Load the state dir's `.env` into process.env if not already set. Generic —
+ * an operator may keep arbitrary vars there (e.g. PARACHUTE_HUB_ORIGIN). The
+ * daemon no longer consumes TELEGRAM_BOT_TOKEN; telegram tokens live per-channel
+ * in channels.json. Mirrors the original daemon's `.env` loading behavior.
  */
 export function loadEnvFile(stateDir: string): void {
   const envFile = join(stateDir, ".env");
@@ -63,7 +64,11 @@ export function loadEnvFile(stateDir: string): void {
 export function instantiateTransport(entry: ChannelEntry): Transport {
   switch (entry.transport) {
     case "telegram":
-      return new TelegramTransport((entry.config ?? {}) as TelegramTransportConfig);
+      // Thread the channel name in so a missing-token error names the channel.
+      return new TelegramTransport({
+        ...(entry.config ?? {}),
+        name: entry.name,
+      } as TelegramTransportConfig);
     case "http-ui":
       // http-ui needs no secret — just a channel name (taken from ctx at start).
       return new HttpUiTransport((entry.config ?? {}) as HttpUiTransportConfig);
@@ -80,10 +85,11 @@ export function instantiateTransport(entry: ChannelEntry): Transport {
 
 /**
  * Resolve the channel entries for this install. Reads channels.json if present;
- * otherwise synthesizes a default telegram channel when a token is available.
+ * otherwise resolves to `[]` (no channels) — explicit per-channel config is
+ * required, there is no env-token synthesis.
  *
- * `loadEnv` (default true) loads the state-dir `.env` so the token fallback can
- * see a `.env`-only token. Tests pass `loadEnv: false` to stay hermetic.
+ * `loadEnv` (default true) still loads the state-dir `.env` for any generic vars
+ * an operator keeps there. Tests pass `loadEnv: false` to stay hermetic.
  */
 export function resolveChannelEntries(opts: {
   stateDir?: string;
@@ -108,12 +114,10 @@ export function resolveChannelEntries(opts: {
     return parsed.channels;
   }
 
-  // Backwards-compat: no channels.json → synthesize a default telegram channel
-  // when a bot token is available.
-  if (process.env.TELEGRAM_BOT_TOKEN) {
-    return [{ name: "telegram", transport: "telegram" }];
-  }
-
+  // No channels.json → no channels. Explicit per-channel config is now
+  // required; there is no daemon-global TELEGRAM_BOT_TOKEN synthesis. Each
+  // telegram channel carries its OWN bot token in channels.json (created via
+  // the admin UI), so the daemon never depends on a global env token.
   return [];
 }
 

--- a/src/transports/telegram.test.ts
+++ b/src/transports/telegram.test.ts
@@ -96,27 +96,32 @@ describe("chunkText", () => {
 // ---------------------------------------------------------------------------
 
 describe("TelegramTransport", () => {
-  test("requires a token", () => {
-    // No config token AND no env → throw.
+  test("throws ChannelConfigError when no config.token (no env fallback)", () => {
+    // The daemon-global TELEGRAM_BOT_TOKEN fallback is gone — a telegram channel
+    // MUST carry its own per-channel token. Even with the env var set, a config
+    // without a token throws: the env is never read as a token source.
     const prev = process.env.TELEGRAM_BOT_TOKEN;
-    delete process.env.TELEGRAM_BOT_TOKEN;
     try {
-      expect(() => new TelegramTransport({})).toThrow(/token required/);
+      // (1) no config token, env UNSET → throws.
+      delete process.env.TELEGRAM_BOT_TOKEN;
+      expect(() => new TelegramTransport({ name: "tele-x" })).toThrow(ChannelConfigError);
+      expect(() => new TelegramTransport({ name: "tele-x" })).toThrow(
+        /telegram channel tele-x requires a per-channel bot token/,
+      );
+
+      // (2) no config token, env SET → STILL throws (env is not a token source).
+      process.env.TELEGRAM_BOT_TOKEN = "env-tok";
+      expect(() => new TelegramTransport({ name: "tele-x" })).toThrow(ChannelConfigError);
     } finally {
       if (prev === undefined) delete process.env.TELEGRAM_BOT_TOKEN;
       else process.env.TELEGRAM_BOT_TOKEN = prev;
     }
   });
 
-  test("token precedence: explicit per-channel config.token wins over the env", () => {
-    // The transport stores the resolved token on its TelegramApi. We can't read
-    // it directly, but the constructor's resolution is `config.token ?? env`.
-    // Assert the behavior at the boundary: with a config token present, the env
-    // is irrelevant (construction succeeds even if env is unset), and with NO
-    // config token, the env is the fallback (construction succeeds off env).
+  test("a per-channel config.token constructs, regardless of the env", () => {
     const prev = process.env.TELEGRAM_BOT_TOKEN;
     try {
-      // (1) per-channel token, env UNSET → constructs (uses the per-channel token).
+      // env UNSET → constructs off the per-channel token.
       delete process.env.TELEGRAM_BOT_TOKEN;
       const perChannel = new TelegramTransport({
         token: "per-channel-tok",
@@ -124,20 +129,14 @@ describe("TelegramTransport", () => {
       });
       expect(perChannel.kind).toBe("telegram");
 
-      // (2) NO per-channel token, env SET → constructs off the env fallback.
+      // env SET to a DIFFERENT value → the per-channel token is what's used; the
+      // env is irrelevant, construction still succeeds with the config token.
       process.env.TELEGRAM_BOT_TOKEN = "env-tok";
-      const fromEnv = new TelegramTransport({
-        stateDir: "/tmp/parachute-channel-test-precedence",
-      });
-      expect(fromEnv.kind).toBe("telegram");
-
-      // (3) BOTH set → the per-channel token wins; still constructs fine. (The
-      // ?? resolution prefers config.token; env never shadows it.)
-      const both = new TelegramTransport({
+      const withEnvNoise = new TelegramTransport({
         token: "per-channel-tok",
         stateDir: "/tmp/parachute-channel-test-precedence",
       });
-      expect(both.kind).toBe("telegram");
+      expect(withEnvNoise.kind).toBe("telegram");
     } finally {
       if (prev === undefined) delete process.env.TELEGRAM_BOT_TOKEN;
       else process.env.TELEGRAM_BOT_TOKEN = prev;

--- a/src/transports/telegram.ts
+++ b/src/transports/telegram.ts
@@ -101,10 +101,12 @@ const CALLBACK_DATA_RE = /^perm_(allow|deny)_([a-km-z]{5})$/;
 
 /** Config for a Telegram transport instance. */
 export interface TelegramTransportConfig {
-  /** Bot token. Falls back to TELEGRAM_BOT_TOKEN env when omitted. */
+  /** Per-channel bot token from BotFather. REQUIRED — there is no env fallback. */
   token?: string;
   /** Directory holding access.json + inbox/. Defaults to the channel state dir. */
   stateDir?: string;
+  /** Channel name, used only to make the missing-token error message clear. */
+  name?: string;
 }
 
 export class TelegramTransport implements Transport {
@@ -118,10 +120,12 @@ export class TelegramTransport implements Transport {
   private pollTask: Promise<void> | undefined;
 
   constructor(config: TelegramTransportConfig = {}) {
-    const token = config.token ?? process.env.TELEGRAM_BOT_TOKEN;
+    // Per-channel token is REQUIRED — no daemon-global env fallback. Every
+    // telegram channel carries its own bot token in its channels.json config.
+    const token = config.token;
     if (!token) {
-      throw new Error(
-        "TelegramTransport: bot token required (config.token or TELEGRAM_BOT_TOKEN)",
+      throw new ChannelConfigError(
+        `telegram channel ${config.name ?? "(unnamed)"} requires a per-channel bot token in its config`,
       );
     }
     const stateDir =


### PR DESCRIPTION
Two bugs Aaron reported after using the newly-deployed unified channel add-form (`/channel/admin`).

## Bug 1 — bot-token field shows even when telegram isn't selected
> "Its asking me to enter a bot token even if I don't have telegram selected."

Root cause was CSS specificity, not the reveal logic. The per-transport reveal set `field.hidden = transport !== "telegram"`, but `.field { display: flex }` (an author class rule) outranks the user-agent `[hidden] { display: none }` rule — so the telegram bot-token field (and the vault picker) rendered regardless of the `hidden` attribute.

Fix:
- Add `.field[hidden] { display: none; }` at matching specificity so `applyTransportUI`'s `field.hidden` toggling actually shows/hides each field.
- `applyTransportUI` is explicit for **all three** transports — `vault` shows the vault picker + hides the token; `telegram` shows the token + hides the vault picker; `http-ui` hides both. It already ran on `DOMContentLoaded` (line confirmed) and on `change`.
- Gate the bot-token's HTML5 `required` on visibility (`tgInput.required = transport === "telegram"`) so a hidden field can never block submit. The submit handler also blocks a blank telegram token with a clear field error (no env fallback to lean on anymore).

## Change 2 — remove the daemon-global TELEGRAM_BOT_TOKEN reliance entirely
> "I don't think the daemon should have a TELEGRAM_BOT_TOKEN in env at all."

Removed both back-compat env couplings so every telegram channel carries its OWN `config.token`:
- `src/transports/telegram.ts`: dropped `?? process.env.TELEGRAM_BOT_TOKEN`. A missing/empty `config.token` now throws `ChannelConfigError` ("telegram channel <name> requires a per-channel bot token in its config"). The channel name is threaded in via the registry for a clear message.
- `src/registry.ts`: removed the `if (process.env.TELEGRAM_BOT_TOKEN) return [{name:"telegram",...}]` synthesis. With no `channels.json`, `resolveChannelEntries` returns `[]`. The state-dir `.env` is still loaded for generic vars (e.g. `PARACHUTE_HUB_ORIGIN`), but nothing consumes `TELEGRAM_BOT_TOKEN`.
- `src/daemon.ts`: boot message no longer points operators at `TELEGRAM_BOT_TOKEN`.
- Admin-UI field copy + `CLAUDE.md` (env-var table, state-dir `.env` example, Running/Daemon line) updated to "per-channel bot token in channels.json config".

`grep -rn TELEGRAM_BOT_TOKEN src/` now shows the var only in explanatory comments (registry.ts) and test setup — no code path reads it as a token source.

## Migration note
Aaron's box has a `TELEGRAM_BOT_TOKEN` in `~/.parachute/channel/.env`. **Operator state under `~/.parachute` is untouched** — only the code stops consuming it. Any existing env-only telegram channel must be re-created with a per-channel token via the admin UI (the synthesized default is gone).

## Gates
- `bun run typecheck` — clean (tsc --noEmit, 0 errors).
- `bun test ./src` — **186 pass / 0 fail**, 488 expect() calls across 12 files. The `vault transport: tag-schema upsert ... (401/500)` lines are expected harness console noise (no live vault), not failures.
- No binary/NUL introduced; all changed files confirmed UTF-8 text; `</script>` count unchanged (inline-template escaping preserved).

Tests updated: telegram-transport precedence test → "throws ChannelConfigError when no config.token (no env fallback)" + a positive "per-channel config.token constructs"; registry synthesis test → "no channels.json → [] (env is NOT a token source)"; admin-ui copy tests updated for the new required-token hint + added coverage for the `.field[hidden]` CSS fix and the `required`-on-visibility gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)