### PR TITLE
fix(boundary): channel delete composes hub connection teardown (lifecycle symmetry, boundary C2)

### DIFF
--- a/src/admin-ui.test.ts
+++ b/src/admin-ui.test.ts
@@ -344,6 +344,28 @@ describe("vault-backed delete composes hub connection teardown (boundary C2)", (
     expect(html).toContain(
       "if (failedDetail !== null) { askProceedMechanicsOnly(name, btn, failedDetail); return; }",
     );
+    // The ask's confirm routes its runtime values through escapeHtml — one
+    // escaping discipline page-wide, matching the first remove confirm.
+    expect(html).toContain(
+      '"Hub teardown failed for channel \\"" + escapeHtml(name) + "\\":\\n" + escapeHtml(detail) +',
+    );
+  });
+
+  test("daemon 401 after hub teardown keeps the partial-state context", () => {
+    // If the daemon DELETE 401s AFTER the hub teardown already ran, the page
+    // must not show only the generic no-auth banner — the operator is in a
+    // partially-torn-down state (hub side done, channel entry still on disk)
+    // and needs to know that, plus the remediation: sign in, retry the remove.
+    const fmFn = html.slice(
+      html.indexOf("function finishMechanics"),
+      html.indexOf("document.addEventListener"),
+    );
+    expect(fmFn).toContain("if (state.tornDown && state.tornDown.length)");
+    expect(fmFn).toContain("The hub connection teardown already completed");
+    expect(fmFn).toContain("The channel entry remains");
+    expect(fmFn).toContain("and retry the remove.");
+    // The plain 401 with no hub context still gets the generic banner.
+    expect(fmFn).toContain("noAuthBanner()");
   });
 
   test("legacy vault channel with no hub record: mechanics-only + informational note", () => {
@@ -352,7 +374,9 @@ describe("vault-backed delete composes hub connection teardown (boundary C2)", (
     // manual-cleanup note instead of pretending a full teardown happened.
     expect(html).toContain("finishMechanics(name, btn, { legacyNote: true, warnings: [] })");
     expect(html).toContain("No hub connection record was found");
-    expect(html).toContain("pre-2026-06");
+    // Era-relative phrasing ("before the Connections engine existed"), not a
+    // calendar date — it ages better (reviewer nit on #46).
+    expect(html).toContain("the Connections engine existed");
     expect(html).toContain("hub admin");
     // Accurate cross-reference: the hub's DELETE /vaults cascade scans
     // channel's list and reports such channels as orphaned_channels.

--- a/src/admin-ui.test.ts
+++ b/src/admin-ui.test.ts
@@ -261,6 +261,125 @@ describe("escape hardening (channel#37)", () => {
   });
 });
 
+describe("vault-backed delete composes hub connection teardown (boundary C2)", () => {
+  // Lifecycle symmetry (hub-module-boundary charter; migration Phase C2):
+  // deleting a vault-backed channel must cascade the hub-side identity
+  // artifacts the link flow provisioned — the registered vault trigger + the
+  // long-lived minted tokens, both held on the hub connection record. The page
+  // composes hub teardown FIRST, then the daemon mechanics. Same string-pin
+  // harness as the rest of this file: assert the served page-script's shape.
+  const html = renderAdminPage("");
+
+  test("remove branches on transport: vault routes through the composed teardown", () => {
+    expect(html).toContain(
+      'if (channel && channel.transport === "vault") { removeVaultChannel(name, btn); return; }',
+    );
+    expect(html).toContain("function removeVaultChannel");
+    // The row's Remove button hands over the whole channel record (the list
+    // payload carries name + transport + vault), so the branch can see the
+    // transport.
+    expect(html).toContain("removeChannel(c, rm)");
+  });
+
+  test("drives connections-list → connections-DELETE → daemon-DELETE, in that order", () => {
+    // (a) The list read lives in removeVaultChannel: cookie-gated, same-origin
+    // (credentials:"include" — the same-origin fetch carries a matching Origin
+    // header, so the hub's C1 CSRF belt passes automatically).
+    const vaultFn = html.slice(
+      html.indexOf("function removeVaultChannel"),
+      html.indexOf("function teardownConnections"),
+    );
+    expect(vaultFn).toContain('window.location.origin + "/admin/connections"');
+    expect(vaultFn).toContain('credentials: "include"');
+    // The hub teardown gates the daemon mechanics: finishMechanics only runs
+    // from teardownConnections' completion callback (or the no-record branch).
+    expect(vaultFn).toContain("teardownConnections(matches, 0, [], function (failedDetail, warnings)");
+    expect(vaultFn).toContain("finishMechanics(name, btn, { tornDown: matches, warnings: warnings })");
+    // (b) The item DELETE lives in teardownConnections, credentials included.
+    const tdFn = html.slice(
+      html.indexOf("function teardownConnections"),
+      html.indexOf("function askProceedMechanicsOnly"),
+    );
+    expect(tdFn).toContain('window.location.origin + "/admin/connections/" + encodeURIComponent(rec.id)');
+    expect(tdFn).toContain('method: "DELETE"');
+    expect(tdFn).toContain('credentials: "include"');
+    // (c) The daemon mechanics run in finishMechanics, AFTER the hub side —
+    // through the same DELETE /api/channels path as before (channel:admin
+    // Bearer), tolerating already-gone (the hub's channel-sink step may have
+    // removed the entry first).
+    const fmFn = html.slice(
+      html.indexOf("function finishMechanics"),
+      html.indexOf("document.addEventListener"),
+    );
+    expect(fmFn).toContain("deleteChannelConfig(name, { treat404AsGone: true })");
+  });
+
+  test("identifies the channel's record by its sink, with the hub's id fallback", () => {
+    // Match: sink.module === "channel" && sink.params.channel === name; when
+    // params.channel is absent, fall back to record-id-as-channel-name — the
+    // exact fallback the hub's own teardownConnection applies, so the page
+    // tears down precisely what the hub would.
+    expect(html).toContain("function connectionMatchesChannel");
+    expect(html).toContain('c.sink.module !== "channel"');
+    expect(html).toContain("p.channel === name");
+    expect(html).toContain("return c.id === name");
+  });
+
+  test("hub-teardown failure surfaces the explicit two-step state (no silent fallthrough)", () => {
+    expect(html).toContain("function askProceedMechanicsOnly");
+    // The ask is an explicit confirm with both outcomes spelled out…
+    expect(html).toContain("OK = remove config only. Cancel = keep the channel.");
+    // …Cancel keeps the channel and says so…
+    expect(html).toContain("Removal cancelled.");
+    expect(html).toContain("was left intact.");
+    // …OK marks the state so the final banner says the hub side did NOT run.
+    expect(html).toContain("finishMechanics(name, btn, { hubFailed: detail, warnings: [] })");
+    expect(html).toContain("hub teardown did NOT run.");
+    // Every hub-side failure routes through the ask: list 401 / list non-OK /
+    // list parse failure / network error, and a per-connection DELETE failure.
+    expect(html).toContain("not signed in to the hub (the connections list returned 401)");
+    expect(html).toContain('"the hub connections list returned HTTP " + res.status');
+    expect(html).toContain("could not parse the hub connections list");
+    expect(html).toContain("network error reaching the hub: ");
+    expect(html).toContain(
+      "if (failedDetail !== null) { askProceedMechanicsOnly(name, btn, failedDetail); return; }",
+    );
+  });
+
+  test("legacy vault channel with no hub record: mechanics-only + informational note", () => {
+    // No record found (linked pre-Connections-era, or via the legacy
+    // /admin/channels path) → proceed with the daemon delete and show the
+    // manual-cleanup note instead of pretending a full teardown happened.
+    expect(html).toContain("finishMechanics(name, btn, { legacyNote: true, warnings: [] })");
+    expect(html).toContain("No hub connection record was found");
+    expect(html).toContain("pre-2026-06");
+    expect(html).toContain("hub admin");
+    // Accurate cross-reference: the hub's DELETE /vaults cascade scans
+    // channel's list and reports such channels as orphaned_channels.
+    expect(html).toContain("orphaned_channels");
+  });
+
+  test("non-vault delete keeps the simple daemon-only path", () => {
+    // The non-vault branch goes straight to the daemon mechanics — no
+    // treat404AsGone, no hub calls — with the same success banner as before.
+    expect(html).toContain("deleteChannelConfig(name, {}).then(function (out)");
+    expect(html).toContain("</code> is gone.");
+    // The daemon DELETE still targets <mount>/api/channels/<name> with the
+    // channel:admin Bearer (authHeaders), exactly as today.
+    expect(html).toContain('API_URL + "/" + encodeURIComponent(name)');
+    expect(html).toContain("headers: authHeaders()");
+  });
+
+  test("hub partial teardown (207) and legacy-mint records surface as warnings, not failures", () => {
+    // A 207 from the hub = record removed, some steps failed — carried into
+    // the final banner as notes; rec.legacy = pre-B0 unregistered mints that
+    // ride to expiry, surfaced honestly rather than claiming revocation.
+    expect(html).toContain("payload.partial && Array.isArray(payload.errors)");
+    expect(html).toContain("Partial-teardown notes: ");
+    expect(html).toContain("ride to their original expiry");
+  });
+});
+
 describe("module.json — modular-UI (P4) declaration", () => {
   // The manifest sits at <repo>/.parachute/module.json; this test file is in
   // <repo>/src, so go up one.

--- a/src/admin-ui.ts
+++ b/src/admin-ui.ts
@@ -1071,8 +1071,11 @@ const PAGE_SCRIPT = String.raw`
   // manual cleanup), Cancel keeps the channel intact. Never a silent
   // fallthrough into a delete that LOOKS complete but isn't.
   function askProceedMechanicsOnly(name, btn, detail) {
+    // confirm() is text-context (no HTML sink), but route the runtime values
+    // through escapeHtml anyway -- one escaping discipline page-wide, matching
+    // the first remove confirm.
     var proceed = window.confirm(
-      "Hub teardown failed for channel \"" + name + "\":\n" + detail +
+      "Hub teardown failed for channel \"" + escapeHtml(name) + "\":\n" + escapeHtml(detail) +
       "\n\nRemove the channel config anyway (mechanics only)? Its vault trigger and minted tokens may stay live until cleaned up in hub admin -> Connections." +
       "\n\nOK = remove config only. Cancel = keep the channel."
     );
@@ -1095,7 +1098,26 @@ const PAGE_SCRIPT = String.raw`
   // the operator always knows which half ran.
   function finishMechanics(name, btn, state) {
     deleteChannelConfig(name, { treat404AsGone: true }).then(function (out) {
-      if (out.auth) { noAuthBanner(); restoreRemoveBtn(btn); return; }
+      if (out.auth) {
+        // A daemon 401 AFTER the hub teardown already ran is a partially-
+        // torn-down state: hub side done, channel entry still on disk. Say
+        // so, with the remediation, instead of only the generic no-auth
+        // banner (which would hide that half the delete already happened).
+        if (state.tornDown && state.tornDown.length) {
+          setBanner(
+            "warn",
+            "<strong>Not authenticated.</strong> The hub connection teardown already completed " +
+              "(vault trigger deregistered, tokens revoked), but removing the channel entry needs a " +
+              "<code>channel:admin</code> token, minted for the logged-in operator by the hub. " +
+              "The channel entry remains &mdash; open this page through the Parachute hub portal " +
+              "(signed in) and retry the remove."
+          );
+        } else {
+          noAuthBanner();
+        }
+        restoreRemoveBtn(btn);
+        return;
+      }
       if (!out.ok) {
         var failHtml = "<strong>Remove failed.</strong> " + escapeHtml(out.error || "");
         if (state.tornDown && state.tornDown.length) {
@@ -1116,8 +1138,8 @@ const PAGE_SCRIPT = String.raw`
         setBanner(
           "warn",
           "<strong>Channel removed.</strong> <code>" + escapeHtml(name) + "</code> is gone. " +
-            "No hub connection record was found for this vault-backed channel &mdash; if it was linked pre-2026-06 " +
-            "(before the Connections engine), its vault trigger and tokens may need manual cleanup: see hub admin &rarr; Connections. " +
+            "No hub connection record was found for this vault-backed channel &mdash; if it was linked before " +
+            "the Connections engine existed, its vault trigger and tokens may need manual cleanup: see hub admin &rarr; Connections. " +
             "(Deleting the backing vault from the hub also reports such channels as <code>orphaned_channels</code>.)"
         );
       } else {

--- a/src/admin-ui.ts
+++ b/src/admin-ui.ts
@@ -29,7 +29,20 @@
  *                       with `{ name, transport:"telegram", config:{ token } }`.
  *        - `http-ui`  → no extra fields → `POST <mount>/api/channels` with
  *                       `{ name, transport:"http-ui" }`.
- *   5. A remove button (with confirm) → `DELETE <mount>/api/channels/:name`.
+ *   5. A remove button (with confirm). Non-vault channels (telegram/http-ui)
+ *      delete daemon-only: `DELETE <mount>/api/channels/:name`. VAULT-BACKED
+ *      channels compose BOTH sides (lifecycle symmetry — hub-module-boundary
+ *      charter, migration Phase C2): first find + tear down the channel's hub
+ *      connection record(s) (`GET /admin/connections` → `DELETE
+ *      /admin/connections/<id>`, cookie-gated, `credentials: "include"` — the
+ *      hub deregisters the vault trigger + revokes the registered token
+ *      mints), THEN the daemon mechanics `DELETE <mount>/api/channels/:name`.
+ *      Hub teardown runs first, while the channel config still exists for the
+ *      hub's channel-sink step to read. A hub-side failure surfaces an
+ *      explicit two-step ask (proceed mechanics-only / keep the channel) —
+ *      never a silent fallthrough. A vault-backed channel with NO hub record
+ *      (linked pre-Connections-era) deletes mechanics-only with an
+ *      informational manual-cleanup note.
  *
  * Auth posture (mirrors scribe's stateless design):
  *   - When loaded through the hub's reverse proxy to a logged-in operator, the
@@ -759,7 +772,9 @@ const PAGE_SCRIPT = String.raw`
       rm.type = "button";
       rm.className = "btn-remove";
       rm.textContent = "Remove";
-      rm.addEventListener("click", function () { removeChannel(c.name, rm); });
+      // Pass the whole channel record -- removeChannel branches on transport
+      // (vault-backed channels compose the hub connection teardown, C2).
+      rm.addEventListener("click", function () { removeChannel(c, rm); });
       li.appendChild(rm);
 
       list.appendChild(li);
@@ -886,26 +901,237 @@ const PAGE_SCRIPT = String.raw`
   }
 
   // --- Remove -------------------------------------------------------------
-  function removeChannel(name, btn) {
-    if (!window.confirm("Remove channel \"" + escapeHtml(name) + "\"? Sessions on it will stop receiving messages.")) return;
-    clearBanner();
-    if (btn) { btn.disabled = true; btn.textContent = "Removing..."; }
-    fetch(API_URL + "/" + encodeURIComponent(name), {
+  // Channel delete is LIFECYCLE-SYMMETRIC for vault-backed channels (the
+  // hub-module-boundary charter's lifecycle-symmetry rule; boundary migration
+  // Phase C2). Linking a vault provisioned hub-side identity artifacts -- a
+  // registered vault trigger + long-lived minted tokens, recorded as a hub
+  // connection -- so deleting the channel must cascade them. The page composes
+  // BOTH sides, hub teardown FIRST (while the channel config still exists for
+  // the hub's channel-sink step to read), then the daemon mechanics:
+  //
+  //   (a) GET <origin>/admin/connections (cookie-gated; same-origin under the
+  //       proxy, credentials:"include") -- find the record(s) whose SINK
+  //       delivers to this channel;
+  //   (b) DELETE <origin>/admin/connections/<id> -- the hub deregisters the
+  //       vault trigger + revokes the registered token mints (post-B0);
+  //   (c) DELETE <mount>/api/channels/<name> (Bearer channel:admin) -- the
+  //       daemon mechanics, as today.
+  //
+  // A hub-side failure surfaces an explicit two-step ask (proceed with the
+  // mechanics only, or keep the channel) -- never a silent fallthrough.
+  // Non-vault channels (telegram / http-ui) provision no hub-side identity
+  // artifacts and keep the simple daemon-only delete.
+
+  function restoreRemoveBtn(btn) {
+    if (btn) { btn.disabled = false; btn.textContent = "Remove"; }
+  }
+
+  // The daemon mechanics: DELETE <mount>/api/channels/<name> (channel:admin
+  // Bearer via authHeaders). Promise-shaped, never rejects -- resolves
+  // { ok:true } | { ok:false, auth:true } | { ok:false, error }. The daemon's
+  // DELETE is idempotent (a missing channel still 200s with removed:false);
+  // treat404AsGone is a belt for the vault path, where the hub teardown's
+  // channel-sink step may already have removed the entry.
+  function deleteChannelConfig(name, opts) {
+    opts = opts || {};
+    return fetch(API_URL + "/" + encodeURIComponent(name), {
       method: "DELETE",
       headers: authHeaders(),
     }).then(function (res) {
       return res.json().catch(function () { return {}; }).then(function (payload) {
-        if (res.status === 401 || res.status === 403) { noAuthBanner(); return; }
-        if (!res.ok) {
-          setBanner("error", "<strong>Remove failed.</strong> " + escapeHtml((payload && payload.error) || ("HTTP " + res.status)));
-          return;
-        }
-        setBanner("success", "<strong>Channel removed.</strong> <code>" + escapeHtml(name) + "</code> is gone.");
-        loadChannels();
+        if (res.status === 401 || res.status === 403) return { ok: false, auth: true };
+        if (res.status === 404 && opts.treat404AsGone) return { ok: true };
+        if (!res.ok) return { ok: false, error: (payload && payload.error) || ("HTTP " + res.status) };
+        return { ok: true };
       });
     }).catch(function (err) {
-      setBanner("error", "<strong>Network error.</strong> " + escapeHtml(err && err.message ? err.message : String(err)));
-      if (btn) { btn.disabled = false; btn.textContent = "Remove"; }
+      return { ok: false, error: "network error: " + (err && err.message ? err.message : String(err)) };
+    });
+  }
+
+  function removeChannel(channel, btn) {
+    var name = channel && channel.name ? channel.name : "";
+    if (!window.confirm("Remove channel \"" + escapeHtml(name) + "\"? Sessions on it will stop receiving messages.")) return;
+    clearBanner();
+    if (btn) { btn.disabled = true; btn.textContent = "Removing..."; }
+    // Vault-backed channels compose the hub connection teardown first (C2).
+    if (channel && channel.transport === "vault") { removeVaultChannel(name, btn); return; }
+    // telegram / http-ui: the simple daemon-only delete, unchanged.
+    deleteChannelConfig(name, {}).then(function (out) {
+      if (out.auth) { noAuthBanner(); restoreRemoveBtn(btn); return; }
+      if (!out.ok) {
+        setBanner("error", "<strong>Remove failed.</strong> " + escapeHtml(out.error || ""));
+        restoreRemoveBtn(btn);
+        return;
+      }
+      setBanner("success", "<strong>Channel removed.</strong> <code>" + escapeHtml(name) + "</code> is gone.");
+      loadChannels();
+    });
+  }
+
+  // A hub connection record belongs to this channel when its SINK delivers to
+  // it: sink.module === "channel" with sink.params.channel === name. The hub's
+  // own teardown falls back to the record id as the channel name when
+  // params.channel is absent -- mirror that fallback so this match agrees with
+  // what the hub would tear down.
+  function connectionMatchesChannel(c, name) {
+    if (!c || !c.sink || c.sink.module !== "channel") return false;
+    var p = c.sink.params;
+    if (p && typeof p.channel === "string") return p.channel === name;
+    return c.id === name;
+  }
+
+  // (a)+(b) of the composed delete: find + tear down the channel's hub
+  // connection record(s), then hand off to the daemon mechanics. Same-origin
+  // under the /channel proxy, so the operator's hub session cookie flows with
+  // credentials:"include" and the fetch carries a matching Origin header --
+  // the hub's CSRF Origin check on /admin/* mutations (C1) passes
+  // automatically; no token dance needed. Mirrors the link-vault flow above.
+  function removeVaultChannel(name, btn) {
+    fetch(window.location.origin + "/admin/connections", {
+      credentials: "include",
+      headers: { accept: "application/json" },
+    }).then(function (res) {
+      if (res.status === 401) {
+        askProceedMechanicsOnly(name, btn, "not signed in to the hub (the connections list returned 401); sign in to the hub portal and retry for a full teardown");
+        return;
+      }
+      if (!res.ok) {
+        askProceedMechanicsOnly(name, btn, "the hub connections list returned HTTP " + res.status);
+        return;
+      }
+      res.json().catch(function () { return null; }).then(function (payload) {
+        if (payload === null) {
+          askProceedMechanicsOnly(name, btn, "could not parse the hub connections list");
+          return;
+        }
+        var records = (payload && Array.isArray(payload.connections)) ? payload.connections : [];
+        var matches = records.filter(function (c) { return connectionMatchesChannel(c, name); });
+        if (!matches.length) {
+          // Legacy/edge: a vault-backed channel with NO hub connection record
+          // (linked pre-Connections-era, or via the legacy /admin/channels
+          // path). Proceed mechanics-only; finishMechanics shows the
+          // informational manual-cleanup note.
+          finishMechanics(name, btn, { legacyNote: true, warnings: [] });
+          return;
+        }
+        teardownConnections(matches, 0, [], function (failedDetail, warnings) {
+          if (failedDetail !== null) { askProceedMechanicsOnly(name, btn, failedDetail); return; }
+          finishMechanics(name, btn, { tornDown: matches, warnings: warnings });
+        });
+      });
+    }).catch(function (err) {
+      askProceedMechanicsOnly(name, btn, "network error reaching the hub: " + (err && err.message ? err.message : String(err)));
+    });
+  }
+
+  // DELETE each matching hub connection, sequentially. The hub deregisters the
+  // vault trigger + revokes the registered jtis; its channel-sink step may
+  // also remove the daemon's config entry (our mechanics pass is idempotent,
+  // so that's fine). A 404 means already-gone: skip. A 207 is a PARTIAL
+  // teardown (record removed, some steps failed) -- carried as a warning, not
+  // a hard failure, because the hub removes the record + revokes what it can
+  // either way. Calls done(failedDetail-or-null, warnings).
+  function teardownConnections(matches, i, warnings, done) {
+    if (i >= matches.length) { done(null, warnings); return; }
+    var rec = matches[i];
+    fetch(window.location.origin + "/admin/connections/" + encodeURIComponent(rec.id), {
+      method: "DELETE",
+      credentials: "include",
+      headers: { accept: "application/json" },
+    }).then(function (res) {
+      return res.json().catch(function () { return {}; }).then(function (payload) {
+        if (res.status === 404) { teardownConnections(matches, i + 1, warnings, done); return; }
+        if (res.status === 401) { done("not signed in to the hub (the connection teardown returned 401)", warnings); return; }
+        if (!res.ok) {
+          done("hub teardown of connection " + rec.id + " failed: " + ((payload && (payload.error_description || payload.error)) || ("HTTP " + res.status)), warnings);
+          return;
+        }
+        if (payload && payload.partial && Array.isArray(payload.errors)) {
+          payload.errors.forEach(function (e) {
+            warnings.push("connection " + rec.id + ", step " + (e && e.step ? e.step : "?") + ": " + (e && e.detail ? e.detail : ""));
+          });
+        }
+        if (rec.legacy) {
+          // The hub flags records provisioned before the registered-mint rule
+          // (B0): their long-lived tokens were never registered, so the
+          // teardown can't revoke them -- they ride to their original expiry.
+          warnings.push("connection " + rec.id + " predates registered token mints; its minted tokens ride to their original expiry");
+        }
+        teardownConnections(matches, i + 1, warnings, done);
+      });
+    }).catch(function (err) {
+      done("network error tearing down connection " + rec.id + ": " + (err && err.message ? err.message : String(err)), warnings);
+    });
+  }
+
+  // The hub teardown failed (or its records were unreadable): a CLEAR two-step
+  // state. Surface the failure, then ASK whether to proceed mechanics-only --
+  // OK removes the channel config (leaving the hub-side trigger/tokens for
+  // manual cleanup), Cancel keeps the channel intact. Never a silent
+  // fallthrough into a delete that LOOKS complete but isn't.
+  function askProceedMechanicsOnly(name, btn, detail) {
+    var proceed = window.confirm(
+      "Hub teardown failed for channel \"" + name + "\":\n" + detail +
+      "\n\nRemove the channel config anyway (mechanics only)? Its vault trigger and minted tokens may stay live until cleaned up in hub admin -> Connections." +
+      "\n\nOK = remove config only. Cancel = keep the channel."
+    );
+    if (!proceed) {
+      setBanner(
+        "warn",
+        "<strong>Removal cancelled.</strong> Channel <code>" + escapeHtml(name) +
+          "</code> was left intact. Hub teardown failed: " + escapeHtml(detail) +
+          ". Fix the hub side (or sign in) and retry for a full teardown."
+      );
+      restoreRemoveBtn(btn);
+      return;
+    }
+    finishMechanics(name, btn, { hubFailed: detail, warnings: [] });
+  }
+
+  // (c) The daemon mechanics, after the hub side resolved. The state arg says
+  // how the hub side went -- { tornDown?: matched-records, legacyNote?: true,
+  // hubFailed?: detail, warnings: [] } -- and the final banner reflects it, so
+  // the operator always knows which half ran.
+  function finishMechanics(name, btn, state) {
+    deleteChannelConfig(name, { treat404AsGone: true }).then(function (out) {
+      if (out.auth) { noAuthBanner(); restoreRemoveBtn(btn); return; }
+      if (!out.ok) {
+        var failHtml = "<strong>Remove failed.</strong> " + escapeHtml(out.error || "");
+        if (state.tornDown && state.tornDown.length) {
+          failHtml += " The hub connection teardown already completed (vault trigger deregistered, tokens revoked); the channel config entry remains &mdash; retry Remove.";
+        }
+        setBanner("error", failHtml);
+        restoreRemoveBtn(btn);
+        return;
+      }
+      if (state.hubFailed) {
+        setBanner(
+          "warn",
+          "<strong>Channel config removed &mdash; hub teardown did NOT run.</strong> <code>" + escapeHtml(name) +
+            "</code> is gone from the daemon, but the hub side failed (" + escapeHtml(state.hubFailed) +
+            "). Its vault trigger and minted tokens may still be live &mdash; clean up in hub admin &rarr; Connections."
+        );
+      } else if (state.legacyNote) {
+        setBanner(
+          "warn",
+          "<strong>Channel removed.</strong> <code>" + escapeHtml(name) + "</code> is gone. " +
+            "No hub connection record was found for this vault-backed channel &mdash; if it was linked pre-2026-06 " +
+            "(before the Connections engine), its vault trigger and tokens may need manual cleanup: see hub admin &rarr; Connections. " +
+            "(Deleting the backing vault from the hub also reports such channels as <code>orphaned_channels</code>.)"
+        );
+      } else {
+        var ids = (state.tornDown || []).map(function (r) { return r.id; });
+        var okHtml = "<strong>Channel removed.</strong> <code>" + escapeHtml(name) + "</code> is gone. " +
+          "Hub connection" + (ids.length === 1 ? "" : "s") + " <code>" + escapeHtml(ids.join(", ")) +
+          "</code> torn down &mdash; vault trigger deregistered, minted tokens revoked.";
+        if (state.warnings && state.warnings.length) {
+          setBanner("warn", okHtml + " Partial-teardown notes: " + escapeHtml(state.warnings.join("; ")) + ".");
+        } else {
+          setBanner("success", okHtml);
+        }
+      }
+      loadChannels();
     });
   }
 


### PR DESCRIPTION
## What

Phase **C2** of the [hub–module boundary migration](https://github.com/ParachuteComputer/parachute-patterns/blob/main/migrations/2026-06-09-hub-module-boundary.md): deleting a **vault-backed** channel from channel's admin page now composes the hub connection teardown with the daemon mechanics, closing the lifecycle-symmetry violation the 2026-06-09 audit flagged (mechanics-only delete left the hub-registered vault trigger firing uniform 401s and the hub-minted long-lived tokens live).

Charter rule: [`patterns/hub-module-boundary.md` § Lifecycle symmetry](https://github.com/ParachuteComputer/parachute-patterns/blob/main/patterns/hub-module-boundary.md) — *"Every provision flow must have a deprovision flow that cascades the identity artifacts it created."* The link-vault flow (this same page) provisions a hub connection record (vault trigger + registered token mints); Remove now cascades it.

## How (the composed delete, hub side FIRST)

For `transport === "vault"` channels, in order:

1. **`GET /admin/connections`** — cookie-gated, same-origin under the `/channel` proxy, `credentials: "include"` (the same pattern as this page's link-vault flow; the C1 Origin belt on `/admin/*` mutations passes automatically for same-origin fetch — hub#638). Matches the record(s) whose **sink** delivers to this channel: `sink.module === "channel" && sink.params.channel === <name>`, with the hub's own *id-as-channel-name* fallback when `params.channel` is absent — so the page tears down exactly what the hub's `teardownConnection` would.
2. **`DELETE /admin/connections/<id>`** — the hub deregisters the vault trigger + revokes the registered jtis (post-B0, hub#637). Runs **before** the daemon delete, while the channel config still exists for the hub's channel-sink step to read. Multiple matching records tear down sequentially.
3. **`DELETE /api/channels/<name>`** — the daemon mechanics, `channel:admin` Bearer as today. Tolerant of already-gone (the hub's own channel-sink teardown step deletes the daemon entry too; the daemon DELETE is idempotent anyway).

Non-vault channels (telegram / http-ui) keep the simple daemon-only delete — they provision no hub-side identity artifacts.

## Failure + edge UX

- **Hub teardown fails** (not signed in / list unreadable / DELETE error / network): an explicit **two-step ask** — surface the failure, then confirm *"remove config only"* vs *"keep the channel"*. Proceeding shows a banner stating the hub side did **NOT** run, pointing at hub admin → Connections. Never a silent fallthrough.
- **207 partial teardown** + **legacy pre-B0 records** (`legacy: true` — unregistered mints that ride to original expiry): surfaced as warnings on the success banner, honestly, not as failures and not claiming revocation the system didn't make.
- **No hub record** (vault-backed channel linked pre-Connections-era or via the legacy `/admin/channels` path): proceeds mechanics-only with an informational note — manual cleanup pointer to hub admin → Connections, plus the (verified-accurate) cross-reference that the hub's `DELETE /vaults` cascade reports such channels as `orphaned_channels`.

## Tests

New describe block in `src/admin-ui.test.ts` (same string-pin harness as the rest of the file), 7 tests covering the four required paths: composed order (list → connections-DELETE → daemon-DELETE, asserted via per-function slices), record-matching logic, two-step failure state (all five hub-failure routes pinned), legacy no-record note, non-vault path unchanged, 207/legacy warnings.

## Gates (exact)

- `bun test ./src`: **193 pass / 0 fail**, 526 expect() calls, 12 files (`src/admin-ui.test.ts` alone: 38 pass / 0 fail). The vault-transport tag-schema 401/500 stderr lines are the known harness noise.
- `bun run typecheck` (`tsc --noEmit`): clean.
- NUL/binary scan with **positive control** (control file: 1 NUL detected; both changed files: 0). Emitted page scripts parse as JS (`new Function` on both extracted `<script>` blocks); String.raw non-ASCII artifact count unchanged from main (4 — pre-existing); inline-template escaping discipline preserved (all dynamic banner values route through `escapeHtml`).

## Notes for review

- **Judgment call — daemon DELETE kept as step (c) even though the hub's teardown also deletes the channel entry**: belt + suspenders; the daemon DELETE is idempotent (200 `removed:false`), and `treat404AsGone` covers any future stricter daemon. The mechanics step is also the only path that runs for legacy/hub-failed branches.
- **Judgment call — 207 ≠ failure**: the hub removes the record + revokes what it can on 207; treating it as a hard failure would offer a "retry" that can't succeed (record gone). Warnings carry the per-step details.
- **Judgment call — list-401 is a hub-teardown failure, not a legacy case**: without the list we can't know whether a record exists, so it goes through the two-step ask rather than the "no record" note.
- No version bump (per current RC discipline — tag-time bumps only).
- Sequenced per the migration: hub#637 (B0 registered mints) + hub#638 (C1 Origin belt) are both on hub main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)