### PR TITLE
feat(agents): Phase 1 core — sandbox adapter + agent-spec + spawn/scope (sandbox-runtime)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "parachute-channel",
       "dependencies": {
+        "@anthropic-ai/sandbox-runtime": "0.0.54",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@openparachute/scope-guard": "^0.4.0",
       },
@@ -17,11 +18,15 @@
     },
   },
   "packages": {
+    "@anthropic-ai/sandbox-runtime": ["@anthropic-ai/sandbox-runtime@0.0.54", "", { "dependencies": { "@pondwader/socks5-server": "^1.0.10", "commander": "^12.1.0", "node-forge": "^1.4.0", "shell-quote": "^1.8.4", "zod": "^3.24.1" }, "bin": { "srt": "dist/cli.js" } }, "sha512-zszEoq/z02SgJLlPFcoegqz2UonYbn3Gi//Hwza6KdUolg9HeGw/mPuO7Ybp4EzgLxG6ifA4KOrozErYKJuFag=="],
+
     "@hono/node-server": ["@hono/node-server@1.19.13", "", { "peerDependencies": { "hono": "^4" } }, "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "@openparachute/scope-guard": ["@openparachute/scope-guard@0.4.0", "", { "dependencies": { "jose": "^6.2.2" }, "peerDependencies": { "typescript": "^5" } }, "sha512-Atzc2TcEAdZvOK+BBN7iNEYzllO3svn63Rmn5+ZnJZkRo2jBWfent9J6nazS/uVrvoP6eGj2F1kuHKe93JkwsQ=="],
+
+    "@pondwader/socks5-server": ["@pondwader/socks5-server@1.0.10", "", {}, "sha512-bQY06wzzR8D2+vVCUoBsr5QS2U6UgPUQRmErNwtsuI6vLcyRKkafjkr3KxbtGFf9aBBIV2mcvlsKD1UYaIV+sg=="],
 
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
@@ -42,6 +47,8 @@
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
 
     "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
 
@@ -141,6 +148,8 @@
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
+    "node-forge": ["node-forge@1.4.0", "", {}, "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ=="],
+
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
@@ -181,6 +190,8 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
+    "shell-quote": ["shell-quote@1.8.4", "", {}, "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ=="],
+
     "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
 
     "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
@@ -207,8 +218,10 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
-    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@anthropic-ai/sandbox-runtime": "0.0.54",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "@openparachute/scope-guard": "^0.4.0"
   },

--- a/src/agent-mcp-config.test.ts
+++ b/src/agent-mcp-config.test.ts
@@ -1,0 +1,94 @@
+import { describe, test, expect } from "bun:test";
+import {
+  buildAgentMcpServers,
+  buildAgentMcpConfigJson,
+  channelEntryKey,
+  vaultEntryKey,
+} from "./agent-mcp-config.ts";
+
+describe("buildAgentMcpServers — N-entry strict config", () => {
+  test("one entry per channel with its own URL + Bearer", () => {
+    const servers = buildAgentMcpServers({
+      channelUrl: "http://127.0.0.1:1941",
+      channels: [
+        { channel: "aaron-dev", token: "TOK-A" },
+        { channel: "ops", token: "TOK-B" },
+      ],
+    });
+    expect(servers[channelEntryKey("aaron-dev")]).toEqual({
+      type: "http",
+      url: "http://127.0.0.1:1941/mcp/aaron-dev",
+      headers: { Authorization: "Bearer TOK-A" },
+    });
+    expect(servers[channelEntryKey("ops")]).toEqual({
+      type: "http",
+      url: "http://127.0.0.1:1941/mcp/ops",
+      headers: { Authorization: "Bearer TOK-B" },
+    });
+    expect(Object.keys(servers)).toHaveLength(2);
+  });
+
+  test("adds a vault entry with its OWN token (one token per aud)", () => {
+    const servers = buildAgentMcpServers({
+      channelUrl: "http://127.0.0.1:1941",
+      channels: [{ channel: "ch", token: "CH-TOK" }],
+      vault: { url: "http://127.0.0.1:1940", entry: { name: "default", token: "VAULT-TOK" } },
+    });
+    expect(servers[vaultEntryKey("default")]).toEqual({
+      type: "http",
+      url: "http://127.0.0.1:1940/vault/default/mcp",
+      headers: { Authorization: "Bearer VAULT-TOK" },
+    });
+    // The channel token and the vault token are DIFFERENT (separate auds).
+    expect(servers[channelEntryKey("ch")]!.headers!.Authorization).toBe("Bearer CH-TOK");
+    expect(servers[vaultEntryKey("default")]!.headers!.Authorization).toBe("Bearer VAULT-TOK");
+  });
+
+  test("adds otherMcps; an entry without a token gets no Authorization header", () => {
+    const servers = buildAgentMcpServers({
+      channelUrl: "http://127.0.0.1:1941",
+      channels: [{ channel: "ch", token: "T" }],
+      otherMcps: [
+        { name: "extra", url: "https://mcp.example.com/mcp", token: "X" },
+        { name: "open", url: "https://open.example.com/mcp" },
+      ],
+    });
+    expect(servers.extra!.headers).toEqual({ Authorization: "Bearer X" });
+    expect(servers.open!.headers).toBeUndefined();
+  });
+
+  test("strips a trailing slash on the base URL", () => {
+    const servers = buildAgentMcpServers({
+      channelUrl: "http://127.0.0.1:1941/",
+      channels: [{ channel: "ch", token: "T" }],
+    });
+    expect(servers[channelEntryKey("ch")]!.url).toBe("http://127.0.0.1:1941/mcp/ch");
+  });
+});
+
+describe("buildAgentMcpConfigJson", () => {
+  test("emits two-space-indented JSON with the mcpServers wrapper", () => {
+    const json = buildAgentMcpConfigJson({
+      channelUrl: "http://127.0.0.1:1941",
+      channels: [{ channel: "ch", token: "T" }],
+    });
+    const parsed = JSON.parse(json);
+    expect(parsed.mcpServers).toBeDefined();
+    expect(parsed.mcpServers[channelEntryKey("ch")].type).toBe("http");
+    // Two-space indent (matches runner/vault emission convention).
+    expect(json).toContain('\n  "mcpServers"');
+  });
+
+  test("round-trips: parse(emit(x)) carries every entry's token", () => {
+    const input = {
+      channelUrl: "http://127.0.0.1:1941",
+      channels: [{ channel: "a", token: "TA" }],
+      vault: { url: "http://127.0.0.1:1940", entry: { name: "default", token: "TV" } },
+    };
+    const parsed = JSON.parse(buildAgentMcpConfigJson(input)) as {
+      mcpServers: Record<string, { headers?: { Authorization: string } }>;
+    };
+    expect(parsed.mcpServers[channelEntryKey("a")]!.headers!.Authorization).toBe("Bearer TA");
+    expect(parsed.mcpServers[vaultEntryKey("default")]!.headers!.Authorization).toBe("Bearer TV");
+  });
+});

--- a/src/agent-mcp-config.ts
+++ b/src/agent-mcp-config.ts
@@ -1,0 +1,114 @@
+/**
+ * Build the multi-entry inline `--mcp-config` JSON for a sandboxed agent session
+ * (design §4.2 step 2).
+ *
+ * This generalizes runner's single-entry `buildMcpConfigJson`
+ * (`parachute-runner/src/mcp-config.ts`) into one `mcpServers` object carrying
+ * EVERY channel's `/mcp/<channel>` entry plus the optional vault's
+ * `/vault/<name>/mcp` entry plus any `otherMcps` — each with its OWN Bearer
+ * (one token per `aud`; the manager mints them, §4.2 step 1).
+ *
+ * The session launches with `--strict-mcp-config`, so it sees exactly these
+ * servers and nothing else — the MCP surface is closed to the spec.
+ *
+ * Each entry is the HTTP-MCP shape both channel (`src/mcp-http.ts`) and vault
+ * (its `/vault/<name>/mcp`) serve:
+ *   { "type": "http", "url": "<url>", "headers": { "Authorization": "Bearer <tok>" } }
+ *
+ * Treat the output as secret — it inlines bearer tokens.
+ */
+
+export interface ChannelMcpEntry {
+  /** Channel name (the `/mcp/<channel>` segment + entry-key suffix). */
+  channel: string;
+  /** Per-channel hub-issued token (aud: channel; channel:read[+write]). */
+  token: string;
+}
+
+export interface VaultMcpEntry {
+  /** Vault instance name. */
+  name: string;
+  /** Per-vault hub-issued token (aud: vault; vault:<name>:<verb>). */
+  token: string;
+}
+
+export interface OtherMcpEntry {
+  /** Entry key in mcpServers. */
+  name: string;
+  /** MCP URL. */
+  url: string;
+  /** Optional token; omitted = no Authorization header. */
+  token?: string;
+}
+
+export interface BuildAgentMcpConfigInput {
+  /** Daemon base URL the channel `/mcp/<channel>` endpoints live under. */
+  channelUrl: string;
+  /** Channels to attach (one entry each). */
+  channels: ChannelMcpEntry[];
+  /** Optional vault binding. */
+  vault?: { url: string; entry: VaultMcpEntry };
+  /** Additional MCP servers. */
+  otherMcps?: OtherMcpEntry[];
+}
+
+interface McpHttpServer {
+  type: "http";
+  url: string;
+  headers?: { Authorization: string };
+}
+
+/** Build the channel entry key — matches launch-session.sh's `channel-<name>`. */
+export function channelEntryKey(channel: string): string {
+  return `channel-${channel}`;
+}
+
+/** Build the vault entry key — matches runner's `parachute-vault-<name>`. */
+export function vaultEntryKey(name: string): string {
+  return `parachute-vault-${name}`;
+}
+
+function stripTrailingSlash(url: string): string {
+  return url.replace(/\/$/, "");
+}
+
+function httpServer(url: string, token?: string): McpHttpServer {
+  const server: McpHttpServer = { type: "http", url };
+  if (token) server.headers = { Authorization: `Bearer ${token}` };
+  return server;
+}
+
+/**
+ * Build the multi-entry `mcpServers` object (not yet JSON-stringified). Exposed
+ * for assertions that inspect the structure directly.
+ */
+export function buildAgentMcpServers(
+  input: BuildAgentMcpConfigInput,
+): Record<string, McpHttpServer> {
+  const servers: Record<string, McpHttpServer> = {};
+  const base = stripTrailingSlash(input.channelUrl);
+
+  for (const ch of input.channels) {
+    servers[channelEntryKey(ch.channel)] = httpServer(`${base}/mcp/${ch.channel}`, ch.token);
+  }
+
+  if (input.vault) {
+    const vbase = stripTrailingSlash(input.vault.url);
+    const v = input.vault.entry;
+    servers[vaultEntryKey(v.name)] = httpServer(`${vbase}/vault/${v.name}/mcp`, v.token);
+  }
+
+  for (const o of input.otherMcps ?? []) {
+    servers[o.name] = httpServer(o.url, o.token);
+  }
+
+  return servers;
+}
+
+/**
+ * Build the inline `--mcp-config` JSON. Two-space indent, matching runner's +
+ * vault's emission convention so cross-repo diffs stay clean.
+ */
+export function buildAgentMcpConfigJson(input: BuildAgentMcpConfigInput): string {
+  return JSON.stringify({ mcpServers: buildAgentMcpServers(input) }, null, 2);
+}

--- a/src/mint-token.test.ts
+++ b/src/mint-token.test.ts
@@ -1,0 +1,152 @@
+import { describe, test, expect } from "bun:test";
+import {
+  mintScopedToken,
+  channelScope,
+  vaultScope,
+  MintError,
+  type MintTokenDeps,
+} from "./mint-token.ts";
+
+/** A fake hub mint endpoint. Records the request; returns a scripted response. */
+function fakeHub(
+  handler: (body: Record<string, unknown>, headers: Headers) => { status: number; json: unknown },
+): { fetchFn: typeof fetch; calls: Array<{ body: Record<string, unknown>; auth: string | null }> } {
+  const calls: Array<{ body: Record<string, unknown>; auth: string | null }> = [];
+  const fetchFn = (async (url: string | URL | Request, init?: RequestInit) => {
+    const headers = new Headers(init?.headers);
+    const body = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+    calls.push({ body, auth: headers.get("authorization") });
+    const { status, json } = handler(body, headers);
+    return new Response(JSON.stringify(json), {
+      status,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  return { fetchFn, calls };
+}
+
+function depsWith(fetchFn: typeof fetch): MintTokenDeps {
+  return { hubOrigin: "https://hub.example.com", managerBearer: "MANAGER-BEARER", fetchFn };
+}
+
+describe("scope string helpers", () => {
+  test("channelScope", () => {
+    expect(channelScope({ write: false })).toBe("channel:read");
+    expect(channelScope({ write: true })).toBe("channel:read channel:write");
+  });
+  test("vaultScope", () => {
+    expect(vaultScope("default", "read")).toBe("vault:default:read");
+    expect(vaultScope("work", "write")).toBe("vault:work:write");
+  });
+});
+
+describe("mintScopedToken — happy path", () => {
+  test("POSTs to /api/auth/mint-token with the manager bearer + scope, returns the token", async () => {
+    const hub = fakeHub((body) => ({
+      status: 200,
+      json: {
+        jti: "j1",
+        token: "MINTED-TOKEN",
+        expires_at: "2026-09-01T00:00:00Z",
+        scope: body.scope,
+      },
+    }));
+    const res = await mintScopedToken({ scope: "channel:read channel:write" }, depsWith(hub.fetchFn));
+    expect(res.token).toBe("MINTED-TOKEN");
+    expect(res.jti).toBe("j1");
+    // Presented the MANAGER's bearer (the attenuation principal).
+    expect(hub.calls[0]!.auth).toBe("Bearer MANAGER-BEARER");
+    expect(hub.calls[0]!.body.scope).toBe("channel:read channel:write");
+  });
+
+  test("passes audience + permissions (scoped_tags) through to the hub", async () => {
+    const hub = fakeHub(() => ({
+      status: 200,
+      json: { jti: "j", token: "T", expires_at: "", scope: "vault:default:read" },
+    }));
+    await mintScopedToken(
+      {
+        scope: "vault:default:read",
+        audience: "vault.default",
+        permissions: { scoped_tags: ["#channel-message"] },
+      },
+      depsWith(hub.fetchFn),
+    );
+    expect(hub.calls[0]!.body.audience).toBe("vault.default");
+    expect(hub.calls[0]!.body.permissions).toEqual({ scoped_tags: ["#channel-message"] });
+  });
+});
+
+describe("mintScopedToken — attenuation + error surfacing", () => {
+  test("CAPABILITY ATTENUATION: the hub's 400 invalid_scope (over-broad request) becomes a MintError", async () => {
+    // Simulate the hub's canGrant guard: a vault:default:read manager bearer
+    // requests vault:default:write → the hub refuses 400 invalid_scope. The
+    // attenuation bound lives in the hub; this asserts the client surfaces the
+    // refusal as a hard error (never launches a session with an ungrantable cred).
+    const hub = fakeHub((body) => {
+      // Manager bearer in this scenario only holds vault:default:read; a write
+      // request exceeds it → hub returns 400.
+      if (String(body.scope).includes(":write")) {
+        return {
+          status: 400,
+          json: {
+            error: "invalid_scope",
+            error_description:
+              "scope vault:default:write is not grantable by this bearer; use OAuth flow or operator rotation",
+          },
+        };
+      }
+      return { status: 200, json: { jti: "j", token: "ok", expires_at: "", scope: body.scope } };
+    });
+
+    // The grantable read mint succeeds.
+    const ok = await mintScopedToken({ scope: "vault:default:read" }, depsWith(hub.fetchFn));
+    expect(ok.token).toBe("ok");
+
+    // The over-broad write mint is refused — surfaced as a MintError carrying the code.
+    let err: unknown;
+    try {
+      await mintScopedToken({ scope: "vault:default:write" }, depsWith(hub.fetchFn));
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(MintError);
+    expect((err as MintError).status).toBe(400);
+    expect((err as MintError).code).toBe("invalid_scope");
+  });
+
+  test("a 403 insufficient_scope (no minting authority) becomes a MintError", async () => {
+    const hub = fakeHub(() => ({
+      status: 403,
+      json: { error: "insufficient_scope", error_description: "bearer holds no minting authority" },
+    }));
+    let err: unknown;
+    try {
+      await mintScopedToken({ scope: "channel:read" }, depsWith(hub.fetchFn));
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(MintError);
+    expect((err as MintError).status).toBe(403);
+    expect((err as MintError).code).toBe("insufficient_scope");
+  });
+
+  test("a 200 with no token becomes a MintError (never returns a credential-less success)", async () => {
+    const hub = fakeHub(() => ({ status: 200, json: { jti: "j", expires_at: "" } }));
+    await expect(mintScopedToken({ scope: "channel:read" }, depsWith(hub.fetchFn))).rejects.toBeInstanceOf(MintError);
+  });
+
+  test("a network failure to reach the hub becomes a MintError (status 0)", async () => {
+    const fetchFn = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+    let err: unknown;
+    try {
+      await mintScopedToken({ scope: "channel:read" }, depsWith(fetchFn));
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(MintError);
+    expect((err as MintError).status).toBe(0);
+  });
+});

--- a/src/mint-token.ts
+++ b/src/mint-token.ts
@@ -1,0 +1,139 @@
+/**
+ * Scoped-token minting for a sandboxed agent session (design §4.2 step 1, §4.3).
+ *
+ * A hub-issued JWT's `aud` is single-valued, so each resource an arm reaches gets
+ * its OWN token: `channel:read channel:write` per channel, `vault:<name>:<verb>`
+ * (optionally tag-scoped via `permissions.scoped_tags`) for the vault. The
+ * spawn-manager mints these by attenuating its own grant — it presents its OWN
+ * operator bearer to the hub's `POST /api/auth/mint-token`, which enforces
+ * capability attenuation server-side (`parachute-hub/src/api-mint-token.ts`,
+ * `canGrant`): the manager CANNOT mint a child token exceeding its own authority.
+ * A `vault:default:read` manager bearer cannot mint a child `vault:default:write`
+ * — the hub returns 400 `invalid_scope` (§4.3). This module is the client of that
+ * server-enforced bound; the bound itself lives in the hub.
+ *
+ * One token per `aud`: a multi-resource spec calls this once per resource, each
+ * with the resource's scope (and the hub infers `aud` from the scope, or the
+ * caller pins it). Tokens are ephemeral by default for one-shot helpers; the TTL
+ * is the hub's default unless overridden.
+ */
+
+export interface MintRequest {
+  /** Space-joined scope string, e.g. "channel:read channel:write". */
+  scope: string;
+  /** Pin the audience. Omitted = hub infers it from the scope. */
+  audience?: string;
+  /** TTL in seconds. Omitted = hub default (~90d non-ephemeral). */
+  expiresIn?: number;
+  /**
+   * Extra JWT claims, e.g. `{ scoped_tags: ["#channel-message"] }` for a
+   * tag-scoped vault token. Passed through as the mint API's `permissions`.
+   */
+  permissions?: Record<string, unknown>;
+}
+
+export interface MintResult {
+  jti: string;
+  token: string;
+  expiresAt: string;
+  scope: string;
+  permissions?: Record<string, unknown>;
+}
+
+/** A failed mint — carries the hub's error code + the HTTP status. */
+export class MintError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly code: string | undefined,
+  ) {
+    super(message);
+    this.name = "MintError";
+  }
+}
+
+export interface MintTokenDeps {
+  /** Hub public origin. */
+  hubOrigin: string;
+  /**
+   * The spawn-manager's OWN operator bearer, presented to the hub. The hub
+   * attenuates against THIS bearer's authority — child tokens can never exceed it.
+   */
+  managerBearer: string;
+  /** Inject fetch for tests. Defaults to global fetch. */
+  fetchFn?: typeof fetch;
+}
+
+function stripTrailingSlash(url: string): string {
+  return url.replace(/\/$/, "");
+}
+
+/**
+ * Mint ONE scoped token against the hub, attenuated to the manager's bearer.
+ * Throws {@link MintError} on any non-200 (the hub's attenuation 400, an auth
+ * 401/403, etc.) so the caller fails loud rather than launching a session with a
+ * missing/over-broad credential.
+ */
+export async function mintScopedToken(
+  req: MintRequest,
+  deps: MintTokenDeps,
+): Promise<MintResult> {
+  const fetchFn = deps.fetchFn ?? fetch;
+  const url = `${stripTrailingSlash(deps.hubOrigin)}/api/auth/mint-token`;
+
+  const body: Record<string, unknown> = { scope: req.scope };
+  if (req.audience) body.audience = req.audience;
+  if (req.expiresIn !== undefined) body.expires_in = req.expiresIn;
+  if (req.permissions) body.permissions = req.permissions;
+
+  let res: Response;
+  try {
+    res = await fetchFn(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${deps.managerBearer}`,
+      },
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new MintError(`mint request failed to reach hub: ${msg}`, 0, undefined);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = await res.json();
+  } catch {
+    parsed = undefined;
+  }
+
+  if (!res.ok) {
+    const e = (parsed ?? {}) as { error?: string; error_description?: string; message?: string };
+    const code = e.error;
+    const detail = e.error_description ?? e.message ?? `HTTP ${res.status}`;
+    throw new MintError(`mint refused (${code ?? "error"}): ${detail}`, res.status, code);
+  }
+
+  const r = (parsed ?? {}) as Partial<MintResult> & { expires_at?: string };
+  if (typeof r.token !== "string" || r.token.length === 0) {
+    throw new MintError("mint succeeded but response had no token", res.status, undefined);
+  }
+  return {
+    jti: typeof r.jti === "string" ? r.jti : "",
+    token: r.token,
+    expiresAt: typeof r.expires_at === "string" ? r.expires_at : "",
+    scope: typeof r.scope === "string" ? r.scope : req.scope,
+    ...(r.permissions ? { permissions: r.permissions } : {}),
+  };
+}
+
+/** Build the space-joined channel scope string for a read[+write] grant. */
+export function channelScope(opts: { write: boolean }): string {
+  return opts.write ? "channel:read channel:write" : "channel:read";
+}
+
+/** Build the vault scope string for a named verb, e.g. `vault:default:read`. */
+export function vaultScope(name: string, verb: "read" | "write" | "admin"): string {
+  return `vault:${name}:${verb}`;
+}

--- a/src/sandbox/config.test.ts
+++ b/src/sandbox/config.test.ts
@@ -1,0 +1,102 @@
+import { describe, test, expect } from "bun:test";
+import { buildSandboxConfig } from "./config.ts";
+import type { AgentSpec, BaseBinds } from "./types.ts";
+import type { EgressBaseInput } from "./egress.ts";
+
+const BASE_BINDS: BaseBinds = {
+  workspace: "/state/sessions/arm",
+  runtimeReadOnly: ["/home/op/.claude"],
+};
+const EGRESS_BASE: EgressBaseInput = { hubOrigin: "https://hub.example.com" };
+
+function specOf(p: Partial<AgentSpec> = {}): AgentSpec {
+  return { name: "arm", channels: ["ch"], ...p };
+}
+
+describe("buildSandboxConfig — spec → SandboxRuntimeConfig", () => {
+  test("network: deny-by-default + base floor present, deniedDomains empty", () => {
+    const cfg = buildSandboxConfig({
+      spec: specOf({ egress: [] }),
+      baseBinds: BASE_BINDS,
+      egressBase: EGRESS_BASE,
+      platform: "darwin",
+    });
+    expect(cfg.network.allowedDomains).toContain("api.anthropic.com");
+    expect(cfg.network.allowedDomains).toContain("hub.example.com");
+    expect(cfg.network.deniedDomains).toEqual([]);
+  });
+
+  test("SECURITY: a spec with foreign egress still carries the base floor", () => {
+    const cfg = buildSandboxConfig({
+      spec: specOf({ egress: ["registry.npmjs.org"] }),
+      baseBinds: BASE_BINDS,
+      egressBase: EGRESS_BASE,
+      platform: "darwin",
+    });
+    expect(cfg.network.allowedDomains).toContain("api.anthropic.com");
+    expect(cfg.network.allowedDomains).toContain("hub.example.com");
+    expect(cfg.network.allowedDomains).toContain("registry.npmjs.org");
+  });
+
+  test("filesystem: scoped reads (deny home tree, re-allow binds) + write confinement", () => {
+    const cfg = buildSandboxConfig({
+      spec: specOf({ mounts: [{ hostPath: "/proj", mountPath: "/work", mode: "rw" }] }),
+      baseBinds: BASE_BINDS,
+      egressBase: EGRESS_BASE,
+      platform: "darwin",
+    });
+    expect(cfg.filesystem.denyRead).toContain("/Users");
+    expect(cfg.filesystem.allowRead).toContain("/state/sessions/arm");
+    expect(cfg.filesystem.allowRead).toContain("/home/op/.claude");
+    expect(cfg.filesystem.allowRead).toContain("/proj");
+    expect(cfg.filesystem.allowWrite).toContain("/state/sessions/arm");
+    expect(cfg.filesystem.allowWrite).toContain("/proj");
+  });
+
+  test("Linux platform denies /home instead of /Users", () => {
+    const cfg = buildSandboxConfig({
+      spec: specOf(),
+      baseBinds: BASE_BINDS,
+      egressBase: EGRESS_BASE,
+      platform: "linux",
+    });
+    expect(cfg.filesystem.denyRead).toContain("/home");
+    expect(cfg.filesystem.denyRead).not.toContain("/Users");
+  });
+
+  test("allowPty defaults true (interactive claude needs a pty)", () => {
+    const cfg = buildSandboxConfig({
+      spec: specOf(),
+      baseBinds: BASE_BINDS,
+      egressBase: EGRESS_BASE,
+      platform: "darwin",
+    });
+    expect(cfg.allowPty).toBe(true);
+  });
+
+  test("ripgrep override threads through when provided", () => {
+    const cfg = buildSandboxConfig({
+      spec: specOf(),
+      baseBinds: BASE_BINDS,
+      egressBase: EGRESS_BASE,
+      platform: "darwin",
+      ripgrep: { command: "/abs/rg" },
+    });
+    expect(cfg.ripgrep).toEqual({ command: "/abs/rg" });
+  });
+
+  test("the produced config matches the runtime's required shape (keys present)", () => {
+    const cfg = buildSandboxConfig({
+      spec: specOf(),
+      baseBinds: BASE_BINDS,
+      egressBase: EGRESS_BASE,
+      platform: "darwin",
+    });
+    expect(cfg.network).toHaveProperty("allowedDomains");
+    expect(cfg.network).toHaveProperty("deniedDomains");
+    expect(cfg.filesystem).toHaveProperty("denyRead");
+    expect(cfg.filesystem).toHaveProperty("allowRead");
+    expect(cfg.filesystem).toHaveProperty("allowWrite");
+    expect(cfg.filesystem).toHaveProperty("denyWrite");
+  });
+});

--- a/src/sandbox/config.ts
+++ b/src/sandbox/config.ts
@@ -1,0 +1,77 @@
+/**
+ * Map an agent-spec → a `SandboxRuntimeConfig` for `@anthropic-ai/sandbox-runtime`
+ * (design §3 — the isolation envelope).
+ *
+ * The runtime config shape (verified against the package's own types,
+ * `@anthropic-ai/sandbox-runtime` 0.0.54 `SandboxRuntimeConfig`):
+ *
+ *   {
+ *     network:    { allowedDomains: string[], deniedDomains: string[] },
+ *     filesystem: { denyRead: string[], allowRead?: string[],
+ *                   allowWrite: string[], denyWrite: string[] },
+ *     …optional knobs (allowPty, bwrapPath, ripgrep, …)
+ *   }
+ *
+ * This module is the single place spec → runtime-config happens, so the egress
+ * floor (§4.4) and scoped-read policy (§4.5) are guaranteed on every launch.
+ */
+
+import type { SandboxRuntimeConfig } from "@anthropic-ai/sandbox-runtime";
+import type { AgentSpec, BaseBinds, SandboxPlatform } from "./types.ts";
+import { composeEgressAllowlist, type EgressBaseInput } from "./egress.ts";
+import { composeFilesystemView } from "./mounts.ts";
+
+export interface BuildSandboxConfigInput {
+  spec: AgentSpec;
+  /** Workspace + runtime/config binds the contract always grants. */
+  baseBinds: BaseBinds;
+  /** Origins for the non-removable egress base. */
+  egressBase: EgressBaseInput;
+  /** Target platform. Defaults to the running platform. */
+  platform?: SandboxPlatform;
+  /**
+   * Allow the session to allocate a pty (a tmux/interactive `claude` needs one).
+   * Defaults true. Surfaced so a non-interactive arm can drop it.
+   */
+  allowPty?: boolean;
+  /**
+   * Optional ripgrep override the runtime uses for deny-path scanning. On macOS
+   * the runtime needs a ripgrep binary; pass `{ command: <abs path> }` when the
+   * host has no `rg` on PATH. Omitted = the runtime's own resolution.
+   */
+  ripgrep?: { command: string; args?: string[] };
+}
+
+/** Resolve the running platform to the two we support. */
+export function currentSandboxPlatform(): SandboxPlatform {
+  return process.platform === "darwin" ? "darwin" : "linux";
+}
+
+/**
+ * Build the `SandboxRuntimeConfig` for an agent spec. The egress allowlist is the
+ * non-removable base unioned with the spec's additions; the filesystem view is
+ * scoped-read (home-tree denied, binds re-allowed) with writes confined to the
+ * workspace + rw mounts.
+ */
+export function buildSandboxConfig(input: BuildSandboxConfigInput): SandboxRuntimeConfig {
+  const platform = input.platform ?? currentSandboxPlatform();
+
+  const allowedDomains = composeEgressAllowlist(input.egressBase, input.spec.egress);
+  const fs = composeFilesystemView(input.baseBinds, input.spec.mounts, platform);
+
+  const config: SandboxRuntimeConfig = {
+    network: {
+      allowedDomains,
+      deniedDomains: [],
+    },
+    filesystem: {
+      denyRead: fs.denyRead,
+      allowRead: fs.allowRead,
+      allowWrite: fs.allowWrite,
+      denyWrite: fs.denyWrite,
+    },
+    allowPty: input.allowPty ?? true,
+  };
+  if (input.ripgrep) config.ripgrep = input.ripgrep;
+  return config;
+}

--- a/src/sandbox/egress.test.ts
+++ b/src/sandbox/egress.test.ts
@@ -1,0 +1,113 @@
+import { describe, test, expect } from "bun:test";
+import {
+  ANTHROPIC_EGRESS_HOSTS,
+  baseEgressAllowlist,
+  composeEgressAllowlist,
+  hostFromOrigin,
+  type EgressBaseInput,
+} from "./egress.ts";
+
+const BASE: EgressBaseInput = { hubOrigin: "https://hub.example.com" };
+
+describe("hostFromOrigin", () => {
+  test("reduces an origin to its hostname (strips scheme + port + path)", () => {
+    expect(hostFromOrigin("https://hub.example.com:1939/admin")).toBe("hub.example.com");
+  });
+  test("passes a bare host through", () => {
+    expect(hostFromOrigin("registry.npmjs.org")).toBe("registry.npmjs.org");
+  });
+  test("strips a :port from a bare host:port", () => {
+    expect(hostFromOrigin("127.0.0.1:1939")).toBe("127.0.0.1");
+  });
+  test("preserves loopback (a co-located dev hub is loopback)", () => {
+    expect(hostFromOrigin("http://127.0.0.1:1939")).toBe("127.0.0.1");
+  });
+  test("returns null for empty / nullish input", () => {
+    expect(hostFromOrigin("")).toBeNull();
+    expect(hostFromOrigin(undefined)).toBeNull();
+    expect(hostFromOrigin("   ")).toBeNull();
+  });
+});
+
+describe("baseEgressAllowlist — the non-removable base", () => {
+  test("always includes the Anthropic hosts + the hub host", () => {
+    const base = baseEgressAllowlist(BASE);
+    for (const h of ANTHROPIC_EGRESS_HOSTS) expect(base).toContain(h);
+    expect(base).toContain("hub.example.com");
+  });
+
+  test("includes a distinct vault host when given", () => {
+    const base = baseEgressAllowlist({ ...BASE, vaultOrigin: "https://vault.example.com" });
+    expect(base).toContain("vault.example.com");
+  });
+
+  test("dedupes a vault origin equal to the hub origin", () => {
+    const base = baseEgressAllowlist({
+      hubOrigin: "https://h.example.com",
+      vaultOrigin: "https://h.example.com",
+    });
+    expect(base.filter((h) => h === "h.example.com")).toHaveLength(1);
+  });
+});
+
+describe("composeEgressAllowlist — base floor is non-removable, spec is additive", () => {
+  test("an empty spec egress still gets the full base (weaver-style arm)", () => {
+    const allow = composeEgressAllowlist(BASE, []);
+    for (const h of ANTHROPIC_EGRESS_HOSTS) expect(allow).toContain(h);
+    expect(allow).toContain("hub.example.com");
+  });
+
+  test("an undefined spec egress still gets the full base", () => {
+    const allow = composeEgressAllowlist(BASE, undefined);
+    expect(allow).toContain("api.anthropic.com");
+    expect(allow).toContain("hub.example.com");
+  });
+
+  test("spec hosts are ADDED on top of the base", () => {
+    const allow = composeEgressAllowlist(BASE, ["registry.npmjs.org", "pypi.org"]);
+    // base present...
+    expect(allow).toContain("api.anthropic.com");
+    expect(allow).toContain("hub.example.com");
+    // ...plus the additions
+    expect(allow).toContain("registry.npmjs.org");
+    expect(allow).toContain("pypi.org");
+  });
+
+  test("SECURITY: a spec that lists ONLY a foreign host CANNOT drop the base — the base is still present", () => {
+    // A spec authored to omit the base entirely (the malicious-omit case).
+    const allow = composeEgressAllowlist(BASE, ["evil.example.com"]);
+    // The base floor survives regardless of what the spec listed.
+    expect(allow).toContain("api.anthropic.com");
+    expect(allow).toContain("hub.example.com");
+    // The spec's own host is added (additive), not a replacement.
+    expect(allow).toContain("evil.example.com");
+  });
+
+  test("SECURITY: a spec cannot REPLACE the Anthropic host with a look-alike — both end up present, base is not dropped", () => {
+    // A spec that tries to "override" the Anthropic host by re-declaring a near-miss.
+    const allow = composeEgressAllowlist(BASE, ["api.anthropic.com.evil.example.com"]);
+    // The real Anthropic apex is still on the list (the base recomputed from code).
+    expect(allow).toContain("api.anthropic.com");
+    // The look-alike is just an additional (separate) host, not a substitution.
+    expect(allow).toContain("api.anthropic.com.evil.example.com");
+    // And the look-alike did not evict the real host.
+    expect(allow.indexOf("api.anthropic.com")).toBeGreaterThanOrEqual(0);
+  });
+
+  test("the base always sorts FIRST (recomputed from code, prepended)", () => {
+    const allow = composeEgressAllowlist(BASE, ["z-late.example.com"]);
+    expect(allow[0]).toBe("api.anthropic.com");
+    expect(allow[allow.length - 1]).toBe("z-late.example.com");
+  });
+
+  test("spec origins are normalized to hosts (full URL and bare host land the same)", () => {
+    const a = composeEgressAllowlist(BASE, ["https://registry.npmjs.org"]);
+    const b = composeEgressAllowlist(BASE, ["registry.npmjs.org"]);
+    expect(a).toEqual(b);
+  });
+
+  test("dedupes a spec host that duplicates a base host", () => {
+    const allow = composeEgressAllowlist(BASE, ["hub.example.com"]);
+    expect(allow.filter((h) => h === "hub.example.com")).toHaveLength(1);
+  });
+});

--- a/src/sandbox/egress.ts
+++ b/src/sandbox/egress.ts
@@ -1,0 +1,123 @@
+/**
+ * Network egress composition (design §3.3, §4.4).
+ *
+ * Egress is the load-bearing control for a session fed foreign-authored channel
+ * input: every allowlisted host is an exfiltration path, not just a fetch path.
+ * So the policy is:
+ *
+ *   - DENY all egress by default (the sandbox-runtime's `allowedDomains: []`
+ *     means no network — see its README "Network Isolation (allow-only)").
+ *   - A NON-REMOVABLE BASE allowlist of `{ the Anthropic API host(s), the
+ *     hub/vault origin }` is ALWAYS included — what every arm needs to think and
+ *     to do its scoped work.
+ *   - The spec's `egress[]` is ADDITIVE only. A spec cannot drop the base or
+ *     override it away; it can only widen with hosts of its own.
+ *
+ * The base is anchored in code, not config, precisely so a spec (which may be
+ * generated from foreign-influenced input down the line) can never quietly strip
+ * the host's own control-plane reachability or — worse — replace the Anthropic
+ * host with an attacker endpoint.
+ */
+
+/**
+ * The Anthropic API hosts every arm needs to reach to run `claude`. Includes the
+ * wildcard so regional/edge subdomains resolve; the bare apex covers the canonical
+ * host. Held in code as part of the non-removable base.
+ */
+export const ANTHROPIC_EGRESS_HOSTS: readonly string[] = [
+  "api.anthropic.com",
+  "*.anthropic.com",
+] as const;
+
+/** A hostname (no scheme/port/path) extracted from an origin or passed through. */
+export type EgressHost = string;
+
+/**
+ * Reduce an origin (`https://host:port`) or a bare host to the hostname the
+ * sandbox-runtime allowlist matches on. The runtime matches on domain, not
+ * scheme or port, so we strip both. A bare hostname passes through unchanged.
+ * Returns null for an unparseable/empty input (callers skip nulls).
+ */
+export function hostFromOrigin(originOrHost: string | undefined | null): EgressHost | null {
+  if (!originOrHost) return null;
+  const trimmed = originOrHost.trim();
+  if (trimmed.length === 0) return null;
+  // If it parses as a URL, take its hostname. Otherwise treat the whole thing as
+  // a host (possibly with a :port we strip).
+  try {
+    const u = new URL(trimmed.includes("://") ? trimmed : `https://${trimmed}`);
+    const h = u.hostname;
+    return h.length > 0 ? h : null;
+  } catch {
+    const noPort = trimmed.replace(/:\d+$/, "");
+    return noPort.length > 0 ? noPort : null;
+  }
+}
+
+export interface EgressBaseInput {
+  /**
+   * The hub origin (also the vault origin in the co-located deploy — the vault is
+   * reached under the hub's path-proxy). Origin or bare host; reduced to a host.
+   */
+  hubOrigin: string;
+  /**
+   * Optional distinct vault origin, if the vault is reached at a different host
+   * than the hub. Usually omitted (co-located). Origin or bare host.
+   */
+  vaultOrigin?: string;
+  /**
+   * Override the Anthropic hosts (tests). Defaults to {@link ANTHROPIC_EGRESS_HOSTS}.
+   */
+  anthropicHosts?: readonly string[];
+}
+
+/**
+ * Build the NON-REMOVABLE base egress allowlist: the Anthropic API host(s) plus
+ * the hub/vault origin host(s). This is what every arm gets regardless of spec.
+ * Deduped, loopback/local hosts preserved (a co-located dev hub is loopback).
+ */
+export function baseEgressAllowlist(input: EgressBaseInput): EgressHost[] {
+  const anthropic = input.anthropicHosts ?? ANTHROPIC_EGRESS_HOSTS;
+  const hosts: EgressHost[] = [...anthropic];
+  const hub = hostFromOrigin(input.hubOrigin);
+  if (hub) hosts.push(hub);
+  const vault = hostFromOrigin(input.vaultOrigin);
+  if (vault) hosts.push(vault);
+  return dedupePreserveOrder(hosts);
+}
+
+/**
+ * Compose the final egress allowlist: the non-removable base UNIONED with the
+ * spec's additive `egress[]`. The base is always present and always first; spec
+ * hosts are appended. Because we recompute the base from code on every call and
+ * union (never start from the spec), a spec that tries to omit or "override" the
+ * base still gets it — the contract the test in egress.test.ts pins.
+ *
+ * Each spec host is normalized through {@link hostFromOrigin} so an arm may
+ * declare either bare hosts (`registry.npmjs.org`) or full origins
+ * (`https://registry.npmjs.org`) and they land the same.
+ */
+export function composeEgressAllowlist(
+  base: EgressBaseInput,
+  specEgress: readonly string[] | undefined,
+): EgressHost[] {
+  const baseHosts = baseEgressAllowlist(base);
+  const additions: EgressHost[] = [];
+  for (const e of specEgress ?? []) {
+    const h = hostFromOrigin(e);
+    if (h) additions.push(h);
+  }
+  return dedupePreserveOrder([...baseHosts, ...additions]);
+}
+
+function dedupePreserveOrder(xs: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const x of xs) {
+    if (!seen.has(x)) {
+      seen.add(x);
+      out.push(x);
+    }
+  }
+  return out;
+}

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -15,13 +15,30 @@
  * through `initialize` → wrap → reset; the adapter makes that explicit.
  */
 
+// `@anthropic-ai/sandbox-runtime` is pinned EXACT (not `^`) in package.json — it's
+// an anthropic-experimental research preview whose config/API may evolve between
+// patch releases, and it is the load-bearing isolation engine. Treat a version
+// bump as an upgrade-gate: only raise the pin behind a green run of the sandbox
+// test suite (esp. the LIVE Seatbelt assertions in `live-seatbelt.test.ts`, which
+// prove the real boundary still holds against the new version).
 import { SandboxManager as RealSandboxManager } from "@anthropic-ai/sandbox-runtime";
 import type { SandboxRuntimeConfig } from "@anthropic-ai/sandbox-runtime";
 import type { AgentSpec, BaseBinds, SandboxPlatform } from "./types.ts";
 import { buildSandboxConfig, currentSandboxPlatform } from "./config.ts";
 import type { EgressBaseInput } from "./egress.ts";
 
-export type { AgentSpec, AgentMount, AgentVaultSpec, OtherMcpSpec, BaseBinds, MountMode, SandboxPlatform } from "./types.ts";
+export type {
+  AgentSpec,
+  AgentMount,
+  AgentVaultSpec,
+  AgentChannel,
+  AgentChannelSpec,
+  OtherMcpSpec,
+  BaseBinds,
+  MountMode,
+  SandboxPlatform,
+} from "./types.ts";
+export { normalizeChannel } from "./types.ts";
 export {
   composeEgressAllowlist,
   baseEgressAllowlist,

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -1,0 +1,142 @@
+/**
+ * The `Sandbox` adapter — the constant contract, the per-platform mechanism
+ * behind it (design §3.1).
+ *
+ * v1 mechanism: Anthropic's `@anthropic-ai/sandbox-runtime` (Seatbelt on macOS,
+ * bubblewrap on Linux). We reach it by **library link** — never PATH resolution
+ * (design Q4 decision: a poisoned PATH entry would execute *before* the sandbox
+ * is established). The `SandboxManager` singleton is imported at module load, so
+ * the trust boundary is anchored to the pinned, library-resolved artifact.
+ *
+ * The adapter wraps the singleton so callers depend on this small surface — not
+ * on the runtime's full API — and so the escalation rung (§3.4) can become a
+ * second backend behind the same contract later. `SandboxManager` being a
+ * process-global singleton (one set of host proxies) means launches serialize
+ * through `initialize` → wrap → reset; the adapter makes that explicit.
+ */
+
+import { SandboxManager as RealSandboxManager } from "@anthropic-ai/sandbox-runtime";
+import type { SandboxRuntimeConfig } from "@anthropic-ai/sandbox-runtime";
+import type { AgentSpec, BaseBinds, SandboxPlatform } from "./types.ts";
+import { buildSandboxConfig, currentSandboxPlatform } from "./config.ts";
+import type { EgressBaseInput } from "./egress.ts";
+
+export type { AgentSpec, AgentMount, AgentVaultSpec, OtherMcpSpec, BaseBinds, MountMode, SandboxPlatform } from "./types.ts";
+export {
+  composeEgressAllowlist,
+  baseEgressAllowlist,
+  hostFromOrigin,
+  ANTHROPIC_EGRESS_HOSTS,
+  type EgressBaseInput,
+} from "./egress.ts";
+export {
+  composeFilesystemView,
+  homeTreeDenyRoot,
+  sharedMounts,
+  type FilesystemView,
+} from "./mounts.ts";
+export { buildSandboxConfig, currentSandboxPlatform, type BuildSandboxConfigInput } from "./config.ts";
+
+/**
+ * The minimal slice of the sandbox-runtime singleton the adapter uses. Pinned
+ * here so a test can inject a fake without depending on the full runtime API,
+ * and so a drift in the runtime's surface fails the typecheck loudly.
+ */
+export interface SandboxEngine {
+  isSupportedPlatform(): boolean;
+  isSandboxingEnabled(): boolean;
+  initialize(config: SandboxRuntimeConfig): Promise<void>;
+  /** Wrap a shell command string; returns the argv + env to spawn. */
+  wrapWithSandboxArgv(
+    command: string,
+  ): Promise<{ argv: string[]; env: Record<string, string | undefined> }>;
+  reset(): Promise<void>;
+}
+
+/** The real engine, library-linked (never via PATH). */
+export const defaultEngine: SandboxEngine = RealSandboxManager as unknown as SandboxEngine;
+
+export interface WrapInput {
+  spec: AgentSpec;
+  baseBinds: BaseBinds;
+  egressBase: EgressBaseInput;
+  /** The shell command to run sandboxed (e.g. the `claude …` invocation). */
+  command: string;
+  platform?: SandboxPlatform;
+  allowPty?: boolean;
+  ripgrep?: { command: string; args?: string[] };
+}
+
+export interface WrappedCommand {
+  /** argv to spawn (Seatbelt/bubblewrap wrapper + the command). */
+  argv: string[];
+  /** env the wrapper needs (proxy vars, sandbox markers). */
+  env: Record<string, string | undefined>;
+  /** The config the engine was initialized with (for assertion/audit/logging). */
+  config: SandboxRuntimeConfig;
+}
+
+/**
+ * The `Sandbox` — initialize the engine with the spec's config, then wrap the
+ * command. The returned `{argv, env}` is what the spawn step launches in tmux.
+ *
+ * Serialization caveat: the engine is a process-global singleton (it starts host
+ * egress proxies on `initialize` and tears them down on `reset`). v1 launches one
+ * sandboxed session at a time through this path; concurrent launches must
+ * serialize. The injectable `engine` keeps this unit-testable + lets a future
+ * per-session backend (§3.4) slot in.
+ */
+export class Sandbox {
+  private readonly engine: SandboxEngine;
+
+  constructor(engine: SandboxEngine = defaultEngine) {
+    this.engine = engine;
+  }
+
+  /** Whether this host can sandbox at all (Seatbelt present / bubblewrap deps). */
+  isSupportedPlatform(): boolean {
+    return this.engine.isSupportedPlatform();
+  }
+
+  /**
+   * Build the config from the spec, initialize the engine, and wrap the command.
+   * The config is returned so callers can assert/log the exact allowlist + binds.
+   */
+  async wrap(input: WrapInput): Promise<WrappedCommand> {
+    const config = buildSandboxConfig({
+      spec: input.spec,
+      baseBinds: input.baseBinds,
+      egressBase: input.egressBase,
+      ...(input.platform ? { platform: input.platform } : {}),
+      ...(input.allowPty !== undefined ? { allowPty: input.allowPty } : {}),
+      ...(input.ripgrep ? { ripgrep: input.ripgrep } : {}),
+    });
+    await this.engine.initialize(config);
+    const { argv, env } = await this.engine.wrapWithSandboxArgv(input.command);
+    return { argv, env, config };
+  }
+
+  /** Tear down the engine's host proxies. Call on session death. */
+  async reset(): Promise<void> {
+    await this.engine.reset();
+  }
+}
+
+/** Convenience: just build the config (no engine init) — used in tests + audits. */
+export function configForSpec(input: {
+  spec: AgentSpec;
+  baseBinds: BaseBinds;
+  egressBase: EgressBaseInput;
+  platform?: SandboxPlatform;
+  allowPty?: boolean;
+}): SandboxRuntimeConfig {
+  return buildSandboxConfig({
+    spec: input.spec,
+    baseBinds: input.baseBinds,
+    egressBase: input.egressBase,
+    ...(input.platform ? { platform: input.platform } : {}),
+    ...(input.allowPty !== undefined ? { allowPty: input.allowPty } : {}),
+  });
+}
+
+export { currentSandboxPlatform as platform };

--- a/src/sandbox/live-seatbelt.test.ts
+++ b/src/sandbox/live-seatbelt.test.ts
@@ -20,7 +20,7 @@
 import { describe, test, expect, afterEach } from "bun:test";
 import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
-import { tmpdir } from "node:os";
+import { tmpdir, homedir } from "node:os";
 import { SandboxManager } from "@anthropic-ai/sandbox-runtime";
 import { buildSandboxConfig } from "./config.ts";
 import type { AgentSpec, BaseBinds } from "./types.ts";
@@ -137,6 +137,47 @@ d("LIVE Seatbelt — filesystem read confinement", () => {
       const r = await runSandboxed(cfg, `cat ${secretFile}`);
       expect(r.code).not.toBe(0);
       expect(r.stdout).not.toContain("TOPSECRET");
+    } finally {
+      rmSync(secretDir, { recursive: true, force: true });
+    }
+  }, 60_000);
+
+  test("PRODUCTION PATH: the spec-derived /Users deny blocks a read of a real home-dir file (no manual patch)", async () => {
+    // The §4.5 scoped-read property is "an arm cannot read the operator's home."
+    // Prove it through the PRODUCTION config — secret under the REAL home dir,
+    // workspace also under home (so the re-allow path is exercised against the
+    // real `/Users` deny), and NO manual `denyRead` patch. This is the test that
+    // proves the deployed `denyRead:["/Users"]` actually confines reads.
+    const home = homedir();
+    workspace = mkdtempSync(join(home, ".sbx-live-ws-"));
+    const secretDir = mkdtempSync(join(home, ".sbx-live-secret-"));
+    const secretFile = join(secretDir, "home-secret.txt");
+    writeFileSync(secretFile, "HOME-TOPSECRET-do-not-read");
+    try {
+      const spec: AgentSpec = { name: "homeread", channels: ["c"], egress: [] };
+      // buildSandboxConfig with platform "darwin" → denyRead:["/Users"],
+      // allowRead:[workspace]. We pass the config THROUGH unmodified.
+      const cfg = buildSandboxConfig({
+        spec,
+        baseBinds: { workspace, runtimeReadOnly: [] },
+        egressBase: { hubOrigin: "http://127.0.0.1:1939" },
+        platform: "darwin",
+      });
+      expect(cfg.filesystem.denyRead).toEqual(["/Users"]);
+      expect(cfg.filesystem.allowRead).toContain(workspace);
+      // The secret sits under /Users/<me>/… and is NOT in any bind → blocked.
+      const r = await runSandboxed(cfg, `cat ${secretFile}`);
+      expect(r.code).not.toBe(0);
+      expect(r.stdout).not.toContain("HOME-TOPSECRET");
+
+      // Positive control on the SAME production config: a file inside the
+      // workspace (also under /Users, but re-allowed by allowRead) IS readable —
+      // proving the deny didn't just break all reads.
+      const insideFile = join(workspace, "inside.txt");
+      writeFileSync(insideFile, "HOME-WORKSPACE-readable");
+      const ok = await runSandboxed(cfg, `cat ${insideFile}`);
+      expect(ok.code).toBe(0);
+      expect(ok.stdout).toContain("HOME-WORKSPACE-readable");
     } finally {
       rmSync(secretDir, { recursive: true, force: true });
     }

--- a/src/sandbox/live-seatbelt.test.ts
+++ b/src/sandbox/live-seatbelt.test.ts
@@ -1,0 +1,197 @@
+/**
+ * LIVE sandbox-runtime assertions on this host (Seatbelt on macOS).
+ *
+ * These run a REAL sandboxed process and assert it is genuinely confined:
+ *   - egress to a non-allowlisted host is DENIED;
+ *   - egress to an allowlisted host is permitted to ATTEMPT (proxy admits it);
+ *   - a read OUTSIDE the declared binds is DENIED;
+ *   - a read INSIDE a bind is permitted.
+ *
+ * The sandbox-runtime singleton starts host proxies on `initialize` and tears
+ * them down on `reset`; it is process-global, so these cases serialize (one
+ * describe block, sequential `initialize`→wrap→reset per case). Sandboxed in a
+ * fresh temp workspace — NEVER the operator's live ~/.parachute.
+ *
+ * Skipped automatically when the platform can't sandbox (`isSupportedPlatform()`
+ * false) or its deps aren't satisfied — so CI on an unsupported runner stays
+ * green while a capable host (this Mac) exercises the real boundary. The
+ * config-shape tests (egress/mounts/config.test.ts) ALWAYS run regardless.
+ */
+import { describe, test, expect, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { SandboxManager } from "@anthropic-ai/sandbox-runtime";
+import { buildSandboxConfig } from "./config.ts";
+import type { AgentSpec, BaseBinds } from "./types.ts";
+
+const CAN_SANDBOX =
+  SandboxManager.isSupportedPlatform() && SandboxManager.checkDependencies().errors.length === 0;
+
+// A positive control: prove the harness can actually run a sandboxed process at
+// all before asserting on denials (negative-scans-need-positive-controls).
+const d = CAN_SANDBOX ? describe : describe.skip;
+
+async function runSandboxed(
+  cfg: ReturnType<typeof buildSandboxConfig>,
+  command: string,
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  await SandboxManager.initialize(cfg);
+  try {
+    const { argv, env } = await SandboxManager.wrapWithSandboxArgv(command);
+    const proc = Bun.spawn(argv, {
+      env: env as Record<string, string>,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, code] = await Promise.all([
+      new Response(proc.stdout as ReadableStream<Uint8Array>).text(),
+      new Response(proc.stderr as ReadableStream<Uint8Array>).text(),
+      proc.exited,
+    ]);
+    return { code, stdout, stderr };
+  } finally {
+    await SandboxManager.reset();
+  }
+}
+
+let workspace: string;
+
+afterEach(() => {
+  if (workspace) rmSync(workspace, { recursive: true, force: true });
+});
+
+d("LIVE Seatbelt — network egress", () => {
+  test("positive control: the harness can run a trivial sandboxed command", async () => {
+    workspace = mkdtempSync(join(tmpdir(), "sbx-live-pos-"));
+    const spec: AgentSpec = { name: "pos", channels: ["c"], egress: [] };
+    const cfg = buildSandboxConfig({
+      spec,
+      baseBinds: { workspace, runtimeReadOnly: [] },
+      egressBase: { hubOrigin: "http://127.0.0.1:1939" },
+      platform: "darwin",
+    });
+    const r = await runSandboxed(cfg, "echo sandbox-alive");
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain("sandbox-alive");
+  }, 60_000);
+
+  test("DENIED: curl to a host NOT in the allowlist is blocked", async () => {
+    workspace = mkdtempSync(join(tmpdir(), "sbx-live-deny-"));
+    // Allowlist the base only (anthropic + the loopback hub). example.com is NOT on it.
+    const spec: AgentSpec = { name: "deny", channels: ["c"], egress: [] };
+    const cfg = buildSandboxConfig({
+      spec,
+      baseBinds: { workspace, runtimeReadOnly: [] },
+      egressBase: { hubOrigin: "http://127.0.0.1:1939" },
+      platform: "darwin",
+    });
+    const r = await runSandboxed(
+      cfg,
+      "curl -sS -m 8 -o /dev/null -w '%{http_code}' https://example.com",
+    );
+    // The egress proxy refuses a non-allowlisted host: curl exits non-zero
+    // (commonly 56 "CONNECT tunnel failed, response 403"). The key assertion is
+    // that the request did NOT succeed with a 2xx.
+    expect(r.code).not.toBe(0);
+    expect(r.stdout).not.toMatch(/^2\d\d$/);
+  }, 60_000);
+
+  test("a spec that adds an egress host gets that host on the allowlist (additive)", async () => {
+    workspace = mkdtempSync(join(tmpdir(), "sbx-live-add-"));
+    const spec: AgentSpec = { name: "add", channels: ["c"], egress: ["example.com"] };
+    const cfg = buildSandboxConfig({
+      spec,
+      baseBinds: { workspace, runtimeReadOnly: [] },
+      egressBase: { hubOrigin: "http://127.0.0.1:1939" },
+      platform: "darwin",
+    });
+    // We assert the CONFIG carries the host (a live fetch to example.com would be
+    // a network-flaky external dependency; the denial test above is the live
+    // boundary proof). The base floor is also present.
+    expect(cfg.network.allowedDomains).toContain("example.com");
+    expect(cfg.network.allowedDomains).toContain("api.anthropic.com");
+  }, 60_000);
+});
+
+d("LIVE Seatbelt — filesystem read confinement", () => {
+  test("DENIED: reading a file OUTSIDE the declared binds fails", async () => {
+    workspace = mkdtempSync(join(tmpdir(), "sbx-live-read-"));
+    // A secret OUTSIDE the workspace, under a sibling temp dir we do NOT bind.
+    const secretDir = mkdtempSync(join(tmpdir(), "sbx-live-secret-"));
+    const secretFile = join(secretDir, "secret.txt");
+    writeFileSync(secretFile, "TOPSECRET-do-not-read");
+    try {
+      const spec: AgentSpec = { name: "read", channels: ["c"], egress: [] };
+      const cfg = buildSandboxConfig({
+        spec,
+        baseBinds: { workspace, runtimeReadOnly: [] },
+        egressBase: { hubOrigin: "http://127.0.0.1:1939" },
+        platform: "darwin",
+      });
+      // Deny the temp root so the unbound secret dir is unreadable; re-allow only
+      // the workspace. (buildSandboxConfig denies /Users; the macOS temp dir lives
+      // under /var/folders, so we additionally deny the secret's parent to make the
+      // confinement assertion robust regardless of where the OS placed the tmp dir.)
+      cfg.filesystem.denyRead = [...cfg.filesystem.denyRead, secretDir];
+      const r = await runSandboxed(cfg, `cat ${secretFile}`);
+      expect(r.code).not.toBe(0);
+      expect(r.stdout).not.toContain("TOPSECRET");
+    } finally {
+      rmSync(secretDir, { recursive: true, force: true });
+    }
+  }, 60_000);
+
+  test("ALLOWED: reading a file INSIDE the workspace bind succeeds", async () => {
+    workspace = mkdtempSync(join(tmpdir(), "sbx-live-read-ok-"));
+    const f = join(workspace, "inside.txt");
+    writeFileSync(f, "READABLE-inside-workspace");
+    const spec: AgentSpec = { name: "readok", channels: ["c"], egress: [] };
+    const cfg = buildSandboxConfig({
+      spec,
+      baseBinds: { workspace, runtimeReadOnly: [] },
+      egressBase: { hubOrigin: "http://127.0.0.1:1939" },
+      platform: "darwin",
+    });
+    const r = await runSandboxed(cfg, `cat ${f}`);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain("READABLE-inside-workspace");
+  }, 60_000);
+
+  test("DENIED: writing OUTSIDE the workspace fails (write confinement)", async () => {
+    workspace = mkdtempSync(join(tmpdir(), "sbx-live-write-"));
+    const outsideDir = mkdtempSync(join(tmpdir(), "sbx-live-outside-"));
+    const target = join(outsideDir, "should-not-exist.txt");
+    try {
+      const spec: AgentSpec = { name: "write", channels: ["c"], egress: [] };
+      const cfg = buildSandboxConfig({
+        spec,
+        baseBinds: { workspace, runtimeReadOnly: [] },
+        egressBase: { hubOrigin: "http://127.0.0.1:1939" },
+        platform: "darwin",
+      });
+      const r = await runSandboxed(cfg, `echo pwned > ${target}`);
+      expect(r.code).not.toBe(0);
+      // The file must not have been created (write was blocked at the OS level).
+      expect(await Bun.file(target).exists()).toBe(false);
+    } finally {
+      rmSync(outsideDir, { recursive: true, force: true });
+    }
+  }, 60_000);
+
+  test("ALLOWED: writing INSIDE the workspace succeeds", async () => {
+    workspace = mkdtempSync(join(tmpdir(), "sbx-live-write-ok-"));
+    const target = join(workspace, "out.txt");
+    const spec: AgentSpec = { name: "writeok", channels: ["c"], egress: [] };
+    const cfg = buildSandboxConfig({
+      spec,
+      baseBinds: { workspace, runtimeReadOnly: [] },
+      egressBase: { hubOrigin: "http://127.0.0.1:1939" },
+      platform: "darwin",
+    });
+    const r = await runSandboxed(cfg, `echo written-inside > ${target}`);
+    expect(r.code).toBe(0);
+    const written = await Bun.file(target).text();
+    expect(written).toContain("written-inside");
+  }, 60_000);
+});

--- a/src/sandbox/mounts.test.ts
+++ b/src/sandbox/mounts.test.ts
@@ -1,0 +1,113 @@
+import { describe, test, expect } from "bun:test";
+import {
+  composeFilesystemView,
+  homeTreeDenyRoot,
+  sharedMounts,
+} from "./mounts.ts";
+import type { AgentMount, BaseBinds } from "./types.ts";
+
+const BASE: BaseBinds = {
+  workspace: "/state/sessions/arm",
+  runtimeReadOnly: ["/home/op/.claude"],
+};
+
+describe("homeTreeDenyRoot — platform nuance", () => {
+  test("macOS denies /Users", () => {
+    expect(homeTreeDenyRoot("darwin")).toBe("/Users");
+  });
+  test("Linux denies /home", () => {
+    expect(homeTreeDenyRoot("linux")).toBe("/home");
+  });
+});
+
+describe("composeFilesystemView — scoped reads + write confinement", () => {
+  test("with no mounts: reads = workspace + runtime, writes = workspace only", () => {
+    const fs = composeFilesystemView(BASE, undefined, "darwin");
+    expect(fs.allowRead).toContain("/state/sessions/arm");
+    expect(fs.allowRead).toContain("/home/op/.claude");
+    expect(fs.allowWrite).toEqual(["/state/sessions/arm"]);
+  });
+
+  test("the home tree is denied for reads (scoped-read policy, §4.5)", () => {
+    const fs = composeFilesystemView(BASE, undefined, "darwin");
+    expect(fs.denyRead).toContain("/Users");
+  });
+
+  test("the home tree denied is platform-correct on Linux", () => {
+    const fs = composeFilesystemView(BASE, undefined, "linux");
+    expect(fs.denyRead).toContain("/home");
+  });
+
+  test("an ro mount is readable but NOT writable", () => {
+    const mounts: AgentMount[] = [{ hostPath: "/refs/tree", mountPath: "/ref", mode: "ro" }];
+    const fs = composeFilesystemView(BASE, mounts, "darwin");
+    expect(fs.allowRead).toContain("/refs/tree");
+    expect(fs.allowWrite).not.toContain("/refs/tree");
+  });
+
+  test("an rw mount is BOTH readable and writable", () => {
+    const mounts: AgentMount[] = [{ hostPath: "/proj/foo", mountPath: "/work/foo", mode: "rw" }];
+    const fs = composeFilesystemView(BASE, mounts, "darwin");
+    expect(fs.allowRead).toContain("/proj/foo");
+    expect(fs.allowWrite).toContain("/proj/foo");
+  });
+
+  test("SECURITY: a path OUTSIDE all binds is not in the read surface (scoped, not broad)", () => {
+    const mounts: AgentMount[] = [{ hostPath: "/proj/foo", mountPath: "/work/foo", mode: "rw" }];
+    const fs = composeFilesystemView(BASE, mounts, "darwin");
+    // The operator's SSH dir / other vaults are NOT re-allowed within the denied home tree.
+    expect(fs.allowRead).not.toContain("/Users/op/.ssh");
+    expect(fs.allowRead).not.toContain("/Users/op/other-vault");
+    // And nothing widened the deny away.
+    expect(fs.denyRead).toEqual(["/Users"]);
+  });
+
+  test("SECURITY: writes are confined — only workspace + rw mounts, never an ro mount or arbitrary path", () => {
+    const mounts: AgentMount[] = [
+      { hostPath: "/refs/tree", mountPath: "/ref", mode: "ro" },
+      { hostPath: "/proj/foo", mountPath: "/work/foo", mode: "rw" },
+    ];
+    const fs = composeFilesystemView(BASE, mounts, "darwin");
+    expect(new Set(fs.allowWrite)).toEqual(new Set(["/state/sessions/arm", "/proj/foo"]));
+  });
+
+  test("the base binds are always present even if the spec declares none", () => {
+    const fs = composeFilesystemView(BASE, [], "linux");
+    expect(fs.allowRead).toContain("/state/sessions/arm");
+    expect(fs.allowRead).toContain("/home/op/.claude");
+    expect(fs.allowWrite).toContain("/state/sessions/arm");
+  });
+
+  test("dedupes a mount equal to the workspace", () => {
+    const mounts: AgentMount[] = [
+      { hostPath: "/state/sessions/arm", mountPath: "/work", mode: "rw" },
+    ];
+    const fs = composeFilesystemView(BASE, mounts, "darwin");
+    expect(fs.allowWrite.filter((p) => p === "/state/sessions/arm")).toHaveLength(1);
+  });
+});
+
+describe("sharedMounts — the named cross-session relaxation", () => {
+  test("surfaces only mounts carrying a non-empty `shared` tag", () => {
+    const mounts: AgentMount[] = [
+      { hostPath: "/a", mountPath: "/a", mode: "ro" },
+      { hostPath: "/cache", mountPath: "/cache", mode: "ro", shared: "build-cache" },
+      { hostPath: "/b", mountPath: "/b", mode: "rw", shared: "" },
+    ];
+    const shared = sharedMounts(mounts);
+    expect(shared).toHaveLength(1);
+    expect(shared[0]!.shared).toBe("build-cache");
+  });
+
+  test("a shared mount is still bound like any other (honored in the fs view)", () => {
+    const mounts: AgentMount[] = [
+      { hostPath: "/cache", mountPath: "/cache", mode: "ro", shared: "build-cache" },
+    ];
+    const fs = composeFilesystemView(BASE, mounts, "darwin");
+    expect(fs.allowRead).toContain("/cache");
+  });
+
+  test("empty input → no shared mounts", () => {
+    expect(sharedMounts(undefined)).toEqual([]);
+  });
+});

--- a/src/sandbox/mounts.ts
+++ b/src/sandbox/mounts.ts
@@ -1,0 +1,102 @@
+/**
+ * Filesystem-view composition: scoped reads + write confinement (design §3.1
+ * item 2, §4.5).
+ *
+ * The contract:
+ *
+ *   - WRITES are confined to the private per-session workspace plus any `rw`
+ *     mount the spec declares. The sandbox-runtime's write model is allow-only:
+ *     `allowWrite: [...binds]`, empty = no writes.
+ *
+ *   - READS are scoped to declared binds — a DELIBERATE divergence from
+ *     Anthropic's broad-read default (design §4.5). The runtime's read model is
+ *     deny-then-allow: by default everything is readable. To confine reads we
+ *     DENY the home tree (`/Users` on macOS, `/home` on Linux) and then RE-ALLOW
+ *     exactly the binds (workspace + runtime/config + declared mounts). System
+ *     paths (`/usr`, `/lib`, …) stay readable so `claude` + its toolchain run.
+ *     `allowRead` overrides `denyRead` in the runtime, so the re-allow wins.
+ *
+ * Platform nuance (verified against the runtime README "Path Syntax"):
+ *   - macOS: paths support git-style globs.
+ *   - Linux: literal paths only — no glob matching.
+ * We never synthesize globs; we bind the literal host paths the caller passes,
+ * which is correct on both platforms. The `platform` arg only selects the
+ * home-tree deny root.
+ */
+
+import type { AgentMount, BaseBinds, SandboxPlatform } from "./types.ts";
+
+/** The home-tree root denied for scoped reads, per platform. */
+export function homeTreeDenyRoot(platform: SandboxPlatform): string {
+  return platform === "darwin" ? "/Users" : "/home";
+}
+
+export interface FilesystemView {
+  /** Paths to deny reads under (the home tree) — scoped-read enforcement. */
+  denyRead: string[];
+  /** Paths to re-allow reads within the denied region (the binds). */
+  allowRead: string[];
+  /** Paths writes are confined to (workspace + rw mounts). */
+  allowWrite: string[];
+  /** Paths to deny writes within allowed regions. Empty in v1. */
+  denyWrite: string[];
+}
+
+/**
+ * Compose the filesystem view for an arm from the always-present base binds and
+ * the spec's additive mounts.
+ *
+ * Read surface  = workspace (rw) + runtime/config (ro) + every declared mount
+ *                 (ro and rw alike — you can read what you can write).
+ * Write surface = workspace (rw) + every `rw` mount.
+ *
+ * The home tree is denied and the read surface re-allowed within it, giving the
+ * scoped-read policy (§4.5). The base binds are always included regardless of
+ * the spec, so a spec cannot strip its own workspace or the runtime/config.
+ */
+export function composeFilesystemView(
+  base: BaseBinds,
+  mounts: readonly AgentMount[] | undefined,
+  platform: SandboxPlatform,
+): FilesystemView {
+  const declared = mounts ?? [];
+
+  // Every bind is readable; only workspace + rw mounts are writable.
+  const readPaths: string[] = [base.workspace, ...base.runtimeReadOnly];
+  const writePaths: string[] = [base.workspace];
+
+  for (const m of declared) {
+    readPaths.push(m.hostPath);
+    if (m.mode === "rw") writePaths.push(m.hostPath);
+  }
+
+  return {
+    denyRead: [homeTreeDenyRoot(platform)],
+    allowRead: dedupePreserveOrder(readPaths),
+    allowWrite: dedupePreserveOrder(writePaths),
+    denyWrite: [],
+  };
+}
+
+/**
+ * The cross-session `shared` mounts declared by a spec (design §4.5). v1 honors
+ * them by binding them like any other mount (composeFilesystemView already does);
+ * this helper surfaces them by name so a caller can log/audit the deliberate
+ * cross-session channel. The trust caveat (prefer shared-`ro` from the producer,
+ * never shared-`rw` across a trust boundary) is doc-level for v1.
+ */
+export function sharedMounts(mounts: readonly AgentMount[] | undefined): AgentMount[] {
+  return (mounts ?? []).filter((m) => typeof m.shared === "string" && m.shared.length > 0);
+}
+
+function dedupePreserveOrder(xs: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const x of xs) {
+    if (!seen.has(x)) {
+      seen.add(x);
+      out.push(x);
+    }
+  }
+  return out;
+}

--- a/src/sandbox/sandbox.test.ts
+++ b/src/sandbox/sandbox.test.ts
@@ -1,0 +1,113 @@
+import { describe, test, expect } from "bun:test";
+import { Sandbox, configForSpec, type SandboxEngine } from "./index.ts";
+import type { SandboxRuntimeConfig } from "@anthropic-ai/sandbox-runtime";
+import type { AgentSpec, BaseBinds } from "./types.ts";
+import type { EgressBaseInput } from "./egress.ts";
+
+const BASE_BINDS: BaseBinds = { workspace: "/state/sessions/arm", runtimeReadOnly: ["/cfg"] };
+const EGRESS_BASE: EgressBaseInput = { hubOrigin: "https://hub.example.com" };
+
+/** A fake engine that records what it was initialized with + what it wrapped. */
+function fakeEngine(): SandboxEngine & {
+  initializedWith: SandboxRuntimeConfig | null;
+  wrappedCommands: string[];
+  resets: number;
+} {
+  const rec = {
+    initializedWith: null as SandboxRuntimeConfig | null,
+    wrappedCommands: [] as string[],
+    resets: 0,
+    isSupportedPlatform: () => true,
+    isSandboxingEnabled: () => true,
+    async initialize(cfg: SandboxRuntimeConfig) {
+      rec.initializedWith = cfg;
+    },
+    async wrapWithSandboxArgv(command: string) {
+      rec.wrappedCommands.push(command);
+      return {
+        argv: ["/bin/bash", "-c", `SANDBOXED ${command}`],
+        env: { SANDBOX_RUNTIME: "1", HTTP_PROXY: "http://localhost:9999" },
+      };
+    },
+    async reset() {
+      rec.resets += 1;
+    },
+  };
+  return rec;
+}
+
+const SPEC: AgentSpec = {
+  name: "arm",
+  channels: ["ch"],
+  egress: ["registry.npmjs.org"],
+  mounts: [{ hostPath: "/proj", mountPath: "/work", mode: "rw" }],
+};
+
+describe("Sandbox adapter", () => {
+  test("initializes the engine with the spec-derived config, then wraps the command", async () => {
+    const engine = fakeEngine();
+    const sandbox = new Sandbox(engine);
+    const wrapped = await sandbox.wrap({
+      spec: SPEC,
+      baseBinds: BASE_BINDS,
+      egressBase: EGRESS_BASE,
+      command: "claude --strict-mcp-config",
+      platform: "darwin",
+    });
+
+    // It initialized with the right config (egress floor + scoped reads).
+    expect(engine.initializedWith).not.toBeNull();
+    expect(engine.initializedWith!.network.allowedDomains).toContain("api.anthropic.com");
+    expect(engine.initializedWith!.network.allowedDomains).toContain("registry.npmjs.org");
+    expect(engine.initializedWith!.filesystem.denyRead).toContain("/Users");
+    expect(engine.initializedWith!.filesystem.allowWrite).toContain("/proj");
+
+    // It wrapped exactly the command we passed.
+    expect(engine.wrappedCommands).toEqual(["claude --strict-mcp-config"]);
+
+    // It returns argv + env + the config used.
+    expect(wrapped.argv[0]).toBe("/bin/bash");
+    expect(wrapped.argv[2]).toContain("SANDBOXED claude");
+    expect(wrapped.env.SANDBOX_RUNTIME).toBe("1");
+    expect(wrapped.config).toBe(engine.initializedWith!);
+  });
+
+  test("reset() tears the engine down", async () => {
+    const engine = fakeEngine();
+    const sandbox = new Sandbox(engine);
+    await sandbox.reset();
+    expect(engine.resets).toBe(1);
+  });
+
+  test("isSupportedPlatform delegates to the engine", () => {
+    const engine = fakeEngine();
+    expect(new Sandbox(engine).isSupportedPlatform()).toBe(true);
+  });
+
+  test("SECURITY: a spec omitting egress still gets the base floor in the engine config", async () => {
+    const engine = fakeEngine();
+    const sandbox = new Sandbox(engine);
+    await sandbox.wrap({
+      spec: { name: "x", channels: ["c"] }, // no egress declared
+      baseBinds: BASE_BINDS,
+      egressBase: EGRESS_BASE,
+      command: "claude",
+      platform: "darwin",
+    });
+    expect(engine.initializedWith!.network.allowedDomains).toContain("api.anthropic.com");
+    expect(engine.initializedWith!.network.allowedDomains).toContain("hub.example.com");
+  });
+});
+
+describe("configForSpec helper", () => {
+  test("builds the config without touching an engine", () => {
+    const cfg = configForSpec({
+      spec: SPEC,
+      baseBinds: BASE_BINDS,
+      egressBase: EGRESS_BASE,
+      platform: "darwin",
+    });
+    expect(cfg.network.allowedDomains).toContain("registry.npmjs.org");
+    expect(cfg.filesystem.allowWrite).toContain("/proj");
+  });
+});

--- a/src/sandbox/types.ts
+++ b/src/sandbox/types.ts
@@ -1,0 +1,127 @@
+/**
+ * Agent-spec + Sandbox contract types.
+ *
+ * The **agent spec** (design §4.1) is the single declaration of everything an
+ * arm may reach: its MCP surface (channels + vault), its network egress, and its
+ * filesystem view. Scope and isolation are both read off this one object, so
+ * there is exactly one place that says "what is this arm allowed to touch."
+ *
+ *   design/2026-06-14-sandboxed-agent-sessions.md §4.1, §4.4, §4.5
+ *
+ * The Sandbox **contract** (design §3.1) is held constant; the **mechanism**
+ * varies by platform (Seatbelt on macOS, bubblewrap on Linux) behind it. v1
+ * ships one backend (Anthropic's sandbox-runtime); the escalation rung (§3.4 —
+ * gVisor / full VM) is a second backend added later without touching callers.
+ */
+
+/** Read/write mode for a declared mount. */
+export type MountMode = "ro" | "rw";
+
+/**
+ * A filesystem bind beyond the implicit workspace + runtime/config. Each entry
+ * binds a host path to a mount path at `ro` or `rw` (design §4.5).
+ *
+ * On macOS the sandbox profile is glob-capable, so `hostPath` may contain glob
+ * patterns; on Linux it must be a literal path (the runtime does not glob there).
+ * For v1 we bind the host path directly (`mountPath` is recorded for the future
+ * bubblewrap bind-remap and for the spec→mandate seam, §4.6 — it does not change
+ * the v1 Seatbelt path, which has no path-remapping layer).
+ */
+export interface AgentMount {
+  /** Path on the host to expose into the session. */
+  hostPath: string;
+  /** Path the session sees it at. Recorded for the future bind-remap; see note above. */
+  mountPath: string;
+  /** Read-only or read-write. */
+  mode: MountMode;
+  /**
+   * Opt-in cross-session share by name (design §4.5). A deliberate hole in
+   * session-to-session isolation — honored here, but the trust caveat (prefer
+   * shared-`ro` from the producer, never shared-`rw` across a trust boundary) is
+   * doc-level for v1. Plumbed through so a future use is a considered decision.
+   */
+  shared?: string;
+}
+
+/** The vault binding for an arm: which vault, what access, optionally tag-scoped. */
+export interface AgentVaultSpec {
+  /** Vault instance name (e.g. "default"). */
+  name: string;
+  /** Access verb minted into the vault token. */
+  access: "read" | "write" | "admin";
+  /**
+   * Optional tag scope — narrows the minted vault token to these tags via the
+   * `permissions.scoped_tags` claim (e.g. `["#channel-message"]`). Omitted = the
+   * verb's full scope across the vault.
+   */
+  tags?: string[];
+}
+
+/** An additional MCP server to wire in, by URL (design §4.1 `otherMcps`). */
+export interface OtherMcpSpec {
+  /** Entry key in the generated `mcpServers` object. */
+  name: string;
+  /** Streamable-HTTP MCP URL. */
+  url: string;
+  /**
+   * Scope to mint a token for, if this MCP is hub-gated. Omitted = no token
+   * (an unauthenticated / externally-authenticated MCP).
+   */
+  scope?: string;
+  /** Audience to mint the token under. Defaults to inferred from scope by the hub. */
+  audience?: string;
+}
+
+/**
+ * An agent spec — the complete least-privilege envelope for one launched arm
+ * (design §4.1). `egress` and `mounts` are additive to a non-removable base; the
+ * spec only ever *adds*.
+ */
+export interface AgentSpec {
+  /** Human-readable arm name; used as the tmux session + workspace slug. */
+  name: string;
+  /** Channels to attach (one MCP entry each). */
+  channels: string[];
+  /** Optional vault binding. */
+  vault?: AgentVaultSpec;
+  /** Additional MCP servers, by URL. */
+  otherMcps?: OtherMcpSpec[];
+  /**
+   * Network egress — ADDITIVE to a minimal non-removable base of
+   * `{ the Anthropic API host(s), the hub/vault origin }` (design §4.4). A
+   * weaver-style arm declares `[]` (base only); a code-building arm opens
+   * exactly the package/source hosts it needs.
+   */
+  egress?: string[];
+  /**
+   * Filesystem mounts — ADDITIVE to the default private per-session workspace
+   * (rw) + the implicit runtime/claude-config (ro). Reads are scoped to declared
+   * binds, NOT broad (design §4.5).
+   */
+  mounts?: AgentMount[];
+  /**
+   * Which stored Claude credential to inject (design §6). Default = "operator".
+   * This stream injects the credential as a passed-in param/placeholder; Stream 3
+   * builds the real per-channel secret store.
+   */
+  credentialRef?: string;
+}
+
+/**
+ * The default workspace + runtime binds the contract always grants, independent
+ * of any spec. The caller supplies the concrete paths (resolved against the
+ * session's state dir + the runtime/config location) — keeping this module
+ * free of filesystem-layout assumptions and test-sandboxable.
+ */
+export interface BaseBinds {
+  /** Private per-session workspace (rw). */
+  workspace: string;
+  /**
+   * Read-only runtime/claude-config paths the session needs to run `claude`
+   * (e.g. the claude config dir). Always bound `ro`.
+   */
+  runtimeReadOnly: string[];
+}
+
+/** Platform the Sandbox config is being built for. */
+export type SandboxPlatform = "darwin" | "linux";

--- a/src/sandbox/types.ts
+++ b/src/sandbox/types.ts
@@ -77,11 +77,35 @@ export interface OtherMcpSpec {
  * (design §4.1). `egress` and `mounts` are additive to a non-removable base; the
  * spec only ever *adds*.
  */
+/**
+ * A channel binding for an arm. A bare string is shorthand for `{ name, access:
+ * "write" }` (back-compat — the common read+write resident session); the object
+ * form scopes a channel read-only so an arm that only *watches* a channel mints
+ * `channel:read` and never `channel:write` (the "scope an arm to channel X
+ * read-only" use case).
+ */
+export interface AgentChannelSpec {
+  /** Channel name (the `/mcp/<channel>` segment). */
+  name: string;
+  /**
+   * Channel access. `"write"` (default) mints `channel:read channel:write`;
+   * `"read"` mints `channel:read` only — the arm can be woken + read the channel
+   * but cannot reply.
+   */
+  access?: "read" | "write";
+}
+
+/** A channel entry: a bare name (= write access) or the scoped object form. */
+export type AgentChannel = string | AgentChannelSpec;
+
 export interface AgentSpec {
   /** Human-readable arm name; used as the tmux session + workspace slug. */
   name: string;
-  /** Channels to attach (one MCP entry each). */
-  channels: string[];
+  /**
+   * Channels to attach (one MCP entry each). Each entry is a bare name (read+write,
+   * back-compat) or `{ name, access: "read" }` to scope a channel read-only.
+   */
+  channels: AgentChannel[];
   /** Optional vault binding. */
   vault?: AgentVaultSpec;
   /** Additional MCP servers, by URL. */
@@ -125,3 +149,13 @@ export interface BaseBinds {
 
 /** Platform the Sandbox config is being built for. */
 export type SandboxPlatform = "darwin" | "linux";
+
+/**
+ * Normalize a channel entry (bare name or object) to `{ name, access }`. A bare
+ * string defaults to `write` (back-compat); the object form defaults to `write`
+ * when `access` is omitted.
+ */
+export function normalizeChannel(ch: AgentChannel): { name: string; access: "read" | "write" } {
+  if (typeof ch === "string") return { name: ch, access: "write" };
+  return { name: ch.name, access: ch.access ?? "write" };
+}

--- a/src/spawn-agent.test.ts
+++ b/src/spawn-agent.test.ts
@@ -6,6 +6,8 @@ import {
   spawnAgent,
   buildAgentChildEnv,
   buildAgentClaudeArgs,
+  buildLaunchScript,
+  realTmuxLauncher,
   sessionName,
   shellJoin,
   type SpawnAgentDeps,
@@ -397,5 +399,88 @@ describe("spawnAgent — full wiring with stubs (no real token)", () => {
       spawnAgent({ name: "s-c", channels: ["c"] }, baseDeps({ sandboxEngine: slowEngine(), tmux: recordingTmux() })),
     ]);
     expect(maxActive).toBe(1);
+  });
+});
+
+// ---- buildLaunchScript (the tmux-buffer fix) -------------------------------
+
+describe("buildLaunchScript — script body per argv shape, token-free", () => {
+  test("macOS `/bin/bash -c <cmd>` shape: the body IS the command", () => {
+    const script = buildLaunchScript(["/bin/bash", "-c", "sandbox-exec -p '...' claude --foo"]);
+    expect(script.startsWith("#!/bin/bash\nset -euo pipefail\n")).toBe(true);
+    expect(script).toContain("sandbox-exec -p '...' claude --foo");
+    // No `exec <bash> -c` re-wrapping for this canonical shape.
+    expect(script).not.toContain("exec /bin/bash");
+  });
+
+  test("general argv (Linux bubblewrap shape): exec's the quoted argv", () => {
+    const script = buildLaunchScript(["bwrap", "--ro-bind", "/usr", "/usr", "claude", "--mcp-config", "/ws/.mcp.json"]);
+    expect(script.startsWith("#!/bin/bash\nset -euo pipefail\n")).toBe(true);
+    expect(script).toContain("exec bwrap --ro-bind /usr /usr claude --mcp-config /ws/.mcp.json");
+  });
+});
+
+describe("realTmuxLauncher — launch-script indirection (tmux can't take the ~84KB profile inline)", () => {
+  /** A recording spawnFn matching the `Bun.spawn` shape the launcher awaits. */
+  function recordingSpawn(): {
+    fn: typeof Bun.spawn;
+    calls: string[][];
+  } {
+    const calls: string[][] = [];
+    const fn = ((argv: string[]) => {
+      calls.push(argv);
+      return {
+        exited: Promise.resolve(0),
+        stderr: new Response("").body,
+      };
+    }) as unknown as typeof Bun.spawn;
+    return { fn, calls };
+  }
+
+  test("a >100KB wrapped command is NOT passed inline — tmux gets a short script-path argv; the script is written 0600 with the command; token rides env via -e", async () => {
+    const workspace = mkdtempSync(join(tmpdir(), "launch-script-"));
+    try {
+      // A wrapped argv whose command embeds a giant (>100KB) profile inline — the
+      // exact shape that overran tmux's buffer in the integration smoke.
+      const bigProfile = "X".repeat(100_000);
+      const bigCommand = `sandbox-exec -p '${bigProfile}' claude --strict-mcp-config --mcp-config ${join(workspace, ".mcp.json")}`;
+      const wrappedArgv = ["/bin/bash", "-c", bigCommand];
+      expect(bigCommand.length).toBeGreaterThan(100_000);
+
+      const { fn, calls } = recordingSpawn();
+      const launcher = realTmuxLauncher(fn);
+      await launcher.newSession({
+        name: "big-agent",
+        argv: wrappedArgv,
+        env: { CLAUDE_CODE_OAUTH_TOKEN: "OAUTH-SECRET", SANDBOX_RUNTIME: "1" },
+        cwd: workspace,
+      });
+
+      // (a) the argv handed to tmux is SHORT — a script path, not the 100KB inline.
+      expect(calls).toHaveLength(1);
+      const tmuxArgv = calls[0]!;
+      const scriptPath = join(workspace, ".launch.sh");
+      expect(tmuxArgv[tmuxArgv.length - 2]).toBe("/bin/bash");
+      expect(tmuxArgv[tmuxArgv.length - 1]).toBe(scriptPath);
+      // The 100KB profile is NOWHERE on the tmux command line.
+      expect(tmuxArgv.some((a) => a.length > 50_000)).toBe(false);
+      expect(tmuxArgv.join(" ")).not.toContain(bigProfile);
+
+      // (b) the launch script is written, mode 0600, and contains the wrapped command.
+      expect(statSync(scriptPath).mode & 0o777).toBe(0o600);
+      const body = readFileSync(scriptPath, "utf8");
+      expect(body.startsWith("#!/bin/bash\nset -euo pipefail\n")).toBe(true);
+      expect(body).toContain(bigCommand);
+
+      // (c) env still passed via `-e KEY=VAL`.
+      expect(tmuxArgv).toContain("-e");
+      expect(tmuxArgv).toContain("CLAUDE_CODE_OAUTH_TOKEN=OAUTH-SECRET");
+      expect(tmuxArgv).toContain("SANDBOX_RUNTIME=1");
+
+      // SECURITY: the secret rides the ENV, never the script body.
+      expect(body).not.toContain("OAUTH-SECRET");
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
+    }
   });
 });

--- a/src/spawn-agent.test.ts
+++ b/src/spawn-agent.test.ts
@@ -281,4 +281,121 @@ describe("spawnAgent — full wiring with stubs (no real token)", () => {
     // The attenuation failure happened BEFORE any tmux launch.
     expect(tmux.launched).toHaveLength(0);
   });
+
+  test("SECURITY: an adversarial spec.name is rejected BEFORE any fs/tmux/mint side effect", async () => {
+    sessionsDir = mkdtempSync(join(tmpdir(), "spawn-agent-name-"));
+    for (const bad of ["..", "a/b", "a b", "../escape", ".", "a..b", "x;rm", ""]) {
+      const tmux = recordingTmux();
+      let minted = false;
+      const fetchFn = (async () => {
+        minted = true;
+        return new Response("{}", { status: 200 });
+      }) as unknown as typeof fetch;
+      await expect(
+        spawnAgent({ name: bad, channels: ["c"] }, baseDeps({ tmux, fetchFn })),
+      ).rejects.toThrow(/slug/);
+      // No side effects: no tmux launch, no mint attempt.
+      expect(tmux.launched).toHaveLength(0);
+      expect(minted).toBe(false);
+    }
+  });
+
+  test("a valid slug name is accepted (dashes + underscores ok)", async () => {
+    sessionsDir = mkdtempSync(join(tmpdir(), "spawn-agent-okname-"));
+    const res = await spawnAgent({ name: "aaron_dev-2", channels: ["c"] }, baseDeps());
+    expect(res.alreadyRunning).toBe(false);
+    expect(res.session).toBe("aaron_dev-2-agent");
+  });
+
+  test("read-only channel mints channel:read ONLY (not read+write)", async () => {
+    sessionsDir = mkdtempSync(join(tmpdir(), "spawn-agent-roch-"));
+    const scopes: string[] = [];
+    const fetchFn = (async (_u: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { scope: string };
+      scopes.push(body.scope);
+      return new Response(
+        JSON.stringify({ jti: "j", token: `T-${scopes.length}`, expires_at: "", scope: body.scope }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+
+    const spec: AgentSpec = {
+      name: "watcher",
+      channels: [
+        { name: "readonly-ch", access: "read" },
+        { name: "rw-ch", access: "write" },
+        "bare-ch", // bare string = write (back-compat)
+      ],
+    };
+    await spawnAgent(spec, baseDeps({ fetchFn }));
+    expect(scopes).toContain("channel:read"); // the read-only channel
+    expect(scopes.filter((s) => s === "channel:read")).toHaveLength(1);
+    expect(scopes.filter((s) => s === "channel:read channel:write")).toHaveLength(2); // rw + bare
+  });
+
+  test("CONCURRENCY: two concurrent spawnAgent calls produce correct, independent MCP configs + wrapping", async () => {
+    sessionsDir = mkdtempSync(join(tmpdir(), "spawn-agent-conc-"));
+    // Independent engines/tmux per call so we can assert no cross-clobber. Each
+    // mint hub returns a token namespaced to the spec so configs are tellable apart.
+    function depsForArm(arm: string) {
+      let n = 0;
+      const fetchFn = (async (_u: string | URL | Request, init?: RequestInit) => {
+        const body = JSON.parse(String(init?.body ?? "{}")) as { scope: string };
+        n += 1;
+        return new Response(
+          JSON.stringify({ jti: `${arm}-${n}`, token: `${arm}-TOK-${n}`, expires_at: "", scope: body.scope }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }) as unknown as typeof fetch;
+      return baseDeps({ tmux: recordingTmux(), sandboxEngine: fakeEngine(), fetchFn });
+    }
+
+    const [a, b] = await Promise.all([
+      spawnAgent({ name: "arm-a", channels: ["ca"] }, depsForArm("A")),
+      spawnAgent({ name: "arm-b", channels: ["cb"] }, depsForArm("B")),
+    ]);
+
+    // Each got its OWN channel entry + token — no clobber across the race.
+    const pa = JSON.parse(a.mcpConfigJson) as { mcpServers: Record<string, { url: string; headers?: { Authorization: string } }> };
+    const pb = JSON.parse(b.mcpConfigJson) as { mcpServers: Record<string, { url: string; headers?: { Authorization: string } }> };
+    expect(pa.mcpServers[channelEntryKey("ca")]!.url).toBe("http://127.0.0.1:1941/mcp/ca");
+    expect(pb.mcpServers[channelEntryKey("cb")]!.url).toBe("http://127.0.0.1:1941/mcp/cb");
+    expect(pa.mcpServers[channelEntryKey("ca")]!.headers!.Authorization).toBe("Bearer A-TOK-1");
+    expect(pb.mcpServers[channelEntryKey("cb")]!.headers!.Authorization).toBe("Bearer B-TOK-1");
+    // Independent sandbox configs (each carries its own workspace allowWrite).
+    expect(a.wrapped.config.filesystem.allowWrite).toContain(a.workspace);
+    expect(b.wrapped.config.filesystem.allowWrite).toContain(b.workspace);
+    expect(a.workspace).not.toBe(b.workspace);
+  });
+
+  test("CONCURRENCY: the init→wrap window is serialized (never two engines in it at once)", async () => {
+    sessionsDir = mkdtempSync(join(tmpdir(), "spawn-agent-serial-"));
+    // An engine whose initialize overlaps wrap by an await; if the lock didn't
+    // hold, two would be "in the window" simultaneously and maxActive would be >1.
+    let active = 0;
+    let maxActive = 0;
+    function slowEngine(): SandboxEngine {
+      return {
+        isSupportedPlatform: () => true,
+        isSandboxingEnabled: () => true,
+        async initialize() {
+          active += 1;
+          maxActive = Math.max(maxActive, active);
+          await Bun.sleep(15);
+        },
+        async wrapWithSandboxArgv(command: string) {
+          await Bun.sleep(15);
+          active -= 1;
+          return { argv: ["/bin/bash", "-c", command], env: {} };
+        },
+        async reset() {},
+      };
+    }
+    await Promise.all([
+      spawnAgent({ name: "s-a", channels: ["c"] }, baseDeps({ sandboxEngine: slowEngine(), tmux: recordingTmux() })),
+      spawnAgent({ name: "s-b", channels: ["c"] }, baseDeps({ sandboxEngine: slowEngine(), tmux: recordingTmux() })),
+      spawnAgent({ name: "s-c", channels: ["c"] }, baseDeps({ sandboxEngine: slowEngine(), tmux: recordingTmux() })),
+    ]);
+    expect(maxActive).toBe(1);
+  });
 });

--- a/src/spawn-agent.test.ts
+++ b/src/spawn-agent.test.ts
@@ -1,0 +1,284 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  spawnAgent,
+  buildAgentChildEnv,
+  buildAgentClaudeArgs,
+  sessionName,
+  shellJoin,
+  type SpawnAgentDeps,
+  type TmuxLauncher,
+} from "./spawn-agent.ts";
+import type { SandboxEngine } from "./sandbox/index.ts";
+import type { SandboxRuntimeConfig } from "@anthropic-ai/sandbox-runtime";
+import type { AgentSpec } from "./sandbox/types.ts";
+import { channelEntryKey, vaultEntryKey } from "./agent-mcp-config.ts";
+
+let sessionsDir: string;
+afterEach(() => {
+  if (sessionsDir) rmSync(sessionsDir, { recursive: true, force: true });
+});
+
+// ---- fakes -----------------------------------------------------------------
+
+/** A recording tmux launcher. */
+function recordingTmux(existing = new Set<string>()): TmuxLauncher & {
+  launched: Array<{ name: string; argv: string[]; env: Record<string, string | undefined>; cwd: string }>;
+} {
+  const launched: Array<{
+    name: string;
+    argv: string[];
+    env: Record<string, string | undefined>;
+    cwd: string;
+  }> = [];
+  return {
+    launched,
+    async hasSession(name) {
+      return existing.has(name);
+    },
+    async newSession(opts) {
+      launched.push(opts);
+    },
+  };
+}
+
+/** A fake sandbox engine — records config, returns a deterministic wrap. */
+function fakeEngine(): SandboxEngine & { initializedWith: SandboxRuntimeConfig | null } {
+  const rec = {
+    initializedWith: null as SandboxRuntimeConfig | null,
+    isSupportedPlatform: () => true,
+    isSandboxingEnabled: () => true,
+    async initialize(cfg: SandboxRuntimeConfig) {
+      rec.initializedWith = cfg;
+    },
+    async wrapWithSandboxArgv(command: string) {
+      // Emulate the real shape: a bash -c wrapper carrying the command + proxy env.
+      return {
+        argv: ["/bin/bash", "-c", `SBX ${command}`],
+        env: { SANDBOX_RUNTIME: "1", HTTPS_PROXY: "http://localhost:5555" },
+      };
+    },
+    async reset() {},
+  };
+  return rec;
+}
+
+/** A fake mint hub: returns a distinct token per scope so we can tell them apart. */
+function fakeMintFetch(): typeof fetch {
+  let n = 0;
+  return (async (_url: string | URL | Request, init?: RequestInit) => {
+    const body = JSON.parse(String(init?.body ?? "{}")) as { scope: string };
+    n += 1;
+    const token = `TOK-${n}-${body.scope.replace(/[^a-z]/gi, "").slice(0, 6)}`;
+    return new Response(
+      JSON.stringify({ jti: `j${n}`, token, expires_at: "2026-09-01T00:00:00Z", scope: body.scope }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  }) as unknown as typeof fetch;
+}
+
+function baseDeps(over: Partial<SpawnAgentDeps> = {}): SpawnAgentDeps {
+  return {
+    hubOrigin: "https://hub.example.com",
+    managerBearer: "MANAGER",
+    channelUrl: "http://127.0.0.1:1941",
+    vaultUrl: "http://127.0.0.1:1940",
+    sessionsDir,
+    runtimeReadOnly: ["/cfg/.claude"],
+    claudeOauthToken: "OAUTH-CRED-PLACEHOLDER",
+    sandboxEngine: fakeEngine(),
+    tmux: recordingTmux(),
+    fetchFn: fakeMintFetch(),
+    parentEnv: {
+      PATH: "/usr/bin",
+      HOME: "/home/op",
+      ANTHROPIC_API_KEY: "sk-ant-SHOULD-NOT-LEAK",
+      CLAUDE_API_KEY: "also-should-not-leak",
+      SECRET_THING: "do-not-pass",
+    },
+    claudeBin: "claude",
+    ...over,
+  };
+}
+
+// ---- pure-helper tests -----------------------------------------------------
+
+describe("buildAgentChildEnv — scrub, inject OAuth, NEVER ANTHROPIC_API_KEY", () => {
+  test("injects CLAUDE_CODE_OAUTH_TOKEN as the session auth", () => {
+    const env = buildAgentChildEnv({ PATH: "/usr/bin", HOME: "/h" }, "THE-OAUTH-TOKEN");
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe("THE-OAUTH-TOKEN");
+  });
+
+  test("SECURITY: ANTHROPIC_API_KEY is NOT passed through (would route to API billing)", () => {
+    const env = buildAgentChildEnv(
+      { PATH: "/usr/bin", HOME: "/h", ANTHROPIC_API_KEY: "sk-ant-x", CLAUDE_API_KEY: "y" },
+      "tok",
+    );
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(env.CLAUDE_API_KEY).toBeUndefined();
+  });
+
+  test("scrubs unrelated parent env (only the allowlist + locale pass)", () => {
+    const env = buildAgentChildEnv(
+      { PATH: "/usr/bin", HOME: "/h", SECRET_THING: "nope", LC_ALL: "en_US.UTF-8" },
+      "tok",
+    );
+    expect(env.SECRET_THING).toBeUndefined();
+    expect(env.PATH).toBe("/usr/bin");
+    expect(env.HOME).toBe("/h");
+    expect(env.LC_ALL).toBe("en_US.UTF-8");
+  });
+
+  test("provides a default PATH if the parent had none", () => {
+    const env = buildAgentChildEnv({}, "tok");
+    expect(env.PATH).toBe("/usr/local/bin:/usr/bin:/bin");
+  });
+});
+
+describe("buildAgentClaudeArgs", () => {
+  test("interactive claude (no -p) with strict MCP config + dev-channels for the first channel", () => {
+    const argv = buildAgentClaudeArgs({
+      mcpConfigPath: "/ws/.mcp.json",
+      firstChannelEntryKey: "channel-aaron-dev",
+    });
+    expect(argv).toContain("--strict-mcp-config");
+    expect(argv).toContain("--mcp-config");
+    expect(argv).toContain("/ws/.mcp.json");
+    expect(argv).toContain("--dangerously-load-development-channels=server:channel-aaron-dev");
+    // NOT headless: no `-p`.
+    expect(argv).not.toContain("-p");
+  });
+});
+
+describe("shellJoin", () => {
+  test("leaves safe args bare, quotes args with spaces", () => {
+    expect(shellJoin(["claude", "--mcp-config", "/a/b.json"])).toBe("claude --mcp-config /a/b.json");
+    expect(shellJoin(["echo", "a b"])).toBe("echo 'a b'");
+  });
+});
+
+// ---- full wiring tests -----------------------------------------------------
+
+describe("spawnAgent — full wiring with stubs (no real token)", () => {
+  test("creates the tmux session, writes a strict MCP config, injects OAuth, omits ANTHROPIC_API_KEY", async () => {
+    sessionsDir = mkdtempSync(join(tmpdir(), "spawn-agent-"));
+    const tmux = recordingTmux();
+    const engine = fakeEngine();
+    const spec: AgentSpec = {
+      name: "aaron-dev",
+      channels: ["aaron-dev"],
+      vault: { name: "default", access: "read", tags: ["#channel-message"] },
+    };
+    const res = await spawnAgent(spec, baseDeps({ tmux, sandboxEngine: engine }));
+
+    // 1. tmux session created with the spec's name.
+    expect(res.alreadyRunning).toBe(false);
+    expect(res.session).toBe(sessionName("aaron-dev"));
+    expect(tmux.launched).toHaveLength(1);
+    const launch = tmux.launched[0]!;
+    expect(launch.name).toBe("aaron-dev-agent");
+
+    // 2. The launched argv is the sandbox wrapper carrying the claude command.
+    expect(launch.argv[0]).toBe("/bin/bash");
+    expect(launch.argv[2]).toContain("SBX claude");
+    expect(launch.argv[2]).toContain("--strict-mcp-config");
+
+    // 3. The injected env has CLAUDE_CODE_OAUTH_TOKEN and NO ANTHROPIC_API_KEY.
+    expect(launch.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("OAUTH-CRED-PLACEHOLDER");
+    expect(launch.env.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(launch.env.CLAUDE_API_KEY).toBeUndefined();
+    // ...and the sandbox proxy env layered on top.
+    expect(launch.env.SANDBOX_RUNTIME).toBe("1");
+    expect(launch.env.HTTPS_PROXY).toBe("http://localhost:5555");
+
+    // 4. The MCP config has the right entries with DISTINCT tokens (one per aud).
+    const parsed = JSON.parse(res.mcpConfigJson) as {
+      mcpServers: Record<string, { url: string; headers?: { Authorization: string } }>;
+    };
+    const chKey = channelEntryKey("aaron-dev");
+    const vKey = vaultEntryKey("default");
+    expect(parsed.mcpServers[chKey]!.url).toBe("http://127.0.0.1:1941/mcp/aaron-dev");
+    expect(parsed.mcpServers[vKey]!.url).toBe("http://127.0.0.1:1940/vault/default/mcp");
+    const chAuth = parsed.mcpServers[chKey]!.headers!.Authorization;
+    const vAuth = parsed.mcpServers[vKey]!.headers!.Authorization;
+    expect(chAuth).toMatch(/^Bearer TOK-/);
+    expect(vAuth).toMatch(/^Bearer TOK-/);
+    expect(chAuth).not.toBe(vAuth); // distinct tokens, distinct auds
+
+    // 5. The on-disk config is 0600 (it inlines tokens).
+    const mcpPath = join(res.workspace, ".mcp.json");
+    expect(statSync(mcpPath).mode & 0o777).toBe(0o600);
+    expect(readFileSync(mcpPath, "utf8")).toBe(res.mcpConfigJson);
+
+    // 6. The sandbox config carried the egress floor + scoped reads.
+    expect(engine.initializedWith!.network.allowedDomains).toContain("api.anthropic.com");
+    expect(engine.initializedWith!.network.allowedDomains).toContain("hub.example.com");
+    expect(engine.initializedWith!.filesystem.allowWrite).toContain(res.workspace);
+  });
+
+  test("mints ONE token per channel for a multi-channel spec", async () => {
+    sessionsDir = mkdtempSync(join(tmpdir(), "spawn-agent-multi-"));
+    const spec: AgentSpec = { name: "multi", channels: ["a", "b"] };
+    const res = await spawnAgent(spec, baseDeps());
+    expect(Object.keys(res.tokens)).toContain("a");
+    expect(Object.keys(res.tokens)).toContain("b");
+    expect(res.tokens.a!.token).not.toBe(res.tokens.b!.token);
+    const parsed = JSON.parse(res.mcpConfigJson) as { mcpServers: Record<string, unknown> };
+    expect(parsed.mcpServers[channelEntryKey("a")]).toBeDefined();
+    expect(parsed.mcpServers[channelEntryKey("b")]).toBeDefined();
+  });
+
+  test("tag-scoped vault: the scoped_tags permission rides the vault mint request", async () => {
+    sessionsDir = mkdtempSync(join(tmpdir(), "spawn-agent-vault-"));
+    const calls: Array<Record<string, unknown>> = [];
+    const fetchFn = (async (_u: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+      calls.push(body);
+      return new Response(
+        JSON.stringify({ jti: "j", token: `T-${calls.length}`, expires_at: "", scope: body.scope }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+
+    const spec: AgentSpec = {
+      name: "weaver",
+      channels: ["c"],
+      vault: { name: "default", access: "read", tags: ["#channel-message"] },
+    };
+    await spawnAgent(spec, baseDeps({ fetchFn }));
+    const vaultCall = calls.find((c) => String(c.scope).startsWith("vault:"));
+    expect(vaultCall).toBeDefined();
+    expect(vaultCall!.scope).toBe("vault:default:read");
+    expect(vaultCall!.permissions).toEqual({ scoped_tags: ["#channel-message"] });
+  });
+
+  test("idempotent: an already-running session is a no-op", async () => {
+    sessionsDir = mkdtempSync(join(tmpdir(), "spawn-agent-idem-"));
+    const tmux = recordingTmux(new Set(["arm-agent"]));
+    const res = await spawnAgent({ name: "arm", channels: ["c"] }, baseDeps({ tmux }));
+    expect(res.alreadyRunning).toBe(true);
+    expect(tmux.launched).toHaveLength(0);
+  });
+
+  test("a spec with no channels is rejected", async () => {
+    sessionsDir = mkdtempSync(join(tmpdir(), "spawn-agent-noch-"));
+    await expect(spawnAgent({ name: "x", channels: [] }, baseDeps())).rejects.toThrow(/no channels/);
+  });
+
+  test("SECURITY: an over-broad mint (hub 400) aborts the launch — no tmux session created", async () => {
+    sessionsDir = mkdtempSync(join(tmpdir(), "spawn-agent-deny-"));
+    const tmux = recordingTmux();
+    const fetchFn = (async () =>
+      new Response(
+        JSON.stringify({ error: "invalid_scope", error_description: "not grantable by this bearer" }),
+        { status: 400, headers: { "content-type": "application/json" } },
+      )) as unknown as typeof fetch;
+    await expect(
+      spawnAgent({ name: "x", channels: ["c"] }, baseDeps({ tmux, fetchFn })),
+    ).rejects.toThrow(/mint refused/);
+    // The attenuation failure happened BEFORE any tmux launch.
+    expect(tmux.launched).toHaveLength(0);
+  });
+});

--- a/src/spawn-agent.ts
+++ b/src/spawn-agent.ts
@@ -22,9 +22,10 @@
  * subscription path).
  */
 
-import { writeFileSync, mkdirSync, chmodSync } from "node:fs";
+import { writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import type { AgentSpec, BaseBinds } from "./sandbox/types.ts";
+import { normalizeChannel } from "./sandbox/types.ts";
 import { Sandbox, type SandboxEngine, type WrappedCommand } from "./sandbox/index.ts";
 import type { EgressBaseInput } from "./sandbox/egress.ts";
 import {
@@ -40,6 +41,39 @@ import {
   type MintTokenDeps,
   type MintResult,
 } from "./mint-token.ts";
+
+/**
+ * Slug guard for `spec.name`. The name is used UNESCAPED as a tmux session
+ * target (`-t`) and a path segment under `sessionsDir`, so it must be a strict
+ * slug — mirrors `scripts/launch-session.sh`'s existing check. Anything with
+ * `..`, `/`, or spaces would traverse the sessions dir or break tmux targeting.
+ * Phase 2 makes spawns API/MCP-triggered (the name becomes less-trusted input),
+ * so the guard is enforced now, before any fs/tmux side effect.
+ */
+const AGENT_NAME_SLUG = /^[a-z0-9_-]+$/i;
+
+/**
+ * Process-wide serialization for the sandbox-runtime singleton. `SandboxManager`
+ * is global (initialize → wrap → reset share one set of host proxies), so two
+ * concurrent `spawnAgent` calls would race the initialize→wrap window (a second
+ * `initialize` could clobber the first's config before its command is wrapped).
+ * Only that brief window needs the lock — the sandbox policy is baked into the
+ * argv at `wrapWithSandboxArgv`, after which the spawned process runs
+ * independently. This is a minimal FIFO async mutex: each acquirer chains onto
+ * the previous one's release.
+ */
+let spawnLock: Promise<void> = Promise.resolve();
+async function withSpawnLock<T>(fn: () => Promise<T>): Promise<T> {
+  const prior = spawnLock;
+  let release!: () => void;
+  spawnLock = new Promise<void>((r) => (release = r));
+  await prior;
+  try {
+    return await fn();
+  } finally {
+    release();
+  }
+}
 
 /** A tmux launcher seam — real impl spawns tmux; tests inject a recorder. */
 export interface TmuxLauncher {
@@ -194,13 +228,26 @@ export function buildAgentClaudeArgs(opts: {
  * Spawn a sandboxed agent session from a spec. Idempotent: an existing tmux
  * session is a no-op (returns `alreadyRunning: true`).
  *
- * Order: mint per-resource tokens → write MCP config → build claude argv →
- * sandbox-wrap → tmux launch with scrubbed env.
+ * Order: validate name → mint per-resource tokens → write MCP config → build
+ * claude argv → sandbox-wrap → tmux launch with scrubbed env.
+ *
+ * **Concurrency-safe.** The sandbox-runtime singleton's initialize→wrap window is
+ * serialized process-wide (see `withSpawnLock`), so concurrent `spawnAgent` calls
+ * don't clobber each other's sandbox config. Each produces an independent MCP
+ * config + wrapped argv; the spawned processes then run independently.
  */
 export async function spawnAgent(
   spec: AgentSpec,
   deps: SpawnAgentDeps,
 ): Promise<SpawnAgentResult> {
+  // SECURITY: the name lands UNESCAPED in a tmux `-t` target and a path segment;
+  // reject anything that isn't a strict slug BEFORE any fs/tmux side effect.
+  if (!AGENT_NAME_SLUG.test(spec.name)) {
+    throw new Error(
+      `spawnAgent: spec name "${spec.name}" must be a slug (alphanumeric, dash, underscore only)`,
+    );
+  }
+
   const session = sessionName(spec.name);
   const workspace = sessionWorkspace(deps.sessionsDir, spec.name);
 
@@ -230,9 +277,12 @@ export async function spawnAgent(
   //    session with a credential the manager couldn't actually grant (§4.3).
   const tokens: Record<string, MintResult> = {};
   const channelEntries: ChannelMcpEntry[] = [];
-  for (const channel of spec.channels) {
+  for (const rawChannel of spec.channels) {
+    const { name: channel, access } = normalizeChannel(rawChannel);
+    // A read-only channel mints `channel:read` only — the arm is woken + reads
+    // but cannot reply; a write channel mints `channel:read channel:write`.
     const minted = await mintScopedToken(
-      { scope: channelScope({ write: true }), audience: "channel" },
+      { scope: channelScope({ write: access === "write" }), audience: "channel" },
       mintDeps,
     );
     tokens[channel] = minted;
@@ -280,11 +330,13 @@ export async function spawnAgent(
   });
   mkdirSync(workspace, { recursive: true });
   const mcpConfigPath = join(workspace, ".mcp.json");
+  // `mode: 0o600` on the write is sufficient here — the file is always newly
+  // created per-launch under the per-session workspace, so there's no pre-existing
+  // looser-perms file to tighten (unlike registry.ts's read-modify-write).
   writeFileSync(mcpConfigPath, mcpConfigJson, { mode: 0o600 });
-  chmodSync(mcpConfigPath, 0o600);
 
   // 3. Build the claude argv, sandbox-wrap it, launch in tmux with scrubbed env.
-  const firstChannel = spec.channels[0]!;
+  const firstChannel = normalizeChannel(spec.channels[0]!).name;
   const claudeArgs = buildAgentClaudeArgs({
     mcpConfigPath,
     firstChannelEntryKey: `channel-${firstChannel}`,
@@ -300,14 +352,19 @@ export async function spawnAgent(
     ...(deps.vaultUrl ? { vaultOrigin: deps.vaultUrl } : {}),
   };
 
+  // Serialize the sandbox-runtime singleton's initialize→wrap window across
+  // concurrent spawns (the policy is baked into the argv at wrap, so only this
+  // window races). Outside the lock the spawned process runs independently.
   const sandbox = new Sandbox(deps.sandboxEngine);
-  const wrapped = await sandbox.wrap({
-    spec,
-    baseBinds,
-    egressBase,
-    command: shellJoin(claudeArgs),
-    ...(deps.ripgrep ? { ripgrep: deps.ripgrep } : {}),
-  });
+  const wrapped = await withSpawnLock(() =>
+    sandbox.wrap({
+      spec,
+      baseBinds,
+      egressBase,
+      command: shellJoin(claudeArgs),
+      ...(deps.ripgrep ? { ripgrep: deps.ripgrep } : {}),
+    }),
+  );
 
   // Layer the scrubbed agent env UNDER the sandbox wrapper's env (proxy vars,
   // sandbox markers from the engine win on conflict; CLAUDE_CODE_OAUTH_TOKEN +
@@ -360,6 +417,10 @@ function shellQuote(arg: string): string {
 export function realTmuxLauncher(spawnFn: typeof Bun.spawn = Bun.spawn): TmuxLauncher {
   return {
     async hasSession(name: string): Promise<boolean> {
+      // Read-only existence probe — it inherits the parent's full env, which is
+      // fine and intentional: it only checks whether a session exists and starts
+      // no child process. The scrubbed-env discipline applies to `newSession`
+      // (which actually launches the agent), not to this side-effect-free query.
       const proc = spawnFn(["tmux", "has-session", "-t", name], {
         stdout: "ignore",
         stderr: "ignore",

--- a/src/spawn-agent.ts
+++ b/src/spawn-agent.ts
@@ -1,0 +1,399 @@
+/**
+ * Spawn/scope command — graduate `scripts/launch-session.sh` into a real module
+ * (design §4). Given an agent spec:
+ *
+ *   1. Mint one scoped token PER resource via the hub mint API (attenuated to the
+ *      manager's own bearer): `channel:read[+write]` per channel, `vault:<name>:<verb>`
+ *      (optionally tag-scoped) for the vault — one token per `aud` (§4.2 step 1, §4.3).
+ *   2. Build the multi-entry strict MCP config from those tokens (§4.2 step 2).
+ *   3. Launch `claude` WRAPPED BY THE SANDBOX in a tmux session, with a scrubbed
+ *      env: inject the per-channel OAuth credential as `CLAUDE_CODE_OAUTH_TOKEN`,
+ *      and NEVER set `ANTHROPIC_API_KEY` (which would silently route the session
+ *      onto API billing, §6). `--strict-mcp-config` closes the MCP surface to
+ *      exactly the spec.
+ *
+ * The credential injected here is a passed-in param/placeholder for THIS stream;
+ * Stream 3 builds the real per-channel secret store (design §6, §4.1 credentialRef).
+ *
+ * Env-scrubbing follows runner's `buildChildEnv` instinct
+ * (`parachute-runner/src/spawn.ts`): pass only what claude needs, drop everything
+ * else — but UNLIKE runner, we deliberately do NOT pass `ANTHROPIC_API_KEY`
+ * through (runner is the API-key path; the channel session is the interactive
+ * subscription path).
+ */
+
+import { writeFileSync, mkdirSync, chmodSync } from "node:fs";
+import { join } from "node:path";
+import type { AgentSpec, BaseBinds } from "./sandbox/types.ts";
+import { Sandbox, type SandboxEngine, type WrappedCommand } from "./sandbox/index.ts";
+import type { EgressBaseInput } from "./sandbox/egress.ts";
+import {
+  buildAgentMcpConfigJson,
+  type ChannelMcpEntry,
+  type VaultMcpEntry,
+  type OtherMcpEntry,
+} from "./agent-mcp-config.ts";
+import {
+  mintScopedToken,
+  channelScope,
+  vaultScope,
+  type MintTokenDeps,
+  type MintResult,
+} from "./mint-token.ts";
+
+/** A tmux launcher seam — real impl spawns tmux; tests inject a recorder. */
+export interface TmuxLauncher {
+  /**
+   * Create a detached tmux session `name` that runs `argv` with `env` from `cwd`.
+   * Returns the spawned argv (for assertion). Must not block on the session.
+   */
+  newSession(opts: {
+    name: string;
+    argv: string[];
+    env: Record<string, string | undefined>;
+    cwd: string;
+  }): Promise<void>;
+  /** Whether a session by this name already exists (idempotency). */
+  hasSession(name: string): Promise<boolean>;
+}
+
+export interface SpawnAgentDeps {
+  /** Hub origin + manager bearer for minting (§4.3). */
+  hubOrigin: string;
+  managerBearer: string;
+  /** Daemon base URL the channel MCP endpoints live under. */
+  channelUrl: string;
+  /** Vault base URL (if the spec binds a vault). Defaults to hubOrigin. */
+  vaultUrl?: string;
+  /** Base for session workspaces (e.g. `~/.parachute/channel/sessions`). */
+  sessionsDir: string;
+  /**
+   * Read-only runtime/config binds the sandbox always grants (the claude config
+   * dir, etc.). Workspace is derived per-session under `sessionsDir`.
+   */
+  runtimeReadOnly: string[];
+  /**
+   * The Claude credential to inject as `CLAUDE_CODE_OAUTH_TOKEN`. For THIS stream
+   * a passed-in param/placeholder; Stream 3 resolves it from the per-channel
+   * secret store keyed by `spec.credentialRef`.
+   */
+  claudeOauthToken: string;
+  /** Sandbox engine override (tests inject a fake). */
+  sandboxEngine?: SandboxEngine;
+  /** tmux launcher (tests inject a recorder). */
+  tmux: TmuxLauncher;
+  /** fetch override for the mint client (tests). */
+  fetchFn?: typeof fetch;
+  /** Parent env to scrub from. Defaults to process.env. */
+  parentEnv?: Record<string, string | undefined>;
+  /** claude binary. Defaults to "claude" (resolved by the shell at run, not us). */
+  claudeBin?: string;
+  /**
+   * Optional ripgrep override threaded to the sandbox (macOS deny-path scan needs
+   * a real `rg` binary; pass one when the host has none on PATH).
+   */
+  ripgrep?: { command: string; args?: string[] };
+}
+
+export interface SpawnAgentResult {
+  /** tmux session name (`<spec.name>-agent`). */
+  session: string;
+  /** Per-session workspace dir. */
+  workspace: string;
+  /** The minted tokens, by resource key (channel name / `vault:<name>` / mcp name). */
+  tokens: Record<string, MintResult>;
+  /** The inline MCP config JSON written for the session. */
+  mcpConfigJson: string;
+  /** The sandbox-wrapped argv + env + config the session was launched with. */
+  wrapped: WrappedCommand;
+  /** Already-running? (idempotent no-op). */
+  alreadyRunning: boolean;
+}
+
+/** tmux session name for a spec — matches launch-session.sh's `<name>-agent`. */
+export function sessionName(specName: string): string {
+  return `${specName}-agent`;
+}
+
+/** Per-session workspace dir under the sessions base. */
+export function sessionWorkspace(sessionsDir: string, specName: string): string {
+  return join(sessionsDir, specName);
+}
+
+/**
+ * Build the scrubbed child env for the sandboxed claude. Mirrors runner's
+ * passthrough allowlist MINUS `ANTHROPIC_API_KEY` (and the `ANTHROPIC_*`/`CLAUDE_*`
+ * wildcards, which would re-admit it) — the channel session runs on the
+ * interactive subscription, so an API key must never leak in (§6). The injected
+ * `CLAUDE_CODE_OAUTH_TOKEN` is the session's auth.
+ *
+ * The sandbox engine's own env (proxy vars, sandbox markers) is layered on TOP of
+ * this by the wrap step; this is the base the wrapper extends.
+ */
+export function buildAgentChildEnv(
+  parentEnv: Record<string, string | undefined>,
+  claudeOauthToken: string,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  // Fundamentals + locale, like runner — but NOT ANTHROPIC_API_KEY / CLAUDE_API_KEY.
+  const passthrough = [
+    "PATH",
+    "HOME",
+    "USER",
+    "LOGNAME",
+    "SHELL",
+    "TERM",
+    "LANG",
+    "TZ",
+    "CLAUDE_CONFIG_DIR",
+    "XDG_CONFIG_HOME",
+    "XDG_DATA_HOME",
+    "XDG_CACHE_HOME",
+    "XDG_RUNTIME_DIR",
+  ];
+  for (const k of passthrough) {
+    const v = parentEnv[k];
+    if (typeof v === "string" && v.length > 0) out[k] = v;
+  }
+  // Pass through LC_* locale vars only. Deliberately NOT the broad ANTHROPIC_*/
+  // CLAUDE_* wildcards runner uses — those would re-admit ANTHROPIC_API_KEY and
+  // route the session onto metered API billing instead of the subscription.
+  for (const [k, v] of Object.entries(parentEnv)) {
+    if (typeof v === "string" && v.length > 0 && k.startsWith("LC_")) out[k] = v;
+  }
+  if (!out.PATH) out.PATH = "/usr/local/bin:/usr/bin:/bin";
+
+  // The interactive subscription credential (design §6). Explicitly the ONLY
+  // Claude auth var set; ANTHROPIC_API_KEY is intentionally absent.
+  out.CLAUDE_CODE_OAUTH_TOKEN = claudeOauthToken;
+  return out;
+}
+
+/**
+ * Build the `claude` invocation argv (pre-sandbox-wrap). Interactive `claude`
+ * (NOT `claude -p` — the session runs on the subscription, §1/§6) with the
+ * strict, multi-entry MCP config and the dev-channels flag for the first channel
+ * (the wake transport). `--strict-mcp-config` closes the MCP surface to the spec.
+ */
+export function buildAgentClaudeArgs(opts: {
+  mcpConfigPath: string;
+  firstChannelEntryKey: string;
+  claudeBin?: string;
+}): string[] {
+  const bin = opts.claudeBin ?? "claude";
+  return [
+    bin,
+    "--strict-mcp-config",
+    "--mcp-config",
+    opts.mcpConfigPath,
+    `--dangerously-load-development-channels=server:${opts.firstChannelEntryKey}`,
+  ];
+}
+
+/**
+ * Spawn a sandboxed agent session from a spec. Idempotent: an existing tmux
+ * session is a no-op (returns `alreadyRunning: true`).
+ *
+ * Order: mint per-resource tokens → write MCP config → build claude argv →
+ * sandbox-wrap → tmux launch with scrubbed env.
+ */
+export async function spawnAgent(
+  spec: AgentSpec,
+  deps: SpawnAgentDeps,
+): Promise<SpawnAgentResult> {
+  const session = sessionName(spec.name);
+  const workspace = sessionWorkspace(deps.sessionsDir, spec.name);
+
+  if (await deps.tmux.hasSession(session)) {
+    return {
+      session,
+      workspace,
+      tokens: {},
+      mcpConfigJson: "",
+      wrapped: { argv: [], env: {}, config: { network: { allowedDomains: [], deniedDomains: [] }, filesystem: { denyRead: [], allowWrite: [], denyWrite: [] } } },
+      alreadyRunning: true,
+    };
+  }
+
+  if (spec.channels.length === 0) {
+    throw new Error(`spawnAgent: spec "${spec.name}" declares no channels`);
+  }
+
+  const mintDeps: MintTokenDeps = {
+    hubOrigin: deps.hubOrigin,
+    managerBearer: deps.managerBearer,
+    ...(deps.fetchFn ? { fetchFn: deps.fetchFn } : {}),
+  };
+
+  // 1. Mint one token per resource (one aud each, attenuated). Any over-broad or
+  //    unauthorized scope fails here (the hub's canGrant), so we never launch a
+  //    session with a credential the manager couldn't actually grant (§4.3).
+  const tokens: Record<string, MintResult> = {};
+  const channelEntries: ChannelMcpEntry[] = [];
+  for (const channel of spec.channels) {
+    const minted = await mintScopedToken(
+      { scope: channelScope({ write: true }), audience: "channel" },
+      mintDeps,
+    );
+    tokens[channel] = minted;
+    channelEntries.push({ channel, token: minted.token });
+  }
+
+  let vaultArg: { url: string; entry: VaultMcpEntry } | undefined;
+  if (spec.vault) {
+    const v = spec.vault;
+    const minted = await mintScopedToken(
+      {
+        scope: vaultScope(v.name, v.access),
+        audience: `vault.${v.name}`,
+        ...(v.tags && v.tags.length > 0 ? { permissions: { scoped_tags: v.tags } } : {}),
+      },
+      mintDeps,
+    );
+    tokens[`vault:${v.name}`] = minted;
+    vaultArg = {
+      url: deps.vaultUrl ?? deps.hubOrigin,
+      entry: { name: v.name, token: minted.token },
+    };
+  }
+
+  const otherEntries: OtherMcpEntry[] = [];
+  for (const o of spec.otherMcps ?? []) {
+    let token: string | undefined;
+    if (o.scope) {
+      const minted = await mintScopedToken(
+        { scope: o.scope, ...(o.audience ? { audience: o.audience } : {}) },
+        mintDeps,
+      );
+      tokens[o.name] = minted;
+      token = minted.token;
+    }
+    otherEntries.push({ name: o.name, url: o.url, ...(token ? { token } : {}) });
+  }
+
+  // 2. Build the multi-entry strict MCP config + write it 0600 (it inlines tokens).
+  const mcpConfigJson = buildAgentMcpConfigJson({
+    channelUrl: deps.channelUrl,
+    channels: channelEntries,
+    ...(vaultArg ? { vault: vaultArg } : {}),
+    ...(otherEntries.length > 0 ? { otherMcps: otherEntries } : {}),
+  });
+  mkdirSync(workspace, { recursive: true });
+  const mcpConfigPath = join(workspace, ".mcp.json");
+  writeFileSync(mcpConfigPath, mcpConfigJson, { mode: 0o600 });
+  chmodSync(mcpConfigPath, 0o600);
+
+  // 3. Build the claude argv, sandbox-wrap it, launch in tmux with scrubbed env.
+  const firstChannel = spec.channels[0]!;
+  const claudeArgs = buildAgentClaudeArgs({
+    mcpConfigPath,
+    firstChannelEntryKey: `channel-${firstChannel}`,
+    ...(deps.claudeBin ? { claudeBin: deps.claudeBin } : {}),
+  });
+
+  const baseBinds: BaseBinds = {
+    workspace,
+    runtimeReadOnly: deps.runtimeReadOnly,
+  };
+  const egressBase: EgressBaseInput = {
+    hubOrigin: deps.hubOrigin,
+    ...(deps.vaultUrl ? { vaultOrigin: deps.vaultUrl } : {}),
+  };
+
+  const sandbox = new Sandbox(deps.sandboxEngine);
+  const wrapped = await sandbox.wrap({
+    spec,
+    baseBinds,
+    egressBase,
+    command: shellJoin(claudeArgs),
+    ...(deps.ripgrep ? { ripgrep: deps.ripgrep } : {}),
+  });
+
+  // Layer the scrubbed agent env UNDER the sandbox wrapper's env (proxy vars,
+  // sandbox markers from the engine win on conflict; CLAUDE_CODE_OAUTH_TOKEN +
+  // the passthrough fundamentals come from us). ANTHROPIC_API_KEY is absent.
+  const childEnv = buildAgentChildEnv(deps.parentEnv ?? process.env, deps.claudeOauthToken);
+  const launchEnv: Record<string, string | undefined> = { ...childEnv, ...wrapped.env };
+
+  await deps.tmux.newSession({
+    name: session,
+    argv: wrapped.argv,
+    env: launchEnv,
+    cwd: workspace,
+  });
+
+  return {
+    session,
+    workspace,
+    tokens,
+    mcpConfigJson,
+    wrapped,
+    alreadyRunning: false,
+  };
+}
+
+/**
+ * Minimal POSIX shell-quote for joining argv into the single command string the
+ * sandbox engine wraps (`wrapWithSandboxArgv` takes a command string). Quotes any
+ * arg containing shell-significant chars; safe for the controlled argv we build
+ * (claude bin, flags, a workspace-local config path).
+ */
+export function shellJoin(argv: string[]): string {
+  return argv.map(shellQuote).join(" ");
+}
+
+function shellQuote(arg: string): string {
+  if (arg.length > 0 && /^[A-Za-z0-9_@%+=:,./-]+$/.test(arg)) return arg;
+  // Single-quote, escaping embedded single quotes the POSIX way.
+  return `'${arg.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * The real tmux launcher — `tmux new-session -d` running the sandboxed argv. The
+ * env is applied via `tmux new-session`'s `-e KEY=VAL` (tmux ≥3.0) so the child
+ * inherits exactly the launch env (scrubbed agent env + sandbox proxy vars), not
+ * the operator's shell env. `argv` is the sandbox wrapper's argv (already
+ * `["/bin/bash","-c", "<env … sandbox-exec … claude …>"]` on macOS), so tmux
+ * runs it directly. Injected here (not used by tests, which use a recorder) so
+ * the module is a real command, not just a planner.
+ */
+export function realTmuxLauncher(spawnFn: typeof Bun.spawn = Bun.spawn): TmuxLauncher {
+  return {
+    async hasSession(name: string): Promise<boolean> {
+      const proc = spawnFn(["tmux", "has-session", "-t", name], {
+        stdout: "ignore",
+        stderr: "ignore",
+      });
+      const code = await proc.exited;
+      return code === 0;
+    },
+    async newSession(opts): Promise<void> {
+      const envArgs: string[] = [];
+      for (const [k, v] of Object.entries(opts.env)) {
+        if (typeof v === "string") envArgs.push("-e", `${k}=${v}`);
+      }
+      const argv = [
+        "tmux",
+        "new-session",
+        "-d",
+        "-s",
+        opts.name,
+        "-c",
+        opts.cwd,
+        "-x",
+        "220",
+        "-y",
+        "50",
+        ...envArgs,
+        "--",
+        ...opts.argv,
+      ];
+      const proc = spawnFn(argv, { stdout: "pipe", stderr: "pipe" });
+      const code = await proc.exited;
+      if (code !== 0) {
+        const err = await new Response(proc.stderr as ReadableStream<Uint8Array>).text();
+        throw new Error(`tmux new-session failed (exit ${code}): ${err.trim()}`);
+      }
+    },
+  };
+}

--- a/src/spawn-agent.ts
+++ b/src/spawn-agent.ts
@@ -22,7 +22,7 @@
  * subscription path).
  */
 
-import { writeFileSync, mkdirSync } from "node:fs";
+import { writeFileSync, mkdirSync, chmodSync } from "node:fs";
 import { join } from "node:path";
 import type { AgentSpec, BaseBinds } from "./sandbox/types.ts";
 import { normalizeChannel } from "./sandbox/types.ts";
@@ -406,13 +406,63 @@ function shellQuote(arg: string): string {
 }
 
 /**
- * The real tmux launcher — `tmux new-session -d` running the sandboxed argv. The
- * env is applied via `tmux new-session`'s `-e KEY=VAL` (tmux ≥3.0) so the child
- * inherits exactly the launch env (scrubbed agent env + sandbox proxy vars), not
- * the operator's shell env. `argv` is the sandbox wrapper's argv (already
- * `["/bin/bash","-c", "<env … sandbox-exec … claude …>"]` on macOS), so tmux
- * runs it directly. Injected here (not used by tests, which use a recorder) so
- * the module is a real command, not just a planner.
+ * Build the per-session **launch script** body for an already-sandbox-wrapped argv.
+ *
+ * Why a script and not inline argv: on macOS `wrapWithSandboxArgv` returns
+ * `["/bin/bash","-c","<command embedding the ~84 KB Seatbelt -p profile inline>"]`.
+ * Passing that ~84 KB string as a tmux argument exceeds tmux's per-argument /
+ * command buffer, so `tmux new-session -- /bin/bash -c <84KB>` fails. Instead we
+ * write the wrapped command to a file and have tmux run only the short
+ * `/bin/bash <script-path>` argv — the 84 KB profile lives in the file, never on
+ * the tmux command line.
+ *
+ * Two argv shapes are handled generally:
+ *  - macOS Seatbelt: `["/bin/bash","-c", cmd]` → the script body IS `cmd` (it
+ *    already embeds the sandbox-exec invocation + the claude command).
+ *  - General argv (e.g. Linux bubblewrap `["bwrap", ...args, "claude", ...]`) →
+ *    the body `exec`s the argv with POSIX quoting (reusing `shellJoin`).
+ *
+ * The injected secret (CLAUDE_CODE_OAUTH_TOKEN) is passed via the environment by
+ * `newSession` (`-e KEY=VAL`), NOT written into the script — so the launch script
+ * body is token-free.
+ */
+export function buildLaunchScript(argv: string[]): string {
+  const header = "#!/bin/bash\nset -euo pipefail\n";
+  // The canonical macOS shape: `/bin/bash -c "<cmd>"`. The command string already
+  // is a complete shell program (it embeds the sandbox-exec call and the claude
+  // invocation), so the script body is exactly that command.
+  if (argv.length === 3 && argv[0] === "/bin/bash" && argv[1] === "-c") {
+    return `${header}${argv[2]}\n`;
+  }
+  // General argv: exec it directly with proper quoting so a giant arg (or many
+  // args) stays in the file, not on the tmux command line. `exec` so the wrapped
+  // process replaces this shell (no extra PID, signals reach claude directly).
+  return `${header}exec ${shellJoin(argv)}\n`;
+}
+
+/** Per-session launch-script path under the session workspace (`cwd`). */
+function launchScriptPath(cwd: string): string {
+  return join(cwd, ".launch.sh");
+}
+
+/**
+ * The real tmux launcher — `tmux new-session -d` running the sandboxed argv via a
+ * per-session **launch script**. The env is applied via `tmux new-session`'s
+ * `-e KEY=VAL` (tmux ≥3.0) so the child inherits exactly the launch env (scrubbed
+ * agent env + sandbox proxy vars), not the operator's shell env.
+ *
+ * `argv` is the sandbox wrapper's argv (on macOS already
+ * `["/bin/bash","-c", "<sandbox-exec … claude …>"]` where the command embeds the
+ * ~84 KB Seatbelt `-p` profile inline). That string is far too large to pass as a
+ * tmux argument — `tmux new-session -- /bin/bash -c <84KB>` overruns tmux's
+ * command buffer and fails. So we write the wrapped command to a per-session
+ * launch script (`<workspace>/.launch.sh`, 0600) and hand tmux only the SHORT argv
+ * `/bin/bash <script-path>`; the 84 KB profile lives in the file, off the command
+ * line. See `buildLaunchScript` for how the two argv shapes are handled.
+ *
+ * The script carries NO secret: the OAuth credential is injected via `-e` into the
+ * env, not written into the script body. Injected here (not used by tests, which
+ * use a recorder) so the module is a real command, not just a planner.
  */
 export function realTmuxLauncher(spawnFn: typeof Bun.spawn = Bun.spawn): TmuxLauncher {
   return {
@@ -429,6 +479,17 @@ export function realTmuxLauncher(spawnFn: typeof Bun.spawn = Bun.spawn): TmuxLau
       return code === 0;
     },
     async newSession(opts): Promise<void> {
+      // Write the wrapped command to a per-session launch script so tmux receives
+      // a short argv (the ~84 KB macOS Seatbelt profile would overrun tmux's
+      // command buffer if passed inline). The script lives in the session
+      // workspace alongside .mcp.json, 0600 — it carries no secret (the OAuth
+      // token rides the env via `-e`, below).
+      const scriptPath = launchScriptPath(opts.cwd);
+      writeFileSync(scriptPath, buildLaunchScript(opts.argv), { mode: 0o600 });
+      // Defensive: guarantee 0600 even under a permissive umask (the file is
+      // freshly created per-launch, so there's no looser-perms predecessor).
+      chmodSync(scriptPath, 0o600);
+
       const envArgs: string[] = [];
       for (const [k, v] of Object.entries(opts.env)) {
         if (typeof v === "string") envArgs.push("-e", `${k}=${v}`);
@@ -447,7 +508,8 @@ export function realTmuxLauncher(spawnFn: typeof Bun.spawn = Bun.spawn): TmuxLau
         "50",
         ...envArgs,
         "--",
-        ...opts.argv,
+        "/bin/bash",
+        scriptPath,
       ];
       const proc = spawnFn(argv, { stdout: "pipe", stderr: "pipe" });
       const code = await proc.exited;


### PR DESCRIPTION
## Phase 1 core — sandbox adapter + agent-spec + spawn/scope

Builds the **scope + isolation core** of the [sandboxed-agent-sessions design](./design/2026-06-14-sandboxed-agent-sessions.md) (§3, §4). This is the **foundation branch** later Phase-1 streams (in-page terminal §5, VPS cloud-init §7, per-channel secret store §6) stack on. Owner-operated desktop tier (Seatbelt); the Linux/bubblewrap path is coded but tested here on macOS.

### What's here

**Isolation envelope (`src/sandbox/*`)** — maps an agent-spec → `@anthropic-ai/sandbox-runtime` config behind a constant `Sandbox` contract.
- Pinned `@anthropic-ai/sandbox-runtime@0.0.54`, **library-linked** — never via PATH (design Q4: a poisoned PATH would execute before the sandbox is established).
- **Egress (§4.4):** a NON-REMOVABLE base allowlist `{Anthropic API host(s) + hub/vault origin}` is always present; `spec.egress[]` is additive-only. A spec that omits or tries to override the base still gets it (base recomputed from code, then unioned).
- **Mounts / scoped reads (§4.5):** default binds = private per-session workspace (rw) + runtime/config (ro); `spec.mounts[]` additive. Reads confined to declared binds (deny the home tree, re-allow binds) — tightens Anthropic's broad-read default. macOS-glob vs Linux-literal nuance handled. `shared` mounts plumbed (trust caveat is doc-level).
- `AgentSpec` type per §4.1.

**Spawn/scope command (`src/spawn-agent.ts`, `src/mint-token.ts`, `src/agent-mcp-config.ts`)** — graduates `launch-session.sh`.
- Mints **one scoped token per `aud`** via the hub mint API, attenuated to the manager's own bearer (capability attenuation enforced server-side; an over-broad mint aborts the launch).
- Generalizes runner's single-entry MCP config to **N entries** (channels + vault + otherMcps), each with its own Bearer, `--strict-mcp-config`.
- Launches **interactive `claude`** (not `-p`) wrapped by the Sandbox in tmux, env scrubbed runner-style, injecting `CLAUDE_CODE_OAUTH_TOKEN` and **never `ANTHROPIC_API_KEY`** (§6 — keeps the session on the interactive subscription).

### Tests — `bun test src/`: **269 pass / 0 fail** (75 new across 8 files)

Includes **live Seatbelt assertions on a real `sandbox-exec` process**: a sandboxed `curl` to a non-allowlisted host is denied (HTTP 403 from the egress proxy); reads/writes outside the declared binds are denied, inside succeed. Gated on `isSupportedPlatform()` + deps so unsupported CI stays green. All sandboxed in temp dirs — never the operator's live `~/.parachute`.

### Stub-vs-live boundary
Everything is verified here EXCEPT what needs Aaron's real `CLAUDE_CODE_OAUTH_TOKEN` + a live hub:
- A real interactive `claude` authenticating inside the sandbox from the injected token alone (no `/login`) — design R3, needs the real token.
- A real end-to-end hub mint (attenuation tested against a faked hub; the `canGrant` bound itself lives in the hub).

### Deviations from the design doc (flagged, not papered over)
- **Resource limits (§3.1 item 4: memory/CPU caps).** `sandbox-runtime` 0.0.54's config surface exposes no memory/CPU knob — it's a filesystem/network/syscall sandbox, not a cgroup/rlimit manager. So this contract item is **not deliverable through the chosen v1 mechanism**; it belongs to the escalation rung (§3.4, cgroups/VM) or a host-level wrapper. Left out of v1 rather than faked.
- **macOS ripgrep dependency.** The runtime's macOS deny-path scan wants a real `rg` binary; this box has only claude's bundled one (a shell function). `config.ts` threads a `ripgrep` override; `checkDependencies()` returns clean here and the live tests pass, so it's not blocking, but a host without `rg` should pass the override.

### Verified sandbox-runtime API surface (0.0.54)
`SandboxManager` is a **singleton** (not a class): `initialize(config)`, `wrapWithSandboxArgv(cmd) → {argv, env}`, `wrapWithSandbox(cmd) → string`, `isSupportedPlatform()`, `checkDependencies()`, `reset()`. Config: `{ network: {allowedDomains, deniedDomains}, filesystem: {denyRead, allowRead?, allowWrite, denyWrite}, allowPty?, ripgrep? }`. Reads default to **broad-allowed** (so scoped reads require the deny-home-tree + re-allow-binds recipe); network is **deny-by-default allowlist-only**. macOS = globs, Linux = literal paths.

Do not merge — governance (no self-merge); reviewer dispatch pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
