### PR TITLE
feat(deploy): full-tier cloud-init + deploy-tiers doc (Phase 1)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,178 @@
+# Deploying Parachute — tiers + the full-tier cloud-init
+
+Parachute deploys in **two tiers**. Pick by whether you need **resident agent
+sessions** (sandboxed Claude Code sessions you chat with through a channel).
+
+| | **Lite** | **Full** |
+|---|---|---|
+| What runs | hub + vault + static surfaces | hub + vault + **channel + sandboxed agent sessions** |
+| Where | Render / Fly (a single container) | your **desktop** today, or a **Linux VPS** via `cloud-init-full.yaml` |
+| Isolation engine | n/a (no sessions) | `@anthropic-ai/sandbox-runtime` — **Seatbelt** on macOS, **bubblewrap** on Linux |
+| Resources | 512MB is fine | ~8GB RAM (sessions are real `claude` processes) |
+| How you set it up | one-click Blueprint / `flyctl` | paste this user-data → boot → SSH → `expose` |
+
+**Lite** is the existing hosted self-deploy: the `render.yaml` Blueprint and the
+Fly script in `parachute-hub`. It's a single container with one persistent disk —
+great for the vault + hub + surfaces, but it deliberately doesn't run agent
+sessions (no per-session sandbox; a PaaS container is the wrong substrate for
+spawning `claude` under bubblewrap).
+
+**Full** is this directory. The primary artifact is a **provider-agnostic
+cloud-init** script that boots a fresh Ubuntu/Debian VPS into a working full-tier
+box: hub + channel + the sandbox toolchain (`bun`, the `claude` CLI,
+`@anthropic-ai/sandbox-runtime`, `tmux`, `bubblewrap`, `ripgrep`, `socat`). The
+desktop path is just "install the hub + channel locally" — `cloud-init-full.yaml`
+is the same install, scripted for a headless box.
+
+> Design context: `design/2026-06-14-sandboxed-agent-sessions.md` §7. The
+> isolation contract is held constant; only the *mechanism* differs by platform
+> (Seatbelt / bubblewrap) behind `@anthropic-ai/sandbox-runtime`.
+
+---
+
+## The full-tier cloud-init (`cloud-init-full.yaml`)
+
+It's a standard `#cloud-config` user-data file. Every major cloud accepts
+cloud-init user-data, so the **same file** works on DigitalOcean, Hetzner, GCP,
+AWS EC2, or any generic cloud-init datasource. On first boot it:
+
+1. Patches the box, installs the apt deps (`tmux bubblewrap ripgrep socat git …`).
+2. Relaxes Ubuntu 24.04's `apparmor_restrict_unprivileged_userns` so bubblewrap
+   can create capability-bearing user namespaces (no-op on older kernels).
+3. Installs `bun`, then `@openparachute/hub`, `@openparachute/channel`, the
+   `claude` CLI, and `@anthropic-ai/sandbox-runtime` — all as a **non-root
+   `parachute` user**.
+4. Runs `parachute init --expose none --no-expose-prompt --cli-wizard` (starts
+   the hub as a systemd unit that survives reboots; loopback-only; no browser).
+5. Prints the one-time **admin bootstrap token** + the `/admin/setup` URL to the
+   **serial/console log**, and tells you to run `parachute expose` for a URL.
+
+The hub and the agent sessions run unprivileged as `parachute`; only the apt
+package install needs root (cloud-init runs as root for that).
+
+### Provider paste-instructions (the actual click path)
+
+The shape is identical everywhere: **create a VPS → paste the user-data → boot →
+read the console for the token → SSH in → `expose` → open `/admin/setup`.**
+
+#### DigitalOcean (simplest default — no KYC)
+
+1. Create Droplet → **Ubuntu 24.04** → an **8 GB** plan (sessions are real
+   processes; 8 GB is the comfortable floor).
+2. Under **Advanced options → Add Initialization scripts (free)**, paste the
+   contents of `cloud-init-full.yaml`.
+3. Add your SSH key → Create.
+4. When it's up, open the Droplet's **Console** (or **Recovery → Console**) and
+   read the `PARACHUTE FULL-TIER BOOTSTRAP COMPLETE` banner for the token.
+5. `ssh parachute@<droplet-ip>` → `parachute expose cloudflare --domain <host>`
+   (public HTTPS; needs a Cloudflare-managed domain) **or**
+   `parachute expose tailnet` if you run Tailscale.
+6. Open the printed URL's `/admin/setup`, paste the token, create your admin
+   account. Then install/connect the Channel module and launch sessions.
+
+#### Hetzner Cloud (cheapest in the EU)
+
+1. Create Server → **Ubuntu 24.04** → a **CPX41 / CX42-class (8 GB)** instance.
+2. Expand **Cloud config** and paste `cloud-init-full.yaml`.
+3. Add your SSH key → Create.
+4. Read the token from the server's **Console** in the Hetzner panel.
+5. Same as DO step 5–6 (`ssh parachute@<ip>` → `parachute expose …` → `/admin/setup`).
+
+#### GCP
+
+```sh
+gcloud compute instances create parachute-full \
+  --image-family=ubuntu-2404-lts --image-project=ubuntu-os-cloud \
+  --machine-type=e2-standard-2 \
+  --metadata-from-file=user-data=cloud-init-full.yaml
+```
+Read the token: `gcloud compute instances get-serial-port-output parachute-full | grep parachute-bootstrap-`.
+Then SSH in and `parachute expose …`.
+
+#### AWS EC2
+
+Launch an **Ubuntu 24.04 AMI** (t3.large / 8 GB), paste `cloud-init-full.yaml`
+into **Advanced details → User data**. Read the token from **Actions → Monitor
+and troubleshoot → Get system log**, then SSH in and `expose`.
+
+#### Any other cloud / self-hosted
+
+It's plain cloud-init user-data — drop it into whatever your platform calls the
+"user data" / "cloud config" field (Vultr, Linode, Proxmox NoCloud seed, libvirt
+`--user-data`, etc.). Nothing in the file is provider-specific.
+
+### Can't (or don't want to) expose?
+
+Tunnel the loopback hub over SSH from your laptop and do setup locally:
+
+```sh
+ssh -L 1939:127.0.0.1:1939 parachute@<box-ip>
+# then open http://127.0.0.1:1939/admin/setup and paste the token
+```
+
+### Retrieve the token later
+
+If you missed it in the console:
+
+```sh
+ssh parachute@<box-ip>
+journalctl --user | grep parachute-bootstrap-          # primary on Linux (hub runs under systemd → journald)
+# or: grep parachute-bootstrap- ~/.parachute/hub/logs/hub.log
+```
+
+---
+
+## Provider cost snapshot (secondary — the point is "it boots a working box")
+
+| Provider | ~8 GB instance | Notes |
+|---|---|---|
+| **DigitalOcean** | ~$48/mo | **Default.** Simplest console + no-KYC; the smooth first-run path. |
+| **Hetzner** | ~$7/mo (EU) · ~$17/mo (US) | Cheapest, but **KYC** (ID verification) can delay/limit new accounts, and capacity is region-gated. Great once you're in. |
+| GCP / AWS | varies | Use if you're already there; `e2-standard-2` / `t3.large`-class. |
+
+Sessions are real `claude` processes — **8 GB RAM is the comfortable floor** for a
+couple of resident sessions. A 4 GB box can run the hub + vault + one light
+session, but don't size below 8 GB if you expect to actually work in sessions.
+
+---
+
+## Validation
+
+- `cloud-init-full.yaml` parses as YAML and passes `cloud-init schema
+  --config-file` (validated in an Ubuntu 24.04 container — see the PR description).
+- The install steps (apt deps + bun + `claude` CLI) and a **bubblewrap
+  egress-deny smoke** were exercised in an Ubuntu 24.04 container: with
+  `bwrap --unshare-net` (the Linux deny-all-egress mechanism the sandbox-runtime
+  uses) a sandboxed `curl` to `api.anthropic.com` is **blocked**, while the host
+  reaches it — the positive control. This is the one isolation path macOS
+  Seatbelt can't cover, so it's the load-bearing Linux test.
+
+### The single live smoke for the operator (one-time)
+
+A container can't fully exercise the **systemd-user-unit boot + reboot survival**
+path (no init/journald in a plain container). Run this once on a real VPS:
+
+```sh
+# 1. Create an 8GB Ubuntu 24.04 VPS with cloud-init-full.yaml as user-data.
+# 2. Watch the console for "PARACHUTE FULL-TIER BOOTSTRAP COMPLETE" + a token.
+# 3. SSH in and confirm the stack:
+ssh parachute@<box-ip>
+parachute status            # hub active; vault active
+command -v claude bwrap rg tmux parachute-channel   # all present
+# 4. Expose + finish setup:
+parachute expose cloudflare --domain <host>   # or: parachute expose tailnet
+#    open <url>/admin/setup, paste the token, create the admin account.
+# 5. Reboot survival:
+sudo reboot
+ssh parachute@<box-ip> 'parachute status'     # hub still active after boot
+```
+
+---
+
+## Follow-ons (NOT built here)
+
+- **A DigitalOcean 1-Click image** (Marketplace): bake this cloud-init into a
+  snapshot so operators get a literal one-click "Parachute Full" droplet.
+- **`parachute provision <provider>`**: a hub CLI verb that calls the provider's
+  API to create the VPS with this user-data and stream back the token — turning
+  the whole flow above into one local command.

--- a/deploy/cloud-init-full.yaml
+++ b/deploy/cloud-init-full.yaml
@@ -1,0 +1,270 @@
+#cloud-config
+# ---------------------------------------------------------------------------
+# Parachute — FULL-tier cloud-init (Phase 1, sandboxed agent sessions)
+# ---------------------------------------------------------------------------
+# Provider-agnostic VPS user-data. Boots a fresh Ubuntu/Debian Linux box into a
+# working full-tier Parachute install: the hub + the channel module + everything
+# the sandboxed-agent-session path needs (bun, the `claude` CLI, the Anthropic
+# sandbox-runtime, tmux, bubblewrap, ripgrep, socat). On first boot it starts the
+# hub and prints the one-time admin bootstrap token + the /admin/setup URL to the
+# serial/console log, then tells the operator to run `parachute expose` for a
+# public URL.
+#
+# WHY full-tier (vs the Render/Fly "lite" tier): the lite tier runs only the
+# vault + hub + static surfaces in a single container — no agent sessions. The
+# FULL tier adds resident Claude Code sessions sandboxed with bubblewrap (the
+# Linux mechanism behind @anthropic-ai/sandbox-runtime; Seatbelt is the macOS
+# mechanism). Sessions need a real machine with bubblewrap, tmux, and the claude
+# CLI — that's what this script provisions. See
+# design/2026-06-14-sandboxed-agent-sessions.md §7 and deploy/README.md.
+#
+# PROVIDER-AGNOSTIC: every major cloud takes cloud-init user-data —
+#   - DigitalOcean: "User data" field on the create-droplet page (default,
+#     no-KYC; pick an 8GB droplet).
+#   - Hetzner Cloud: "Cloud config" field (cheapest; KYC caveat — see README).
+#   - GCP: `--metadata-from-file user-data=cloud-init-full.yaml`.
+#   - AWS EC2 (Ubuntu AMI): "User data" field — cloud-init is the default agent.
+#   - Generic libvirt/Proxmox/any cloud-init datasource: standard NoCloud seed.
+# Nothing below is provider-specific.
+#
+# RUN USER: the hub + sessions run as a non-root user (`parachute`), created
+# below. Only the package-install steps need root (cloud-init runs as root). The
+# hub installs its own systemd *user* unit under that account so it survives
+# reboots without running the agent stack as root.
+# ---------------------------------------------------------------------------
+
+# Keep the box patched on first boot.
+package_update: true
+package_upgrade: true
+
+# --- OS packages (apt) --------------------------------------------------------
+# unzip + curl: bun's install script needs them.
+# tmux: each resident Claude Code session runs in its own tmux session.
+# bubblewrap: the Linux sandbox mechanism for @anthropic-ai/sandbox-runtime.
+# ripgrep: the sandbox-runtime uses `rg` to scan deny-paths on Linux (required).
+# socat: the Linux sandbox bridges egress proxies over Unix sockets via socat.
+# gcc + libseccomp-dev: optional — the sandbox-runtime's seccomp Unix-socket
+#   layer compiles from C source on Linux; without them the box still sandboxes
+#   filesystem + network, only the extra Unix-socket-creation block degrades.
+# git: vault import + general module operations.
+# ca-certificates: TLS to api.anthropic.com / the npm registry / Cloudflare.
+packages:
+  - curl
+  - unzip
+  - git
+  - tmux
+  - bubblewrap
+  - ripgrep
+  - socat
+  - gcc
+  - libseccomp-dev
+  - ca-certificates
+
+# --- non-root run user --------------------------------------------------------
+# `parachute` owns the whole stack. Passwordless sudo is granted so the operator
+# can still administer the box after SSHing in as this user, but the hub +
+# sessions themselves run unprivileged.
+users:
+  - default
+  - name: parachute
+    gecos: Parachute service account
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [sudo]
+    # Inherit the cloud's injected SSH keys so the operator can `ssh parachute@<ip>`.
+    ssh_authorized_keys: []
+
+write_files:
+  # The whole install lives in one script so it's auditable + re-runnable. It is
+  # idempotent: bun/claude/hub installs short-circuit if already present, and
+  # `parachute init` is itself idempotent.
+  - path: /usr/local/sbin/parachute-full-bootstrap.sh
+    permissions: "0755"
+    owner: root:root
+    content: |
+      #!/usr/bin/env bash
+      # Full-tier Parachute bootstrap — runs ONCE on first boot as the `parachute`
+      # user (invoked by the runcmd below via `sudo -iu parachute`).
+      set -euo pipefail
+
+      log() { echo "[parachute-bootstrap] $*"; }
+
+      # ----------------------------------------------------------------------
+      # 0. Ubuntu 24.04+ unprivileged-userns hardening.
+      #    bubblewrap + the seccomp layer need capability-bearing user
+      #    namespaces. 24.04 ships kernel.apparmor_restrict_unprivileged_userns=1
+      #    which strips caps from new userns. Relax it (persisted) so the sandbox
+      #    can create its namespaces. No-op on older kernels / non-Ubuntu.
+      # ----------------------------------------------------------------------
+      if [ -e /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
+        log "relaxing apparmor_restrict_unprivileged_userns for bubblewrap"
+        echo 'kernel.apparmor_restrict_unprivileged_userns=0' | sudo tee /etc/sysctl.d/60-parachute-userns.conf >/dev/null
+        sudo sysctl --system >/dev/null 2>&1 || true
+      fi
+
+      # ----------------------------------------------------------------------
+      # 1. Bun — the runtime everything runs on.
+      # ----------------------------------------------------------------------
+      export BUN_INSTALL="$HOME/.bun"
+      export PATH="$BUN_INSTALL/bin:$PATH"
+      if ! command -v bun >/dev/null 2>&1; then
+        log "installing bun"
+        curl -fsSL https://bun.sh/install | bash
+      fi
+      # Persist PATH for future logins (so `parachute …` / `claude …` just work).
+      if ! grep -q 'BUN_INSTALL' "$HOME/.bashrc" 2>/dev/null; then
+        {
+          echo ''
+          echo '# Parachute — bun + globally-installed bins on PATH'
+          echo 'export BUN_INSTALL="$HOME/.bun"'
+          echo 'export PATH="$BUN_INSTALL/bin:$PATH"'
+        } >> "$HOME/.bashrc"
+      fi
+      log "bun: $(bun --version)"
+
+      # ----------------------------------------------------------------------
+      # 2. The Parachute hub (provides the `parachute` binary).
+      # ----------------------------------------------------------------------
+      if ! command -v parachute >/dev/null 2>&1; then
+        log "installing @openparachute/hub"
+        bun add -g @openparachute/hub
+      fi
+      log "parachute: $(parachute --version 2>/dev/null || echo '(installed)')"
+
+      # ----------------------------------------------------------------------
+      # 3. The channel module (the agent-session gateway) — installed globally so
+      #    the `parachute-channel` binary is on PATH for the hub supervisor to
+      #    resolve via Bun.which. (module.json startCmd = ["parachute-channel"].)
+      # ----------------------------------------------------------------------
+      if ! command -v parachute-channel >/dev/null 2>&1; then
+        log "installing @openparachute/channel"
+        bun add -g @openparachute/channel
+      fi
+
+      # ----------------------------------------------------------------------
+      # 4. The Anthropic sandbox-runtime (the isolation engine) + the `claude`
+      #    CLI (what each resident session runs). Both global so they're on PATH.
+      #    sandbox-runtime is pinned EXACT in the channel module's package.json;
+      #    here we install the same family globally so `srt` is present for any
+      #    out-of-process sandbox smoke. The channel module library-links its own
+      #    pinned copy at runtime (it never PATH-resolves the engine).
+      # ----------------------------------------------------------------------
+      if ! command -v claude >/dev/null 2>&1; then
+        log "installing @anthropic-ai/claude-code (the claude CLI)"
+        bun add -g @anthropic-ai/claude-code
+      fi
+      if ! command -v srt >/dev/null 2>&1; then
+        log "installing @anthropic-ai/sandbox-runtime (srt)"
+        bun add -g @anthropic-ai/sandbox-runtime
+      fi
+
+      # ----------------------------------------------------------------------
+      # 5. Sanity: confirm the sandbox prerequisites are actually present. These
+      #    are the load-bearing Linux deps; fail loudly now rather than at first
+      #    session launch.
+      # ----------------------------------------------------------------------
+      for bin in bwrap rg socat tmux git; do
+        if ! command -v "$bin" >/dev/null 2>&1; then
+          log "FATAL: required sandbox dependency '$bin' missing after install"
+          exit 1
+        fi
+      done
+      log "sandbox prerequisites present: bwrap rg socat tmux git"
+
+      # ----------------------------------------------------------------------
+      # 6. Bring the hub up. `parachute init` installs + starts the hub as a
+      #    systemd unit (survives reboots), always installs the vault module, and
+      #    would normally drop into the wizard. On a headless box we DON'T want
+      #    the interactive wizard or an auto-expose prompt — we want it to start,
+      #    print the bootstrap token, and hand control back. So:
+      #      --no-expose-prompt : don't try to interactively configure expose.
+      #      --expose none      : start loopback-only; operator runs `expose` later.
+      #      --cli-wizard       : never try to open a browser (there is none).
+      #    The one-time admin bootstrap token is printed to the hub log on first
+      #    boot ("parachute-bootstrap-<...>"); we surface it to the console below.
+      # ----------------------------------------------------------------------
+      log "running parachute init (headless, loopback-only)"
+      parachute init --expose none --no-expose-prompt --cli-wizard </dev/null || {
+        log "parachute init returned non-zero; the hub may still be up — checking status"
+      }
+
+      # Give the unit a moment, then confirm.
+      for _ in $(seq 1 30); do
+        if parachute status >/dev/null 2>&1; then break; fi
+        sleep 1
+      done
+      parachute status || true
+
+      # ----------------------------------------------------------------------
+      # 7. Surface the bootstrap token + setup URL to the SERIAL/CONSOLE log so
+      #    the operator can read it from the provider's console without SSH.
+      #    The token is generated on first boot and logged as
+      #    "parachute-bootstrap-<token>"; we grep it out of the hub log.
+      # ----------------------------------------------------------------------
+      # On Linux the hub runs under a systemd unit whose stdout goes to JOURNALD
+      # (the rendered unit sets no StandardOutput= file redirect — only the macOS
+      # launchd plist redirects to a file). So journald is the PRIMARY source for
+      # the token on a VPS; the on-disk hub log is a secondary fallback (it exists
+      # for the launchd/manual-foreground paths). PARACHUTE_HOME defaults to
+      # ~/.parachute, and the hub writes its file log under <home>/hub/logs/.
+      HUB_LOG="${PARACHUTE_HOME:-$HOME/.parachute}/hub/logs/hub.log"
+      TOKEN=""
+      for _ in $(seq 1 30); do
+        # Primary: systemd-user journal for the hub unit's stdout.
+        TOKEN="$(journalctl --user -n 1000 --no-pager 2>/dev/null | grep -ho 'parachute-bootstrap-[A-Za-z0-9_-]\+' | tail -n1 || true)"
+        # Fallback A: the on-disk hub log (launchd / foreground-serve path).
+        if [ -z "$TOKEN" ] && [ -f "$HUB_LOG" ]; then
+          TOKEN="$(grep -ho 'parachute-bootstrap-[A-Za-z0-9_-]\+' "$HUB_LOG" 2>/dev/null | tail -n1 || true)"
+        fi
+        # Fallback B: the bootstrap script's own tee'd log (captures init stdout).
+        if [ -z "$TOKEN" ] && [ -f /var/log/parachute-bootstrap.log ]; then
+          TOKEN="$(grep -ho 'parachute-bootstrap-[A-Za-z0-9_-]\+' /var/log/parachute-bootstrap.log 2>/dev/null | tail -n1 || true)"
+        fi
+        [ -n "$TOKEN" ] && break
+        sleep 2
+      done
+
+      echo "" | tee /dev/console
+      echo "==================================================================" | tee /dev/console
+      echo " PARACHUTE FULL-TIER BOOTSTRAP COMPLETE" | tee /dev/console
+      echo "==================================================================" | tee /dev/console
+      if [ -n "$TOKEN" ]; then
+        echo " One-time admin setup token:" | tee /dev/console
+        echo "     $TOKEN" | tee /dev/console
+      else
+        echo " Bootstrap token not found in the log yet. Retrieve it with:" | tee /dev/console
+        echo "     sudo -iu parachute journalctl --user | grep parachute-bootstrap-" | tee /dev/console
+        echo "     # (or: sudo -iu parachute grep parachute-bootstrap- ~/.parachute/hub/logs/hub.log)" | tee /dev/console
+      fi
+      echo "" | tee /dev/console
+      echo " The hub is running LOOPBACK-ONLY on this box (port 1939)." | tee /dev/console
+      echo " To finish setup you need a URL you can reach. Two options:" | tee /dev/console
+      echo "" | tee /dev/console
+      echo "  A) Get a public URL (recommended). SSH in as the parachute user:" | tee /dev/console
+      echo "        ssh parachute@<this-box-ip>" | tee /dev/console
+      echo "        parachute expose cloudflare --domain <your-host>   # public HTTPS via a Cloudflare Tunnel (needs a Cloudflare-managed domain)" | tee /dev/console
+      echo "        #   or, if you run Tailscale on the box + your devices:" | tee /dev/console
+      echo "        #     parachute expose tailnet     # private HTTPS, only your tailnet devices" | tee /dev/console
+      echo "     then open the printed URL's /admin/setup and paste the token above." | tee /dev/console
+      echo "" | tee /dev/console
+      echo "  B) Or tunnel the loopback port over SSH from your laptop:" | tee /dev/console
+      echo "        ssh -L 1939:127.0.0.1:1939 parachute@<this-box-ip>" | tee /dev/console
+      echo "     then open http://127.0.0.1:1939/admin/setup and paste the token." | tee /dev/console
+      echo "" | tee /dev/console
+      echo " After setup: install the Channel module + create agent sessions" | tee /dev/console
+      echo " from the admin UI (or `parachute install channel`)." | tee /dev/console
+      echo "==================================================================" | tee /dev/console
+
+      log "bootstrap script finished"
+
+runcmd:
+  # Run the bootstrap as the non-root `parachute` user (login shell so PATH +
+  # HOME resolve to that account). Tee a copy to a stable log for `cloud-init`
+  # post-mortems. `-i` gives a login env; the script re-derives BUN PATH itself.
+  - [ bash, -lc, "sudo -iu parachute /usr/local/sbin/parachute-full-bootstrap.sh 2>&1 | tee /var/log/parachute-bootstrap.log" ]
+
+# A clear console banner once cloud-init is fully done.
+final_message: |
+  Parachute full-tier bootstrap finished after $UPTIME seconds.
+  Read the admin setup token above (or: sudo -iu parachute grep parachute-bootstrap- ~/.parachute/logs/hub.log),
+  then SSH in and run `parachute expose public` for a URL, and visit /admin/setup.


### PR DESCRIPTION
Provider-agnostic cloud-init `user_data` that boots a fresh Linux VPS to a working full Parachute (hub+channel+bun+sandbox-runtime+claude+tmux+bubblewrap), surfaces the bootstrap token + /admin/setup URL, then `parachute expose` for a public URL. + deploy-tiers doc (lite=Render/Fly vs full=desktop/VPS), per-provider paste steps (DO default / Hetzner cost), and the documented single live-VPS-boot smoke for Aaron. **bubblewrap egress-deny test PASSED** in a Linux container (the real Linux-sandbox proof Seatbelt can't give). Phase 1 stack; base ag-agents-phase1; do not merge yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)