### PR TITLE
feat(creds): per-channel Claude OAuth secret storage + spawn wiring (Phase 1)

### DIFF
--- a/src/credentials.test.ts
+++ b/src/credentials.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Per-channel Claude OAuth credential store (design §6).
+ *
+ * Covers: store/retrieve round-trip, 0600 on the secret file, redaction (the
+ * raw token never appears in the inspection helper / serialized output), and
+ * default-vs-override resolution (override wins, falls back to default, errors
+ * when neither). All hermetic under a throwaway state dir.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, existsSync, readFileSync, statSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  setDefaultClaudeCredential,
+  setChannelClaudeCredential,
+  removeChannelClaudeCredential,
+  resolveClaudeCredential,
+  describeClaudeCredentials,
+  readCredentialsFile,
+  credentialsFilePath,
+  CredentialNotConfiguredError,
+} from "./credentials.ts";
+
+const DEFAULT_TOKEN = "oat_DEFAULT-OPERATOR-TOKEN-SECRET";
+const OVERRIDE_TOKEN = "oat_PER-CHANNEL-OVERRIDE-SECRET";
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "channel-creds-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("store / retrieve round-trip", () => {
+  test("default token: set then resolve returns it", () => {
+    setDefaultClaudeCredential(DEFAULT_TOKEN, dir);
+    expect(resolveClaudeCredential("any-channel", dir)).toBe(DEFAULT_TOKEN);
+  });
+
+  test("per-channel override: set then resolve returns it for that channel", () => {
+    setChannelClaudeCredential("aaron-dev", OVERRIDE_TOKEN, dir);
+    expect(resolveClaudeCredential("aaron-dev", dir)).toBe(OVERRIDE_TOKEN);
+  });
+
+  test("setting one slice preserves the other (read-modify-write)", () => {
+    setDefaultClaudeCredential(DEFAULT_TOKEN, dir);
+    setChannelClaudeCredential("aaron-dev", OVERRIDE_TOKEN, dir);
+    setChannelClaudeCredential("ops", "oat_OPS", dir);
+    const file = readCredentialsFile(dir);
+    expect(file.claude!.default).toBe(DEFAULT_TOKEN);
+    expect(file.claude!.channels!["aaron-dev"]).toBe(OVERRIDE_TOKEN);
+    expect(file.claude!.channels!["ops"]).toBe("oat_OPS");
+  });
+
+  test("empty token is rejected (never persists a blank credential)", () => {
+    expect(() => setDefaultClaudeCredential("", dir)).toThrow(/non-empty token/);
+    expect(() => setChannelClaudeCredential("c", "", dir)).toThrow(/non-empty token/);
+    expect(existsSync(credentialsFilePath(dir))).toBe(false);
+  });
+});
+
+describe("0600 on the secret file", () => {
+  test("the credentials file is written 0600 (holds a secret)", () => {
+    setDefaultClaudeCredential(DEFAULT_TOKEN, dir);
+    const file = credentialsFilePath(dir);
+    expect(existsSync(file)).toBe(true);
+    expect(statSync(file).mode & 0o777).toBe(0o600);
+  });
+
+  test("a subsequent write keeps it 0600 (chmod is unconditional)", () => {
+    setDefaultClaudeCredential(DEFAULT_TOKEN, dir);
+    // Loosen perms behind the store's back, then write again → must re-tighten.
+    const fs = require("fs") as typeof import("fs");
+    fs.chmodSync(credentialsFilePath(dir), 0o644);
+    setChannelClaudeCredential("c", OVERRIDE_TOKEN, dir);
+    expect(statSync(credentialsFilePath(dir)).mode & 0o777).toBe(0o600);
+  });
+});
+
+describe("redaction — the raw token never leaks via the inspection helper", () => {
+  test("describeClaudeCredentials reports presence + channel names, NOT the token", () => {
+    setDefaultClaudeCredential(DEFAULT_TOKEN, dir);
+    setChannelClaudeCredential("aaron-dev", OVERRIDE_TOKEN, dir);
+    setChannelClaudeCredential("ops", "oat_OPS", dir);
+    const desc = describeClaudeCredentials(dir);
+    expect(desc.defaultSet).toBe(true);
+    expect(desc.channels).toEqual(["aaron-dev", "ops"]); // sorted, names only
+    const serialized = JSON.stringify(desc);
+    expect(serialized).not.toContain(DEFAULT_TOKEN);
+    expect(serialized).not.toContain(OVERRIDE_TOKEN);
+    expect(serialized).not.toContain("oat_OPS");
+  });
+
+  test("describe on an empty store: defaultSet false, no channels", () => {
+    const desc = describeClaudeCredentials(dir);
+    expect(desc).toEqual({ defaultSet: false, channels: [] });
+  });
+});
+
+describe("default-vs-override resolution", () => {
+  test("override WINS over the default for its channel", () => {
+    setDefaultClaudeCredential(DEFAULT_TOKEN, dir);
+    setChannelClaudeCredential("aaron-dev", OVERRIDE_TOKEN, dir);
+    expect(resolveClaudeCredential("aaron-dev", dir)).toBe(OVERRIDE_TOKEN);
+    // A different channel with no override falls back to the default.
+    expect(resolveClaudeCredential("other", dir)).toBe(DEFAULT_TOKEN);
+  });
+
+  test("falls back to the default when the channel has no override", () => {
+    setDefaultClaudeCredential(DEFAULT_TOKEN, dir);
+    expect(resolveClaudeCredential("never-configured", dir)).toBe(DEFAULT_TOKEN);
+  });
+
+  test("ERRORS when neither an override nor a default is set", () => {
+    expect(() => resolveClaudeCredential("ghost", dir)).toThrow(CredentialNotConfiguredError);
+    expect(() => resolveClaudeCredential("ghost", dir)).toThrow(/no Claude credential for channel "ghost"/);
+  });
+
+  test("removing an override falls back to the default; removing a missing one is a no-op", () => {
+    setDefaultClaudeCredential(DEFAULT_TOKEN, dir);
+    setChannelClaudeCredential("aaron-dev", OVERRIDE_TOKEN, dir);
+    expect(removeChannelClaudeCredential("aaron-dev", dir)).toBe(true);
+    expect(resolveClaudeCredential("aaron-dev", dir)).toBe(DEFAULT_TOKEN); // back to default
+    expect(removeChannelClaudeCredential("aaron-dev", dir)).toBe(false); // already gone
+    // The default is untouched by an override removal.
+    expect(readCredentialsFile(dir).claude!.default).toBe(DEFAULT_TOKEN);
+  });
+
+  test("resolution is read dynamically — a rotate takes effect on the next resolve", () => {
+    setDefaultClaudeCredential(DEFAULT_TOKEN, dir);
+    expect(resolveClaudeCredential("c", dir)).toBe(DEFAULT_TOKEN);
+    setDefaultClaudeCredential("oat_ROTATED", dir);
+    expect(resolveClaudeCredential("c", dir)).toBe("oat_ROTATED");
+  });
+});

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -1,0 +1,189 @@
+/**
+ * Per-channel Claude OAuth credential store (design §6).
+ *
+ * The Claude `CLAUDE_CODE_OAUTH_TOKEN` (from `claude setup-token`, the documented
+ * 1-year headless/CI auth path) is the credential a launched agent session runs
+ * on — injected into the sandbox at launch as the session's auth (NEVER
+ * `ANTHROPIC_API_KEY`, which would silently route onto API billing; see
+ * `spawn-agent.ts`). This module persists that secret, following the SAME
+ * file-store discipline `registry.ts` uses for per-channel transport tokens:
+ * a read-modify-write JSON file, written 0600 and `chmod`-ed 0600 unconditionally
+ * (so an existing file created under a looser umask is tightened on every write).
+ *
+ * Two principal levels (design §6 — "default one operator token; per-channel
+ * override"):
+ *
+ *   - a **default / operator-level** token, used when a channel has no override,
+ *   - a **per-channel override**, the multi-principal seam (multi-user isn't a
+ *     rewrite — just populating per-channel, eventually per-principal, tokens).
+ *
+ * Resolution (`resolveClaudeCredential`): channel override ?? default ?? error.
+ *
+ * The secret lives in its OWN file (`credentials.json`), separate from
+ * `channels.json`: the default/operator token isn't tied to any single channel,
+ * and the credential lifecycle (set the operator token once, override per
+ * channel) is distinct from the channel-registry lifecycle. The file is
+ * NAMESPACED by credential type (`{ claude: { ... } }`) so a future credential
+ * type can coexist without a schema migration.
+ *
+ * Redaction discipline: the raw token is NEVER returned by the listing/inspection
+ * helper (`describeClaudeCredentials`) and NEVER logged — exactly the posture the
+ * config API + transports already keep for `config.token` / `webhookSecret`.
+ */
+
+import { readFileSync, writeFileSync, existsSync, chmodSync, mkdirSync } from "fs";
+import { join } from "path";
+import { defaultStateDir } from "./registry.ts";
+
+/** The Claude-credential slice of the store. */
+export interface ClaudeCredentialStore {
+  /** Default / operator-level OAuth token, used when a channel has no override. */
+  default?: string;
+  /** Per-channel overrides, keyed by channel name. */
+  channels?: Record<string, string>;
+}
+
+/** The on-disk `credentials.json` shape (namespaced by credential type). */
+export interface CredentialsFile {
+  claude?: ClaudeCredentialStore;
+}
+
+/** The default credential reference an unspecified spec resolves against. */
+export const DEFAULT_CREDENTIAL_REF = "operator" as const;
+
+/** Absolute path to the credentials.json store in a state dir. */
+export function credentialsFilePath(stateDir?: string): string {
+  return join(stateDir ?? defaultStateDir(), "credentials.json");
+}
+
+/**
+ * Read `credentials.json` as a plain `CredentialsFile`. Returns an empty `{}` if
+ * the file is absent. Mirrors `registry.readChannelsFile` — the read half of the
+ * read-modify-write the setters use.
+ */
+export function readCredentialsFile(stateDir?: string): CredentialsFile {
+  const file = credentialsFilePath(stateDir);
+  if (!existsSync(file)) return {};
+  const parsed = JSON.parse(readFileSync(file, "utf8")) as CredentialsFile;
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error(`credentials: ${file} must be a JSON object`);
+  }
+  return parsed;
+}
+
+/**
+ * Persist the store back to `credentials.json` with 0600 perms — the file holds
+ * the Claude OAuth secret. Creates the state dir if needed. `chmod`s 0600
+ * unconditionally (writeFileSync's `mode` only applies on CREATE, so an existing
+ * file created under a looser umask is tightened on every write) — the exact
+ * discipline `registry.upsertChannelEntry` keeps for the secret-bearing
+ * channels.json.
+ */
+function writeCredentialsFile(file: CredentialsFile, stateDir?: string): void {
+  const dir = stateDir ?? defaultStateDir();
+  mkdirSync(dir, { recursive: true });
+  const path = credentialsFilePath(dir);
+  writeFileSync(path, JSON.stringify(file, null, 2) + "\n", { mode: 0o600 });
+  chmodSync(path, 0o600);
+}
+
+/**
+ * Set the default / operator-level Claude OAuth token. Used by any channel that
+ * has no per-channel override. Read-modify-write so existing per-channel
+ * overrides are preserved.
+ */
+export function setDefaultClaudeCredential(token: string, stateDir?: string): void {
+  if (typeof token !== "string" || token.length === 0) {
+    throw new Error("credentials: a non-empty token is required");
+  }
+  const file = readCredentialsFile(stateDir);
+  const claude = file.claude ?? {};
+  claude.default = token;
+  file.claude = claude;
+  writeCredentialsFile(file, stateDir);
+}
+
+/**
+ * Set a per-channel Claude OAuth override. Wins over the default for that channel.
+ * Read-modify-write so the default + other channels' overrides are preserved.
+ */
+export function setChannelClaudeCredential(
+  channel: string,
+  token: string,
+  stateDir?: string,
+): void {
+  if (typeof channel !== "string" || channel.length === 0) {
+    throw new Error("credentials: a channel name is required");
+  }
+  if (typeof token !== "string" || token.length === 0) {
+    throw new Error("credentials: a non-empty token is required");
+  }
+  const file = readCredentialsFile(stateDir);
+  const claude = file.claude ?? {};
+  const channels = claude.channels ?? {};
+  channels[channel] = token;
+  claude.channels = channels;
+  file.claude = claude;
+  writeCredentialsFile(file, stateDir);
+}
+
+/**
+ * Remove a per-channel override (the channel falls back to the default after
+ * this). Returns true if an override existed, false if there was nothing to
+ * remove. The default token is untouched.
+ */
+export function removeChannelClaudeCredential(channel: string, stateDir?: string): boolean {
+  const file = readCredentialsFile(stateDir);
+  const channels = file.claude?.channels;
+  if (!channels || !(channel in channels)) return false;
+  delete channels[channel];
+  writeCredentialsFile(file, stateDir);
+  return true;
+}
+
+/** Thrown when neither a per-channel override nor a default token is configured. */
+export class CredentialNotConfiguredError extends Error {
+  constructor(channel: string) {
+    super(
+      `no Claude credential for channel "${channel}": set a per-channel override or the ` +
+        `default/operator token (POST /api/credentials/claude). Get one with ` +
+        `\`claude setup-token\`.`,
+    );
+    this.name = "CredentialNotConfiguredError";
+  }
+}
+
+/**
+ * Resolve the Claude OAuth token a session on `channel` should run on:
+ *
+ *   channel override ?? default ?? throw CredentialNotConfiguredError
+ *
+ * Read at resolve time (not cached) so a token set/rotated via the config API
+ * takes effect on the next spawn without a daemon restart — the dynamic-read
+ * discipline. Throwing (rather than returning empty) means a misconfigured
+ * install fails loud BEFORE a session launches with no auth.
+ */
+export function resolveClaudeCredential(channel: string, stateDir?: string): string {
+  const claude = readCredentialsFile(stateDir).claude;
+  const override = claude?.channels?.[channel];
+  if (override) return override;
+  const fallback = claude?.default;
+  if (fallback) return fallback;
+  throw new CredentialNotConfiguredError(channel);
+}
+
+/**
+ * Describe the credential store for an operator-facing read WITHOUT leaking the
+ * secret: whether a default is set, and which channels carry an override (names
+ * only). The raw token is never returned — same redaction posture the config
+ * API keeps for transport tokens. (`GET /api/credentials/claude`.)
+ */
+export function describeClaudeCredentials(
+  stateDir?: string,
+): { defaultSet: boolean; channels: string[] } {
+  const claude = readCredentialsFile(stateDir).claude;
+  return {
+    defaultSet: Boolean(claude?.default),
+    channels: Object.keys(claude?.channels ?? {}).sort(),
+  };
+}

--- a/src/daemon-config-api.test.ts
+++ b/src/daemon-config-api.test.ts
@@ -49,6 +49,7 @@ import { ClientRegistry } from "./routing.ts";
 import { VaultTransport, CHANNEL_VAULT_TRIGGER_TEMPLATE } from "./transports/vault.ts";
 import { channelsFilePath } from "./registry.ts";
 import type { Channel } from "./registry.ts";
+import { credentialsFilePath, resolveClaudeCredential } from "./credentials.ts";
 import type { TransportContext, InboundMessage } from "./transport.ts";
 
 const sendAuth = { authorization: "Bearer " + SEND_TOKEN } as const;
@@ -554,6 +555,177 @@ describe("C — CHANNEL_VAULT_TRIGGER_TEMPLATE exposed via /.parachute/config", 
       expect(body.triggerTemplate.name).toBe("channel_inbound_<channel>");
       expect(body.triggerTemplate.when.tags).toEqual(["#channel-message/inbound"]);
       expect(body.triggerTemplate.action.webhook).toBe("<hub-origin>/channel/api/vault/inbound");
+    } finally {
+      srv.stop(true);
+    }
+  });
+});
+
+// ===========================================================================
+// D. Claude OAuth credential store API (channel:admin) — design §6
+// ===========================================================================
+describe("D — Claude credential store API (channel:admin)", () => {
+  test("POST /api/credentials/claude sets the default; persisted 0600; resolve returns it", async () => {
+    const { srv, base } = buildServer([]);
+    try {
+      const res = await fetch(`${base}/api/credentials/claude`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ token: "oat_DEFAULT-OPERATOR" }),
+      });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toMatchObject({ ok: true, scope: "default" });
+
+      const file = credentialsFilePath(stateDir);
+      expect(existsSync(file)).toBe(true);
+      expect(statSync(file).mode & 0o777).toBe(0o600);
+      // The token resolves for any channel (no override → default).
+      expect(resolveClaudeCredential("any-channel", stateDir)).toBe("oat_DEFAULT-OPERATOR");
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("POST /api/credentials/claude/:channel sets an override that WINS over the default", async () => {
+    const { srv, base } = buildServer([]);
+    try {
+      await fetch(`${base}/api/credentials/claude`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ token: "oat_DEFAULT" }),
+      });
+      const res = await fetch(`${base}/api/credentials/claude/aaron-dev`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ token: "oat_AARON-OVERRIDE" }),
+      });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toMatchObject({ ok: true, scope: "channel", channel: "aaron-dev" });
+
+      expect(resolveClaudeCredential("aaron-dev", stateDir)).toBe("oat_AARON-OVERRIDE"); // override wins
+      expect(resolveClaudeCredential("other", stateDir)).toBe("oat_DEFAULT"); // other → default
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("GET /api/credentials/claude reports presence + channel names — NEVER the token", async () => {
+    const { srv, base } = buildServer([]);
+    try {
+      await fetch(`${base}/api/credentials/claude`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ token: "oat_SECRET-DEFAULT" }),
+      });
+      await fetch(`${base}/api/credentials/claude/aaron-dev`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ token: "oat_SECRET-OVERRIDE" }),
+      });
+
+      const res = await fetch(`${base}/api/credentials/claude`, { headers: { ...adminAuth } });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { defaultSet: boolean; channels: string[] };
+      expect(body.defaultSet).toBe(true);
+      expect(body.channels).toEqual(["aaron-dev"]);
+      // No secret leaks.
+      const serialized = JSON.stringify(body);
+      expect(serialized).not.toContain("oat_SECRET-DEFAULT");
+      expect(serialized).not.toContain("oat_SECRET-OVERRIDE");
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("DELETE /api/credentials/claude/:channel removes the override (falls back to default)", async () => {
+    const { srv, base } = buildServer([]);
+    try {
+      await fetch(`${base}/api/credentials/claude`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ token: "oat_DEFAULT" }),
+      });
+      await fetch(`${base}/api/credentials/claude/aaron-dev`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ token: "oat_OVERRIDE" }),
+      });
+      const del = await fetch(`${base}/api/credentials/claude/aaron-dev`, {
+        method: "DELETE",
+        headers: { ...adminAuth },
+      });
+      expect(del.status).toBe(200);
+      expect(await del.json()).toMatchObject({ ok: true, channel: "aaron-dev", removed: true });
+      expect(resolveClaudeCredential("aaron-dev", stateDir)).toBe("oat_DEFAULT"); // back to default
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("POST with an empty/missing token → 400, nothing persisted", async () => {
+    const { srv, base } = buildServer([]);
+    try {
+      const empty = await fetch(`${base}/api/credentials/claude`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ token: "" }),
+      });
+      expect(empty.status).toBe(400);
+      const missing = await fetch(`${base}/api/credentials/claude`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({}),
+      });
+      expect(missing.status).toBe(400);
+      expect(existsSync(credentialsFilePath(stateDir))).toBe(false);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("credential API without channel:admin → 401 (none) / 403 (wrong scope), on every verb", async () => {
+    const { srv, base } = buildServer([]);
+    try {
+      // GET default
+      expect((await fetch(`${base}/api/credentials/claude`)).status).toBe(401);
+      expect((await fetch(`${base}/api/credentials/claude`, { headers: { ...readAuth } })).status).toBe(403);
+      // POST default
+      expect(
+        (await fetch(`${base}/api/credentials/claude`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ token: "x" }),
+        })).status,
+      ).toBe(401);
+      expect(
+        (await fetch(`${base}/api/credentials/claude`, {
+          method: "POST",
+          headers: { "content-type": "application/json", ...sendAuth },
+          body: JSON.stringify({ token: "x" }),
+        })).status,
+      ).toBe(403);
+      // POST per-channel
+      expect(
+        (await fetch(`${base}/api/credentials/claude/c`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ token: "x" }),
+        })).status,
+      ).toBe(401);
+      expect(
+        (await fetch(`${base}/api/credentials/claude/c`, {
+          method: "POST",
+          headers: { "content-type": "application/json", ...readAuth },
+          body: JSON.stringify({ token: "x" }),
+        })).status,
+      ).toBe(403);
+      // DELETE per-channel
+      expect((await fetch(`${base}/api/credentials/claude/c`, { method: "DELETE" })).status).toBe(401);
+      expect(
+        (await fetch(`${base}/api/credentials/claude/c`, { method: "DELETE", headers: { ...readAuth } })).status,
+      ).toBe(403);
+      // Nothing was persisted by any unauthorized call.
+      expect(existsSync(credentialsFilePath(stateDir))).toBe(false);
     } finally {
       srv.stop(true);
     }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -52,6 +52,12 @@ import {
   type ChannelEntry,
 } from "./registry.ts";
 import { VaultTransport, CHANNEL_VAULT_TRIGGER_TEMPLATE } from "./transports/vault.ts";
+import {
+  setDefaultClaudeCredential,
+  setChannelClaudeCredential,
+  removeChannelClaudeCredential,
+  describeClaudeCredentials,
+} from "./credentials.ts";
 import { ClientRegistry } from "./routing.ts";
 import {
   requireScope,
@@ -831,6 +837,82 @@ export function createFetchHandler(
         return json({ ok: true, name, removed: false }, 200);
       }
       return json({ ok: true, name, removed: true });
+    }
+
+    // ---------------------------------------------------------------------
+    // Claude OAuth credential store (design §6) — the per-channel secret a
+    // launched agent session runs on (`CLAUDE_CODE_OAUTH_TOKEN`). Same
+    // `channel:admin` gate + 0600 file-store + redaction-on-read posture as the
+    // channel config API above. The token comes from `claude setup-token`.
+    //
+    //   GET    /api/credentials/claude          → { defaultSet, channels:[names] } (NO secret)
+    //   POST   /api/credentials/claude          { token } → set the default/operator token
+    //   POST   /api/credentials/claude/:channel { token } → set a per-channel override
+    //   DELETE /api/credentials/claude/:channel → remove an override (falls back to default)
+    //
+    // Externally hub strips `/channel`, so these are `<hub>/channel/api/credentials/claude`.
+    // ---------------------------------------------------------------------
+    if (url.pathname === "/api/credentials/claude" && (req.method === "GET" || req.method === "POST")) {
+      const denied = await requireScope(req, url, SCOPE_ADMIN);
+      if (denied) return denied;
+
+      if (req.method === "GET") {
+        // Inspect WITHOUT leaking the secret: whether a default is set + which
+        // channels carry an override (names only).
+        return json(describeClaudeCredentials(defaultStateDir()));
+      }
+
+      // POST — set the default / operator-level token.
+      let credBody: { token?: unknown };
+      try {
+        credBody = (await req.json()) as typeof credBody;
+      } catch {
+        return json({ error: "invalid JSON body" }, 400);
+      }
+      if (typeof credBody.token !== "string" || credBody.token.length === 0) {
+        return json({ error: "body.token (non-empty string) is required" }, 400);
+      }
+      try {
+        setDefaultClaudeCredential(credBody.token, defaultStateDir());
+      } catch (err) {
+        return json({ error: `failed to write credentials.json: ${(err as Error).message}` }, 500);
+      }
+      // Echo back only the fact of the write — never the token.
+      return json({ ok: true, scope: "default" });
+    }
+
+    const credMatch = url.pathname.match(/^\/api\/credentials\/claude\/([^/]+)$/);
+    if (credMatch && (req.method === "POST" || req.method === "DELETE")) {
+      const denied = await requireScope(req, url, SCOPE_ADMIN);
+      if (denied) return denied;
+      const channel = decodeURIComponent(credMatch[1]!);
+
+      if (req.method === "DELETE") {
+        let removed: boolean;
+        try {
+          removed = removeChannelClaudeCredential(channel, defaultStateDir());
+        } catch (err) {
+          return json({ error: `failed to update credentials.json: ${(err as Error).message}` }, 500);
+        }
+        return json({ ok: true, channel, removed });
+      }
+
+      // POST — set a per-channel override.
+      let credBody: { token?: unknown };
+      try {
+        credBody = (await req.json()) as typeof credBody;
+      } catch {
+        return json({ error: "invalid JSON body" }, 400);
+      }
+      if (typeof credBody.token !== "string" || credBody.token.length === 0) {
+        return json({ error: "body.token (non-empty string) is required" }, 400);
+      }
+      try {
+        setChannelClaudeCredential(channel, credBody.token, defaultStateDir());
+      } catch (err) {
+        return json({ error: `failed to write credentials.json: ${(err as Error).message}` }, 500);
+      }
+      return json({ ok: true, scope: "channel", channel });
     }
 
     // ---------------------------------------------------------------------

--- a/src/spawn-agent.test.ts
+++ b/src/spawn-agent.test.ts
@@ -15,6 +15,10 @@ import type { SandboxEngine } from "./sandbox/index.ts";
 import type { SandboxRuntimeConfig } from "@anthropic-ai/sandbox-runtime";
 import type { AgentSpec } from "./sandbox/types.ts";
 import { channelEntryKey, vaultEntryKey } from "./agent-mcp-config.ts";
+import {
+  setDefaultClaudeCredential,
+  setChannelClaudeCredential,
+} from "./credentials.ts";
 
 let sessionsDir: string;
 afterEach(() => {
@@ -87,7 +91,9 @@ function baseDeps(over: Partial<SpawnAgentDeps> = {}): SpawnAgentDeps {
     vaultUrl: "http://127.0.0.1:1940",
     sessionsDir,
     runtimeReadOnly: ["/cfg/.claude"],
-    claudeOauthToken: "OAUTH-CRED-PLACEHOLDER",
+    // Stub the credential resolver so the test never touches a real store; the
+    // assertion below checks this exact token lands in CLAUDE_CODE_OAUTH_TOKEN.
+    resolveClaudeToken: () => "OAUTH-CRED-PLACEHOLDER",
     sandboxEngine: fakeEngine(),
     tmux: recordingTmux(),
     fetchFn: fakeMintFetch(),
@@ -399,3 +405,88 @@ describe("spawnAgent — full wiring with stubs (no real token)", () => {
     expect(maxActive).toBe(1);
   });
 });
+
+// ---- credential wiring (Stream 3 — resolve from the per-channel store) -------
+
+describe("spawnAgent — resolves the Claude credential from the per-channel store", () => {
+  let storeDir: string;
+  afterEach(() => {
+    if (storeDir) rmSync(storeDir, { recursive: true, force: true });
+  });
+
+  // The wiring under test reads `credentials.ts` keyed on the WAKE channel (the
+  // first channel). These tests use the REAL resolver (no `resolveClaudeToken`
+  // stub) against a throwaway store, proving the end-to-end resolve→inject path.
+  function depsWithRealResolver(): SpawnAgentDeps {
+    const d = baseDeps();
+    delete (d as { resolveClaudeToken?: unknown }).resolveClaudeToken;
+    return d;
+  }
+
+  test("injects the PER-CHANNEL override when the wake channel has one", async () => {
+    sessionsDir = mkdtempSync(join(tmpdir(), "spawn-agent-cred-ovr-"));
+    storeDir = mkdtempSync(join(tmpdir(), "channel-creds-ovr-"));
+    setDefaultClaudeCredential("oat_DEFAULT", storeDir);
+    setChannelClaudeCredential("aaron-dev", "oat_AARON-OVERRIDE", storeDir);
+
+    const tmux = recordingTmux();
+    const deps = { ...depsWithRealResolver(), tmux, resolveClaudeToken: (ch: string) => resolveAgainst(storeDir, ch) };
+    const res = await spawnAgent({ name: "aaron-dev", channels: ["aaron-dev"] }, deps);
+    expect(res.alreadyRunning).toBe(false);
+    // The override (not the default) lands in CLAUDE_CODE_OAUTH_TOKEN.
+    expect(tmux.launched[0]!.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("oat_AARON-OVERRIDE");
+    expect(tmux.launched[0]!.env.ANTHROPIC_API_KEY).toBeUndefined();
+  });
+
+  test("falls back to the DEFAULT/operator token when the wake channel has no override", async () => {
+    sessionsDir = mkdtempSync(join(tmpdir(), "spawn-agent-cred-def-"));
+    storeDir = mkdtempSync(join(tmpdir(), "channel-creds-def-"));
+    setDefaultClaudeCredential("oat_DEFAULT", storeDir);
+
+    const tmux = recordingTmux();
+    const deps = { ...baseDeps(), tmux, resolveClaudeToken: (ch: string) => resolveAgainst(storeDir, ch) };
+    const res = await spawnAgent({ name: "other", channels: ["unconfigured-ch"] }, deps);
+    expect(res.alreadyRunning).toBe(false);
+    expect(tmux.launched[0]!.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("oat_DEFAULT");
+  });
+
+  test("resolves on the WAKE channel (first), not a later one", async () => {
+    sessionsDir = mkdtempSync(join(tmpdir(), "spawn-agent-cred-wake-"));
+    storeDir = mkdtempSync(join(tmpdir(), "channel-creds-wake-"));
+    setDefaultClaudeCredential("oat_DEFAULT", storeDir);
+    setChannelClaudeCredential("first", "oat_FIRST", storeDir);
+    setChannelClaudeCredential("second", "oat_SECOND", storeDir);
+
+    const tmux = recordingTmux();
+    const deps = { ...baseDeps(), tmux, resolveClaudeToken: (ch: string) => resolveAgainst(storeDir, ch) };
+    await spawnAgent({ name: "multi", channels: ["first", "second"] }, deps);
+    // The wake channel is the first → its override is the session's auth.
+    expect(tmux.launched[0]!.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("oat_FIRST");
+  });
+
+  test("SECURITY: an unconfigured store ABORTS the launch BEFORE any mint/tmux side effect", async () => {
+    sessionsDir = mkdtempSync(join(tmpdir(), "spawn-agent-cred-none-"));
+    storeDir = mkdtempSync(join(tmpdir(), "channel-creds-none-")); // empty store
+    const tmux = recordingTmux();
+    let minted = false;
+    const fetchFn = (async () => {
+      minted = true;
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
+    const deps = { ...baseDeps(), tmux, fetchFn, resolveClaudeToken: (ch: string) => resolveAgainst(storeDir, ch) };
+    await expect(
+      spawnAgent({ name: "x", channels: ["ghost"] }, deps),
+    ).rejects.toThrow(/no Claude credential/);
+    // No session launched, no token minted.
+    expect(tmux.launched).toHaveLength(0);
+    expect(minted).toBe(false);
+  });
+});
+
+// Resolve against a specific store dir (the real resolver hard-wires the default
+// state dir; this test helper threads the throwaway dir through, exercising the
+// SAME `resolveClaudeCredential` the production resolver calls).
+function resolveAgainst(storeDir: string, channel: string): string {
+  const { resolveClaudeCredential } = require("./credentials.ts") as typeof import("./credentials.ts");
+  return resolveClaudeCredential(channel, storeDir);
+}

--- a/src/spawn-agent.ts
+++ b/src/spawn-agent.ts
@@ -12,8 +12,11 @@
  *      onto API billing, §6). `--strict-mcp-config` closes the MCP surface to
  *      exactly the spec.
  *
- * The credential injected here is a passed-in param/placeholder for THIS stream;
- * Stream 3 builds the real per-channel secret store (design §6, §4.1 credentialRef).
+ * The credential is resolved at launch from the per-channel secret store
+ * (`credentials.ts`, design §6): the spec's wake channel's per-channel override,
+ * falling back to the default/operator token, erroring when neither is set. The
+ * resolver is injectable (`deps.resolveClaudeToken`) so tests run hermetically
+ * without touching a real store.
  *
  * Env-scrubbing follows runner's `buildChildEnv` instinct
  * (`parachute-runner/src/spawn.ts`): pass only what claude needs, drop everything
@@ -41,6 +44,7 @@ import {
   type MintTokenDeps,
   type MintResult,
 } from "./mint-token.ts";
+import { resolveClaudeCredential } from "./credentials.ts";
 
 /**
  * Slug guard for `spec.name`. The name is used UNESCAPED as a tmux session
@@ -107,11 +111,15 @@ export interface SpawnAgentDeps {
    */
   runtimeReadOnly: string[];
   /**
-   * The Claude credential to inject as `CLAUDE_CODE_OAUTH_TOKEN`. For THIS stream
-   * a passed-in param/placeholder; Stream 3 resolves it from the per-channel
-   * secret store keyed by `spec.credentialRef`.
+   * Resolve the Claude OAuth token to inject as `CLAUDE_CODE_OAUTH_TOKEN`, given
+   * the spec's wake channel. Defaults to the real per-channel secret store
+   * (`credentials.ts` — channel override ?? default/operator ?? throw). Tests
+   * inject a stub so they never read a real store. The store throws
+   * `CredentialNotConfiguredError` when neither an override nor a default is set,
+   * which aborts the launch BEFORE any tmux session is created (no session ever
+   * runs without auth).
    */
-  claudeOauthToken: string;
+  resolveClaudeToken?: (channel: string) => string;
   /** Sandbox engine override (tests inject a fake). */
   sandboxEngine?: SandboxEngine;
   /** tmux launcher (tests inject a recorder). */
@@ -266,6 +274,16 @@ export async function spawnAgent(
     throw new Error(`spawnAgent: spec "${spec.name}" declares no channels`);
   }
 
+  // Resolve the Claude OAuth credential from the per-channel store keyed on the
+  // wake channel (the first channel — the one whose dev-channel flag the session
+  // launches under). A missing credential throws here (CredentialNotConfigured),
+  // BEFORE any mint or fs/tmux side effect, so a session never launches without
+  // auth. The token is read at spawn time so a rotate via the config API takes
+  // effect on the next spawn without a daemon restart.
+  const wakeChannel = normalizeChannel(spec.channels[0]!).name;
+  const resolveToken = deps.resolveClaudeToken ?? ((ch: string) => resolveClaudeCredential(ch));
+  const claudeOauthToken = resolveToken(wakeChannel);
+
   const mintDeps: MintTokenDeps = {
     hubOrigin: deps.hubOrigin,
     managerBearer: deps.managerBearer,
@@ -336,10 +354,11 @@ export async function spawnAgent(
   writeFileSync(mcpConfigPath, mcpConfigJson, { mode: 0o600 });
 
   // 3. Build the claude argv, sandbox-wrap it, launch in tmux with scrubbed env.
-  const firstChannel = normalizeChannel(spec.channels[0]!).name;
+  // `wakeChannel` (resolved above) is the first channel — the dev-channel flag's
+  // server name + the key the credential was resolved under.
   const claudeArgs = buildAgentClaudeArgs({
     mcpConfigPath,
-    firstChannelEntryKey: `channel-${firstChannel}`,
+    firstChannelEntryKey: `channel-${wakeChannel}`,
     ...(deps.claudeBin ? { claudeBin: deps.claudeBin } : {}),
   });
 
@@ -369,7 +388,7 @@ export async function spawnAgent(
   // Layer the scrubbed agent env UNDER the sandbox wrapper's env (proxy vars,
   // sandbox markers from the engine win on conflict; CLAUDE_CODE_OAUTH_TOKEN +
   // the passthrough fundamentals come from us). ANTHROPIC_API_KEY is absent.
-  const childEnv = buildAgentChildEnv(deps.parentEnv ?? process.env, deps.claudeOauthToken);
+  const childEnv = buildAgentChildEnv(deps.parentEnv ?? process.env, claudeOauthToken);
   const launchEnv: Record<string, string | undefined> = { ...childEnv, ...wrapped.env };
 
   await deps.tmux.newSession({


### PR DESCRIPTION
Per-channel `CLAUDE_CODE_OAUTH_TOKEN` store (the registry.ts telegram-token pattern: 0600, redacted-on-read), default + per-channel-override resolution, wired into spawn-agent (resolves the real token on the wake channel before any mint/fs/tmux side effect — missing credential aborts the launch, never runs unauthenticated). Operator set-path API (channel:admin-gated). Stored in its own credentials.json (rationale in the commit). **298/0 verified** pre-disk-crisis. Stack PR; base ag-agents-phase1; do not merge yet. NOTE: overlaps the terminal branch on daemon.ts — reconciled at stack assembly (Stream 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)