### PR TITLE
Phase 1: sandboxed agent sessions — sandbox + spawn/scope + in-page terminal + creds + deploy

### DIFF
--- a/.parachute/module.json
+++ b/.parachute/module.json
@@ -9,6 +9,7 @@
   "stripPrefix": true,
   "uiUrl": "/channel/ui",
   "configUiUrl": "/channel/admin",
+  "websocket": true,
   "focus": "experimental",
   "adminCapabilities": ["config"],
   "startCmd": ["parachute-channel"],

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "parachute-channel",
       "dependencies": {
+        "@anthropic-ai/sandbox-runtime": "0.0.54",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@openparachute/scope-guard": "^0.4.0",
       },
@@ -17,11 +18,15 @@
     },
   },
   "packages": {
+    "@anthropic-ai/sandbox-runtime": ["@anthropic-ai/sandbox-runtime@0.0.54", "", { "dependencies": { "@pondwader/socks5-server": "^1.0.10", "commander": "^12.1.0", "node-forge": "^1.4.0", "shell-quote": "^1.8.4", "zod": "^3.24.1" }, "bin": { "srt": "dist/cli.js" } }, "sha512-zszEoq/z02SgJLlPFcoegqz2UonYbn3Gi//Hwza6KdUolg9HeGw/mPuO7Ybp4EzgLxG6ifA4KOrozErYKJuFag=="],
+
     "@hono/node-server": ["@hono/node-server@1.19.13", "", { "peerDependencies": { "hono": "^4" } }, "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "@openparachute/scope-guard": ["@openparachute/scope-guard@0.4.0", "", { "dependencies": { "jose": "^6.2.2" }, "peerDependencies": { "typescript": "^5" } }, "sha512-Atzc2TcEAdZvOK+BBN7iNEYzllO3svn63Rmn5+ZnJZkRo2jBWfent9J6nazS/uVrvoP6eGj2F1kuHKe93JkwsQ=="],
+
+    "@pondwader/socks5-server": ["@pondwader/socks5-server@1.0.10", "", {}, "sha512-bQY06wzzR8D2+vVCUoBsr5QS2U6UgPUQRmErNwtsuI6vLcyRKkafjkr3KxbtGFf9aBBIV2mcvlsKD1UYaIV+sg=="],
 
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
@@ -42,6 +47,8 @@
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
 
     "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
 
@@ -141,6 +148,8 @@
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
+    "node-forge": ["node-forge@1.4.0", "", {}, "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ=="],
+
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
@@ -181,6 +190,8 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
+    "shell-quote": ["shell-quote@1.8.4", "", {}, "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ=="],
+
     "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
 
     "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
@@ -207,8 +218,10 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
-    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
   }
 }

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,178 @@
+# Deploying Parachute — tiers + the full-tier cloud-init
+
+Parachute deploys in **two tiers**. Pick by whether you need **resident agent
+sessions** (sandboxed Claude Code sessions you chat with through a channel).
+
+| | **Lite** | **Full** |
+|---|---|---|
+| What runs | hub + vault + static surfaces | hub + vault + **channel + sandboxed agent sessions** |
+| Where | Render / Fly (a single container) | your **desktop** today, or a **Linux VPS** via `cloud-init-full.yaml` |
+| Isolation engine | n/a (no sessions) | `@anthropic-ai/sandbox-runtime` — **Seatbelt** on macOS, **bubblewrap** on Linux |
+| Resources | 512MB is fine | ~8GB RAM (sessions are real `claude` processes) |
+| How you set it up | one-click Blueprint / `flyctl` | paste this user-data → boot → SSH → `expose` |
+
+**Lite** is the existing hosted self-deploy: the `render.yaml` Blueprint and the
+Fly script in `parachute-hub`. It's a single container with one persistent disk —
+great for the vault + hub + surfaces, but it deliberately doesn't run agent
+sessions (no per-session sandbox; a PaaS container is the wrong substrate for
+spawning `claude` under bubblewrap).
+
+**Full** is this directory. The primary artifact is a **provider-agnostic
+cloud-init** script that boots a fresh Ubuntu/Debian VPS into a working full-tier
+box: hub + channel + the sandbox toolchain (`bun`, the `claude` CLI,
+`@anthropic-ai/sandbox-runtime`, `tmux`, `bubblewrap`, `ripgrep`, `socat`). The
+desktop path is just "install the hub + channel locally" — `cloud-init-full.yaml`
+is the same install, scripted for a headless box.
+
+> Design context: `design/2026-06-14-sandboxed-agent-sessions.md` §7. The
+> isolation contract is held constant; only the *mechanism* differs by platform
+> (Seatbelt / bubblewrap) behind `@anthropic-ai/sandbox-runtime`.
+
+---
+
+## The full-tier cloud-init (`cloud-init-full.yaml`)
+
+It's a standard `#cloud-config` user-data file. Every major cloud accepts
+cloud-init user-data, so the **same file** works on DigitalOcean, Hetzner, GCP,
+AWS EC2, or any generic cloud-init datasource. On first boot it:
+
+1. Patches the box, installs the apt deps (`tmux bubblewrap ripgrep socat git …`).
+2. Relaxes Ubuntu 24.04's `apparmor_restrict_unprivileged_userns` so bubblewrap
+   can create capability-bearing user namespaces (no-op on older kernels).
+3. Installs `bun`, then `@openparachute/hub`, `@openparachute/channel`, the
+   `claude` CLI, and `@anthropic-ai/sandbox-runtime` — all as a **non-root
+   `parachute` user**.
+4. Runs `parachute init --expose none --no-expose-prompt --cli-wizard` (starts
+   the hub as a systemd unit that survives reboots; loopback-only; no browser).
+5. Prints the one-time **admin bootstrap token** + the `/admin/setup` URL to the
+   **serial/console log**, and tells you to run `parachute expose` for a URL.
+
+The hub and the agent sessions run unprivileged as `parachute`; only the apt
+package install needs root (cloud-init runs as root for that).
+
+### Provider paste-instructions (the actual click path)
+
+The shape is identical everywhere: **create a VPS → paste the user-data → boot →
+read the console for the token → SSH in → `expose` → open `/admin/setup`.**
+
+#### DigitalOcean (simplest default — no KYC)
+
+1. Create Droplet → **Ubuntu 24.04** → an **8 GB** plan (sessions are real
+   processes; 8 GB is the comfortable floor).
+2. Under **Advanced options → Add Initialization scripts (free)**, paste the
+   contents of `cloud-init-full.yaml`.
+3. Add your SSH key → Create.
+4. When it's up, open the Droplet's **Console** (or **Recovery → Console**) and
+   read the `PARACHUTE FULL-TIER BOOTSTRAP COMPLETE` banner for the token.
+5. `ssh parachute@<droplet-ip>` → `parachute expose cloudflare --domain <host>`
+   (public HTTPS; needs a Cloudflare-managed domain) **or**
+   `parachute expose tailnet` if you run Tailscale.
+6. Open the printed URL's `/admin/setup`, paste the token, create your admin
+   account. Then install/connect the Channel module and launch sessions.
+
+#### Hetzner Cloud (cheapest in the EU)
+
+1. Create Server → **Ubuntu 24.04** → a **CPX41 / CX42-class (8 GB)** instance.
+2. Expand **Cloud config** and paste `cloud-init-full.yaml`.
+3. Add your SSH key → Create.
+4. Read the token from the server's **Console** in the Hetzner panel.
+5. Same as DO step 5–6 (`ssh parachute@<ip>` → `parachute expose …` → `/admin/setup`).
+
+#### GCP
+
+```sh
+gcloud compute instances create parachute-full \
+  --image-family=ubuntu-2404-lts --image-project=ubuntu-os-cloud \
+  --machine-type=e2-standard-2 \
+  --metadata-from-file=user-data=cloud-init-full.yaml
+```
+Read the token: `gcloud compute instances get-serial-port-output parachute-full | grep parachute-bootstrap-`.
+Then SSH in and `parachute expose …`.
+
+#### AWS EC2
+
+Launch an **Ubuntu 24.04 AMI** (t3.large / 8 GB), paste `cloud-init-full.yaml`
+into **Advanced details → User data**. Read the token from **Actions → Monitor
+and troubleshoot → Get system log**, then SSH in and `expose`.
+
+#### Any other cloud / self-hosted
+
+It's plain cloud-init user-data — drop it into whatever your platform calls the
+"user data" / "cloud config" field (Vultr, Linode, Proxmox NoCloud seed, libvirt
+`--user-data`, etc.). Nothing in the file is provider-specific.
+
+### Can't (or don't want to) expose?
+
+Tunnel the loopback hub over SSH from your laptop and do setup locally:
+
+```sh
+ssh -L 1939:127.0.0.1:1939 parachute@<box-ip>
+# then open http://127.0.0.1:1939/admin/setup and paste the token
+```
+
+### Retrieve the token later
+
+If you missed it in the console:
+
+```sh
+ssh parachute@<box-ip>
+journalctl --user | grep parachute-bootstrap-          # primary on Linux (hub runs under systemd → journald)
+# or: grep parachute-bootstrap- ~/.parachute/hub/logs/hub.log
+```
+
+---
+
+## Provider cost snapshot (secondary — the point is "it boots a working box")
+
+| Provider | ~8 GB instance | Notes |
+|---|---|---|
+| **DigitalOcean** | ~$48/mo | **Default.** Simplest console + no-KYC; the smooth first-run path. |
+| **Hetzner** | ~$7/mo (EU) · ~$17/mo (US) | Cheapest, but **KYC** (ID verification) can delay/limit new accounts, and capacity is region-gated. Great once you're in. |
+| GCP / AWS | varies | Use if you're already there; `e2-standard-2` / `t3.large`-class. |
+
+Sessions are real `claude` processes — **8 GB RAM is the comfortable floor** for a
+couple of resident sessions. A 4 GB box can run the hub + vault + one light
+session, but don't size below 8 GB if you expect to actually work in sessions.
+
+---
+
+## Validation
+
+- `cloud-init-full.yaml` parses as YAML and passes `cloud-init schema
+  --config-file` (validated in an Ubuntu 24.04 container — see the PR description).
+- The install steps (apt deps + bun + `claude` CLI) and a **bubblewrap
+  egress-deny smoke** were exercised in an Ubuntu 24.04 container: with
+  `bwrap --unshare-net` (the Linux deny-all-egress mechanism the sandbox-runtime
+  uses) a sandboxed `curl` to `api.anthropic.com` is **blocked**, while the host
+  reaches it — the positive control. This is the one isolation path macOS
+  Seatbelt can't cover, so it's the load-bearing Linux test.
+
+### The single live smoke for the operator (one-time)
+
+A container can't fully exercise the **systemd-user-unit boot + reboot survival**
+path (no init/journald in a plain container). Run this once on a real VPS:
+
+```sh
+# 1. Create an 8GB Ubuntu 24.04 VPS with cloud-init-full.yaml as user-data.
+# 2. Watch the console for "PARACHUTE FULL-TIER BOOTSTRAP COMPLETE" + a token.
+# 3. SSH in and confirm the stack:
+ssh parachute@<box-ip>
+parachute status            # hub active; vault active
+command -v claude bwrap rg tmux parachute-channel   # all present
+# 4. Expose + finish setup:
+parachute expose cloudflare --domain <host>   # or: parachute expose tailnet
+#    open <url>/admin/setup, paste the token, create the admin account.
+# 5. Reboot survival:
+sudo reboot
+ssh parachute@<box-ip> 'parachute status'     # hub still active after boot
+```
+
+---
+
+## Follow-ons (NOT built here)
+
+- **A DigitalOcean 1-Click image** (Marketplace): bake this cloud-init into a
+  snapshot so operators get a literal one-click "Parachute Full" droplet.
+- **`parachute provision <provider>`**: a hub CLI verb that calls the provider's
+  API to create the VPS with this user-data and stream back the token — turning
+  the whole flow above into one local command.

--- a/deploy/cloud-init-full.yaml
+++ b/deploy/cloud-init-full.yaml
@@ -1,0 +1,270 @@
+#cloud-config
+# ---------------------------------------------------------------------------
+# Parachute — FULL-tier cloud-init (Phase 1, sandboxed agent sessions)
+# ---------------------------------------------------------------------------
+# Provider-agnostic VPS user-data. Boots a fresh Ubuntu/Debian Linux box into a
+# working full-tier Parachute install: the hub + the channel module + everything
+# the sandboxed-agent-session path needs (bun, the `claude` CLI, the Anthropic
+# sandbox-runtime, tmux, bubblewrap, ripgrep, socat). On first boot it starts the
+# hub and prints the one-time admin bootstrap token + the /admin/setup URL to the
+# serial/console log, then tells the operator to run `parachute expose` for a
+# public URL.
+#
+# WHY full-tier (vs the Render/Fly "lite" tier): the lite tier runs only the
+# vault + hub + static surfaces in a single container — no agent sessions. The
+# FULL tier adds resident Claude Code sessions sandboxed with bubblewrap (the
+# Linux mechanism behind @anthropic-ai/sandbox-runtime; Seatbelt is the macOS
+# mechanism). Sessions need a real machine with bubblewrap, tmux, and the claude
+# CLI — that's what this script provisions. See
+# design/2026-06-14-sandboxed-agent-sessions.md §7 and deploy/README.md.
+#
+# PROVIDER-AGNOSTIC: every major cloud takes cloud-init user-data —
+#   - DigitalOcean: "User data" field on the create-droplet page (default,
+#     no-KYC; pick an 8GB droplet).
+#   - Hetzner Cloud: "Cloud config" field (cheapest; KYC caveat — see README).
+#   - GCP: `--metadata-from-file user-data=cloud-init-full.yaml`.
+#   - AWS EC2 (Ubuntu AMI): "User data" field — cloud-init is the default agent.
+#   - Generic libvirt/Proxmox/any cloud-init datasource: standard NoCloud seed.
+# Nothing below is provider-specific.
+#
+# RUN USER: the hub + sessions run as a non-root user (`parachute`), created
+# below. Only the package-install steps need root (cloud-init runs as root). The
+# hub installs its own systemd *user* unit under that account so it survives
+# reboots without running the agent stack as root.
+# ---------------------------------------------------------------------------
+
+# Keep the box patched on first boot.
+package_update: true
+package_upgrade: true
+
+# --- OS packages (apt) --------------------------------------------------------
+# unzip + curl: bun's install script needs them.
+# tmux: each resident Claude Code session runs in its own tmux session.
+# bubblewrap: the Linux sandbox mechanism for @anthropic-ai/sandbox-runtime.
+# ripgrep: the sandbox-runtime uses `rg` to scan deny-paths on Linux (required).
+# socat: the Linux sandbox bridges egress proxies over Unix sockets via socat.
+# gcc + libseccomp-dev: optional — the sandbox-runtime's seccomp Unix-socket
+#   layer compiles from C source on Linux; without them the box still sandboxes
+#   filesystem + network, only the extra Unix-socket-creation block degrades.
+# git: vault import + general module operations.
+# ca-certificates: TLS to api.anthropic.com / the npm registry / Cloudflare.
+packages:
+  - curl
+  - unzip
+  - git
+  - tmux
+  - bubblewrap
+  - ripgrep
+  - socat
+  - gcc
+  - libseccomp-dev
+  - ca-certificates
+
+# --- non-root run user --------------------------------------------------------
+# `parachute` owns the whole stack. Passwordless sudo is granted so the operator
+# can still administer the box after SSHing in as this user, but the hub +
+# sessions themselves run unprivileged.
+users:
+  - default
+  - name: parachute
+    gecos: Parachute service account
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [sudo]
+    # Inherit the cloud's injected SSH keys so the operator can `ssh parachute@<ip>`.
+    ssh_authorized_keys: []
+
+write_files:
+  # The whole install lives in one script so it's auditable + re-runnable. It is
+  # idempotent: bun/claude/hub installs short-circuit if already present, and
+  # `parachute init` is itself idempotent.
+  - path: /usr/local/sbin/parachute-full-bootstrap.sh
+    permissions: "0755"
+    owner: root:root
+    content: |
+      #!/usr/bin/env bash
+      # Full-tier Parachute bootstrap — runs ONCE on first boot as the `parachute`
+      # user (invoked by the runcmd below via `sudo -iu parachute`).
+      set -euo pipefail
+
+      log() { echo "[parachute-bootstrap] $*"; }
+
+      # ----------------------------------------------------------------------
+      # 0. Ubuntu 24.04+ unprivileged-userns hardening.
+      #    bubblewrap + the seccomp layer need capability-bearing user
+      #    namespaces. 24.04 ships kernel.apparmor_restrict_unprivileged_userns=1
+      #    which strips caps from new userns. Relax it (persisted) so the sandbox
+      #    can create its namespaces. No-op on older kernels / non-Ubuntu.
+      # ----------------------------------------------------------------------
+      if [ -e /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
+        log "relaxing apparmor_restrict_unprivileged_userns for bubblewrap"
+        echo 'kernel.apparmor_restrict_unprivileged_userns=0' | sudo tee /etc/sysctl.d/60-parachute-userns.conf >/dev/null
+        sudo sysctl --system >/dev/null 2>&1 || true
+      fi
+
+      # ----------------------------------------------------------------------
+      # 1. Bun — the runtime everything runs on.
+      # ----------------------------------------------------------------------
+      export BUN_INSTALL="$HOME/.bun"
+      export PATH="$BUN_INSTALL/bin:$PATH"
+      if ! command -v bun >/dev/null 2>&1; then
+        log "installing bun"
+        curl -fsSL https://bun.sh/install | bash
+      fi
+      # Persist PATH for future logins (so `parachute …` / `claude …` just work).
+      if ! grep -q 'BUN_INSTALL' "$HOME/.bashrc" 2>/dev/null; then
+        {
+          echo ''
+          echo '# Parachute — bun + globally-installed bins on PATH'
+          echo 'export BUN_INSTALL="$HOME/.bun"'
+          echo 'export PATH="$BUN_INSTALL/bin:$PATH"'
+        } >> "$HOME/.bashrc"
+      fi
+      log "bun: $(bun --version)"
+
+      # ----------------------------------------------------------------------
+      # 2. The Parachute hub (provides the `parachute` binary).
+      # ----------------------------------------------------------------------
+      if ! command -v parachute >/dev/null 2>&1; then
+        log "installing @openparachute/hub"
+        bun add -g @openparachute/hub
+      fi
+      log "parachute: $(parachute --version 2>/dev/null || echo '(installed)')"
+
+      # ----------------------------------------------------------------------
+      # 3. The channel module (the agent-session gateway) — installed globally so
+      #    the `parachute-channel` binary is on PATH for the hub supervisor to
+      #    resolve via Bun.which. (module.json startCmd = ["parachute-channel"].)
+      # ----------------------------------------------------------------------
+      if ! command -v parachute-channel >/dev/null 2>&1; then
+        log "installing @openparachute/channel"
+        bun add -g @openparachute/channel
+      fi
+
+      # ----------------------------------------------------------------------
+      # 4. The Anthropic sandbox-runtime (the isolation engine) + the `claude`
+      #    CLI (what each resident session runs). Both global so they're on PATH.
+      #    sandbox-runtime is pinned EXACT in the channel module's package.json;
+      #    here we install the same family globally so `srt` is present for any
+      #    out-of-process sandbox smoke. The channel module library-links its own
+      #    pinned copy at runtime (it never PATH-resolves the engine).
+      # ----------------------------------------------------------------------
+      if ! command -v claude >/dev/null 2>&1; then
+        log "installing @anthropic-ai/claude-code (the claude CLI)"
+        bun add -g @anthropic-ai/claude-code
+      fi
+      if ! command -v srt >/dev/null 2>&1; then
+        log "installing @anthropic-ai/sandbox-runtime (srt)"
+        bun add -g @anthropic-ai/sandbox-runtime
+      fi
+
+      # ----------------------------------------------------------------------
+      # 5. Sanity: confirm the sandbox prerequisites are actually present. These
+      #    are the load-bearing Linux deps; fail loudly now rather than at first
+      #    session launch.
+      # ----------------------------------------------------------------------
+      for bin in bwrap rg socat tmux git; do
+        if ! command -v "$bin" >/dev/null 2>&1; then
+          log "FATAL: required sandbox dependency '$bin' missing after install"
+          exit 1
+        fi
+      done
+      log "sandbox prerequisites present: bwrap rg socat tmux git"
+
+      # ----------------------------------------------------------------------
+      # 6. Bring the hub up. `parachute init` installs + starts the hub as a
+      #    systemd unit (survives reboots), always installs the vault module, and
+      #    would normally drop into the wizard. On a headless box we DON'T want
+      #    the interactive wizard or an auto-expose prompt — we want it to start,
+      #    print the bootstrap token, and hand control back. So:
+      #      --no-expose-prompt : don't try to interactively configure expose.
+      #      --expose none      : start loopback-only; operator runs `expose` later.
+      #      --cli-wizard       : never try to open a browser (there is none).
+      #    The one-time admin bootstrap token is printed to the hub log on first
+      #    boot ("parachute-bootstrap-<...>"); we surface it to the console below.
+      # ----------------------------------------------------------------------
+      log "running parachute init (headless, loopback-only)"
+      parachute init --expose none --no-expose-prompt --cli-wizard </dev/null || {
+        log "parachute init returned non-zero; the hub may still be up — checking status"
+      }
+
+      # Give the unit a moment, then confirm.
+      for _ in $(seq 1 30); do
+        if parachute status >/dev/null 2>&1; then break; fi
+        sleep 1
+      done
+      parachute status || true
+
+      # ----------------------------------------------------------------------
+      # 7. Surface the bootstrap token + setup URL to the SERIAL/CONSOLE log so
+      #    the operator can read it from the provider's console without SSH.
+      #    The token is generated on first boot and logged as
+      #    "parachute-bootstrap-<token>"; we grep it out of the hub log.
+      # ----------------------------------------------------------------------
+      # On Linux the hub runs under a systemd unit whose stdout goes to JOURNALD
+      # (the rendered unit sets no StandardOutput= file redirect — only the macOS
+      # launchd plist redirects to a file). So journald is the PRIMARY source for
+      # the token on a VPS; the on-disk hub log is a secondary fallback (it exists
+      # for the launchd/manual-foreground paths). PARACHUTE_HOME defaults to
+      # ~/.parachute, and the hub writes its file log under <home>/hub/logs/.
+      HUB_LOG="${PARACHUTE_HOME:-$HOME/.parachute}/hub/logs/hub.log"
+      TOKEN=""
+      for _ in $(seq 1 30); do
+        # Primary: systemd-user journal for the hub unit's stdout.
+        TOKEN="$(journalctl --user -n 1000 --no-pager 2>/dev/null | grep -ho 'parachute-bootstrap-[A-Za-z0-9_-]\+' | tail -n1 || true)"
+        # Fallback A: the on-disk hub log (launchd / foreground-serve path).
+        if [ -z "$TOKEN" ] && [ -f "$HUB_LOG" ]; then
+          TOKEN="$(grep -ho 'parachute-bootstrap-[A-Za-z0-9_-]\+' "$HUB_LOG" 2>/dev/null | tail -n1 || true)"
+        fi
+        # Fallback B: the bootstrap script's own tee'd log (captures init stdout).
+        if [ -z "$TOKEN" ] && [ -f /var/log/parachute-bootstrap.log ]; then
+          TOKEN="$(grep -ho 'parachute-bootstrap-[A-Za-z0-9_-]\+' /var/log/parachute-bootstrap.log 2>/dev/null | tail -n1 || true)"
+        fi
+        [ -n "$TOKEN" ] && break
+        sleep 2
+      done
+
+      echo "" | tee /dev/console
+      echo "==================================================================" | tee /dev/console
+      echo " PARACHUTE FULL-TIER BOOTSTRAP COMPLETE" | tee /dev/console
+      echo "==================================================================" | tee /dev/console
+      if [ -n "$TOKEN" ]; then
+        echo " One-time admin setup token:" | tee /dev/console
+        echo "     $TOKEN" | tee /dev/console
+      else
+        echo " Bootstrap token not found in the log yet. Retrieve it with:" | tee /dev/console
+        echo "     sudo -iu parachute journalctl --user | grep parachute-bootstrap-" | tee /dev/console
+        echo "     # (or: sudo -iu parachute grep parachute-bootstrap- ~/.parachute/hub/logs/hub.log)" | tee /dev/console
+      fi
+      echo "" | tee /dev/console
+      echo " The hub is running LOOPBACK-ONLY on this box (port 1939)." | tee /dev/console
+      echo " To finish setup you need a URL you can reach. Two options:" | tee /dev/console
+      echo "" | tee /dev/console
+      echo "  A) Get a public URL (recommended). SSH in as the parachute user:" | tee /dev/console
+      echo "        ssh parachute@<this-box-ip>" | tee /dev/console
+      echo "        parachute expose cloudflare --domain <your-host>   # public HTTPS via a Cloudflare Tunnel (needs a Cloudflare-managed domain)" | tee /dev/console
+      echo "        #   or, if you run Tailscale on the box + your devices:" | tee /dev/console
+      echo "        #     parachute expose tailnet     # private HTTPS, only your tailnet devices" | tee /dev/console
+      echo "     then open the printed URL's /admin/setup and paste the token above." | tee /dev/console
+      echo "" | tee /dev/console
+      echo "  B) Or tunnel the loopback port over SSH from your laptop:" | tee /dev/console
+      echo "        ssh -L 1939:127.0.0.1:1939 parachute@<this-box-ip>" | tee /dev/console
+      echo "     then open http://127.0.0.1:1939/admin/setup and paste the token." | tee /dev/console
+      echo "" | tee /dev/console
+      echo " After setup: install the Channel module + create agent sessions" | tee /dev/console
+      echo " from the admin UI (or `parachute install channel`)." | tee /dev/console
+      echo "==================================================================" | tee /dev/console
+
+      log "bootstrap script finished"
+
+runcmd:
+  # Run the bootstrap as the non-root `parachute` user (login shell so PATH +
+  # HOME resolve to that account). Tee a copy to a stable log for `cloud-init`
+  # post-mortems. `-i` gives a login env; the script re-derives BUN PATH itself.
+  - [ bash, -lc, "sudo -iu parachute /usr/local/sbin/parachute-full-bootstrap.sh 2>&1 | tee /var/log/parachute-bootstrap.log" ]
+
+# A clear console banner once cloud-init is fully done.
+final_message: |
+  Parachute full-tier bootstrap finished after $UPTIME seconds.
+  Read the admin setup token above (or: sudo -iu parachute grep parachute-bootstrap- ~/.parachute/logs/hub.log),
+  then SSH in and run `parachute expose public` for a URL, and visit /admin/setup.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@anthropic-ai/sandbox-runtime": "0.0.54",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "@openparachute/scope-guard": "^0.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "daemon": "bun src/daemon.ts",
     "bridge": "bun src/bridge.ts",
+    "spawn-agent": "bun scripts/spawn-agent.ts",
     "test": "bun test src/",
     "test:e2e": "bun e2e/llm/run.ts",
     "typecheck": "tsc --noEmit"

--- a/scripts/spawn-agent.ts
+++ b/scripts/spawn-agent.ts
@@ -1,0 +1,424 @@
+#!/usr/bin/env bun
+/**
+ * `spawn-agent` — the operator CLI for launching a sandboxed Claude Code agent
+ * session, wired to one or more channels (and optionally a vault). This is the
+ * "graduate `scripts/launch-session.sh` into a real command" step (design §4,
+ * PLAN.md "Session lifecycle/supervision"): launch-session.sh hand-rolled the
+ * token mint + .mcp.json + tmux launch in bash with NO sandbox; this thin CLI
+ * parses args into an {@link AgentSpec} and calls {@link spawnAgent} with the
+ * REAL deps — the real hub mint client, the real sandbox engine, the real tmux
+ * launcher, and the real per-channel Claude-credential resolver.
+ *
+ * It does NOT re-implement scoping or sandboxing — every least-privilege decision
+ * lives in `spawnAgent`/`sandbox/*`. The CLI's only jobs are: parse flags → build
+ * the spec → resolve the real deps → call `spawnAgent` → print the result (or a
+ * clean, actionable error).
+ *
+ * Usage:
+ *   bun scripts/spawn-agent.ts <name> [flags]
+ *
+ * Flags (mirroring launch-session.sh's ergonomics, generalized to the spec):
+ *   --channel <name>[:read|write]   repeatable; default write. First = wake channel.
+ *   --vault <name>:<read|write>[:tag1,tag2]   optional vault MCP scope (+ tag-scope).
+ *   --egress <host,host,...>        optional additive egress allowlist.
+ *   --mount <hostPath:mountPath:ro|rw[:sharedName]>   repeatable; optional.
+ *   --help                          usage.
+ *
+ * Environment:
+ *   PARACHUTE_HOME              base for operator.token (default ~/.parachute).
+ *   PARACHUTE_HUB_ORIGIN       hub public origin (else expose-state self-heal → loopback).
+ *   PARACHUTE_CHANNEL_URL      daemon base URL (default http://127.0.0.1:<port>).
+ *   PARACHUTE_CHANNEL_PORT     daemon port for the default channel URL (default 1941).
+ *   PARACHUTE_CHANNEL_STATE_DIR  state dir (sessions, credentials.json) — default ~/.parachute/channel.
+ *   PARACHUTE_VAULT_URL        vault base URL when a --vault is bound (default http://127.0.0.1:1940).
+ *   CLAUDE_CONFIG_DIR          claude config dir bound read-only into the sandbox (default ~/.claude).
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve, join } from "node:path";
+import {
+  spawnAgent,
+  realTmuxLauncher,
+  type SpawnAgentDeps,
+} from "../src/spawn-agent.ts";
+import { CredentialNotConfiguredError, resolveClaudeCredential } from "../src/credentials.ts";
+import { defaultStateDir } from "../src/registry.ts";
+import { getHubOrigin } from "../src/hub-jwt.ts";
+import { channelEntryKey, vaultEntryKey } from "../src/agent-mcp-config.ts";
+import { MintError } from "../src/mint-token.ts";
+import type {
+  AgentSpec,
+  AgentChannelSpec,
+  AgentVaultSpec,
+  AgentMount,
+} from "../src/sandbox/types.ts";
+
+const DEFAULT_CHANNEL_PORT = 1941;
+const DEFAULT_VAULT_URL = "http://127.0.0.1:1940";
+
+const USAGE = `spawn-agent — launch a sandboxed Claude Code agent session
+
+Usage:
+  bun scripts/spawn-agent.ts <name> [flags]
+
+Arguments:
+  <name>                          agent/session slug (alphanumeric, dash, underscore).
+
+Flags:
+  --channel <name>[:read|write]   channel to scope to (repeatable; default write).
+                                  The FIRST channel is the wake channel.
+  --vault <name>:<read|write>[:tag1,tag2]
+                                  optional vault MCP scope (+ optional tag-scope).
+  --egress <host,host,...>        optional additive egress allowlist (beyond the base).
+  --mount <hostPath:mountPath:ro|rw[:shared]>
+                                  filesystem mount (repeatable; optional).
+  --help                          show this help.
+
+Example:
+  bun scripts/spawn-agent.ts aaron --channel aaron --vault default:read:#channel-message
+`;
+
+/** Parsed CLI request: the spec plus the `--help` short-circuit flag. */
+export interface ParsedArgs {
+  /** True when --help/-h was passed — print usage and exit 0, build no spec. */
+  help: boolean;
+  /** The agent spec assembled from the flags (undefined when help). */
+  spec?: AgentSpec;
+}
+
+/** A user-facing argument error — the CLI prints `.message` and exits non-zero. */
+export class ArgError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ArgError";
+  }
+}
+
+/**
+ * Parse one channel token `name[:read|write]` into an {@link AgentChannelSpec}.
+ * A bare name defaults to `write` (mirrors the spec's back-compat: a resident
+ * session reads + replies). `:read` scopes a watcher channel read-only.
+ */
+function parseChannel(value: string): AgentChannelSpec {
+  const [name, access, extra] = value.split(":");
+  if (!name) throw new ArgError(`--channel: empty channel name in "${value}"`);
+  if (extra !== undefined) {
+    throw new ArgError(`--channel "${value}": expected <name>[:read|write], got extra ":"`);
+  }
+  if (access !== undefined && access !== "read" && access !== "write") {
+    throw new ArgError(`--channel "${value}": access must be "read" or "write", got "${access}"`);
+  }
+  return access === undefined ? { name } : { name, access };
+}
+
+/**
+ * Parse `--vault <name>:<read|write>[:tag1,tag2]` into an {@link AgentVaultSpec}.
+ * (The spec also supports `admin`, but the CLI surface mirrors launch's
+ * read/write ergonomics; admin is an explicit, rare grant left to the API path.)
+ */
+function parseVault(value: string): AgentVaultSpec {
+  const parts = value.split(":");
+  const name = parts[0];
+  const access = parts[1];
+  const tagPart = parts[2];
+  if (parts.length < 2 || parts.length > 3) {
+    throw new ArgError(`--vault "${value}": expected <name>:<read|write>[:tag1,tag2]`);
+  }
+  if (!name) throw new ArgError(`--vault "${value}": empty vault name`);
+  if (access !== "read" && access !== "write") {
+    throw new ArgError(`--vault "${value}": access must be "read" or "write", got "${access}"`);
+  }
+  const spec: AgentVaultSpec = { name, access };
+  if (tagPart !== undefined) {
+    const tags = tagPart.split(",").map((t) => t.trim()).filter((t) => t.length > 0);
+    if (tags.length === 0) {
+      throw new ArgError(`--vault "${value}": tag list after the access is empty`);
+    }
+    spec.tags = tags;
+  }
+  return spec;
+}
+
+/**
+ * Parse `--mount <hostPath:mountPath:ro|rw[:shared]>` into an {@link AgentMount}.
+ * hostPath/mountPath are absolute paths; the mode is `ro`|`rw`; an optional 4th
+ * segment names a cross-session share.
+ */
+function parseMount(value: string): AgentMount {
+  const parts = value.split(":");
+  if (parts.length < 3 || parts.length > 4) {
+    throw new ArgError(`--mount "${value}": expected <hostPath:mountPath:ro|rw[:shared]>`);
+  }
+  const [hostPath, mountPath, mode, shared] = parts;
+  if (!hostPath || !mountPath) {
+    throw new ArgError(`--mount "${value}": hostPath and mountPath are required`);
+  }
+  if (mode !== "ro" && mode !== "rw") {
+    throw new ArgError(`--mount "${value}": mode must be "ro" or "rw", got "${mode}"`);
+  }
+  const mount: AgentMount = { hostPath, mountPath, mode };
+  if (shared !== undefined) {
+    if (shared.length === 0) throw new ArgError(`--mount "${value}": empty shared name`);
+    mount.shared = shared;
+  }
+  return mount;
+}
+
+/** Read the value that must follow a flag, or throw a clean ArgError. */
+function takeValue(argv: string[], i: number, flag: string): string {
+  const v = argv[i + 1];
+  if (v === undefined || v.startsWith("--")) {
+    throw new ArgError(`${flag}: expected a value`);
+  }
+  return v;
+}
+
+/**
+ * Parse argv (everything AFTER `bun scripts/spawn-agent.ts`) into a spec. Pure +
+ * exported so the unit test exercises it without any fs/tmux/mint side effect.
+ * Throws {@link ArgError} on any malformed input.
+ */
+export function parseArgs(argv: string[]): ParsedArgs {
+  let name: string | undefined;
+  const channels: AgentChannelSpec[] = [];
+  let vault: AgentVaultSpec | undefined;
+  const egress: string[] = [];
+  const mounts: AgentMount[] = [];
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!;
+    switch (arg) {
+      case "--help":
+      case "-h":
+        return { help: true };
+      case "--channel": {
+        channels.push(parseChannel(takeValue(argv, i, "--channel")));
+        i++;
+        break;
+      }
+      case "--vault": {
+        if (vault) throw new ArgError("--vault may only be given once");
+        vault = parseVault(takeValue(argv, i, "--vault"));
+        i++;
+        break;
+      }
+      case "--egress": {
+        const raw = takeValue(argv, i, "--egress");
+        for (const h of raw.split(",").map((s) => s.trim()).filter((s) => s.length > 0)) {
+          egress.push(h);
+        }
+        i++;
+        break;
+      }
+      case "--mount": {
+        mounts.push(parseMount(takeValue(argv, i, "--mount")));
+        i++;
+        break;
+      }
+      default: {
+        if (arg.startsWith("-")) throw new ArgError(`unknown flag "${arg}" (try --help)`);
+        if (name !== undefined) {
+          throw new ArgError(`unexpected positional "${arg}" — only one <name> is accepted`);
+        }
+        name = arg;
+      }
+    }
+  }
+
+  if (name === undefined) throw new ArgError("missing required <name> (try --help)");
+  if (channels.length === 0) {
+    throw new ArgError("at least one --channel is required (the first is the wake channel)");
+  }
+
+  const spec: AgentSpec = { name, channels };
+  if (vault) spec.vault = vault;
+  if (egress.length > 0) spec.egress = egress;
+  if (mounts.length > 0) spec.mounts = mounts;
+  return { help: false, spec };
+}
+
+// ---------------------------------------------------------------------------
+// Real-dep resolution (only reached on the actual run, not in unit tests).
+// ---------------------------------------------------------------------------
+
+/** Base for `operator.token` — `$PARACHUTE_HOME` else `~/.parachute`. */
+function parachuteHome(): string {
+  return process.env.PARACHUTE_HOME ?? resolve(homedir(), ".parachute");
+}
+
+/**
+ * The spawn-manager's OWN bearer — `~/.parachute/operator.token`, the local
+ * operator credential the hub attenuates child mints against (same file vault's
+ * `readOperatorToken` reads). Mirrors launch-session.sh leaning on the operator's
+ * logged-in `parachute auth mint-token`; here we present the operator bearer to
+ * the hub directly so the mint runs in-process with no shell-out.
+ */
+function readManagerBearer(): string | null {
+  try {
+    const path = resolve(parachuteHome(), "operator.token");
+    if (!existsSync(path)) return null;
+    const raw = readFileSync(path, "utf-8").trim();
+    return raw.length > 0 ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Default channel daemon base URL: PARACHUTE_CHANNEL_URL, else loopback:<port>. */
+function resolveChannelUrl(): string {
+  const explicit = process.env.PARACHUTE_CHANNEL_URL?.replace(/\/$/, "");
+  if (explicit) return explicit;
+  const port = parseInt(process.env.PARACHUTE_CHANNEL_PORT ?? "", 10) || DEFAULT_CHANNEL_PORT;
+  return `http://127.0.0.1:${port}`;
+}
+
+/** Claude config dir bound read-only so the sandboxed session can read its config. */
+function claudeConfigDir(): string {
+  return process.env.CLAUDE_CONFIG_DIR ?? resolve(homedir(), ".claude");
+}
+
+/** Build the real SpawnAgentDeps from the environment. */
+function realDeps(): SpawnAgentDeps {
+  const managerBearer = readManagerBearer();
+  if (!managerBearer) {
+    throw new ArgError(
+      `no operator token at ${resolve(parachuteHome(), "operator.token")} — the manager bearer the\n` +
+        `hub attenuates child mints against. Log in / provision the hub so the operator token exists\n` +
+        `(it's what \`parachute auth mint-token\` uses), then re-run.`,
+    );
+  }
+
+  const stateDir = defaultStateDir();
+  const sessionsDir = join(stateDir, "sessions");
+  const vaultUrl = process.env.PARACHUTE_VAULT_URL?.replace(/\/$/, "") || DEFAULT_VAULT_URL;
+
+  return {
+    hubOrigin: getHubOrigin(),
+    managerBearer,
+    channelUrl: resolveChannelUrl(),
+    vaultUrl,
+    sessionsDir,
+    // The claude config dir is the one runtime path the sandboxed `claude` must
+    // read (system paths /usr,/lib stay readable; the home tree is denied). The
+    // per-session workspace (rw) is added by spawnAgent under sessionsDir.
+    runtimeReadOnly: [claudeConfigDir()],
+    // The real per-channel Claude OAuth resolver (channel override ?? default ?? throw).
+    resolveClaudeToken: (channel: string) => resolveClaudeCredential(channel, stateDir),
+    // The real tmux launcher (writes the per-session launch script, runs tmux).
+    tmux: realTmuxLauncher(),
+    // sandboxEngine omitted → spawnAgent's `new Sandbox()` uses the real, pinned,
+    // library-linked engine.
+  };
+}
+
+/** Format a per-aud scope summary line for each minted token. */
+function scopeLines(result: Awaited<ReturnType<typeof spawnAgent>>): string[] {
+  const lines: string[] = [];
+  for (const [resource, minted] of Object.entries(result.tokens)) {
+    lines.push(`    ${resource.padEnd(20)} ${minted.scope}`);
+  }
+  return lines;
+}
+
+async function main(): Promise<number> {
+  let parsed: ParsedArgs;
+  try {
+    parsed = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    if (err instanceof ArgError) {
+      process.stderr.write(`error: ${err.message}\n\n${USAGE}`);
+      return 2;
+    }
+    throw err;
+  }
+
+  if (parsed.help || !parsed.spec) {
+    process.stdout.write(USAGE);
+    return 0;
+  }
+  const spec = parsed.spec;
+
+  let deps: SpawnAgentDeps;
+  try {
+    deps = realDeps();
+  } catch (err) {
+    process.stderr.write(`error: ${err instanceof Error ? err.message : String(err)}\n`);
+    return 1;
+  }
+
+  const wakeChannel =
+    typeof spec.channels[0] === "string" ? spec.channels[0] : spec.channels[0]!.name;
+
+  let result: Awaited<ReturnType<typeof spawnAgent>>;
+  try {
+    result = await spawnAgent(spec, deps);
+  } catch (err) {
+    // A missing Claude credential is the most common operator error — surface the
+    // exact creds-API curl to set it, and exit non-zero (no session launched).
+    if (err instanceof CredentialNotConfiguredError) {
+      process.stderr.write(
+        `error: ${err.message}\n\n` +
+          `Set the operator Claude credential (get a token with \`claude setup-token\`), then re-run:\n` +
+          `  curl -X POST ${deps.channelUrl}/api/credentials/claude \\\n` +
+          `    -H 'authorization: Bearer <channel:admin JWT>' \\\n` +
+          `    -H 'content-type: application/json' \\\n` +
+          `    -d '{"token":"<oat_… from claude setup-token>"}'\n\n` +
+          `Or scope it to just the wake channel "${wakeChannel}":\n` +
+          `  curl -X POST ${deps.channelUrl}/api/credentials/claude/${encodeURIComponent(wakeChannel)} \\\n` +
+          `    -H 'authorization: Bearer <channel:admin JWT>' \\\n` +
+          `    -H 'content-type: application/json' \\\n` +
+          `    -d '{"token":"<oat_…>"}'\n`,
+      );
+      return 1;
+    }
+    // A bad slug name (spawnAgent's guard) or a refused/over-broad mint — surface
+    // the message cleanly; no session was created in either case.
+    if (err instanceof MintError) {
+      process.stderr.write(`error: token mint failed — ${err.message}\n`);
+      return 1;
+    }
+    process.stderr.write(`error: ${err instanceof Error ? err.message : String(err)}\n`);
+    return 1;
+  }
+
+  if (result.alreadyRunning) {
+    process.stdout.write(
+      `session "${result.session}" is already running (no-op).\n` +
+        `  attach:   tmux attach -t ${result.session}\n` +
+        `  terminal: ${deps.channelUrl.replace(/\/$/, "")}/terminal?session=${encodeURIComponent(result.session)}\n`,
+    );
+    return 0;
+  }
+
+  // Success — print the session, the resolved scopes (per aud), and how to watch it.
+  const out: string[] = [];
+  out.push(`launched session "${result.session}" on channel "${wakeChannel}".`);
+  out.push(`  workspace: ${result.workspace}`);
+  out.push(`  scopes (one token per aud):`);
+  out.push(...scopeLines(result));
+  out.push(`  MCP servers: ${Object.keys(JSON.parse(result.mcpConfigJson).mcpServers).join(", ")}`);
+  out.push("");
+  out.push(`  watch (tmux):   tmux attach -t ${result.session}   (detach: Ctrl-b then d)`);
+  out.push(
+    `  watch (web):    ${deps.channelUrl.replace(/\/$/, "")}/terminal?session=${encodeURIComponent(result.session)}`,
+  );
+  out.push(`  chat:           open the channel UI and pick channel "${wakeChannel}"`);
+  // Note the entry keys so the operator can map scopes → MCP entries at a glance.
+  const entryHints = [
+    ...spec.channels.map((c) => channelEntryKey(typeof c === "string" ? c : c.name)),
+    ...(spec.vault ? [vaultEntryKey(spec.vault.name)] : []),
+  ];
+  out.push(`  mcp entries:    ${entryHints.join(", ")}`);
+  process.stdout.write(out.join("\n") + "\n");
+  return 0;
+}
+
+if (import.meta.main) {
+  main()
+    .then((code) => process.exit(code))
+    .catch((err) => {
+      process.stderr.write(`error: ${err instanceof Error ? err.stack ?? err.message : String(err)}\n`);
+      process.exit(1);
+    });
+}

--- a/src/agent-mcp-config.test.ts
+++ b/src/agent-mcp-config.test.ts
@@ -1,0 +1,94 @@
+import { describe, test, expect } from "bun:test";
+import {
+  buildAgentMcpServers,
+  buildAgentMcpConfigJson,
+  channelEntryKey,
+  vaultEntryKey,
+} from "./agent-mcp-config.ts";
+
+describe("buildAgentMcpServers — N-entry strict config", () => {
+  test("one entry per channel with its own URL + Bearer", () => {
+    const servers = buildAgentMcpServers({
+      channelUrl: "http://127.0.0.1:1941",
+      channels: [
+        { channel: "aaron-dev", token: "TOK-A" },
+        { channel: "ops", token: "TOK-B" },
+      ],
+    });
+    expect(servers[channelEntryKey("aaron-dev")]).toEqual({
+      type: "http",
+      url: "http://127.0.0.1:1941/mcp/aaron-dev",
+      headers: { Authorization: "Bearer TOK-A" },
+    });
+    expect(servers[channelEntryKey("ops")]).toEqual({
+      type: "http",
+      url: "http://127.0.0.1:1941/mcp/ops",
+      headers: { Authorization: "Bearer TOK-B" },
+    });
+    expect(Object.keys(servers)).toHaveLength(2);
+  });
+
+  test("adds a vault entry with its OWN token (one token per aud)", () => {
+    const servers = buildAgentMcpServers({
+      channelUrl: "http://127.0.0.1:1941",
+      channels: [{ channel: "ch", token: "CH-TOK" }],
+      vault: { url: "http://127.0.0.1:1940", entry: { name: "default", token: "VAULT-TOK" } },
+    });
+    expect(servers[vaultEntryKey("default")]).toEqual({
+      type: "http",
+      url: "http://127.0.0.1:1940/vault/default/mcp",
+      headers: { Authorization: "Bearer VAULT-TOK" },
+    });
+    // The channel token and the vault token are DIFFERENT (separate auds).
+    expect(servers[channelEntryKey("ch")]!.headers!.Authorization).toBe("Bearer CH-TOK");
+    expect(servers[vaultEntryKey("default")]!.headers!.Authorization).toBe("Bearer VAULT-TOK");
+  });
+
+  test("adds otherMcps; an entry without a token gets no Authorization header", () => {
+    const servers = buildAgentMcpServers({
+      channelUrl: "http://127.0.0.1:1941",
+      channels: [{ channel: "ch", token: "T" }],
+      otherMcps: [
+        { name: "extra", url: "https://mcp.example.com/mcp", token: "X" },
+        { name: "open", url: "https://open.example.com/mcp" },
+      ],
+    });
+    expect(servers.extra!.headers).toEqual({ Authorization: "Bearer X" });
+    expect(servers.open!.headers).toBeUndefined();
+  });
+
+  test("strips a trailing slash on the base URL", () => {
+    const servers = buildAgentMcpServers({
+      channelUrl: "http://127.0.0.1:1941/",
+      channels: [{ channel: "ch", token: "T" }],
+    });
+    expect(servers[channelEntryKey("ch")]!.url).toBe("http://127.0.0.1:1941/mcp/ch");
+  });
+});
+
+describe("buildAgentMcpConfigJson", () => {
+  test("emits two-space-indented JSON with the mcpServers wrapper", () => {
+    const json = buildAgentMcpConfigJson({
+      channelUrl: "http://127.0.0.1:1941",
+      channels: [{ channel: "ch", token: "T" }],
+    });
+    const parsed = JSON.parse(json);
+    expect(parsed.mcpServers).toBeDefined();
+    expect(parsed.mcpServers[channelEntryKey("ch")].type).toBe("http");
+    // Two-space indent (matches runner/vault emission convention).
+    expect(json).toContain('\n  "mcpServers"');
+  });
+
+  test("round-trips: parse(emit(x)) carries every entry's token", () => {
+    const input = {
+      channelUrl: "http://127.0.0.1:1941",
+      channels: [{ channel: "a", token: "TA" }],
+      vault: { url: "http://127.0.0.1:1940", entry: { name: "default", token: "TV" } },
+    };
+    const parsed = JSON.parse(buildAgentMcpConfigJson(input)) as {
+      mcpServers: Record<string, { headers?: { Authorization: string } }>;
+    };
+    expect(parsed.mcpServers[channelEntryKey("a")]!.headers!.Authorization).toBe("Bearer TA");
+    expect(parsed.mcpServers[vaultEntryKey("default")]!.headers!.Authorization).toBe("Bearer TV");
+  });
+});

--- a/src/agent-mcp-config.ts
+++ b/src/agent-mcp-config.ts
@@ -1,0 +1,114 @@
+/**
+ * Build the multi-entry inline `--mcp-config` JSON for a sandboxed agent session
+ * (design §4.2 step 2).
+ *
+ * This generalizes runner's single-entry `buildMcpConfigJson`
+ * (`parachute-runner/src/mcp-config.ts`) into one `mcpServers` object carrying
+ * EVERY channel's `/mcp/<channel>` entry plus the optional vault's
+ * `/vault/<name>/mcp` entry plus any `otherMcps` — each with its OWN Bearer
+ * (one token per `aud`; the manager mints them, §4.2 step 1).
+ *
+ * The session launches with `--strict-mcp-config`, so it sees exactly these
+ * servers and nothing else — the MCP surface is closed to the spec.
+ *
+ * Each entry is the HTTP-MCP shape both channel (`src/mcp-http.ts`) and vault
+ * (its `/vault/<name>/mcp`) serve:
+ *   { "type": "http", "url": "<url>", "headers": { "Authorization": "Bearer <tok>" } }
+ *
+ * Treat the output as secret — it inlines bearer tokens.
+ */
+
+export interface ChannelMcpEntry {
+  /** Channel name (the `/mcp/<channel>` segment + entry-key suffix). */
+  channel: string;
+  /** Per-channel hub-issued token (aud: channel; channel:read[+write]). */
+  token: string;
+}
+
+export interface VaultMcpEntry {
+  /** Vault instance name. */
+  name: string;
+  /** Per-vault hub-issued token (aud: vault; vault:<name>:<verb>). */
+  token: string;
+}
+
+export interface OtherMcpEntry {
+  /** Entry key in mcpServers. */
+  name: string;
+  /** MCP URL. */
+  url: string;
+  /** Optional token; omitted = no Authorization header. */
+  token?: string;
+}
+
+export interface BuildAgentMcpConfigInput {
+  /** Daemon base URL the channel `/mcp/<channel>` endpoints live under. */
+  channelUrl: string;
+  /** Channels to attach (one entry each). */
+  channels: ChannelMcpEntry[];
+  /** Optional vault binding. */
+  vault?: { url: string; entry: VaultMcpEntry };
+  /** Additional MCP servers. */
+  otherMcps?: OtherMcpEntry[];
+}
+
+interface McpHttpServer {
+  type: "http";
+  url: string;
+  headers?: { Authorization: string };
+}
+
+/** Build the channel entry key — matches launch-session.sh's `channel-<name>`. */
+export function channelEntryKey(channel: string): string {
+  return `channel-${channel}`;
+}
+
+/** Build the vault entry key — matches runner's `parachute-vault-<name>`. */
+export function vaultEntryKey(name: string): string {
+  return `parachute-vault-${name}`;
+}
+
+function stripTrailingSlash(url: string): string {
+  return url.replace(/\/$/, "");
+}
+
+function httpServer(url: string, token?: string): McpHttpServer {
+  const server: McpHttpServer = { type: "http", url };
+  if (token) server.headers = { Authorization: `Bearer ${token}` };
+  return server;
+}
+
+/**
+ * Build the multi-entry `mcpServers` object (not yet JSON-stringified). Exposed
+ * for assertions that inspect the structure directly.
+ */
+export function buildAgentMcpServers(
+  input: BuildAgentMcpConfigInput,
+): Record<string, McpHttpServer> {
+  const servers: Record<string, McpHttpServer> = {};
+  const base = stripTrailingSlash(input.channelUrl);
+
+  for (const ch of input.channels) {
+    servers[channelEntryKey(ch.channel)] = httpServer(`${base}/mcp/${ch.channel}`, ch.token);
+  }
+
+  if (input.vault) {
+    const vbase = stripTrailingSlash(input.vault.url);
+    const v = input.vault.entry;
+    servers[vaultEntryKey(v.name)] = httpServer(`${vbase}/vault/${v.name}/mcp`, v.token);
+  }
+
+  for (const o of input.otherMcps ?? []) {
+    servers[o.name] = httpServer(o.url, o.token);
+  }
+
+  return servers;
+}
+
+/**
+ * Build the inline `--mcp-config` JSON. Two-space indent, matching runner's +
+ * vault's emission convention so cross-repo diffs stay clean.
+ */
+export function buildAgentMcpConfigJson(input: BuildAgentMcpConfigInput): string {
+  return JSON.stringify({ mcpServers: buildAgentMcpServers(input) }, null, 2);
+}

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -26,6 +26,21 @@ export const SCOPE_SEND = "channel:send" as const;
 /** Config-management scope: create/list/delete channels (hub-orchestrated setup). */
 export const SCOPE_ADMIN = "channel:admin" as const;
 
+/**
+ * The scope the in-page terminal requires. The terminal attaches to a session's
+ * live tmux pane — the MOST DANGEROUS capability the daemon exposes (full
+ * interactive control of the session's shell), so it is OPERATOR-GATED, not
+ * session-gated. We reuse `channel:admin`: the hub mints it ONLY for the
+ * logged-in operator's cookie session (`<hub>/admin/channel-token` →
+ * `channel:read channel:send channel:admin`), and never for a connecting Claude
+ * Code session (a session holds `channel:read`/`channel:write`, never
+ * `channel:admin`). So a session can never open a terminal onto itself or
+ * another — only the operator can. This is the design's "operator-gated"
+ * requirement expressed in channel's existing scope vocabulary (no new scope to
+ * mint, no hub change). See `design/2026-06-14-sandboxed-agent-sessions.md` §5.3.
+ */
+export const SCOPE_TERMINAL = SCOPE_ADMIN;
+
 /** JSON Response helper (shared spelling for the auth error bodies). */
 export function json(data: unknown, status = 200): Response {
   return new Response(JSON.stringify(data), {

--- a/src/credentials.test.ts
+++ b/src/credentials.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Per-channel Claude OAuth credential store (design §6).
+ *
+ * Covers: store/retrieve round-trip, 0600 on the secret file, redaction (the
+ * raw token never appears in the inspection helper / serialized output), and
+ * default-vs-override resolution (override wins, falls back to default, errors
+ * when neither). All hermetic under a throwaway state dir.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, existsSync, readFileSync, statSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  setDefaultClaudeCredential,
+  setChannelClaudeCredential,
+  removeChannelClaudeCredential,
+  resolveClaudeCredential,
+  describeClaudeCredentials,
+  readCredentialsFile,
+  credentialsFilePath,
+  CredentialNotConfiguredError,
+} from "./credentials.ts";
+
+const DEFAULT_TOKEN = "oat_DEFAULT-OPERATOR-TOKEN-SECRET";
+const OVERRIDE_TOKEN = "oat_PER-CHANNEL-OVERRIDE-SECRET";
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "channel-creds-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("store / retrieve round-trip", () => {
+  test("default token: set then resolve returns it", () => {
+    setDefaultClaudeCredential(DEFAULT_TOKEN, dir);
+    expect(resolveClaudeCredential("any-channel", dir)).toBe(DEFAULT_TOKEN);
+  });
+
+  test("per-channel override: set then resolve returns it for that channel", () => {
+    setChannelClaudeCredential("aaron-dev", OVERRIDE_TOKEN, dir);
+    expect(resolveClaudeCredential("aaron-dev", dir)).toBe(OVERRIDE_TOKEN);
+  });
+
+  test("setting one slice preserves the other (read-modify-write)", () => {
+    setDefaultClaudeCredential(DEFAULT_TOKEN, dir);
+    setChannelClaudeCredential("aaron-dev", OVERRIDE_TOKEN, dir);
+    setChannelClaudeCredential("ops", "oat_OPS", dir);
+    const file = readCredentialsFile(dir);
+    expect(file.claude!.default).toBe(DEFAULT_TOKEN);
+    expect(file.claude!.channels!["aaron-dev"]).toBe(OVERRIDE_TOKEN);
+    expect(file.claude!.channels!["ops"]).toBe("oat_OPS");
+  });
+
+  test("empty token is rejected (never persists a blank credential)", () => {
+    expect(() => setDefaultClaudeCredential("", dir)).toThrow(/non-empty token/);
+    expect(() => setChannelClaudeCredential("c", "", dir)).toThrow(/non-empty token/);
+    expect(existsSync(credentialsFilePath(dir))).toBe(false);
+  });
+});
+
+describe("0600 on the secret file", () => {
+  test("the credentials file is written 0600 (holds a secret)", () => {
+    setDefaultClaudeCredential(DEFAULT_TOKEN, dir);
+    const file = credentialsFilePath(dir);
+    expect(existsSync(file)).toBe(true);
+    expect(statSync(file).mode & 0o777).toBe(0o600);
+  });
+
+  test("a subsequent write keeps it 0600 (chmod is unconditional)", () => {
+    setDefaultClaudeCredential(DEFAULT_TOKEN, dir);
+    // Loosen perms behind the store's back, then write again → must re-tighten.
+    const fs = require("fs") as typeof import("fs");
+    fs.chmodSync(credentialsFilePath(dir), 0o644);
+    setChannelClaudeCredential("c", OVERRIDE_TOKEN, dir);
+    expect(statSync(credentialsFilePath(dir)).mode & 0o777).toBe(0o600);
+  });
+});
+
+describe("redaction — the raw token never leaks via the inspection helper", () => {
+  test("describeClaudeCredentials reports presence + channel names, NOT the token", () => {
+    setDefaultClaudeCredential(DEFAULT_TOKEN, dir);
+    setChannelClaudeCredential("aaron-dev", OVERRIDE_TOKEN, dir);
+    setChannelClaudeCredential("ops", "oat_OPS", dir);
+    const desc = describeClaudeCredentials(dir);
+    expect(desc.defaultSet).toBe(true);
+    expect(desc.channels).toEqual(["aaron-dev", "ops"]); // sorted, names only
+    const serialized = JSON.stringify(desc);
+    expect(serialized).not.toContain(DEFAULT_TOKEN);
+    expect(serialized).not.toContain(OVERRIDE_TOKEN);
+    expect(serialized).not.toContain("oat_OPS");
+  });
+
+  test("describe on an empty store: defaultSet false, no channels", () => {
+    const desc = describeClaudeCredentials(dir);
+    expect(desc).toEqual({ defaultSet: false, channels: [] });
+  });
+});
+
+describe("default-vs-override resolution", () => {
+  test("override WINS over the default for its channel", () => {
+    setDefaultClaudeCredential(DEFAULT_TOKEN, dir);
+    setChannelClaudeCredential("aaron-dev", OVERRIDE_TOKEN, dir);
+    expect(resolveClaudeCredential("aaron-dev", dir)).toBe(OVERRIDE_TOKEN);
+    // A different channel with no override falls back to the default.
+    expect(resolveClaudeCredential("other", dir)).toBe(DEFAULT_TOKEN);
+  });
+
+  test("falls back to the default when the channel has no override", () => {
+    setDefaultClaudeCredential(DEFAULT_TOKEN, dir);
+    expect(resolveClaudeCredential("never-configured", dir)).toBe(DEFAULT_TOKEN);
+  });
+
+  test("ERRORS when neither an override nor a default is set", () => {
+    expect(() => resolveClaudeCredential("ghost", dir)).toThrow(CredentialNotConfiguredError);
+    expect(() => resolveClaudeCredential("ghost", dir)).toThrow(/no Claude credential for channel "ghost"/);
+  });
+
+  test("removing an override falls back to the default; removing a missing one is a no-op", () => {
+    setDefaultClaudeCredential(DEFAULT_TOKEN, dir);
+    setChannelClaudeCredential("aaron-dev", OVERRIDE_TOKEN, dir);
+    expect(removeChannelClaudeCredential("aaron-dev", dir)).toBe(true);
+    expect(resolveClaudeCredential("aaron-dev", dir)).toBe(DEFAULT_TOKEN); // back to default
+    expect(removeChannelClaudeCredential("aaron-dev", dir)).toBe(false); // already gone
+    // The default is untouched by an override removal.
+    expect(readCredentialsFile(dir).claude!.default).toBe(DEFAULT_TOKEN);
+  });
+
+  test("resolution is read dynamically — a rotate takes effect on the next resolve", () => {
+    setDefaultClaudeCredential(DEFAULT_TOKEN, dir);
+    expect(resolveClaudeCredential("c", dir)).toBe(DEFAULT_TOKEN);
+    setDefaultClaudeCredential("oat_ROTATED", dir);
+    expect(resolveClaudeCredential("c", dir)).toBe("oat_ROTATED");
+  });
+});

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -1,0 +1,189 @@
+/**
+ * Per-channel Claude OAuth credential store (design §6).
+ *
+ * The Claude `CLAUDE_CODE_OAUTH_TOKEN` (from `claude setup-token`, the documented
+ * 1-year headless/CI auth path) is the credential a launched agent session runs
+ * on — injected into the sandbox at launch as the session's auth (NEVER
+ * `ANTHROPIC_API_KEY`, which would silently route onto API billing; see
+ * `spawn-agent.ts`). This module persists that secret, following the SAME
+ * file-store discipline `registry.ts` uses for per-channel transport tokens:
+ * a read-modify-write JSON file, written 0600 and `chmod`-ed 0600 unconditionally
+ * (so an existing file created under a looser umask is tightened on every write).
+ *
+ * Two principal levels (design §6 — "default one operator token; per-channel
+ * override"):
+ *
+ *   - a **default / operator-level** token, used when a channel has no override,
+ *   - a **per-channel override**, the multi-principal seam (multi-user isn't a
+ *     rewrite — just populating per-channel, eventually per-principal, tokens).
+ *
+ * Resolution (`resolveClaudeCredential`): channel override ?? default ?? error.
+ *
+ * The secret lives in its OWN file (`credentials.json`), separate from
+ * `channels.json`: the default/operator token isn't tied to any single channel,
+ * and the credential lifecycle (set the operator token once, override per
+ * channel) is distinct from the channel-registry lifecycle. The file is
+ * NAMESPACED by credential type (`{ claude: { ... } }`) so a future credential
+ * type can coexist without a schema migration.
+ *
+ * Redaction discipline: the raw token is NEVER returned by the listing/inspection
+ * helper (`describeClaudeCredentials`) and NEVER logged — exactly the posture the
+ * config API + transports already keep for `config.token` / `webhookSecret`.
+ */
+
+import { readFileSync, writeFileSync, existsSync, chmodSync, mkdirSync } from "fs";
+import { join } from "path";
+import { defaultStateDir } from "./registry.ts";
+
+/** The Claude-credential slice of the store. */
+export interface ClaudeCredentialStore {
+  /** Default / operator-level OAuth token, used when a channel has no override. */
+  default?: string;
+  /** Per-channel overrides, keyed by channel name. */
+  channels?: Record<string, string>;
+}
+
+/** The on-disk `credentials.json` shape (namespaced by credential type). */
+export interface CredentialsFile {
+  claude?: ClaudeCredentialStore;
+}
+
+/** The default credential reference an unspecified spec resolves against. */
+export const DEFAULT_CREDENTIAL_REF = "operator" as const;
+
+/** Absolute path to the credentials.json store in a state dir. */
+export function credentialsFilePath(stateDir?: string): string {
+  return join(stateDir ?? defaultStateDir(), "credentials.json");
+}
+
+/**
+ * Read `credentials.json` as a plain `CredentialsFile`. Returns an empty `{}` if
+ * the file is absent. Mirrors `registry.readChannelsFile` — the read half of the
+ * read-modify-write the setters use.
+ */
+export function readCredentialsFile(stateDir?: string): CredentialsFile {
+  const file = credentialsFilePath(stateDir);
+  if (!existsSync(file)) return {};
+  const parsed = JSON.parse(readFileSync(file, "utf8")) as CredentialsFile;
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error(`credentials: ${file} must be a JSON object`);
+  }
+  return parsed;
+}
+
+/**
+ * Persist the store back to `credentials.json` with 0600 perms — the file holds
+ * the Claude OAuth secret. Creates the state dir if needed. `chmod`s 0600
+ * unconditionally (writeFileSync's `mode` only applies on CREATE, so an existing
+ * file created under a looser umask is tightened on every write) — the exact
+ * discipline `registry.upsertChannelEntry` keeps for the secret-bearing
+ * channels.json.
+ */
+function writeCredentialsFile(file: CredentialsFile, stateDir?: string): void {
+  const dir = stateDir ?? defaultStateDir();
+  mkdirSync(dir, { recursive: true });
+  const path = credentialsFilePath(dir);
+  writeFileSync(path, JSON.stringify(file, null, 2) + "\n", { mode: 0o600 });
+  chmodSync(path, 0o600);
+}
+
+/**
+ * Set the default / operator-level Claude OAuth token. Used by any channel that
+ * has no per-channel override. Read-modify-write so existing per-channel
+ * overrides are preserved.
+ */
+export function setDefaultClaudeCredential(token: string, stateDir?: string): void {
+  if (typeof token !== "string" || token.length === 0) {
+    throw new Error("credentials: a non-empty token is required");
+  }
+  const file = readCredentialsFile(stateDir);
+  const claude = file.claude ?? {};
+  claude.default = token;
+  file.claude = claude;
+  writeCredentialsFile(file, stateDir);
+}
+
+/**
+ * Set a per-channel Claude OAuth override. Wins over the default for that channel.
+ * Read-modify-write so the default + other channels' overrides are preserved.
+ */
+export function setChannelClaudeCredential(
+  channel: string,
+  token: string,
+  stateDir?: string,
+): void {
+  if (typeof channel !== "string" || channel.length === 0) {
+    throw new Error("credentials: a channel name is required");
+  }
+  if (typeof token !== "string" || token.length === 0) {
+    throw new Error("credentials: a non-empty token is required");
+  }
+  const file = readCredentialsFile(stateDir);
+  const claude = file.claude ?? {};
+  const channels = claude.channels ?? {};
+  channels[channel] = token;
+  claude.channels = channels;
+  file.claude = claude;
+  writeCredentialsFile(file, stateDir);
+}
+
+/**
+ * Remove a per-channel override (the channel falls back to the default after
+ * this). Returns true if an override existed, false if there was nothing to
+ * remove. The default token is untouched.
+ */
+export function removeChannelClaudeCredential(channel: string, stateDir?: string): boolean {
+  const file = readCredentialsFile(stateDir);
+  const channels = file.claude?.channels;
+  if (!channels || !(channel in channels)) return false;
+  delete channels[channel];
+  writeCredentialsFile(file, stateDir);
+  return true;
+}
+
+/** Thrown when neither a per-channel override nor a default token is configured. */
+export class CredentialNotConfiguredError extends Error {
+  constructor(channel: string) {
+    super(
+      `no Claude credential for channel "${channel}": set a per-channel override or the ` +
+        `default/operator token (POST /api/credentials/claude). Get one with ` +
+        `\`claude setup-token\`.`,
+    );
+    this.name = "CredentialNotConfiguredError";
+  }
+}
+
+/**
+ * Resolve the Claude OAuth token a session on `channel` should run on:
+ *
+ *   channel override ?? default ?? throw CredentialNotConfiguredError
+ *
+ * Read at resolve time (not cached) so a token set/rotated via the config API
+ * takes effect on the next spawn without a daemon restart — the dynamic-read
+ * discipline. Throwing (rather than returning empty) means a misconfigured
+ * install fails loud BEFORE a session launches with no auth.
+ */
+export function resolveClaudeCredential(channel: string, stateDir?: string): string {
+  const claude = readCredentialsFile(stateDir).claude;
+  const override = claude?.channels?.[channel];
+  if (override) return override;
+  const fallback = claude?.default;
+  if (fallback) return fallback;
+  throw new CredentialNotConfiguredError(channel);
+}
+
+/**
+ * Describe the credential store for an operator-facing read WITHOUT leaking the
+ * secret: whether a default is set, and which channels carry an override (names
+ * only). The raw token is never returned — same redaction posture the config
+ * API keeps for transport tokens. (`GET /api/credentials/claude`.)
+ */
+export function describeClaudeCredentials(
+  stateDir?: string,
+): { defaultSet: boolean; channels: string[] } {
+  const claude = readCredentialsFile(stateDir).claude;
+  return {
+    defaultSet: Boolean(claude?.default),
+    channels: Object.keys(claude?.channels ?? {}).sort(),
+  };
+}

--- a/src/daemon-config-api.test.ts
+++ b/src/daemon-config-api.test.ts
@@ -49,6 +49,7 @@ import { ClientRegistry } from "./routing.ts";
 import { VaultTransport, CHANNEL_VAULT_TRIGGER_TEMPLATE } from "./transports/vault.ts";
 import { channelsFilePath } from "./registry.ts";
 import type { Channel } from "./registry.ts";
+import { credentialsFilePath, resolveClaudeCredential } from "./credentials.ts";
 import type { TransportContext, InboundMessage } from "./transport.ts";
 
 const sendAuth = { authorization: "Bearer " + SEND_TOKEN } as const;
@@ -554,6 +555,177 @@ describe("C — CHANNEL_VAULT_TRIGGER_TEMPLATE exposed via /.parachute/config", 
       expect(body.triggerTemplate.name).toBe("channel_inbound_<channel>");
       expect(body.triggerTemplate.when.tags).toEqual(["#channel-message/inbound"]);
       expect(body.triggerTemplate.action.webhook).toBe("<hub-origin>/channel/api/vault/inbound");
+    } finally {
+      srv.stop(true);
+    }
+  });
+});
+
+// ===========================================================================
+// D. Claude OAuth credential store API (channel:admin) — design §6
+// ===========================================================================
+describe("D — Claude credential store API (channel:admin)", () => {
+  test("POST /api/credentials/claude sets the default; persisted 0600; resolve returns it", async () => {
+    const { srv, base } = buildServer([]);
+    try {
+      const res = await fetch(`${base}/api/credentials/claude`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ token: "oat_DEFAULT-OPERATOR" }),
+      });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toMatchObject({ ok: true, scope: "default" });
+
+      const file = credentialsFilePath(stateDir);
+      expect(existsSync(file)).toBe(true);
+      expect(statSync(file).mode & 0o777).toBe(0o600);
+      // The token resolves for any channel (no override → default).
+      expect(resolveClaudeCredential("any-channel", stateDir)).toBe("oat_DEFAULT-OPERATOR");
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("POST /api/credentials/claude/:channel sets an override that WINS over the default", async () => {
+    const { srv, base } = buildServer([]);
+    try {
+      await fetch(`${base}/api/credentials/claude`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ token: "oat_DEFAULT" }),
+      });
+      const res = await fetch(`${base}/api/credentials/claude/aaron-dev`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ token: "oat_AARON-OVERRIDE" }),
+      });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toMatchObject({ ok: true, scope: "channel", channel: "aaron-dev" });
+
+      expect(resolveClaudeCredential("aaron-dev", stateDir)).toBe("oat_AARON-OVERRIDE"); // override wins
+      expect(resolveClaudeCredential("other", stateDir)).toBe("oat_DEFAULT"); // other → default
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("GET /api/credentials/claude reports presence + channel names — NEVER the token", async () => {
+    const { srv, base } = buildServer([]);
+    try {
+      await fetch(`${base}/api/credentials/claude`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ token: "oat_SECRET-DEFAULT" }),
+      });
+      await fetch(`${base}/api/credentials/claude/aaron-dev`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ token: "oat_SECRET-OVERRIDE" }),
+      });
+
+      const res = await fetch(`${base}/api/credentials/claude`, { headers: { ...adminAuth } });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { defaultSet: boolean; channels: string[] };
+      expect(body.defaultSet).toBe(true);
+      expect(body.channels).toEqual(["aaron-dev"]);
+      // No secret leaks.
+      const serialized = JSON.stringify(body);
+      expect(serialized).not.toContain("oat_SECRET-DEFAULT");
+      expect(serialized).not.toContain("oat_SECRET-OVERRIDE");
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("DELETE /api/credentials/claude/:channel removes the override (falls back to default)", async () => {
+    const { srv, base } = buildServer([]);
+    try {
+      await fetch(`${base}/api/credentials/claude`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ token: "oat_DEFAULT" }),
+      });
+      await fetch(`${base}/api/credentials/claude/aaron-dev`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ token: "oat_OVERRIDE" }),
+      });
+      const del = await fetch(`${base}/api/credentials/claude/aaron-dev`, {
+        method: "DELETE",
+        headers: { ...adminAuth },
+      });
+      expect(del.status).toBe(200);
+      expect(await del.json()).toMatchObject({ ok: true, channel: "aaron-dev", removed: true });
+      expect(resolveClaudeCredential("aaron-dev", stateDir)).toBe("oat_DEFAULT"); // back to default
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("POST with an empty/missing token → 400, nothing persisted", async () => {
+    const { srv, base } = buildServer([]);
+    try {
+      const empty = await fetch(`${base}/api/credentials/claude`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ token: "" }),
+      });
+      expect(empty.status).toBe(400);
+      const missing = await fetch(`${base}/api/credentials/claude`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({}),
+      });
+      expect(missing.status).toBe(400);
+      expect(existsSync(credentialsFilePath(stateDir))).toBe(false);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("credential API without channel:admin → 401 (none) / 403 (wrong scope), on every verb", async () => {
+    const { srv, base } = buildServer([]);
+    try {
+      // GET default
+      expect((await fetch(`${base}/api/credentials/claude`)).status).toBe(401);
+      expect((await fetch(`${base}/api/credentials/claude`, { headers: { ...readAuth } })).status).toBe(403);
+      // POST default
+      expect(
+        (await fetch(`${base}/api/credentials/claude`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ token: "x" }),
+        })).status,
+      ).toBe(401);
+      expect(
+        (await fetch(`${base}/api/credentials/claude`, {
+          method: "POST",
+          headers: { "content-type": "application/json", ...sendAuth },
+          body: JSON.stringify({ token: "x" }),
+        })).status,
+      ).toBe(403);
+      // POST per-channel
+      expect(
+        (await fetch(`${base}/api/credentials/claude/c`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ token: "x" }),
+        })).status,
+      ).toBe(401);
+      expect(
+        (await fetch(`${base}/api/credentials/claude/c`, {
+          method: "POST",
+          headers: { "content-type": "application/json", ...readAuth },
+          body: JSON.stringify({ token: "x" }),
+        })).status,
+      ).toBe(403);
+      // DELETE per-channel
+      expect((await fetch(`${base}/api/credentials/claude/c`, { method: "DELETE" })).status).toBe(401);
+      expect(
+        (await fetch(`${base}/api/credentials/claude/c`, { method: "DELETE", headers: { ...readAuth } })).status,
+      ).toBe(403);
+      // Nothing was persisted by any unauthorized call.
+      expect(existsSync(credentialsFilePath(stateDir))).toBe(false);
     } finally {
       srv.stop(true);
     }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -56,11 +56,19 @@ import { ClientRegistry } from "./routing.ts";
 import {
   requireScope,
   extractToken,
+  json as authJson,
   SCOPE_READ,
   SCOPE_WRITE,
   SCOPE_SEND,
   SCOPE_ADMIN,
+  SCOPE_TERMINAL,
 } from "./auth.ts";
+import {
+  createTerminalWsHandlers,
+  type TerminalWsData,
+  type SpawnTerminalFn,
+} from "./terminal.ts";
+import { TERMINAL_UI_HTML } from "./terminal-ui.ts";
 import { validateHubJwt } from "./hub-jwt.ts";
 import {
   handleProtectedResource,
@@ -606,15 +614,85 @@ function json(data: unknown, status = 200): Response {
 // ---------------------------------------------------------------------------
 
 /**
+ * Decide whether a terminal WebSocket upgrade is authorized + which tmux session
+ * it targets. Pure over its inputs (no `server.upgrade`, no pty) so the auth +
+ * routing layer is unit-testable without a live hub or a real socket — the same
+ * shape the HTTP gate tests rely on.
+ *
+ * Auth: OPERATOR-GATED on `channel:admin` (`SCOPE_TERMINAL`). The token rides in
+ * as a `?token=` query param (browsers can't set Authorization on
+ * `new WebSocket()`), so `allowQueryParam: true`. The no-token path
+ * short-circuits to 401 before any JWKS fetch (testable offline). The channel
+ * must exist (a terminal onto an unknown channel is a 404, never an enumeration
+ * oracle — but this endpoint is operator-only behind the admin scope, so a plain
+ * 404 is fine).
+ *
+ * Returns either `{ ok: true, ... }` with the tmux session name (`<name>-agent`,
+ * matching `scripts/launch-session.sh:38`) + the client's requested geometry, or
+ * `{ ok: false, response }` carrying the deny Response the caller returns as-is.
+ */
+export async function authorizeTerminalUpgrade(
+  req: Request,
+  url: URL,
+  channels: Map<string, Channel>,
+  channelName: string,
+): Promise<
+  | { ok: true; channel: string; session: string; cols: number; rows: number }
+  | { ok: false; response: Response }
+> {
+  if (!channels.has(channelName)) {
+    return {
+      ok: false,
+      response: authJson(
+        {
+          error: `unknown channel "${channelName}" — known channels: ${
+            [...channels.keys()].join(", ") || "(none)"
+          }`,
+        },
+        404,
+      ),
+    };
+  }
+  // Operator-grade gate. allowQueryParam: true — the only way a browser
+  // WebSocket can present the token (no Authorization header on `new WebSocket`).
+  const denied = await requireScope(req, url, SCOPE_TERMINAL, true);
+  if (denied) return { ok: false, response: denied };
+
+  // tmux session name convention: `<name>-agent` (launch-session.sh:38). Attach
+  // a viewer pty to THIS session; the session itself is created by the launcher.
+  const session = `${channelName}-agent`;
+  const cols = clampQueryDim(url.searchParams.get("cols"), 80);
+  const rows = clampQueryDim(url.searchParams.get("rows"), 24);
+  return { ok: true, channel: channelName, session, cols, rows };
+}
+
+/** Is this request a WebSocket upgrade? (case-insensitive `Upgrade: websocket`). */
+export function isWebSocketUpgrade(req: Request): boolean {
+  return (req.headers.get("upgrade") ?? "").toLowerCase() === "websocket";
+}
+
+/** Parse + clamp a `?cols=`/`?rows=` query dim to [1, 9999], with a fallback. */
+function clampQueryDim(raw: string | null, fallback: number): number {
+  const n = raw === null ? NaN : parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 1) return fallback;
+  return n > 9999 ? 9999 : n;
+}
+
+/**
  * Build the daemon's HTTP fetch handler over a channel registry + client
  * registry. Extracted as a factory so tests can exercise routing + the auth
  * gate on an ephemeral `Bun.serve` without booting the real daemon (and without
  * a live hub — the no-token 401 path short-circuits before JWKS).
+ *
+ * `server` is the `Bun.serve` instance (passed as `fetch`'s 2nd arg at runtime),
+ * needed for `server.upgrade()` on the terminal WS route. It's optional so the
+ * existing tests (which call the handler with one arg) keep working — a terminal
+ * upgrade request with no server falls through to the normal 426-style refusal.
  */
 export function createFetchHandler(
   channels: Map<string, Channel>,
   registry: ClientRegistry,
-): (req: Request) => Promise<Response> {
+): (req: Request, server?: { upgrade: (req: Request, opts: { data: TerminalWsData }) => boolean }) => Promise<Response> {
   /** Resolve the transport for a channel name, or null on miss. */
   function transportFor(channel: string | undefined): Transport | null {
     if (!channel) return null;
@@ -657,8 +735,58 @@ export function createFetchHandler(
     return true;
   }
 
-  return async function fetch(req) {
+  return async function fetch(req, server) {
     const url = new URL(req.url);
+
+    // -------------------------------------------------------------------
+    // Terminal WebSocket upgrade — `/terminal/<channel>` (design §5).
+    //
+    // The in-page xterm.js terminal attaches to the channel's tmux session
+    // (`<channel>-agent`) via Bun's native pty. Externally this is
+    // `<hub>/channel/terminal/<channel>`; the hub strips `/channel` (stripPrefix)
+    // and forwards the `Upgrade: websocket` over its Bun-native WS bridge (which
+    // honors channel's `websocket: true` declaration), so the daemon sees the
+    // bare `/terminal/<channel>` upgrade here. OPERATOR-GATED on channel:admin
+    // (the most dangerous capability), token via `?token=`. Must run BEFORE the
+    // generic routing so the upgrade isn't 404'd.
+    const termMatch = url.pathname.match(/^\/terminal\/([^/]+)$/);
+    if (termMatch && isWebSocketUpgrade(req)) {
+      const channelName = decodeURIComponent(termMatch[1]!);
+      const decision = await authorizeTerminalUpgrade(req, url, channels, channelName);
+      if (!decision.ok) return decision.response;
+      if (!server?.upgrade) {
+        // No server handle (e.g. a unit test calling the handler directly, or a
+        // build where Bun.serve didn't pass it) — the upgrade can't happen here.
+        return authJson(
+          { error: "websocket upgrade unavailable on this server" },
+          503,
+        );
+      }
+      const data: TerminalWsData = {
+        session: decision.session,
+        channel: decision.channel,
+        cols: decision.cols,
+        rows: decision.rows,
+      };
+      const upgraded = server.upgrade(req, { data });
+      if (upgraded) {
+        // Bun's contract: return undefined from fetch after a successful upgrade
+        // — the socket now belongs to the websocket handlers.
+        return undefined as unknown as Response;
+      }
+      return authJson({ error: "websocket upgrade failed" }, 400);
+    }
+
+    // Terminal view (the xterm.js page) — `/terminal` or `/terminal/<channel>`
+    // as a plain GET (no upgrade) serves the page; the page then opens the WS to
+    // `/terminal/<channel>`. Loads OPEN (like /ui and /admin) so it can bootstrap
+    // its hub-minted channel:admin token fetch; the WS upgrade above is what's
+    // gated. Served by the daemon (spans every channel via a picker).
+    if (req.method === "GET" && (url.pathname === "/terminal" || termMatch)) {
+      return new Response(TERMINAL_UI_HTML, {
+        headers: { "content-type": "text/html; charset=utf-8" },
+      });
+    }
 
     // Health check — per-channel client counts.
     if (url.pathname === "/health") {
@@ -1262,11 +1390,21 @@ function main(): void {
 
   const registry = new ClientRegistry();
 
-  const server = Bun.serve({
+  // The terminal WS handler set (pty↔socket relay + backpressure flow control,
+  // src/terminal.ts). One handler object serves every terminal connection;
+  // per-connection state lives on `ws.data`. The fetch handler routes accepted
+  // upgrades into these via `server.upgrade(req, { data })`.
+  const terminalWs = createTerminalWsHandlers();
+
+  const fetchHandler = createFetchHandler(channels, registry);
+  const server = Bun.serve<TerminalWsData, never>({
     port: PORT,
     hostname: "127.0.0.1",
     idleTimeout: 0,
-    fetch: createFetchHandler(channels, registry),
+    // `fetch` receives `server` as its 2nd arg at runtime — needed for
+    // `server.upgrade()` on the terminal WS route.
+    fetch: (req, srv) => fetchHandler(req, srv),
+    websocket: terminalWs,
   });
 
   console.log(`parachute-channel: daemon listening on http://127.0.0.1:${PORT}`);
@@ -1298,6 +1436,27 @@ function main(): void {
       stripPrefix: true,
       uiUrl: "/channel/ui", // portal "Open UI" link (also in module.json; written here in case hub reads it from services.json)
       configUiUrl: "/channel/admin", // module-owned config surface (modular-UI P4); hub frames/links it. Also in module.json.
+      // WebSocket support — tells the hub's Bun-native upgrade bridge to forward
+      // `Upgrade: websocket` requests on `/channel/*` to this daemon (the
+      // in-page terminal, design §5.1). DENY-BY-DEFAULT in the hub: without this
+      // the upgrade is refused (426) before it ever reaches us. Declared on
+      // module.json too (the install-time contract); the hub honors either
+      // source. No hub change needed — the hub already reads this field.
+      websocket: true,
+      // The terminal mount, declared as a `uis` sub-unit with audience "surface"
+      // so the hub's audience gate PASSES IT THROUGH (the channel daemon owns
+      // admission end-to-end — operator-grade channel:admin, enforced here). A
+      // `surface` audience is the same pass-through the no-uis-match default
+      // gives, but declaring it explicitly future-proofs against a later `uis`
+      // declaration accidentally gating the terminal at hub-users. Design §5.3.
+      uis: {
+        terminal: {
+          displayName: "Terminal",
+          tagline: "Attach to a session's live tmux pane in the browser.",
+          path: "/channel/terminal",
+          audience: "surface",
+        },
+      },
     });
     console.log(`parachute-channel: self-registered into services.json (port ${PORT}, mount /channel)`);
   } catch (err) {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -52,6 +52,12 @@ import {
   type ChannelEntry,
 } from "./registry.ts";
 import { VaultTransport, CHANNEL_VAULT_TRIGGER_TEMPLATE } from "./transports/vault.ts";
+import {
+  setDefaultClaudeCredential,
+  setChannelClaudeCredential,
+  removeChannelClaudeCredential,
+  describeClaudeCredentials,
+} from "./credentials.ts";
 import { ClientRegistry } from "./routing.ts";
 import {
   requireScope,
@@ -831,6 +837,82 @@ export function createFetchHandler(
         return json({ ok: true, name, removed: false }, 200);
       }
       return json({ ok: true, name, removed: true });
+    }
+
+    // ---------------------------------------------------------------------
+    // Claude OAuth credential store (design §6) — the per-channel secret a
+    // launched agent session runs on (`CLAUDE_CODE_OAUTH_TOKEN`). Same
+    // `channel:admin` gate + 0600 file-store + redaction-on-read posture as the
+    // channel config API above. The token comes from `claude setup-token`.
+    //
+    //   GET    /api/credentials/claude          → { defaultSet, channels:[names] } (NO secret)
+    //   POST   /api/credentials/claude          { token } → set the default/operator token
+    //   POST   /api/credentials/claude/:channel { token } → set a per-channel override
+    //   DELETE /api/credentials/claude/:channel → remove an override (falls back to default)
+    //
+    // Externally hub strips `/channel`, so these are `<hub>/channel/api/credentials/claude`.
+    // ---------------------------------------------------------------------
+    if (url.pathname === "/api/credentials/claude" && (req.method === "GET" || req.method === "POST")) {
+      const denied = await requireScope(req, url, SCOPE_ADMIN);
+      if (denied) return denied;
+
+      if (req.method === "GET") {
+        // Inspect WITHOUT leaking the secret: whether a default is set + which
+        // channels carry an override (names only).
+        return json(describeClaudeCredentials(defaultStateDir()));
+      }
+
+      // POST — set the default / operator-level token.
+      let credBody: { token?: unknown };
+      try {
+        credBody = (await req.json()) as typeof credBody;
+      } catch {
+        return json({ error: "invalid JSON body" }, 400);
+      }
+      if (typeof credBody.token !== "string" || credBody.token.length === 0) {
+        return json({ error: "body.token (non-empty string) is required" }, 400);
+      }
+      try {
+        setDefaultClaudeCredential(credBody.token, defaultStateDir());
+      } catch (err) {
+        return json({ error: `failed to write credentials.json: ${(err as Error).message}` }, 500);
+      }
+      // Echo back only the fact of the write — never the token.
+      return json({ ok: true, scope: "default" });
+    }
+
+    const credMatch = url.pathname.match(/^\/api\/credentials\/claude\/([^/]+)$/);
+    if (credMatch && (req.method === "POST" || req.method === "DELETE")) {
+      const denied = await requireScope(req, url, SCOPE_ADMIN);
+      if (denied) return denied;
+      const channel = decodeURIComponent(credMatch[1]!);
+
+      if (req.method === "DELETE") {
+        let removed: boolean;
+        try {
+          removed = removeChannelClaudeCredential(channel, defaultStateDir());
+        } catch (err) {
+          return json({ error: `failed to update credentials.json: ${(err as Error).message}` }, 500);
+        }
+        return json({ ok: true, channel, removed });
+      }
+
+      // POST — set a per-channel override.
+      let credBody: { token?: unknown };
+      try {
+        credBody = (await req.json()) as typeof credBody;
+      } catch {
+        return json({ error: "invalid JSON body" }, 400);
+      }
+      if (typeof credBody.token !== "string" || credBody.token.length === 0) {
+        return json({ error: "body.token (non-empty string) is required" }, 400);
+      }
+      try {
+        setChannelClaudeCredential(channel, credBody.token, defaultStateDir());
+      } catch (err) {
+        return json({ error: `failed to write credentials.json: ${(err as Error).message}` }, 500);
+      }
+      return json({ ok: true, scope: "channel", channel });
     }
 
     // ---------------------------------------------------------------------

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -66,7 +66,6 @@ import {
 import {
   createTerminalWsHandlers,
   type TerminalWsData,
-  type SpawnTerminalFn,
 } from "./terminal.ts";
 import { TERMINAL_UI_HTML } from "./terminal-ui.ts";
 import { validateHubJwt } from "./hub-jwt.ts";

--- a/src/mint-token.test.ts
+++ b/src/mint-token.test.ts
@@ -1,0 +1,152 @@
+import { describe, test, expect } from "bun:test";
+import {
+  mintScopedToken,
+  channelScope,
+  vaultScope,
+  MintError,
+  type MintTokenDeps,
+} from "./mint-token.ts";
+
+/** A fake hub mint endpoint. Records the request; returns a scripted response. */
+function fakeHub(
+  handler: (body: Record<string, unknown>, headers: Headers) => { status: number; json: unknown },
+): { fetchFn: typeof fetch; calls: Array<{ body: Record<string, unknown>; auth: string | null }> } {
+  const calls: Array<{ body: Record<string, unknown>; auth: string | null }> = [];
+  const fetchFn = (async (url: string | URL | Request, init?: RequestInit) => {
+    const headers = new Headers(init?.headers);
+    const body = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+    calls.push({ body, auth: headers.get("authorization") });
+    const { status, json } = handler(body, headers);
+    return new Response(JSON.stringify(json), {
+      status,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  return { fetchFn, calls };
+}
+
+function depsWith(fetchFn: typeof fetch): MintTokenDeps {
+  return { hubOrigin: "https://hub.example.com", managerBearer: "MANAGER-BEARER", fetchFn };
+}
+
+describe("scope string helpers", () => {
+  test("channelScope", () => {
+    expect(channelScope({ write: false })).toBe("channel:read");
+    expect(channelScope({ write: true })).toBe("channel:read channel:write");
+  });
+  test("vaultScope", () => {
+    expect(vaultScope("default", "read")).toBe("vault:default:read");
+    expect(vaultScope("work", "write")).toBe("vault:work:write");
+  });
+});
+
+describe("mintScopedToken — happy path", () => {
+  test("POSTs to /api/auth/mint-token with the manager bearer + scope, returns the token", async () => {
+    const hub = fakeHub((body) => ({
+      status: 200,
+      json: {
+        jti: "j1",
+        token: "MINTED-TOKEN",
+        expires_at: "2026-09-01T00:00:00Z",
+        scope: body.scope,
+      },
+    }));
+    const res = await mintScopedToken({ scope: "channel:read channel:write" }, depsWith(hub.fetchFn));
+    expect(res.token).toBe("MINTED-TOKEN");
+    expect(res.jti).toBe("j1");
+    // Presented the MANAGER's bearer (the attenuation principal).
+    expect(hub.calls[0]!.auth).toBe("Bearer MANAGER-BEARER");
+    expect(hub.calls[0]!.body.scope).toBe("channel:read channel:write");
+  });
+
+  test("passes audience + permissions (scoped_tags) through to the hub", async () => {
+    const hub = fakeHub(() => ({
+      status: 200,
+      json: { jti: "j", token: "T", expires_at: "", scope: "vault:default:read" },
+    }));
+    await mintScopedToken(
+      {
+        scope: "vault:default:read",
+        audience: "vault.default",
+        permissions: { scoped_tags: ["#channel-message"] },
+      },
+      depsWith(hub.fetchFn),
+    );
+    expect(hub.calls[0]!.body.audience).toBe("vault.default");
+    expect(hub.calls[0]!.body.permissions).toEqual({ scoped_tags: ["#channel-message"] });
+  });
+});
+
+describe("mintScopedToken — attenuation + error surfacing", () => {
+  test("CAPABILITY ATTENUATION: the hub's 400 invalid_scope (over-broad request) becomes a MintError", async () => {
+    // Simulate the hub's canGrant guard: a vault:default:read manager bearer
+    // requests vault:default:write → the hub refuses 400 invalid_scope. The
+    // attenuation bound lives in the hub; this asserts the client surfaces the
+    // refusal as a hard error (never launches a session with an ungrantable cred).
+    const hub = fakeHub((body) => {
+      // Manager bearer in this scenario only holds vault:default:read; a write
+      // request exceeds it → hub returns 400.
+      if (String(body.scope).includes(":write")) {
+        return {
+          status: 400,
+          json: {
+            error: "invalid_scope",
+            error_description:
+              "scope vault:default:write is not grantable by this bearer; use OAuth flow or operator rotation",
+          },
+        };
+      }
+      return { status: 200, json: { jti: "j", token: "ok", expires_at: "", scope: body.scope } };
+    });
+
+    // The grantable read mint succeeds.
+    const ok = await mintScopedToken({ scope: "vault:default:read" }, depsWith(hub.fetchFn));
+    expect(ok.token).toBe("ok");
+
+    // The over-broad write mint is refused — surfaced as a MintError carrying the code.
+    let err: unknown;
+    try {
+      await mintScopedToken({ scope: "vault:default:write" }, depsWith(hub.fetchFn));
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(MintError);
+    expect((err as MintError).status).toBe(400);
+    expect((err as MintError).code).toBe("invalid_scope");
+  });
+
+  test("a 403 insufficient_scope (no minting authority) becomes a MintError", async () => {
+    const hub = fakeHub(() => ({
+      status: 403,
+      json: { error: "insufficient_scope", error_description: "bearer holds no minting authority" },
+    }));
+    let err: unknown;
+    try {
+      await mintScopedToken({ scope: "channel:read" }, depsWith(hub.fetchFn));
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(MintError);
+    expect((err as MintError).status).toBe(403);
+    expect((err as MintError).code).toBe("insufficient_scope");
+  });
+
+  test("a 200 with no token becomes a MintError (never returns a credential-less success)", async () => {
+    const hub = fakeHub(() => ({ status: 200, json: { jti: "j", expires_at: "" } }));
+    await expect(mintScopedToken({ scope: "channel:read" }, depsWith(hub.fetchFn))).rejects.toBeInstanceOf(MintError);
+  });
+
+  test("a network failure to reach the hub becomes a MintError (status 0)", async () => {
+    const fetchFn = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+    let err: unknown;
+    try {
+      await mintScopedToken({ scope: "channel:read" }, depsWith(fetchFn));
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(MintError);
+    expect((err as MintError).status).toBe(0);
+  });
+});

--- a/src/mint-token.ts
+++ b/src/mint-token.ts
@@ -1,0 +1,139 @@
+/**
+ * Scoped-token minting for a sandboxed agent session (design §4.2 step 1, §4.3).
+ *
+ * A hub-issued JWT's `aud` is single-valued, so each resource an arm reaches gets
+ * its OWN token: `channel:read channel:write` per channel, `vault:<name>:<verb>`
+ * (optionally tag-scoped via `permissions.scoped_tags`) for the vault. The
+ * spawn-manager mints these by attenuating its own grant — it presents its OWN
+ * operator bearer to the hub's `POST /api/auth/mint-token`, which enforces
+ * capability attenuation server-side (`parachute-hub/src/api-mint-token.ts`,
+ * `canGrant`): the manager CANNOT mint a child token exceeding its own authority.
+ * A `vault:default:read` manager bearer cannot mint a child `vault:default:write`
+ * — the hub returns 400 `invalid_scope` (§4.3). This module is the client of that
+ * server-enforced bound; the bound itself lives in the hub.
+ *
+ * One token per `aud`: a multi-resource spec calls this once per resource, each
+ * with the resource's scope (and the hub infers `aud` from the scope, or the
+ * caller pins it). Tokens are ephemeral by default for one-shot helpers; the TTL
+ * is the hub's default unless overridden.
+ */
+
+export interface MintRequest {
+  /** Space-joined scope string, e.g. "channel:read channel:write". */
+  scope: string;
+  /** Pin the audience. Omitted = hub infers it from the scope. */
+  audience?: string;
+  /** TTL in seconds. Omitted = hub default (~90d non-ephemeral). */
+  expiresIn?: number;
+  /**
+   * Extra JWT claims, e.g. `{ scoped_tags: ["#channel-message"] }` for a
+   * tag-scoped vault token. Passed through as the mint API's `permissions`.
+   */
+  permissions?: Record<string, unknown>;
+}
+
+export interface MintResult {
+  jti: string;
+  token: string;
+  expiresAt: string;
+  scope: string;
+  permissions?: Record<string, unknown>;
+}
+
+/** A failed mint — carries the hub's error code + the HTTP status. */
+export class MintError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly code: string | undefined,
+  ) {
+    super(message);
+    this.name = "MintError";
+  }
+}
+
+export interface MintTokenDeps {
+  /** Hub public origin. */
+  hubOrigin: string;
+  /**
+   * The spawn-manager's OWN operator bearer, presented to the hub. The hub
+   * attenuates against THIS bearer's authority — child tokens can never exceed it.
+   */
+  managerBearer: string;
+  /** Inject fetch for tests. Defaults to global fetch. */
+  fetchFn?: typeof fetch;
+}
+
+function stripTrailingSlash(url: string): string {
+  return url.replace(/\/$/, "");
+}
+
+/**
+ * Mint ONE scoped token against the hub, attenuated to the manager's bearer.
+ * Throws {@link MintError} on any non-200 (the hub's attenuation 400, an auth
+ * 401/403, etc.) so the caller fails loud rather than launching a session with a
+ * missing/over-broad credential.
+ */
+export async function mintScopedToken(
+  req: MintRequest,
+  deps: MintTokenDeps,
+): Promise<MintResult> {
+  const fetchFn = deps.fetchFn ?? fetch;
+  const url = `${stripTrailingSlash(deps.hubOrigin)}/api/auth/mint-token`;
+
+  const body: Record<string, unknown> = { scope: req.scope };
+  if (req.audience) body.audience = req.audience;
+  if (req.expiresIn !== undefined) body.expires_in = req.expiresIn;
+  if (req.permissions) body.permissions = req.permissions;
+
+  let res: Response;
+  try {
+    res = await fetchFn(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${deps.managerBearer}`,
+      },
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new MintError(`mint request failed to reach hub: ${msg}`, 0, undefined);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = await res.json();
+  } catch {
+    parsed = undefined;
+  }
+
+  if (!res.ok) {
+    const e = (parsed ?? {}) as { error?: string; error_description?: string; message?: string };
+    const code = e.error;
+    const detail = e.error_description ?? e.message ?? `HTTP ${res.status}`;
+    throw new MintError(`mint refused (${code ?? "error"}): ${detail}`, res.status, code);
+  }
+
+  const r = (parsed ?? {}) as Partial<MintResult> & { expires_at?: string };
+  if (typeof r.token !== "string" || r.token.length === 0) {
+    throw new MintError("mint succeeded but response had no token", res.status, undefined);
+  }
+  return {
+    jti: typeof r.jti === "string" ? r.jti : "",
+    token: r.token,
+    expiresAt: typeof r.expires_at === "string" ? r.expires_at : "",
+    scope: typeof r.scope === "string" ? r.scope : req.scope,
+    ...(r.permissions ? { permissions: r.permissions } : {}),
+  };
+}
+
+/** Build the space-joined channel scope string for a read[+write] grant. */
+export function channelScope(opts: { write: boolean }): string {
+  return opts.write ? "channel:read channel:write" : "channel:read";
+}
+
+/** Build the vault scope string for a named verb, e.g. `vault:default:read`. */
+export function vaultScope(name: string, verb: "read" | "write" | "admin"): string {
+  return `vault:${name}:${verb}`;
+}

--- a/src/sandbox/config.test.ts
+++ b/src/sandbox/config.test.ts
@@ -1,0 +1,102 @@
+import { describe, test, expect } from "bun:test";
+import { buildSandboxConfig } from "./config.ts";
+import type { AgentSpec, BaseBinds } from "./types.ts";
+import type { EgressBaseInput } from "./egress.ts";
+
+const BASE_BINDS: BaseBinds = {
+  workspace: "/state/sessions/arm",
+  runtimeReadOnly: ["/home/op/.claude"],
+};
+const EGRESS_BASE: EgressBaseInput = { hubOrigin: "https://hub.example.com" };
+
+function specOf(p: Partial<AgentSpec> = {}): AgentSpec {
+  return { name: "arm", channels: ["ch"], ...p };
+}
+
+describe("buildSandboxConfig — spec → SandboxRuntimeConfig", () => {
+  test("network: deny-by-default + base floor present, deniedDomains empty", () => {
+    const cfg = buildSandboxConfig({
+      spec: specOf({ egress: [] }),
+      baseBinds: BASE_BINDS,
+      egressBase: EGRESS_BASE,
+      platform: "darwin",
+    });
+    expect(cfg.network.allowedDomains).toContain("api.anthropic.com");
+    expect(cfg.network.allowedDomains).toContain("hub.example.com");
+    expect(cfg.network.deniedDomains).toEqual([]);
+  });
+
+  test("SECURITY: a spec with foreign egress still carries the base floor", () => {
+    const cfg = buildSandboxConfig({
+      spec: specOf({ egress: ["registry.npmjs.org"] }),
+      baseBinds: BASE_BINDS,
+      egressBase: EGRESS_BASE,
+      platform: "darwin",
+    });
+    expect(cfg.network.allowedDomains).toContain("api.anthropic.com");
+    expect(cfg.network.allowedDomains).toContain("hub.example.com");
+    expect(cfg.network.allowedDomains).toContain("registry.npmjs.org");
+  });
+
+  test("filesystem: scoped reads (deny home tree, re-allow binds) + write confinement", () => {
+    const cfg = buildSandboxConfig({
+      spec: specOf({ mounts: [{ hostPath: "/proj", mountPath: "/work", mode: "rw" }] }),
+      baseBinds: BASE_BINDS,
+      egressBase: EGRESS_BASE,
+      platform: "darwin",
+    });
+    expect(cfg.filesystem.denyRead).toContain("/Users");
+    expect(cfg.filesystem.allowRead).toContain("/state/sessions/arm");
+    expect(cfg.filesystem.allowRead).toContain("/home/op/.claude");
+    expect(cfg.filesystem.allowRead).toContain("/proj");
+    expect(cfg.filesystem.allowWrite).toContain("/state/sessions/arm");
+    expect(cfg.filesystem.allowWrite).toContain("/proj");
+  });
+
+  test("Linux platform denies /home instead of /Users", () => {
+    const cfg = buildSandboxConfig({
+      spec: specOf(),
+      baseBinds: BASE_BINDS,
+      egressBase: EGRESS_BASE,
+      platform: "linux",
+    });
+    expect(cfg.filesystem.denyRead).toContain("/home");
+    expect(cfg.filesystem.denyRead).not.toContain("/Users");
+  });
+
+  test("allowPty defaults true (interactive claude needs a pty)", () => {
+    const cfg = buildSandboxConfig({
+      spec: specOf(),
+      baseBinds: BASE_BINDS,
+      egressBase: EGRESS_BASE,
+      platform: "darwin",
+    });
+    expect(cfg.allowPty).toBe(true);
+  });
+
+  test("ripgrep override threads through when provided", () => {
+    const cfg = buildSandboxConfig({
+      spec: specOf(),
+      baseBinds: BASE_BINDS,
+      egressBase: EGRESS_BASE,
+      platform: "darwin",
+      ripgrep: { command: "/abs/rg" },
+    });
+    expect(cfg.ripgrep).toEqual({ command: "/abs/rg" });
+  });
+
+  test("the produced config matches the runtime's required shape (keys present)", () => {
+    const cfg = buildSandboxConfig({
+      spec: specOf(),
+      baseBinds: BASE_BINDS,
+      egressBase: EGRESS_BASE,
+      platform: "darwin",
+    });
+    expect(cfg.network).toHaveProperty("allowedDomains");
+    expect(cfg.network).toHaveProperty("deniedDomains");
+    expect(cfg.filesystem).toHaveProperty("denyRead");
+    expect(cfg.filesystem).toHaveProperty("allowRead");
+    expect(cfg.filesystem).toHaveProperty("allowWrite");
+    expect(cfg.filesystem).toHaveProperty("denyWrite");
+  });
+});

--- a/src/sandbox/config.ts
+++ b/src/sandbox/config.ts
@@ -1,0 +1,77 @@
+/**
+ * Map an agent-spec → a `SandboxRuntimeConfig` for `@anthropic-ai/sandbox-runtime`
+ * (design §3 — the isolation envelope).
+ *
+ * The runtime config shape (verified against the package's own types,
+ * `@anthropic-ai/sandbox-runtime` 0.0.54 `SandboxRuntimeConfig`):
+ *
+ *   {
+ *     network:    { allowedDomains: string[], deniedDomains: string[] },
+ *     filesystem: { denyRead: string[], allowRead?: string[],
+ *                   allowWrite: string[], denyWrite: string[] },
+ *     …optional knobs (allowPty, bwrapPath, ripgrep, …)
+ *   }
+ *
+ * This module is the single place spec → runtime-config happens, so the egress
+ * floor (§4.4) and scoped-read policy (§4.5) are guaranteed on every launch.
+ */
+
+import type { SandboxRuntimeConfig } from "@anthropic-ai/sandbox-runtime";
+import type { AgentSpec, BaseBinds, SandboxPlatform } from "./types.ts";
+import { composeEgressAllowlist, type EgressBaseInput } from "./egress.ts";
+import { composeFilesystemView } from "./mounts.ts";
+
+export interface BuildSandboxConfigInput {
+  spec: AgentSpec;
+  /** Workspace + runtime/config binds the contract always grants. */
+  baseBinds: BaseBinds;
+  /** Origins for the non-removable egress base. */
+  egressBase: EgressBaseInput;
+  /** Target platform. Defaults to the running platform. */
+  platform?: SandboxPlatform;
+  /**
+   * Allow the session to allocate a pty (a tmux/interactive `claude` needs one).
+   * Defaults true. Surfaced so a non-interactive arm can drop it.
+   */
+  allowPty?: boolean;
+  /**
+   * Optional ripgrep override the runtime uses for deny-path scanning. On macOS
+   * the runtime needs a ripgrep binary; pass `{ command: <abs path> }` when the
+   * host has no `rg` on PATH. Omitted = the runtime's own resolution.
+   */
+  ripgrep?: { command: string; args?: string[] };
+}
+
+/** Resolve the running platform to the two we support. */
+export function currentSandboxPlatform(): SandboxPlatform {
+  return process.platform === "darwin" ? "darwin" : "linux";
+}
+
+/**
+ * Build the `SandboxRuntimeConfig` for an agent spec. The egress allowlist is the
+ * non-removable base unioned with the spec's additions; the filesystem view is
+ * scoped-read (home-tree denied, binds re-allowed) with writes confined to the
+ * workspace + rw mounts.
+ */
+export function buildSandboxConfig(input: BuildSandboxConfigInput): SandboxRuntimeConfig {
+  const platform = input.platform ?? currentSandboxPlatform();
+
+  const allowedDomains = composeEgressAllowlist(input.egressBase, input.spec.egress);
+  const fs = composeFilesystemView(input.baseBinds, input.spec.mounts, platform);
+
+  const config: SandboxRuntimeConfig = {
+    network: {
+      allowedDomains,
+      deniedDomains: [],
+    },
+    filesystem: {
+      denyRead: fs.denyRead,
+      allowRead: fs.allowRead,
+      allowWrite: fs.allowWrite,
+      denyWrite: fs.denyWrite,
+    },
+    allowPty: input.allowPty ?? true,
+  };
+  if (input.ripgrep) config.ripgrep = input.ripgrep;
+  return config;
+}

--- a/src/sandbox/egress.test.ts
+++ b/src/sandbox/egress.test.ts
@@ -1,0 +1,113 @@
+import { describe, test, expect } from "bun:test";
+import {
+  ANTHROPIC_EGRESS_HOSTS,
+  baseEgressAllowlist,
+  composeEgressAllowlist,
+  hostFromOrigin,
+  type EgressBaseInput,
+} from "./egress.ts";
+
+const BASE: EgressBaseInput = { hubOrigin: "https://hub.example.com" };
+
+describe("hostFromOrigin", () => {
+  test("reduces an origin to its hostname (strips scheme + port + path)", () => {
+    expect(hostFromOrigin("https://hub.example.com:1939/admin")).toBe("hub.example.com");
+  });
+  test("passes a bare host through", () => {
+    expect(hostFromOrigin("registry.npmjs.org")).toBe("registry.npmjs.org");
+  });
+  test("strips a :port from a bare host:port", () => {
+    expect(hostFromOrigin("127.0.0.1:1939")).toBe("127.0.0.1");
+  });
+  test("preserves loopback (a co-located dev hub is loopback)", () => {
+    expect(hostFromOrigin("http://127.0.0.1:1939")).toBe("127.0.0.1");
+  });
+  test("returns null for empty / nullish input", () => {
+    expect(hostFromOrigin("")).toBeNull();
+    expect(hostFromOrigin(undefined)).toBeNull();
+    expect(hostFromOrigin("   ")).toBeNull();
+  });
+});
+
+describe("baseEgressAllowlist — the non-removable base", () => {
+  test("always includes the Anthropic hosts + the hub host", () => {
+    const base = baseEgressAllowlist(BASE);
+    for (const h of ANTHROPIC_EGRESS_HOSTS) expect(base).toContain(h);
+    expect(base).toContain("hub.example.com");
+  });
+
+  test("includes a distinct vault host when given", () => {
+    const base = baseEgressAllowlist({ ...BASE, vaultOrigin: "https://vault.example.com" });
+    expect(base).toContain("vault.example.com");
+  });
+
+  test("dedupes a vault origin equal to the hub origin", () => {
+    const base = baseEgressAllowlist({
+      hubOrigin: "https://h.example.com",
+      vaultOrigin: "https://h.example.com",
+    });
+    expect(base.filter((h) => h === "h.example.com")).toHaveLength(1);
+  });
+});
+
+describe("composeEgressAllowlist — base floor is non-removable, spec is additive", () => {
+  test("an empty spec egress still gets the full base (weaver-style arm)", () => {
+    const allow = composeEgressAllowlist(BASE, []);
+    for (const h of ANTHROPIC_EGRESS_HOSTS) expect(allow).toContain(h);
+    expect(allow).toContain("hub.example.com");
+  });
+
+  test("an undefined spec egress still gets the full base", () => {
+    const allow = composeEgressAllowlist(BASE, undefined);
+    expect(allow).toContain("api.anthropic.com");
+    expect(allow).toContain("hub.example.com");
+  });
+
+  test("spec hosts are ADDED on top of the base", () => {
+    const allow = composeEgressAllowlist(BASE, ["registry.npmjs.org", "pypi.org"]);
+    // base present...
+    expect(allow).toContain("api.anthropic.com");
+    expect(allow).toContain("hub.example.com");
+    // ...plus the additions
+    expect(allow).toContain("registry.npmjs.org");
+    expect(allow).toContain("pypi.org");
+  });
+
+  test("SECURITY: a spec that lists ONLY a foreign host CANNOT drop the base — the base is still present", () => {
+    // A spec authored to omit the base entirely (the malicious-omit case).
+    const allow = composeEgressAllowlist(BASE, ["evil.example.com"]);
+    // The base floor survives regardless of what the spec listed.
+    expect(allow).toContain("api.anthropic.com");
+    expect(allow).toContain("hub.example.com");
+    // The spec's own host is added (additive), not a replacement.
+    expect(allow).toContain("evil.example.com");
+  });
+
+  test("SECURITY: a spec cannot REPLACE the Anthropic host with a look-alike — both end up present, base is not dropped", () => {
+    // A spec that tries to "override" the Anthropic host by re-declaring a near-miss.
+    const allow = composeEgressAllowlist(BASE, ["api.anthropic.com.evil.example.com"]);
+    // The real Anthropic apex is still on the list (the base recomputed from code).
+    expect(allow).toContain("api.anthropic.com");
+    // The look-alike is just an additional (separate) host, not a substitution.
+    expect(allow).toContain("api.anthropic.com.evil.example.com");
+    // And the look-alike did not evict the real host.
+    expect(allow.indexOf("api.anthropic.com")).toBeGreaterThanOrEqual(0);
+  });
+
+  test("the base always sorts FIRST (recomputed from code, prepended)", () => {
+    const allow = composeEgressAllowlist(BASE, ["z-late.example.com"]);
+    expect(allow[0]).toBe("api.anthropic.com");
+    expect(allow[allow.length - 1]).toBe("z-late.example.com");
+  });
+
+  test("spec origins are normalized to hosts (full URL and bare host land the same)", () => {
+    const a = composeEgressAllowlist(BASE, ["https://registry.npmjs.org"]);
+    const b = composeEgressAllowlist(BASE, ["registry.npmjs.org"]);
+    expect(a).toEqual(b);
+  });
+
+  test("dedupes a spec host that duplicates a base host", () => {
+    const allow = composeEgressAllowlist(BASE, ["hub.example.com"]);
+    expect(allow.filter((h) => h === "hub.example.com")).toHaveLength(1);
+  });
+});

--- a/src/sandbox/egress.ts
+++ b/src/sandbox/egress.ts
@@ -1,0 +1,123 @@
+/**
+ * Network egress composition (design §3.3, §4.4).
+ *
+ * Egress is the load-bearing control for a session fed foreign-authored channel
+ * input: every allowlisted host is an exfiltration path, not just a fetch path.
+ * So the policy is:
+ *
+ *   - DENY all egress by default (the sandbox-runtime's `allowedDomains: []`
+ *     means no network — see its README "Network Isolation (allow-only)").
+ *   - A NON-REMOVABLE BASE allowlist of `{ the Anthropic API host(s), the
+ *     hub/vault origin }` is ALWAYS included — what every arm needs to think and
+ *     to do its scoped work.
+ *   - The spec's `egress[]` is ADDITIVE only. A spec cannot drop the base or
+ *     override it away; it can only widen with hosts of its own.
+ *
+ * The base is anchored in code, not config, precisely so a spec (which may be
+ * generated from foreign-influenced input down the line) can never quietly strip
+ * the host's own control-plane reachability or — worse — replace the Anthropic
+ * host with an attacker endpoint.
+ */
+
+/**
+ * The Anthropic API hosts every arm needs to reach to run `claude`. Includes the
+ * wildcard so regional/edge subdomains resolve; the bare apex covers the canonical
+ * host. Held in code as part of the non-removable base.
+ */
+export const ANTHROPIC_EGRESS_HOSTS: readonly string[] = [
+  "api.anthropic.com",
+  "*.anthropic.com",
+] as const;
+
+/** A hostname (no scheme/port/path) extracted from an origin or passed through. */
+export type EgressHost = string;
+
+/**
+ * Reduce an origin (`https://host:port`) or a bare host to the hostname the
+ * sandbox-runtime allowlist matches on. The runtime matches on domain, not
+ * scheme or port, so we strip both. A bare hostname passes through unchanged.
+ * Returns null for an unparseable/empty input (callers skip nulls).
+ */
+export function hostFromOrigin(originOrHost: string | undefined | null): EgressHost | null {
+  if (!originOrHost) return null;
+  const trimmed = originOrHost.trim();
+  if (trimmed.length === 0) return null;
+  // If it parses as a URL, take its hostname. Otherwise treat the whole thing as
+  // a host (possibly with a :port we strip).
+  try {
+    const u = new URL(trimmed.includes("://") ? trimmed : `https://${trimmed}`);
+    const h = u.hostname;
+    return h.length > 0 ? h : null;
+  } catch {
+    const noPort = trimmed.replace(/:\d+$/, "");
+    return noPort.length > 0 ? noPort : null;
+  }
+}
+
+export interface EgressBaseInput {
+  /**
+   * The hub origin (also the vault origin in the co-located deploy — the vault is
+   * reached under the hub's path-proxy). Origin or bare host; reduced to a host.
+   */
+  hubOrigin: string;
+  /**
+   * Optional distinct vault origin, if the vault is reached at a different host
+   * than the hub. Usually omitted (co-located). Origin or bare host.
+   */
+  vaultOrigin?: string;
+  /**
+   * Override the Anthropic hosts (tests). Defaults to {@link ANTHROPIC_EGRESS_HOSTS}.
+   */
+  anthropicHosts?: readonly string[];
+}
+
+/**
+ * Build the NON-REMOVABLE base egress allowlist: the Anthropic API host(s) plus
+ * the hub/vault origin host(s). This is what every arm gets regardless of spec.
+ * Deduped, loopback/local hosts preserved (a co-located dev hub is loopback).
+ */
+export function baseEgressAllowlist(input: EgressBaseInput): EgressHost[] {
+  const anthropic = input.anthropicHosts ?? ANTHROPIC_EGRESS_HOSTS;
+  const hosts: EgressHost[] = [...anthropic];
+  const hub = hostFromOrigin(input.hubOrigin);
+  if (hub) hosts.push(hub);
+  const vault = hostFromOrigin(input.vaultOrigin);
+  if (vault) hosts.push(vault);
+  return dedupePreserveOrder(hosts);
+}
+
+/**
+ * Compose the final egress allowlist: the non-removable base UNIONED with the
+ * spec's additive `egress[]`. The base is always present and always first; spec
+ * hosts are appended. Because we recompute the base from code on every call and
+ * union (never start from the spec), a spec that tries to omit or "override" the
+ * base still gets it — the contract the test in egress.test.ts pins.
+ *
+ * Each spec host is normalized through {@link hostFromOrigin} so an arm may
+ * declare either bare hosts (`registry.npmjs.org`) or full origins
+ * (`https://registry.npmjs.org`) and they land the same.
+ */
+export function composeEgressAllowlist(
+  base: EgressBaseInput,
+  specEgress: readonly string[] | undefined,
+): EgressHost[] {
+  const baseHosts = baseEgressAllowlist(base);
+  const additions: EgressHost[] = [];
+  for (const e of specEgress ?? []) {
+    const h = hostFromOrigin(e);
+    if (h) additions.push(h);
+  }
+  return dedupePreserveOrder([...baseHosts, ...additions]);
+}
+
+function dedupePreserveOrder(xs: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const x of xs) {
+    if (!seen.has(x)) {
+      seen.add(x);
+      out.push(x);
+    }
+  }
+  return out;
+}

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -15,13 +15,30 @@
  * through `initialize` → wrap → reset; the adapter makes that explicit.
  */
 
+// `@anthropic-ai/sandbox-runtime` is pinned EXACT (not `^`) in package.json — it's
+// an anthropic-experimental research preview whose config/API may evolve between
+// patch releases, and it is the load-bearing isolation engine. Treat a version
+// bump as an upgrade-gate: only raise the pin behind a green run of the sandbox
+// test suite (esp. the LIVE Seatbelt assertions in `live-seatbelt.test.ts`, which
+// prove the real boundary still holds against the new version).
 import { SandboxManager as RealSandboxManager } from "@anthropic-ai/sandbox-runtime";
 import type { SandboxRuntimeConfig } from "@anthropic-ai/sandbox-runtime";
 import type { AgentSpec, BaseBinds, SandboxPlatform } from "./types.ts";
 import { buildSandboxConfig, currentSandboxPlatform } from "./config.ts";
 import type { EgressBaseInput } from "./egress.ts";
 
-export type { AgentSpec, AgentMount, AgentVaultSpec, OtherMcpSpec, BaseBinds, MountMode, SandboxPlatform } from "./types.ts";
+export type {
+  AgentSpec,
+  AgentMount,
+  AgentVaultSpec,
+  AgentChannel,
+  AgentChannelSpec,
+  OtherMcpSpec,
+  BaseBinds,
+  MountMode,
+  SandboxPlatform,
+} from "./types.ts";
+export { normalizeChannel } from "./types.ts";
 export {
   composeEgressAllowlist,
   baseEgressAllowlist,

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -1,0 +1,142 @@
+/**
+ * The `Sandbox` adapter — the constant contract, the per-platform mechanism
+ * behind it (design §3.1).
+ *
+ * v1 mechanism: Anthropic's `@anthropic-ai/sandbox-runtime` (Seatbelt on macOS,
+ * bubblewrap on Linux). We reach it by **library link** — never PATH resolution
+ * (design Q4 decision: a poisoned PATH entry would execute *before* the sandbox
+ * is established). The `SandboxManager` singleton is imported at module load, so
+ * the trust boundary is anchored to the pinned, library-resolved artifact.
+ *
+ * The adapter wraps the singleton so callers depend on this small surface — not
+ * on the runtime's full API — and so the escalation rung (§3.4) can become a
+ * second backend behind the same contract later. `SandboxManager` being a
+ * process-global singleton (one set of host proxies) means launches serialize
+ * through `initialize` → wrap → reset; the adapter makes that explicit.
+ */
+
+import { SandboxManager as RealSandboxManager } from "@anthropic-ai/sandbox-runtime";
+import type { SandboxRuntimeConfig } from "@anthropic-ai/sandbox-runtime";
+import type { AgentSpec, BaseBinds, SandboxPlatform } from "./types.ts";
+import { buildSandboxConfig, currentSandboxPlatform } from "./config.ts";
+import type { EgressBaseInput } from "./egress.ts";
+
+export type { AgentSpec, AgentMount, AgentVaultSpec, OtherMcpSpec, BaseBinds, MountMode, SandboxPlatform } from "./types.ts";
+export {
+  composeEgressAllowlist,
+  baseEgressAllowlist,
+  hostFromOrigin,
+  ANTHROPIC_EGRESS_HOSTS,
+  type EgressBaseInput,
+} from "./egress.ts";
+export {
+  composeFilesystemView,
+  homeTreeDenyRoot,
+  sharedMounts,
+  type FilesystemView,
+} from "./mounts.ts";
+export { buildSandboxConfig, currentSandboxPlatform, type BuildSandboxConfigInput } from "./config.ts";
+
+/**
+ * The minimal slice of the sandbox-runtime singleton the adapter uses. Pinned
+ * here so a test can inject a fake without depending on the full runtime API,
+ * and so a drift in the runtime's surface fails the typecheck loudly.
+ */
+export interface SandboxEngine {
+  isSupportedPlatform(): boolean;
+  isSandboxingEnabled(): boolean;
+  initialize(config: SandboxRuntimeConfig): Promise<void>;
+  /** Wrap a shell command string; returns the argv + env to spawn. */
+  wrapWithSandboxArgv(
+    command: string,
+  ): Promise<{ argv: string[]; env: Record<string, string | undefined> }>;
+  reset(): Promise<void>;
+}
+
+/** The real engine, library-linked (never via PATH). */
+export const defaultEngine: SandboxEngine = RealSandboxManager as unknown as SandboxEngine;
+
+export interface WrapInput {
+  spec: AgentSpec;
+  baseBinds: BaseBinds;
+  egressBase: EgressBaseInput;
+  /** The shell command to run sandboxed (e.g. the `claude …` invocation). */
+  command: string;
+  platform?: SandboxPlatform;
+  allowPty?: boolean;
+  ripgrep?: { command: string; args?: string[] };
+}
+
+export interface WrappedCommand {
+  /** argv to spawn (Seatbelt/bubblewrap wrapper + the command). */
+  argv: string[];
+  /** env the wrapper needs (proxy vars, sandbox markers). */
+  env: Record<string, string | undefined>;
+  /** The config the engine was initialized with (for assertion/audit/logging). */
+  config: SandboxRuntimeConfig;
+}
+
+/**
+ * The `Sandbox` — initialize the engine with the spec's config, then wrap the
+ * command. The returned `{argv, env}` is what the spawn step launches in tmux.
+ *
+ * Serialization caveat: the engine is a process-global singleton (it starts host
+ * egress proxies on `initialize` and tears them down on `reset`). v1 launches one
+ * sandboxed session at a time through this path; concurrent launches must
+ * serialize. The injectable `engine` keeps this unit-testable + lets a future
+ * per-session backend (§3.4) slot in.
+ */
+export class Sandbox {
+  private readonly engine: SandboxEngine;
+
+  constructor(engine: SandboxEngine = defaultEngine) {
+    this.engine = engine;
+  }
+
+  /** Whether this host can sandbox at all (Seatbelt present / bubblewrap deps). */
+  isSupportedPlatform(): boolean {
+    return this.engine.isSupportedPlatform();
+  }
+
+  /**
+   * Build the config from the spec, initialize the engine, and wrap the command.
+   * The config is returned so callers can assert/log the exact allowlist + binds.
+   */
+  async wrap(input: WrapInput): Promise<WrappedCommand> {
+    const config = buildSandboxConfig({
+      spec: input.spec,
+      baseBinds: input.baseBinds,
+      egressBase: input.egressBase,
+      ...(input.platform ? { platform: input.platform } : {}),
+      ...(input.allowPty !== undefined ? { allowPty: input.allowPty } : {}),
+      ...(input.ripgrep ? { ripgrep: input.ripgrep } : {}),
+    });
+    await this.engine.initialize(config);
+    const { argv, env } = await this.engine.wrapWithSandboxArgv(input.command);
+    return { argv, env, config };
+  }
+
+  /** Tear down the engine's host proxies. Call on session death. */
+  async reset(): Promise<void> {
+    await this.engine.reset();
+  }
+}
+
+/** Convenience: just build the config (no engine init) — used in tests + audits. */
+export function configForSpec(input: {
+  spec: AgentSpec;
+  baseBinds: BaseBinds;
+  egressBase: EgressBaseInput;
+  platform?: SandboxPlatform;
+  allowPty?: boolean;
+}): SandboxRuntimeConfig {
+  return buildSandboxConfig({
+    spec: input.spec,
+    baseBinds: input.baseBinds,
+    egressBase: input.egressBase,
+    ...(input.platform ? { platform: input.platform } : {}),
+    ...(input.allowPty !== undefined ? { allowPty: input.allowPty } : {}),
+  });
+}
+
+export { currentSandboxPlatform as platform };

--- a/src/sandbox/live-seatbelt.test.ts
+++ b/src/sandbox/live-seatbelt.test.ts
@@ -20,7 +20,7 @@
 import { describe, test, expect, afterEach } from "bun:test";
 import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
-import { tmpdir } from "node:os";
+import { tmpdir, homedir } from "node:os";
 import { SandboxManager } from "@anthropic-ai/sandbox-runtime";
 import { buildSandboxConfig } from "./config.ts";
 import type { AgentSpec, BaseBinds } from "./types.ts";
@@ -137,6 +137,47 @@ d("LIVE Seatbelt — filesystem read confinement", () => {
       const r = await runSandboxed(cfg, `cat ${secretFile}`);
       expect(r.code).not.toBe(0);
       expect(r.stdout).not.toContain("TOPSECRET");
+    } finally {
+      rmSync(secretDir, { recursive: true, force: true });
+    }
+  }, 60_000);
+
+  test("PRODUCTION PATH: the spec-derived /Users deny blocks a read of a real home-dir file (no manual patch)", async () => {
+    // The §4.5 scoped-read property is "an arm cannot read the operator's home."
+    // Prove it through the PRODUCTION config — secret under the REAL home dir,
+    // workspace also under home (so the re-allow path is exercised against the
+    // real `/Users` deny), and NO manual `denyRead` patch. This is the test that
+    // proves the deployed `denyRead:["/Users"]` actually confines reads.
+    const home = homedir();
+    workspace = mkdtempSync(join(home, ".sbx-live-ws-"));
+    const secretDir = mkdtempSync(join(home, ".sbx-live-secret-"));
+    const secretFile = join(secretDir, "home-secret.txt");
+    writeFileSync(secretFile, "HOME-TOPSECRET-do-not-read");
+    try {
+      const spec: AgentSpec = { name: "homeread", channels: ["c"], egress: [] };
+      // buildSandboxConfig with platform "darwin" → denyRead:["/Users"],
+      // allowRead:[workspace]. We pass the config THROUGH unmodified.
+      const cfg = buildSandboxConfig({
+        spec,
+        baseBinds: { workspace, runtimeReadOnly: [] },
+        egressBase: { hubOrigin: "http://127.0.0.1:1939" },
+        platform: "darwin",
+      });
+      expect(cfg.filesystem.denyRead).toEqual(["/Users"]);
+      expect(cfg.filesystem.allowRead).toContain(workspace);
+      // The secret sits under /Users/<me>/… and is NOT in any bind → blocked.
+      const r = await runSandboxed(cfg, `cat ${secretFile}`);
+      expect(r.code).not.toBe(0);
+      expect(r.stdout).not.toContain("HOME-TOPSECRET");
+
+      // Positive control on the SAME production config: a file inside the
+      // workspace (also under /Users, but re-allowed by allowRead) IS readable —
+      // proving the deny didn't just break all reads.
+      const insideFile = join(workspace, "inside.txt");
+      writeFileSync(insideFile, "HOME-WORKSPACE-readable");
+      const ok = await runSandboxed(cfg, `cat ${insideFile}`);
+      expect(ok.code).toBe(0);
+      expect(ok.stdout).toContain("HOME-WORKSPACE-readable");
     } finally {
       rmSync(secretDir, { recursive: true, force: true });
     }

--- a/src/sandbox/live-seatbelt.test.ts
+++ b/src/sandbox/live-seatbelt.test.ts
@@ -1,0 +1,197 @@
+/**
+ * LIVE sandbox-runtime assertions on this host (Seatbelt on macOS).
+ *
+ * These run a REAL sandboxed process and assert it is genuinely confined:
+ *   - egress to a non-allowlisted host is DENIED;
+ *   - egress to an allowlisted host is permitted to ATTEMPT (proxy admits it);
+ *   - a read OUTSIDE the declared binds is DENIED;
+ *   - a read INSIDE a bind is permitted.
+ *
+ * The sandbox-runtime singleton starts host proxies on `initialize` and tears
+ * them down on `reset`; it is process-global, so these cases serialize (one
+ * describe block, sequential `initialize`→wrap→reset per case). Sandboxed in a
+ * fresh temp workspace — NEVER the operator's live ~/.parachute.
+ *
+ * Skipped automatically when the platform can't sandbox (`isSupportedPlatform()`
+ * false) or its deps aren't satisfied — so CI on an unsupported runner stays
+ * green while a capable host (this Mac) exercises the real boundary. The
+ * config-shape tests (egress/mounts/config.test.ts) ALWAYS run regardless.
+ */
+import { describe, test, expect, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { SandboxManager } from "@anthropic-ai/sandbox-runtime";
+import { buildSandboxConfig } from "./config.ts";
+import type { AgentSpec, BaseBinds } from "./types.ts";
+
+const CAN_SANDBOX =
+  SandboxManager.isSupportedPlatform() && SandboxManager.checkDependencies().errors.length === 0;
+
+// A positive control: prove the harness can actually run a sandboxed process at
+// all before asserting on denials (negative-scans-need-positive-controls).
+const d = CAN_SANDBOX ? describe : describe.skip;
+
+async function runSandboxed(
+  cfg: ReturnType<typeof buildSandboxConfig>,
+  command: string,
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  await SandboxManager.initialize(cfg);
+  try {
+    const { argv, env } = await SandboxManager.wrapWithSandboxArgv(command);
+    const proc = Bun.spawn(argv, {
+      env: env as Record<string, string>,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, code] = await Promise.all([
+      new Response(proc.stdout as ReadableStream<Uint8Array>).text(),
+      new Response(proc.stderr as ReadableStream<Uint8Array>).text(),
+      proc.exited,
+    ]);
+    return { code, stdout, stderr };
+  } finally {
+    await SandboxManager.reset();
+  }
+}
+
+let workspace: string;
+
+afterEach(() => {
+  if (workspace) rmSync(workspace, { recursive: true, force: true });
+});
+
+d("LIVE Seatbelt — network egress", () => {
+  test("positive control: the harness can run a trivial sandboxed command", async () => {
+    workspace = mkdtempSync(join(tmpdir(), "sbx-live-pos-"));
+    const spec: AgentSpec = { name: "pos", channels: ["c"], egress: [] };
+    const cfg = buildSandboxConfig({
+      spec,
+      baseBinds: { workspace, runtimeReadOnly: [] },
+      egressBase: { hubOrigin: "http://127.0.0.1:1939" },
+      platform: "darwin",
+    });
+    const r = await runSandboxed(cfg, "echo sandbox-alive");
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain("sandbox-alive");
+  }, 60_000);
+
+  test("DENIED: curl to a host NOT in the allowlist is blocked", async () => {
+    workspace = mkdtempSync(join(tmpdir(), "sbx-live-deny-"));
+    // Allowlist the base only (anthropic + the loopback hub). example.com is NOT on it.
+    const spec: AgentSpec = { name: "deny", channels: ["c"], egress: [] };
+    const cfg = buildSandboxConfig({
+      spec,
+      baseBinds: { workspace, runtimeReadOnly: [] },
+      egressBase: { hubOrigin: "http://127.0.0.1:1939" },
+      platform: "darwin",
+    });
+    const r = await runSandboxed(
+      cfg,
+      "curl -sS -m 8 -o /dev/null -w '%{http_code}' https://example.com",
+    );
+    // The egress proxy refuses a non-allowlisted host: curl exits non-zero
+    // (commonly 56 "CONNECT tunnel failed, response 403"). The key assertion is
+    // that the request did NOT succeed with a 2xx.
+    expect(r.code).not.toBe(0);
+    expect(r.stdout).not.toMatch(/^2\d\d$/);
+  }, 60_000);
+
+  test("a spec that adds an egress host gets that host on the allowlist (additive)", async () => {
+    workspace = mkdtempSync(join(tmpdir(), "sbx-live-add-"));
+    const spec: AgentSpec = { name: "add", channels: ["c"], egress: ["example.com"] };
+    const cfg = buildSandboxConfig({
+      spec,
+      baseBinds: { workspace, runtimeReadOnly: [] },
+      egressBase: { hubOrigin: "http://127.0.0.1:1939" },
+      platform: "darwin",
+    });
+    // We assert the CONFIG carries the host (a live fetch to example.com would be
+    // a network-flaky external dependency; the denial test above is the live
+    // boundary proof). The base floor is also present.
+    expect(cfg.network.allowedDomains).toContain("example.com");
+    expect(cfg.network.allowedDomains).toContain("api.anthropic.com");
+  }, 60_000);
+});
+
+d("LIVE Seatbelt — filesystem read confinement", () => {
+  test("DENIED: reading a file OUTSIDE the declared binds fails", async () => {
+    workspace = mkdtempSync(join(tmpdir(), "sbx-live-read-"));
+    // A secret OUTSIDE the workspace, under a sibling temp dir we do NOT bind.
+    const secretDir = mkdtempSync(join(tmpdir(), "sbx-live-secret-"));
+    const secretFile = join(secretDir, "secret.txt");
+    writeFileSync(secretFile, "TOPSECRET-do-not-read");
+    try {
+      const spec: AgentSpec = { name: "read", channels: ["c"], egress: [] };
+      const cfg = buildSandboxConfig({
+        spec,
+        baseBinds: { workspace, runtimeReadOnly: [] },
+        egressBase: { hubOrigin: "http://127.0.0.1:1939" },
+        platform: "darwin",
+      });
+      // Deny the temp root so the unbound secret dir is unreadable; re-allow only
+      // the workspace. (buildSandboxConfig denies /Users; the macOS temp dir lives
+      // under /var/folders, so we additionally deny the secret's parent to make the
+      // confinement assertion robust regardless of where the OS placed the tmp dir.)
+      cfg.filesystem.denyRead = [...cfg.filesystem.denyRead, secretDir];
+      const r = await runSandboxed(cfg, `cat ${secretFile}`);
+      expect(r.code).not.toBe(0);
+      expect(r.stdout).not.toContain("TOPSECRET");
+    } finally {
+      rmSync(secretDir, { recursive: true, force: true });
+    }
+  }, 60_000);
+
+  test("ALLOWED: reading a file INSIDE the workspace bind succeeds", async () => {
+    workspace = mkdtempSync(join(tmpdir(), "sbx-live-read-ok-"));
+    const f = join(workspace, "inside.txt");
+    writeFileSync(f, "READABLE-inside-workspace");
+    const spec: AgentSpec = { name: "readok", channels: ["c"], egress: [] };
+    const cfg = buildSandboxConfig({
+      spec,
+      baseBinds: { workspace, runtimeReadOnly: [] },
+      egressBase: { hubOrigin: "http://127.0.0.1:1939" },
+      platform: "darwin",
+    });
+    const r = await runSandboxed(cfg, `cat ${f}`);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain("READABLE-inside-workspace");
+  }, 60_000);
+
+  test("DENIED: writing OUTSIDE the workspace fails (write confinement)", async () => {
+    workspace = mkdtempSync(join(tmpdir(), "sbx-live-write-"));
+    const outsideDir = mkdtempSync(join(tmpdir(), "sbx-live-outside-"));
+    const target = join(outsideDir, "should-not-exist.txt");
+    try {
+      const spec: AgentSpec = { name: "write", channels: ["c"], egress: [] };
+      const cfg = buildSandboxConfig({
+        spec,
+        baseBinds: { workspace, runtimeReadOnly: [] },
+        egressBase: { hubOrigin: "http://127.0.0.1:1939" },
+        platform: "darwin",
+      });
+      const r = await runSandboxed(cfg, `echo pwned > ${target}`);
+      expect(r.code).not.toBe(0);
+      // The file must not have been created (write was blocked at the OS level).
+      expect(await Bun.file(target).exists()).toBe(false);
+    } finally {
+      rmSync(outsideDir, { recursive: true, force: true });
+    }
+  }, 60_000);
+
+  test("ALLOWED: writing INSIDE the workspace succeeds", async () => {
+    workspace = mkdtempSync(join(tmpdir(), "sbx-live-write-ok-"));
+    const target = join(workspace, "out.txt");
+    const spec: AgentSpec = { name: "writeok", channels: ["c"], egress: [] };
+    const cfg = buildSandboxConfig({
+      spec,
+      baseBinds: { workspace, runtimeReadOnly: [] },
+      egressBase: { hubOrigin: "http://127.0.0.1:1939" },
+      platform: "darwin",
+    });
+    const r = await runSandboxed(cfg, `echo written-inside > ${target}`);
+    expect(r.code).toBe(0);
+    const written = await Bun.file(target).text();
+    expect(written).toContain("written-inside");
+  }, 60_000);
+});

--- a/src/sandbox/mounts.test.ts
+++ b/src/sandbox/mounts.test.ts
@@ -1,0 +1,113 @@
+import { describe, test, expect } from "bun:test";
+import {
+  composeFilesystemView,
+  homeTreeDenyRoot,
+  sharedMounts,
+} from "./mounts.ts";
+import type { AgentMount, BaseBinds } from "./types.ts";
+
+const BASE: BaseBinds = {
+  workspace: "/state/sessions/arm",
+  runtimeReadOnly: ["/home/op/.claude"],
+};
+
+describe("homeTreeDenyRoot — platform nuance", () => {
+  test("macOS denies /Users", () => {
+    expect(homeTreeDenyRoot("darwin")).toBe("/Users");
+  });
+  test("Linux denies /home", () => {
+    expect(homeTreeDenyRoot("linux")).toBe("/home");
+  });
+});
+
+describe("composeFilesystemView — scoped reads + write confinement", () => {
+  test("with no mounts: reads = workspace + runtime, writes = workspace only", () => {
+    const fs = composeFilesystemView(BASE, undefined, "darwin");
+    expect(fs.allowRead).toContain("/state/sessions/arm");
+    expect(fs.allowRead).toContain("/home/op/.claude");
+    expect(fs.allowWrite).toEqual(["/state/sessions/arm"]);
+  });
+
+  test("the home tree is denied for reads (scoped-read policy, §4.5)", () => {
+    const fs = composeFilesystemView(BASE, undefined, "darwin");
+    expect(fs.denyRead).toContain("/Users");
+  });
+
+  test("the home tree denied is platform-correct on Linux", () => {
+    const fs = composeFilesystemView(BASE, undefined, "linux");
+    expect(fs.denyRead).toContain("/home");
+  });
+
+  test("an ro mount is readable but NOT writable", () => {
+    const mounts: AgentMount[] = [{ hostPath: "/refs/tree", mountPath: "/ref", mode: "ro" }];
+    const fs = composeFilesystemView(BASE, mounts, "darwin");
+    expect(fs.allowRead).toContain("/refs/tree");
+    expect(fs.allowWrite).not.toContain("/refs/tree");
+  });
+
+  test("an rw mount is BOTH readable and writable", () => {
+    const mounts: AgentMount[] = [{ hostPath: "/proj/foo", mountPath: "/work/foo", mode: "rw" }];
+    const fs = composeFilesystemView(BASE, mounts, "darwin");
+    expect(fs.allowRead).toContain("/proj/foo");
+    expect(fs.allowWrite).toContain("/proj/foo");
+  });
+
+  test("SECURITY: a path OUTSIDE all binds is not in the read surface (scoped, not broad)", () => {
+    const mounts: AgentMount[] = [{ hostPath: "/proj/foo", mountPath: "/work/foo", mode: "rw" }];
+    const fs = composeFilesystemView(BASE, mounts, "darwin");
+    // The operator's SSH dir / other vaults are NOT re-allowed within the denied home tree.
+    expect(fs.allowRead).not.toContain("/Users/op/.ssh");
+    expect(fs.allowRead).not.toContain("/Users/op/other-vault");
+    // And nothing widened the deny away.
+    expect(fs.denyRead).toEqual(["/Users"]);
+  });
+
+  test("SECURITY: writes are confined — only workspace + rw mounts, never an ro mount or arbitrary path", () => {
+    const mounts: AgentMount[] = [
+      { hostPath: "/refs/tree", mountPath: "/ref", mode: "ro" },
+      { hostPath: "/proj/foo", mountPath: "/work/foo", mode: "rw" },
+    ];
+    const fs = composeFilesystemView(BASE, mounts, "darwin");
+    expect(new Set(fs.allowWrite)).toEqual(new Set(["/state/sessions/arm", "/proj/foo"]));
+  });
+
+  test("the base binds are always present even if the spec declares none", () => {
+    const fs = composeFilesystemView(BASE, [], "linux");
+    expect(fs.allowRead).toContain("/state/sessions/arm");
+    expect(fs.allowRead).toContain("/home/op/.claude");
+    expect(fs.allowWrite).toContain("/state/sessions/arm");
+  });
+
+  test("dedupes a mount equal to the workspace", () => {
+    const mounts: AgentMount[] = [
+      { hostPath: "/state/sessions/arm", mountPath: "/work", mode: "rw" },
+    ];
+    const fs = composeFilesystemView(BASE, mounts, "darwin");
+    expect(fs.allowWrite.filter((p) => p === "/state/sessions/arm")).toHaveLength(1);
+  });
+});
+
+describe("sharedMounts — the named cross-session relaxation", () => {
+  test("surfaces only mounts carrying a non-empty `shared` tag", () => {
+    const mounts: AgentMount[] = [
+      { hostPath: "/a", mountPath: "/a", mode: "ro" },
+      { hostPath: "/cache", mountPath: "/cache", mode: "ro", shared: "build-cache" },
+      { hostPath: "/b", mountPath: "/b", mode: "rw", shared: "" },
+    ];
+    const shared = sharedMounts(mounts);
+    expect(shared).toHaveLength(1);
+    expect(shared[0]!.shared).toBe("build-cache");
+  });
+
+  test("a shared mount is still bound like any other (honored in the fs view)", () => {
+    const mounts: AgentMount[] = [
+      { hostPath: "/cache", mountPath: "/cache", mode: "ro", shared: "build-cache" },
+    ];
+    const fs = composeFilesystemView(BASE, mounts, "darwin");
+    expect(fs.allowRead).toContain("/cache");
+  });
+
+  test("empty input → no shared mounts", () => {
+    expect(sharedMounts(undefined)).toEqual([]);
+  });
+});

--- a/src/sandbox/mounts.ts
+++ b/src/sandbox/mounts.ts
@@ -1,0 +1,102 @@
+/**
+ * Filesystem-view composition: scoped reads + write confinement (design §3.1
+ * item 2, §4.5).
+ *
+ * The contract:
+ *
+ *   - WRITES are confined to the private per-session workspace plus any `rw`
+ *     mount the spec declares. The sandbox-runtime's write model is allow-only:
+ *     `allowWrite: [...binds]`, empty = no writes.
+ *
+ *   - READS are scoped to declared binds — a DELIBERATE divergence from
+ *     Anthropic's broad-read default (design §4.5). The runtime's read model is
+ *     deny-then-allow: by default everything is readable. To confine reads we
+ *     DENY the home tree (`/Users` on macOS, `/home` on Linux) and then RE-ALLOW
+ *     exactly the binds (workspace + runtime/config + declared mounts). System
+ *     paths (`/usr`, `/lib`, …) stay readable so `claude` + its toolchain run.
+ *     `allowRead` overrides `denyRead` in the runtime, so the re-allow wins.
+ *
+ * Platform nuance (verified against the runtime README "Path Syntax"):
+ *   - macOS: paths support git-style globs.
+ *   - Linux: literal paths only — no glob matching.
+ * We never synthesize globs; we bind the literal host paths the caller passes,
+ * which is correct on both platforms. The `platform` arg only selects the
+ * home-tree deny root.
+ */
+
+import type { AgentMount, BaseBinds, SandboxPlatform } from "./types.ts";
+
+/** The home-tree root denied for scoped reads, per platform. */
+export function homeTreeDenyRoot(platform: SandboxPlatform): string {
+  return platform === "darwin" ? "/Users" : "/home";
+}
+
+export interface FilesystemView {
+  /** Paths to deny reads under (the home tree) — scoped-read enforcement. */
+  denyRead: string[];
+  /** Paths to re-allow reads within the denied region (the binds). */
+  allowRead: string[];
+  /** Paths writes are confined to (workspace + rw mounts). */
+  allowWrite: string[];
+  /** Paths to deny writes within allowed regions. Empty in v1. */
+  denyWrite: string[];
+}
+
+/**
+ * Compose the filesystem view for an arm from the always-present base binds and
+ * the spec's additive mounts.
+ *
+ * Read surface  = workspace (rw) + runtime/config (ro) + every declared mount
+ *                 (ro and rw alike — you can read what you can write).
+ * Write surface = workspace (rw) + every `rw` mount.
+ *
+ * The home tree is denied and the read surface re-allowed within it, giving the
+ * scoped-read policy (§4.5). The base binds are always included regardless of
+ * the spec, so a spec cannot strip its own workspace or the runtime/config.
+ */
+export function composeFilesystemView(
+  base: BaseBinds,
+  mounts: readonly AgentMount[] | undefined,
+  platform: SandboxPlatform,
+): FilesystemView {
+  const declared = mounts ?? [];
+
+  // Every bind is readable; only workspace + rw mounts are writable.
+  const readPaths: string[] = [base.workspace, ...base.runtimeReadOnly];
+  const writePaths: string[] = [base.workspace];
+
+  for (const m of declared) {
+    readPaths.push(m.hostPath);
+    if (m.mode === "rw") writePaths.push(m.hostPath);
+  }
+
+  return {
+    denyRead: [homeTreeDenyRoot(platform)],
+    allowRead: dedupePreserveOrder(readPaths),
+    allowWrite: dedupePreserveOrder(writePaths),
+    denyWrite: [],
+  };
+}
+
+/**
+ * The cross-session `shared` mounts declared by a spec (design §4.5). v1 honors
+ * them by binding them like any other mount (composeFilesystemView already does);
+ * this helper surfaces them by name so a caller can log/audit the deliberate
+ * cross-session channel. The trust caveat (prefer shared-`ro` from the producer,
+ * never shared-`rw` across a trust boundary) is doc-level for v1.
+ */
+export function sharedMounts(mounts: readonly AgentMount[] | undefined): AgentMount[] {
+  return (mounts ?? []).filter((m) => typeof m.shared === "string" && m.shared.length > 0);
+}
+
+function dedupePreserveOrder(xs: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const x of xs) {
+    if (!seen.has(x)) {
+      seen.add(x);
+      out.push(x);
+    }
+  }
+  return out;
+}

--- a/src/sandbox/sandbox.test.ts
+++ b/src/sandbox/sandbox.test.ts
@@ -1,0 +1,113 @@
+import { describe, test, expect } from "bun:test";
+import { Sandbox, configForSpec, type SandboxEngine } from "./index.ts";
+import type { SandboxRuntimeConfig } from "@anthropic-ai/sandbox-runtime";
+import type { AgentSpec, BaseBinds } from "./types.ts";
+import type { EgressBaseInput } from "./egress.ts";
+
+const BASE_BINDS: BaseBinds = { workspace: "/state/sessions/arm", runtimeReadOnly: ["/cfg"] };
+const EGRESS_BASE: EgressBaseInput = { hubOrigin: "https://hub.example.com" };
+
+/** A fake engine that records what it was initialized with + what it wrapped. */
+function fakeEngine(): SandboxEngine & {
+  initializedWith: SandboxRuntimeConfig | null;
+  wrappedCommands: string[];
+  resets: number;
+} {
+  const rec = {
+    initializedWith: null as SandboxRuntimeConfig | null,
+    wrappedCommands: [] as string[],
+    resets: 0,
+    isSupportedPlatform: () => true,
+    isSandboxingEnabled: () => true,
+    async initialize(cfg: SandboxRuntimeConfig) {
+      rec.initializedWith = cfg;
+    },
+    async wrapWithSandboxArgv(command: string) {
+      rec.wrappedCommands.push(command);
+      return {
+        argv: ["/bin/bash", "-c", `SANDBOXED ${command}`],
+        env: { SANDBOX_RUNTIME: "1", HTTP_PROXY: "http://localhost:9999" },
+      };
+    },
+    async reset() {
+      rec.resets += 1;
+    },
+  };
+  return rec;
+}
+
+const SPEC: AgentSpec = {
+  name: "arm",
+  channels: ["ch"],
+  egress: ["registry.npmjs.org"],
+  mounts: [{ hostPath: "/proj", mountPath: "/work", mode: "rw" }],
+};
+
+describe("Sandbox adapter", () => {
+  test("initializes the engine with the spec-derived config, then wraps the command", async () => {
+    const engine = fakeEngine();
+    const sandbox = new Sandbox(engine);
+    const wrapped = await sandbox.wrap({
+      spec: SPEC,
+      baseBinds: BASE_BINDS,
+      egressBase: EGRESS_BASE,
+      command: "claude --strict-mcp-config",
+      platform: "darwin",
+    });
+
+    // It initialized with the right config (egress floor + scoped reads).
+    expect(engine.initializedWith).not.toBeNull();
+    expect(engine.initializedWith!.network.allowedDomains).toContain("api.anthropic.com");
+    expect(engine.initializedWith!.network.allowedDomains).toContain("registry.npmjs.org");
+    expect(engine.initializedWith!.filesystem.denyRead).toContain("/Users");
+    expect(engine.initializedWith!.filesystem.allowWrite).toContain("/proj");
+
+    // It wrapped exactly the command we passed.
+    expect(engine.wrappedCommands).toEqual(["claude --strict-mcp-config"]);
+
+    // It returns argv + env + the config used.
+    expect(wrapped.argv[0]).toBe("/bin/bash");
+    expect(wrapped.argv[2]).toContain("SANDBOXED claude");
+    expect(wrapped.env.SANDBOX_RUNTIME).toBe("1");
+    expect(wrapped.config).toBe(engine.initializedWith!);
+  });
+
+  test("reset() tears the engine down", async () => {
+    const engine = fakeEngine();
+    const sandbox = new Sandbox(engine);
+    await sandbox.reset();
+    expect(engine.resets).toBe(1);
+  });
+
+  test("isSupportedPlatform delegates to the engine", () => {
+    const engine = fakeEngine();
+    expect(new Sandbox(engine).isSupportedPlatform()).toBe(true);
+  });
+
+  test("SECURITY: a spec omitting egress still gets the base floor in the engine config", async () => {
+    const engine = fakeEngine();
+    const sandbox = new Sandbox(engine);
+    await sandbox.wrap({
+      spec: { name: "x", channels: ["c"] }, // no egress declared
+      baseBinds: BASE_BINDS,
+      egressBase: EGRESS_BASE,
+      command: "claude",
+      platform: "darwin",
+    });
+    expect(engine.initializedWith!.network.allowedDomains).toContain("api.anthropic.com");
+    expect(engine.initializedWith!.network.allowedDomains).toContain("hub.example.com");
+  });
+});
+
+describe("configForSpec helper", () => {
+  test("builds the config without touching an engine", () => {
+    const cfg = configForSpec({
+      spec: SPEC,
+      baseBinds: BASE_BINDS,
+      egressBase: EGRESS_BASE,
+      platform: "darwin",
+    });
+    expect(cfg.network.allowedDomains).toContain("registry.npmjs.org");
+    expect(cfg.filesystem.allowWrite).toContain("/proj");
+  });
+});

--- a/src/sandbox/types.ts
+++ b/src/sandbox/types.ts
@@ -1,0 +1,127 @@
+/**
+ * Agent-spec + Sandbox contract types.
+ *
+ * The **agent spec** (design §4.1) is the single declaration of everything an
+ * arm may reach: its MCP surface (channels + vault), its network egress, and its
+ * filesystem view. Scope and isolation are both read off this one object, so
+ * there is exactly one place that says "what is this arm allowed to touch."
+ *
+ *   design/2026-06-14-sandboxed-agent-sessions.md §4.1, §4.4, §4.5
+ *
+ * The Sandbox **contract** (design §3.1) is held constant; the **mechanism**
+ * varies by platform (Seatbelt on macOS, bubblewrap on Linux) behind it. v1
+ * ships one backend (Anthropic's sandbox-runtime); the escalation rung (§3.4 —
+ * gVisor / full VM) is a second backend added later without touching callers.
+ */
+
+/** Read/write mode for a declared mount. */
+export type MountMode = "ro" | "rw";
+
+/**
+ * A filesystem bind beyond the implicit workspace + runtime/config. Each entry
+ * binds a host path to a mount path at `ro` or `rw` (design §4.5).
+ *
+ * On macOS the sandbox profile is glob-capable, so `hostPath` may contain glob
+ * patterns; on Linux it must be a literal path (the runtime does not glob there).
+ * For v1 we bind the host path directly (`mountPath` is recorded for the future
+ * bubblewrap bind-remap and for the spec→mandate seam, §4.6 — it does not change
+ * the v1 Seatbelt path, which has no path-remapping layer).
+ */
+export interface AgentMount {
+  /** Path on the host to expose into the session. */
+  hostPath: string;
+  /** Path the session sees it at. Recorded for the future bind-remap; see note above. */
+  mountPath: string;
+  /** Read-only or read-write. */
+  mode: MountMode;
+  /**
+   * Opt-in cross-session share by name (design §4.5). A deliberate hole in
+   * session-to-session isolation — honored here, but the trust caveat (prefer
+   * shared-`ro` from the producer, never shared-`rw` across a trust boundary) is
+   * doc-level for v1. Plumbed through so a future use is a considered decision.
+   */
+  shared?: string;
+}
+
+/** The vault binding for an arm: which vault, what access, optionally tag-scoped. */
+export interface AgentVaultSpec {
+  /** Vault instance name (e.g. "default"). */
+  name: string;
+  /** Access verb minted into the vault token. */
+  access: "read" | "write" | "admin";
+  /**
+   * Optional tag scope — narrows the minted vault token to these tags via the
+   * `permissions.scoped_tags` claim (e.g. `["#channel-message"]`). Omitted = the
+   * verb's full scope across the vault.
+   */
+  tags?: string[];
+}
+
+/** An additional MCP server to wire in, by URL (design §4.1 `otherMcps`). */
+export interface OtherMcpSpec {
+  /** Entry key in the generated `mcpServers` object. */
+  name: string;
+  /** Streamable-HTTP MCP URL. */
+  url: string;
+  /**
+   * Scope to mint a token for, if this MCP is hub-gated. Omitted = no token
+   * (an unauthenticated / externally-authenticated MCP).
+   */
+  scope?: string;
+  /** Audience to mint the token under. Defaults to inferred from scope by the hub. */
+  audience?: string;
+}
+
+/**
+ * An agent spec — the complete least-privilege envelope for one launched arm
+ * (design §4.1). `egress` and `mounts` are additive to a non-removable base; the
+ * spec only ever *adds*.
+ */
+export interface AgentSpec {
+  /** Human-readable arm name; used as the tmux session + workspace slug. */
+  name: string;
+  /** Channels to attach (one MCP entry each). */
+  channels: string[];
+  /** Optional vault binding. */
+  vault?: AgentVaultSpec;
+  /** Additional MCP servers, by URL. */
+  otherMcps?: OtherMcpSpec[];
+  /**
+   * Network egress — ADDITIVE to a minimal non-removable base of
+   * `{ the Anthropic API host(s), the hub/vault origin }` (design §4.4). A
+   * weaver-style arm declares `[]` (base only); a code-building arm opens
+   * exactly the package/source hosts it needs.
+   */
+  egress?: string[];
+  /**
+   * Filesystem mounts — ADDITIVE to the default private per-session workspace
+   * (rw) + the implicit runtime/claude-config (ro). Reads are scoped to declared
+   * binds, NOT broad (design §4.5).
+   */
+  mounts?: AgentMount[];
+  /**
+   * Which stored Claude credential to inject (design §6). Default = "operator".
+   * This stream injects the credential as a passed-in param/placeholder; Stream 3
+   * builds the real per-channel secret store.
+   */
+  credentialRef?: string;
+}
+
+/**
+ * The default workspace + runtime binds the contract always grants, independent
+ * of any spec. The caller supplies the concrete paths (resolved against the
+ * session's state dir + the runtime/config location) — keeping this module
+ * free of filesystem-layout assumptions and test-sandboxable.
+ */
+export interface BaseBinds {
+  /** Private per-session workspace (rw). */
+  workspace: string;
+  /**
+   * Read-only runtime/claude-config paths the session needs to run `claude`
+   * (e.g. the claude config dir). Always bound `ro`.
+   */
+  runtimeReadOnly: string[];
+}
+
+/** Platform the Sandbox config is being built for. */
+export type SandboxPlatform = "darwin" | "linux";

--- a/src/sandbox/types.ts
+++ b/src/sandbox/types.ts
@@ -77,11 +77,35 @@ export interface OtherMcpSpec {
  * (design §4.1). `egress` and `mounts` are additive to a non-removable base; the
  * spec only ever *adds*.
  */
+/**
+ * A channel binding for an arm. A bare string is shorthand for `{ name, access:
+ * "write" }` (back-compat — the common read+write resident session); the object
+ * form scopes a channel read-only so an arm that only *watches* a channel mints
+ * `channel:read` and never `channel:write` (the "scope an arm to channel X
+ * read-only" use case).
+ */
+export interface AgentChannelSpec {
+  /** Channel name (the `/mcp/<channel>` segment). */
+  name: string;
+  /**
+   * Channel access. `"write"` (default) mints `channel:read channel:write`;
+   * `"read"` mints `channel:read` only — the arm can be woken + read the channel
+   * but cannot reply.
+   */
+  access?: "read" | "write";
+}
+
+/** A channel entry: a bare name (= write access) or the scoped object form. */
+export type AgentChannel = string | AgentChannelSpec;
+
 export interface AgentSpec {
   /** Human-readable arm name; used as the tmux session + workspace slug. */
   name: string;
-  /** Channels to attach (one MCP entry each). */
-  channels: string[];
+  /**
+   * Channels to attach (one MCP entry each). Each entry is a bare name (read+write,
+   * back-compat) or `{ name, access: "read" }` to scope a channel read-only.
+   */
+  channels: AgentChannel[];
   /** Optional vault binding. */
   vault?: AgentVaultSpec;
   /** Additional MCP servers, by URL. */
@@ -125,3 +149,13 @@ export interface BaseBinds {
 
 /** Platform the Sandbox config is being built for. */
 export type SandboxPlatform = "darwin" | "linux";
+
+/**
+ * Normalize a channel entry (bare name or object) to `{ name, access }`. A bare
+ * string defaults to `write` (back-compat); the object form defaults to `write`
+ * when `access` is omitted.
+ */
+export function normalizeChannel(ch: AgentChannel): { name: string; access: "read" | "write" } {
+  if (typeof ch === "string") return { name: ch, access: "write" };
+  return { name: ch.name, access: ch.access ?? "write" };
+}

--- a/src/spawn-agent-cli.test.ts
+++ b/src/spawn-agent-cli.test.ts
@@ -1,0 +1,162 @@
+import { describe, test, expect } from "bun:test";
+import { parseArgs, ArgError } from "../scripts/spawn-agent.ts";
+import type { AgentChannelSpec } from "./sandbox/types.ts";
+
+// These tests exercise ONLY the pure arg-parser (`parseArgs`) — no fs/tmux/mint
+// side effect. The real-dep wiring (operator token, hub mint, sandbox, tmux) is
+// covered by spawn-agent.test.ts against stubs; here we assert flags → the right
+// AgentSpec, the --help short-circuit, and that bad args reject.
+
+describe("parseArgs — name + channels + vault + egress + mounts → the right AgentSpec", () => {
+  test("a full invocation builds the complete spec", () => {
+    const { help, spec } = parseArgs([
+      "aaron-dev",
+      "--channel",
+      "aaron-dev",
+      "--channel",
+      "ops:read",
+      "--vault",
+      "default:read:#channel-message,#decision",
+      "--egress",
+      "registry.npmjs.org,github.com",
+      "--mount",
+      "/host/code:/work/code:ro",
+      "--mount",
+      "/host/cache:/work/cache:rw:shared-cache",
+    ]);
+    expect(help).toBe(false);
+    expect(spec).toBeDefined();
+    expect(spec!.name).toBe("aaron-dev");
+
+    // Channels: first is the wake channel (write by default); second scoped read.
+    expect(spec!.channels).toEqual([
+      { name: "aaron-dev" },
+      { name: "ops", access: "read" },
+    ] as AgentChannelSpec[]);
+
+    // Vault: name + access + tag-scope.
+    expect(spec!.vault).toEqual({
+      name: "default",
+      access: "read",
+      tags: ["#channel-message", "#decision"],
+    });
+
+    // Egress: additive host list, comma-split.
+    expect(spec!.egress).toEqual(["registry.npmjs.org", "github.com"]);
+
+    // Mounts: ro + rw-with-shared.
+    expect(spec!.mounts).toEqual([
+      { hostPath: "/host/code", mountPath: "/work/code", mode: "ro" },
+      { hostPath: "/host/cache", mountPath: "/work/cache", mode: "rw", shared: "shared-cache" },
+    ]);
+  });
+
+  test("a bare --channel defaults to write (back-compat resident session)", () => {
+    const { spec } = parseArgs(["a", "--channel", "c"]);
+    expect(spec!.channels).toEqual([{ name: "c" }]);
+  });
+
+  test("--channel <name>:write is explicit write", () => {
+    const { spec } = parseArgs(["a", "--channel", "c:write"]);
+    expect(spec!.channels).toEqual([{ name: "c", access: "write" }]);
+  });
+
+  test("a minimal invocation (name + one channel) omits optional fields", () => {
+    const { spec } = parseArgs(["solo", "--channel", "solo"]);
+    expect(spec).toEqual({ name: "solo", channels: [{ name: "solo" }] });
+    expect(spec!.vault).toBeUndefined();
+    expect(spec!.egress).toBeUndefined();
+    expect(spec!.mounts).toBeUndefined();
+  });
+
+  test("--vault without a tag list omits tags", () => {
+    const { spec } = parseArgs(["a", "--channel", "c", "--vault", "default:write"]);
+    expect(spec!.vault).toEqual({ name: "default", access: "write" });
+  });
+
+  test("the FIRST channel is the wake channel (order preserved)", () => {
+    const { spec } = parseArgs(["a", "--channel", "first", "--channel", "second"]);
+    expect(spec!.channels[0]).toEqual({ name: "first" });
+    expect(spec!.channels[1]).toEqual({ name: "second" });
+  });
+});
+
+describe("parseArgs — --help short-circuits", () => {
+  test("--help returns help:true and builds no spec", () => {
+    const r = parseArgs(["--help"]);
+    expect(r.help).toBe(true);
+    expect(r.spec).toBeUndefined();
+  });
+
+  test("-h is the short alias", () => {
+    expect(parseArgs(["-h"]).help).toBe(true);
+  });
+
+  test("--help wins even with other args present", () => {
+    const r = parseArgs(["name", "--channel", "c", "--help"]);
+    expect(r.help).toBe(true);
+    expect(r.spec).toBeUndefined();
+  });
+});
+
+describe("parseArgs — bad args reject", () => {
+  test("missing name", () => {
+    expect(() => parseArgs(["--channel", "c"])).toThrow(ArgError);
+    expect(() => parseArgs(["--channel", "c"])).toThrow(/missing required <name>/);
+  });
+
+  test("no channels", () => {
+    expect(() => parseArgs(["just-a-name"])).toThrow(/at least one --channel/);
+  });
+
+  test("a second positional is rejected", () => {
+    expect(() => parseArgs(["a", "b", "--channel", "c"])).toThrow(/only one <name>/);
+  });
+
+  test("an unknown flag is rejected", () => {
+    expect(() => parseArgs(["a", "--channel", "c", "--bogus"])).toThrow(/unknown flag "--bogus"/);
+  });
+
+  test("a flag with a missing value is rejected", () => {
+    expect(() => parseArgs(["a", "--channel"])).toThrow(/--channel: expected a value/);
+    // A following flag is NOT consumed as the value.
+    expect(() => parseArgs(["a", "--channel", "--vault"])).toThrow(/--channel: expected a value/);
+  });
+
+  test("a bad channel access verb is rejected", () => {
+    expect(() => parseArgs(["a", "--channel", "c:admin"])).toThrow(/access must be "read" or "write"/);
+  });
+
+  test("an over-segmented channel is rejected", () => {
+    expect(() => parseArgs(["a", "--channel", "c:read:extra"])).toThrow(/extra ":"/);
+  });
+
+  test("a bad vault shape is rejected", () => {
+    expect(() => parseArgs(["a", "--channel", "c", "--vault", "default"])).toThrow(
+      /expected <name>:<read\|write>/,
+    );
+    expect(() => parseArgs(["a", "--channel", "c", "--vault", "default:admin"])).toThrow(
+      /access must be "read" or "write"/,
+    );
+  });
+
+  test("--vault given twice is rejected", () => {
+    expect(() =>
+      parseArgs(["a", "--channel", "c", "--vault", "default:read", "--vault", "other:write"]),
+    ).toThrow(/--vault may only be given once/);
+  });
+
+  test("a bad mount shape is rejected", () => {
+    expect(() => parseArgs(["a", "--channel", "c", "--mount", "/h:/m"])).toThrow(
+      /expected <hostPath:mountPath:ro\|rw/,
+    );
+    expect(() => parseArgs(["a", "--channel", "c", "--mount", "/h:/m:rx"])).toThrow(
+      /mode must be "ro" or "rw"/,
+    );
+  });
+
+  test("an empty egress list parses to no egress (not an error)", () => {
+    const { spec } = parseArgs(["a", "--channel", "c", "--egress", ""]);
+    expect(spec!.egress).toBeUndefined();
+  });
+});

--- a/src/spawn-agent.test.ts
+++ b/src/spawn-agent.test.ts
@@ -6,6 +6,8 @@ import {
   spawnAgent,
   buildAgentChildEnv,
   buildAgentClaudeArgs,
+  buildLaunchScript,
+  realTmuxLauncher,
   sessionName,
   shellJoin,
   type SpawnAgentDeps,
@@ -397,5 +399,88 @@ describe("spawnAgent — full wiring with stubs (no real token)", () => {
       spawnAgent({ name: "s-c", channels: ["c"] }, baseDeps({ sandboxEngine: slowEngine(), tmux: recordingTmux() })),
     ]);
     expect(maxActive).toBe(1);
+  });
+});
+
+// ---- buildLaunchScript (the tmux-buffer fix) -------------------------------
+
+describe("buildLaunchScript — script body per argv shape, token-free", () => {
+  test("macOS `/bin/bash -c <cmd>` shape: the body IS the command", () => {
+    const script = buildLaunchScript(["/bin/bash", "-c", "sandbox-exec -p '...' claude --foo"]);
+    expect(script.startsWith("#!/bin/bash\nset -euo pipefail\n")).toBe(true);
+    expect(script).toContain("sandbox-exec -p '...' claude --foo");
+    // No `exec <bash> -c` re-wrapping for this canonical shape.
+    expect(script).not.toContain("exec /bin/bash");
+  });
+
+  test("general argv (Linux bubblewrap shape): exec's the quoted argv", () => {
+    const script = buildLaunchScript(["bwrap", "--ro-bind", "/usr", "/usr", "claude", "--mcp-config", "/ws/.mcp.json"]);
+    expect(script.startsWith("#!/bin/bash\nset -euo pipefail\n")).toBe(true);
+    expect(script).toContain("exec bwrap --ro-bind /usr /usr claude --mcp-config /ws/.mcp.json");
+  });
+});
+
+describe("realTmuxLauncher — launch-script indirection (tmux can't take the ~84KB profile inline)", () => {
+  /** A recording spawnFn matching the `Bun.spawn` shape the launcher awaits. */
+  function recordingSpawn(): {
+    fn: typeof Bun.spawn;
+    calls: string[][];
+  } {
+    const calls: string[][] = [];
+    const fn = ((argv: string[]) => {
+      calls.push(argv);
+      return {
+        exited: Promise.resolve(0),
+        stderr: new Response("").body,
+      };
+    }) as unknown as typeof Bun.spawn;
+    return { fn, calls };
+  }
+
+  test("a >100KB wrapped command is NOT passed inline — tmux gets a short script-path argv; the script is written 0600 with the command; token rides env via -e", async () => {
+    const workspace = mkdtempSync(join(tmpdir(), "launch-script-"));
+    try {
+      // A wrapped argv whose command embeds a giant (>100KB) profile inline — the
+      // exact shape that overran tmux's buffer in the integration smoke.
+      const bigProfile = "X".repeat(100_000);
+      const bigCommand = `sandbox-exec -p '${bigProfile}' claude --strict-mcp-config --mcp-config ${join(workspace, ".mcp.json")}`;
+      const wrappedArgv = ["/bin/bash", "-c", bigCommand];
+      expect(bigCommand.length).toBeGreaterThan(100_000);
+
+      const { fn, calls } = recordingSpawn();
+      const launcher = realTmuxLauncher(fn);
+      await launcher.newSession({
+        name: "big-agent",
+        argv: wrappedArgv,
+        env: { CLAUDE_CODE_OAUTH_TOKEN: "OAUTH-SECRET", SANDBOX_RUNTIME: "1" },
+        cwd: workspace,
+      });
+
+      // (a) the argv handed to tmux is SHORT — a script path, not the 100KB inline.
+      expect(calls).toHaveLength(1);
+      const tmuxArgv = calls[0]!;
+      const scriptPath = join(workspace, ".launch.sh");
+      expect(tmuxArgv[tmuxArgv.length - 2]).toBe("/bin/bash");
+      expect(tmuxArgv[tmuxArgv.length - 1]).toBe(scriptPath);
+      // The 100KB profile is NOWHERE on the tmux command line.
+      expect(tmuxArgv.some((a) => a.length > 50_000)).toBe(false);
+      expect(tmuxArgv.join(" ")).not.toContain(bigProfile);
+
+      // (b) the launch script is written, mode 0600, and contains the wrapped command.
+      expect(statSync(scriptPath).mode & 0o777).toBe(0o600);
+      const body = readFileSync(scriptPath, "utf8");
+      expect(body.startsWith("#!/bin/bash\nset -euo pipefail\n")).toBe(true);
+      expect(body).toContain(bigCommand);
+
+      // (c) env still passed via `-e KEY=VAL`.
+      expect(tmuxArgv).toContain("-e");
+      expect(tmuxArgv).toContain("CLAUDE_CODE_OAUTH_TOKEN=OAUTH-SECRET");
+      expect(tmuxArgv).toContain("SANDBOX_RUNTIME=1");
+
+      // SECURITY: the secret rides the ENV, never the script body.
+      expect(body).not.toContain("OAUTH-SECRET");
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
+    }
   });
 });

--- a/src/spawn-agent.test.ts
+++ b/src/spawn-agent.test.ts
@@ -15,6 +15,10 @@ import type { SandboxEngine } from "./sandbox/index.ts";
 import type { SandboxRuntimeConfig } from "@anthropic-ai/sandbox-runtime";
 import type { AgentSpec } from "./sandbox/types.ts";
 import { channelEntryKey, vaultEntryKey } from "./agent-mcp-config.ts";
+import {
+  setDefaultClaudeCredential,
+  setChannelClaudeCredential,
+} from "./credentials.ts";
 
 let sessionsDir: string;
 afterEach(() => {
@@ -87,7 +91,9 @@ function baseDeps(over: Partial<SpawnAgentDeps> = {}): SpawnAgentDeps {
     vaultUrl: "http://127.0.0.1:1940",
     sessionsDir,
     runtimeReadOnly: ["/cfg/.claude"],
-    claudeOauthToken: "OAUTH-CRED-PLACEHOLDER",
+    // Stub the credential resolver so the test never touches a real store; the
+    // assertion below checks this exact token lands in CLAUDE_CODE_OAUTH_TOKEN.
+    resolveClaudeToken: () => "OAUTH-CRED-PLACEHOLDER",
     sandboxEngine: fakeEngine(),
     tmux: recordingTmux(),
     fetchFn: fakeMintFetch(),
@@ -399,3 +405,88 @@ describe("spawnAgent — full wiring with stubs (no real token)", () => {
     expect(maxActive).toBe(1);
   });
 });
+
+// ---- credential wiring (Stream 3 — resolve from the per-channel store) -------
+
+describe("spawnAgent — resolves the Claude credential from the per-channel store", () => {
+  let storeDir: string;
+  afterEach(() => {
+    if (storeDir) rmSync(storeDir, { recursive: true, force: true });
+  });
+
+  // The wiring under test reads `credentials.ts` keyed on the WAKE channel (the
+  // first channel). These tests use the REAL resolver (no `resolveClaudeToken`
+  // stub) against a throwaway store, proving the end-to-end resolve→inject path.
+  function depsWithRealResolver(): SpawnAgentDeps {
+    const d = baseDeps();
+    delete (d as { resolveClaudeToken?: unknown }).resolveClaudeToken;
+    return d;
+  }
+
+  test("injects the PER-CHANNEL override when the wake channel has one", async () => {
+    sessionsDir = mkdtempSync(join(tmpdir(), "spawn-agent-cred-ovr-"));
+    storeDir = mkdtempSync(join(tmpdir(), "channel-creds-ovr-"));
+    setDefaultClaudeCredential("oat_DEFAULT", storeDir);
+    setChannelClaudeCredential("aaron-dev", "oat_AARON-OVERRIDE", storeDir);
+
+    const tmux = recordingTmux();
+    const deps = { ...depsWithRealResolver(), tmux, resolveClaudeToken: (ch: string) => resolveAgainst(storeDir, ch) };
+    const res = await spawnAgent({ name: "aaron-dev", channels: ["aaron-dev"] }, deps);
+    expect(res.alreadyRunning).toBe(false);
+    // The override (not the default) lands in CLAUDE_CODE_OAUTH_TOKEN.
+    expect(tmux.launched[0]!.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("oat_AARON-OVERRIDE");
+    expect(tmux.launched[0]!.env.ANTHROPIC_API_KEY).toBeUndefined();
+  });
+
+  test("falls back to the DEFAULT/operator token when the wake channel has no override", async () => {
+    sessionsDir = mkdtempSync(join(tmpdir(), "spawn-agent-cred-def-"));
+    storeDir = mkdtempSync(join(tmpdir(), "channel-creds-def-"));
+    setDefaultClaudeCredential("oat_DEFAULT", storeDir);
+
+    const tmux = recordingTmux();
+    const deps = { ...baseDeps(), tmux, resolveClaudeToken: (ch: string) => resolveAgainst(storeDir, ch) };
+    const res = await spawnAgent({ name: "other", channels: ["unconfigured-ch"] }, deps);
+    expect(res.alreadyRunning).toBe(false);
+    expect(tmux.launched[0]!.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("oat_DEFAULT");
+  });
+
+  test("resolves on the WAKE channel (first), not a later one", async () => {
+    sessionsDir = mkdtempSync(join(tmpdir(), "spawn-agent-cred-wake-"));
+    storeDir = mkdtempSync(join(tmpdir(), "channel-creds-wake-"));
+    setDefaultClaudeCredential("oat_DEFAULT", storeDir);
+    setChannelClaudeCredential("first", "oat_FIRST", storeDir);
+    setChannelClaudeCredential("second", "oat_SECOND", storeDir);
+
+    const tmux = recordingTmux();
+    const deps = { ...baseDeps(), tmux, resolveClaudeToken: (ch: string) => resolveAgainst(storeDir, ch) };
+    await spawnAgent({ name: "multi", channels: ["first", "second"] }, deps);
+    // The wake channel is the first → its override is the session's auth.
+    expect(tmux.launched[0]!.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("oat_FIRST");
+  });
+
+  test("SECURITY: an unconfigured store ABORTS the launch BEFORE any mint/tmux side effect", async () => {
+    sessionsDir = mkdtempSync(join(tmpdir(), "spawn-agent-cred-none-"));
+    storeDir = mkdtempSync(join(tmpdir(), "channel-creds-none-")); // empty store
+    const tmux = recordingTmux();
+    let minted = false;
+    const fetchFn = (async () => {
+      minted = true;
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
+    const deps = { ...baseDeps(), tmux, fetchFn, resolveClaudeToken: (ch: string) => resolveAgainst(storeDir, ch) };
+    await expect(
+      spawnAgent({ name: "x", channels: ["ghost"] }, deps),
+    ).rejects.toThrow(/no Claude credential/);
+    // No session launched, no token minted.
+    expect(tmux.launched).toHaveLength(0);
+    expect(minted).toBe(false);
+  });
+});
+
+// Resolve against a specific store dir (the real resolver hard-wires the default
+// state dir; this test helper threads the throwaway dir through, exercising the
+// SAME `resolveClaudeCredential` the production resolver calls).
+function resolveAgainst(storeDir: string, channel: string): string {
+  const { resolveClaudeCredential } = require("./credentials.ts") as typeof import("./credentials.ts");
+  return resolveClaudeCredential(channel, storeDir);
+}

--- a/src/spawn-agent.test.ts
+++ b/src/spawn-agent.test.ts
@@ -281,4 +281,121 @@ describe("spawnAgent — full wiring with stubs (no real token)", () => {
     // The attenuation failure happened BEFORE any tmux launch.
     expect(tmux.launched).toHaveLength(0);
   });
+
+  test("SECURITY: an adversarial spec.name is rejected BEFORE any fs/tmux/mint side effect", async () => {
+    sessionsDir = mkdtempSync(join(tmpdir(), "spawn-agent-name-"));
+    for (const bad of ["..", "a/b", "a b", "../escape", ".", "a..b", "x;rm", ""]) {
+      const tmux = recordingTmux();
+      let minted = false;
+      const fetchFn = (async () => {
+        minted = true;
+        return new Response("{}", { status: 200 });
+      }) as unknown as typeof fetch;
+      await expect(
+        spawnAgent({ name: bad, channels: ["c"] }, baseDeps({ tmux, fetchFn })),
+      ).rejects.toThrow(/slug/);
+      // No side effects: no tmux launch, no mint attempt.
+      expect(tmux.launched).toHaveLength(0);
+      expect(minted).toBe(false);
+    }
+  });
+
+  test("a valid slug name is accepted (dashes + underscores ok)", async () => {
+    sessionsDir = mkdtempSync(join(tmpdir(), "spawn-agent-okname-"));
+    const res = await spawnAgent({ name: "aaron_dev-2", channels: ["c"] }, baseDeps());
+    expect(res.alreadyRunning).toBe(false);
+    expect(res.session).toBe("aaron_dev-2-agent");
+  });
+
+  test("read-only channel mints channel:read ONLY (not read+write)", async () => {
+    sessionsDir = mkdtempSync(join(tmpdir(), "spawn-agent-roch-"));
+    const scopes: string[] = [];
+    const fetchFn = (async (_u: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { scope: string };
+      scopes.push(body.scope);
+      return new Response(
+        JSON.stringify({ jti: "j", token: `T-${scopes.length}`, expires_at: "", scope: body.scope }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+
+    const spec: AgentSpec = {
+      name: "watcher",
+      channels: [
+        { name: "readonly-ch", access: "read" },
+        { name: "rw-ch", access: "write" },
+        "bare-ch", // bare string = write (back-compat)
+      ],
+    };
+    await spawnAgent(spec, baseDeps({ fetchFn }));
+    expect(scopes).toContain("channel:read"); // the read-only channel
+    expect(scopes.filter((s) => s === "channel:read")).toHaveLength(1);
+    expect(scopes.filter((s) => s === "channel:read channel:write")).toHaveLength(2); // rw + bare
+  });
+
+  test("CONCURRENCY: two concurrent spawnAgent calls produce correct, independent MCP configs + wrapping", async () => {
+    sessionsDir = mkdtempSync(join(tmpdir(), "spawn-agent-conc-"));
+    // Independent engines/tmux per call so we can assert no cross-clobber. Each
+    // mint hub returns a token namespaced to the spec so configs are tellable apart.
+    function depsForArm(arm: string) {
+      let n = 0;
+      const fetchFn = (async (_u: string | URL | Request, init?: RequestInit) => {
+        const body = JSON.parse(String(init?.body ?? "{}")) as { scope: string };
+        n += 1;
+        return new Response(
+          JSON.stringify({ jti: `${arm}-${n}`, token: `${arm}-TOK-${n}`, expires_at: "", scope: body.scope }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }) as unknown as typeof fetch;
+      return baseDeps({ tmux: recordingTmux(), sandboxEngine: fakeEngine(), fetchFn });
+    }
+
+    const [a, b] = await Promise.all([
+      spawnAgent({ name: "arm-a", channels: ["ca"] }, depsForArm("A")),
+      spawnAgent({ name: "arm-b", channels: ["cb"] }, depsForArm("B")),
+    ]);
+
+    // Each got its OWN channel entry + token — no clobber across the race.
+    const pa = JSON.parse(a.mcpConfigJson) as { mcpServers: Record<string, { url: string; headers?: { Authorization: string } }> };
+    const pb = JSON.parse(b.mcpConfigJson) as { mcpServers: Record<string, { url: string; headers?: { Authorization: string } }> };
+    expect(pa.mcpServers[channelEntryKey("ca")]!.url).toBe("http://127.0.0.1:1941/mcp/ca");
+    expect(pb.mcpServers[channelEntryKey("cb")]!.url).toBe("http://127.0.0.1:1941/mcp/cb");
+    expect(pa.mcpServers[channelEntryKey("ca")]!.headers!.Authorization).toBe("Bearer A-TOK-1");
+    expect(pb.mcpServers[channelEntryKey("cb")]!.headers!.Authorization).toBe("Bearer B-TOK-1");
+    // Independent sandbox configs (each carries its own workspace allowWrite).
+    expect(a.wrapped.config.filesystem.allowWrite).toContain(a.workspace);
+    expect(b.wrapped.config.filesystem.allowWrite).toContain(b.workspace);
+    expect(a.workspace).not.toBe(b.workspace);
+  });
+
+  test("CONCURRENCY: the init→wrap window is serialized (never two engines in it at once)", async () => {
+    sessionsDir = mkdtempSync(join(tmpdir(), "spawn-agent-serial-"));
+    // An engine whose initialize overlaps wrap by an await; if the lock didn't
+    // hold, two would be "in the window" simultaneously and maxActive would be >1.
+    let active = 0;
+    let maxActive = 0;
+    function slowEngine(): SandboxEngine {
+      return {
+        isSupportedPlatform: () => true,
+        isSandboxingEnabled: () => true,
+        async initialize() {
+          active += 1;
+          maxActive = Math.max(maxActive, active);
+          await Bun.sleep(15);
+        },
+        async wrapWithSandboxArgv(command: string) {
+          await Bun.sleep(15);
+          active -= 1;
+          return { argv: ["/bin/bash", "-c", command], env: {} };
+        },
+        async reset() {},
+      };
+    }
+    await Promise.all([
+      spawnAgent({ name: "s-a", channels: ["c"] }, baseDeps({ sandboxEngine: slowEngine(), tmux: recordingTmux() })),
+      spawnAgent({ name: "s-b", channels: ["c"] }, baseDeps({ sandboxEngine: slowEngine(), tmux: recordingTmux() })),
+      spawnAgent({ name: "s-c", channels: ["c"] }, baseDeps({ sandboxEngine: slowEngine(), tmux: recordingTmux() })),
+    ]);
+    expect(maxActive).toBe(1);
+  });
 });

--- a/src/spawn-agent.test.ts
+++ b/src/spawn-agent.test.ts
@@ -1,0 +1,284 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  spawnAgent,
+  buildAgentChildEnv,
+  buildAgentClaudeArgs,
+  sessionName,
+  shellJoin,
+  type SpawnAgentDeps,
+  type TmuxLauncher,
+} from "./spawn-agent.ts";
+import type { SandboxEngine } from "./sandbox/index.ts";
+import type { SandboxRuntimeConfig } from "@anthropic-ai/sandbox-runtime";
+import type { AgentSpec } from "./sandbox/types.ts";
+import { channelEntryKey, vaultEntryKey } from "./agent-mcp-config.ts";
+
+let sessionsDir: string;
+afterEach(() => {
+  if (sessionsDir) rmSync(sessionsDir, { recursive: true, force: true });
+});
+
+// ---- fakes -----------------------------------------------------------------
+
+/** A recording tmux launcher. */
+function recordingTmux(existing = new Set<string>()): TmuxLauncher & {
+  launched: Array<{ name: string; argv: string[]; env: Record<string, string | undefined>; cwd: string }>;
+} {
+  const launched: Array<{
+    name: string;
+    argv: string[];
+    env: Record<string, string | undefined>;
+    cwd: string;
+  }> = [];
+  return {
+    launched,
+    async hasSession(name) {
+      return existing.has(name);
+    },
+    async newSession(opts) {
+      launched.push(opts);
+    },
+  };
+}
+
+/** A fake sandbox engine — records config, returns a deterministic wrap. */
+function fakeEngine(): SandboxEngine & { initializedWith: SandboxRuntimeConfig | null } {
+  const rec = {
+    initializedWith: null as SandboxRuntimeConfig | null,
+    isSupportedPlatform: () => true,
+    isSandboxingEnabled: () => true,
+    async initialize(cfg: SandboxRuntimeConfig) {
+      rec.initializedWith = cfg;
+    },
+    async wrapWithSandboxArgv(command: string) {
+      // Emulate the real shape: a bash -c wrapper carrying the command + proxy env.
+      return {
+        argv: ["/bin/bash", "-c", `SBX ${command}`],
+        env: { SANDBOX_RUNTIME: "1", HTTPS_PROXY: "http://localhost:5555" },
+      };
+    },
+    async reset() {},
+  };
+  return rec;
+}
+
+/** A fake mint hub: returns a distinct token per scope so we can tell them apart. */
+function fakeMintFetch(): typeof fetch {
+  let n = 0;
+  return (async (_url: string | URL | Request, init?: RequestInit) => {
+    const body = JSON.parse(String(init?.body ?? "{}")) as { scope: string };
+    n += 1;
+    const token = `TOK-${n}-${body.scope.replace(/[^a-z]/gi, "").slice(0, 6)}`;
+    return new Response(
+      JSON.stringify({ jti: `j${n}`, token, expires_at: "2026-09-01T00:00:00Z", scope: body.scope }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  }) as unknown as typeof fetch;
+}
+
+function baseDeps(over: Partial<SpawnAgentDeps> = {}): SpawnAgentDeps {
+  return {
+    hubOrigin: "https://hub.example.com",
+    managerBearer: "MANAGER",
+    channelUrl: "http://127.0.0.1:1941",
+    vaultUrl: "http://127.0.0.1:1940",
+    sessionsDir,
+    runtimeReadOnly: ["/cfg/.claude"],
+    claudeOauthToken: "OAUTH-CRED-PLACEHOLDER",
+    sandboxEngine: fakeEngine(),
+    tmux: recordingTmux(),
+    fetchFn: fakeMintFetch(),
+    parentEnv: {
+      PATH: "/usr/bin",
+      HOME: "/home/op",
+      ANTHROPIC_API_KEY: "sk-ant-SHOULD-NOT-LEAK",
+      CLAUDE_API_KEY: "also-should-not-leak",
+      SECRET_THING: "do-not-pass",
+    },
+    claudeBin: "claude",
+    ...over,
+  };
+}
+
+// ---- pure-helper tests -----------------------------------------------------
+
+describe("buildAgentChildEnv — scrub, inject OAuth, NEVER ANTHROPIC_API_KEY", () => {
+  test("injects CLAUDE_CODE_OAUTH_TOKEN as the session auth", () => {
+    const env = buildAgentChildEnv({ PATH: "/usr/bin", HOME: "/h" }, "THE-OAUTH-TOKEN");
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe("THE-OAUTH-TOKEN");
+  });
+
+  test("SECURITY: ANTHROPIC_API_KEY is NOT passed through (would route to API billing)", () => {
+    const env = buildAgentChildEnv(
+      { PATH: "/usr/bin", HOME: "/h", ANTHROPIC_API_KEY: "sk-ant-x", CLAUDE_API_KEY: "y" },
+      "tok",
+    );
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(env.CLAUDE_API_KEY).toBeUndefined();
+  });
+
+  test("scrubs unrelated parent env (only the allowlist + locale pass)", () => {
+    const env = buildAgentChildEnv(
+      { PATH: "/usr/bin", HOME: "/h", SECRET_THING: "nope", LC_ALL: "en_US.UTF-8" },
+      "tok",
+    );
+    expect(env.SECRET_THING).toBeUndefined();
+    expect(env.PATH).toBe("/usr/bin");
+    expect(env.HOME).toBe("/h");
+    expect(env.LC_ALL).toBe("en_US.UTF-8");
+  });
+
+  test("provides a default PATH if the parent had none", () => {
+    const env = buildAgentChildEnv({}, "tok");
+    expect(env.PATH).toBe("/usr/local/bin:/usr/bin:/bin");
+  });
+});
+
+describe("buildAgentClaudeArgs", () => {
+  test("interactive claude (no -p) with strict MCP config + dev-channels for the first channel", () => {
+    const argv = buildAgentClaudeArgs({
+      mcpConfigPath: "/ws/.mcp.json",
+      firstChannelEntryKey: "channel-aaron-dev",
+    });
+    expect(argv).toContain("--strict-mcp-config");
+    expect(argv).toContain("--mcp-config");
+    expect(argv).toContain("/ws/.mcp.json");
+    expect(argv).toContain("--dangerously-load-development-channels=server:channel-aaron-dev");
+    // NOT headless: no `-p`.
+    expect(argv).not.toContain("-p");
+  });
+});
+
+describe("shellJoin", () => {
+  test("leaves safe args bare, quotes args with spaces", () => {
+    expect(shellJoin(["claude", "--mcp-config", "/a/b.json"])).toBe("claude --mcp-config /a/b.json");
+    expect(shellJoin(["echo", "a b"])).toBe("echo 'a b'");
+  });
+});
+
+// ---- full wiring tests -----------------------------------------------------
+
+describe("spawnAgent — full wiring with stubs (no real token)", () => {
+  test("creates the tmux session, writes a strict MCP config, injects OAuth, omits ANTHROPIC_API_KEY", async () => {
+    sessionsDir = mkdtempSync(join(tmpdir(), "spawn-agent-"));
+    const tmux = recordingTmux();
+    const engine = fakeEngine();
+    const spec: AgentSpec = {
+      name: "aaron-dev",
+      channels: ["aaron-dev"],
+      vault: { name: "default", access: "read", tags: ["#channel-message"] },
+    };
+    const res = await spawnAgent(spec, baseDeps({ tmux, sandboxEngine: engine }));
+
+    // 1. tmux session created with the spec's name.
+    expect(res.alreadyRunning).toBe(false);
+    expect(res.session).toBe(sessionName("aaron-dev"));
+    expect(tmux.launched).toHaveLength(1);
+    const launch = tmux.launched[0]!;
+    expect(launch.name).toBe("aaron-dev-agent");
+
+    // 2. The launched argv is the sandbox wrapper carrying the claude command.
+    expect(launch.argv[0]).toBe("/bin/bash");
+    expect(launch.argv[2]).toContain("SBX claude");
+    expect(launch.argv[2]).toContain("--strict-mcp-config");
+
+    // 3. The injected env has CLAUDE_CODE_OAUTH_TOKEN and NO ANTHROPIC_API_KEY.
+    expect(launch.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("OAUTH-CRED-PLACEHOLDER");
+    expect(launch.env.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(launch.env.CLAUDE_API_KEY).toBeUndefined();
+    // ...and the sandbox proxy env layered on top.
+    expect(launch.env.SANDBOX_RUNTIME).toBe("1");
+    expect(launch.env.HTTPS_PROXY).toBe("http://localhost:5555");
+
+    // 4. The MCP config has the right entries with DISTINCT tokens (one per aud).
+    const parsed = JSON.parse(res.mcpConfigJson) as {
+      mcpServers: Record<string, { url: string; headers?: { Authorization: string } }>;
+    };
+    const chKey = channelEntryKey("aaron-dev");
+    const vKey = vaultEntryKey("default");
+    expect(parsed.mcpServers[chKey]!.url).toBe("http://127.0.0.1:1941/mcp/aaron-dev");
+    expect(parsed.mcpServers[vKey]!.url).toBe("http://127.0.0.1:1940/vault/default/mcp");
+    const chAuth = parsed.mcpServers[chKey]!.headers!.Authorization;
+    const vAuth = parsed.mcpServers[vKey]!.headers!.Authorization;
+    expect(chAuth).toMatch(/^Bearer TOK-/);
+    expect(vAuth).toMatch(/^Bearer TOK-/);
+    expect(chAuth).not.toBe(vAuth); // distinct tokens, distinct auds
+
+    // 5. The on-disk config is 0600 (it inlines tokens).
+    const mcpPath = join(res.workspace, ".mcp.json");
+    expect(statSync(mcpPath).mode & 0o777).toBe(0o600);
+    expect(readFileSync(mcpPath, "utf8")).toBe(res.mcpConfigJson);
+
+    // 6. The sandbox config carried the egress floor + scoped reads.
+    expect(engine.initializedWith!.network.allowedDomains).toContain("api.anthropic.com");
+    expect(engine.initializedWith!.network.allowedDomains).toContain("hub.example.com");
+    expect(engine.initializedWith!.filesystem.allowWrite).toContain(res.workspace);
+  });
+
+  test("mints ONE token per channel for a multi-channel spec", async () => {
+    sessionsDir = mkdtempSync(join(tmpdir(), "spawn-agent-multi-"));
+    const spec: AgentSpec = { name: "multi", channels: ["a", "b"] };
+    const res = await spawnAgent(spec, baseDeps());
+    expect(Object.keys(res.tokens)).toContain("a");
+    expect(Object.keys(res.tokens)).toContain("b");
+    expect(res.tokens.a!.token).not.toBe(res.tokens.b!.token);
+    const parsed = JSON.parse(res.mcpConfigJson) as { mcpServers: Record<string, unknown> };
+    expect(parsed.mcpServers[channelEntryKey("a")]).toBeDefined();
+    expect(parsed.mcpServers[channelEntryKey("b")]).toBeDefined();
+  });
+
+  test("tag-scoped vault: the scoped_tags permission rides the vault mint request", async () => {
+    sessionsDir = mkdtempSync(join(tmpdir(), "spawn-agent-vault-"));
+    const calls: Array<Record<string, unknown>> = [];
+    const fetchFn = (async (_u: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+      calls.push(body);
+      return new Response(
+        JSON.stringify({ jti: "j", token: `T-${calls.length}`, expires_at: "", scope: body.scope }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+
+    const spec: AgentSpec = {
+      name: "weaver",
+      channels: ["c"],
+      vault: { name: "default", access: "read", tags: ["#channel-message"] },
+    };
+    await spawnAgent(spec, baseDeps({ fetchFn }));
+    const vaultCall = calls.find((c) => String(c.scope).startsWith("vault:"));
+    expect(vaultCall).toBeDefined();
+    expect(vaultCall!.scope).toBe("vault:default:read");
+    expect(vaultCall!.permissions).toEqual({ scoped_tags: ["#channel-message"] });
+  });
+
+  test("idempotent: an already-running session is a no-op", async () => {
+    sessionsDir = mkdtempSync(join(tmpdir(), "spawn-agent-idem-"));
+    const tmux = recordingTmux(new Set(["arm-agent"]));
+    const res = await spawnAgent({ name: "arm", channels: ["c"] }, baseDeps({ tmux }));
+    expect(res.alreadyRunning).toBe(true);
+    expect(tmux.launched).toHaveLength(0);
+  });
+
+  test("a spec with no channels is rejected", async () => {
+    sessionsDir = mkdtempSync(join(tmpdir(), "spawn-agent-noch-"));
+    await expect(spawnAgent({ name: "x", channels: [] }, baseDeps())).rejects.toThrow(/no channels/);
+  });
+
+  test("SECURITY: an over-broad mint (hub 400) aborts the launch — no tmux session created", async () => {
+    sessionsDir = mkdtempSync(join(tmpdir(), "spawn-agent-deny-"));
+    const tmux = recordingTmux();
+    const fetchFn = (async () =>
+      new Response(
+        JSON.stringify({ error: "invalid_scope", error_description: "not grantable by this bearer" }),
+        { status: 400, headers: { "content-type": "application/json" } },
+      )) as unknown as typeof fetch;
+    await expect(
+      spawnAgent({ name: "x", channels: ["c"] }, baseDeps({ tmux, fetchFn })),
+    ).rejects.toThrow(/mint refused/);
+    // The attenuation failure happened BEFORE any tmux launch.
+    expect(tmux.launched).toHaveLength(0);
+  });
+});

--- a/src/spawn-agent.ts
+++ b/src/spawn-agent.ts
@@ -22,9 +22,10 @@
  * subscription path).
  */
 
-import { writeFileSync, mkdirSync, chmodSync } from "node:fs";
+import { writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import type { AgentSpec, BaseBinds } from "./sandbox/types.ts";
+import { normalizeChannel } from "./sandbox/types.ts";
 import { Sandbox, type SandboxEngine, type WrappedCommand } from "./sandbox/index.ts";
 import type { EgressBaseInput } from "./sandbox/egress.ts";
 import {
@@ -40,6 +41,39 @@ import {
   type MintTokenDeps,
   type MintResult,
 } from "./mint-token.ts";
+
+/**
+ * Slug guard for `spec.name`. The name is used UNESCAPED as a tmux session
+ * target (`-t`) and a path segment under `sessionsDir`, so it must be a strict
+ * slug — mirrors `scripts/launch-session.sh`'s existing check. Anything with
+ * `..`, `/`, or spaces would traverse the sessions dir or break tmux targeting.
+ * Phase 2 makes spawns API/MCP-triggered (the name becomes less-trusted input),
+ * so the guard is enforced now, before any fs/tmux side effect.
+ */
+const AGENT_NAME_SLUG = /^[a-z0-9_-]+$/i;
+
+/**
+ * Process-wide serialization for the sandbox-runtime singleton. `SandboxManager`
+ * is global (initialize → wrap → reset share one set of host proxies), so two
+ * concurrent `spawnAgent` calls would race the initialize→wrap window (a second
+ * `initialize` could clobber the first's config before its command is wrapped).
+ * Only that brief window needs the lock — the sandbox policy is baked into the
+ * argv at `wrapWithSandboxArgv`, after which the spawned process runs
+ * independently. This is a minimal FIFO async mutex: each acquirer chains onto
+ * the previous one's release.
+ */
+let spawnLock: Promise<void> = Promise.resolve();
+async function withSpawnLock<T>(fn: () => Promise<T>): Promise<T> {
+  const prior = spawnLock;
+  let release!: () => void;
+  spawnLock = new Promise<void>((r) => (release = r));
+  await prior;
+  try {
+    return await fn();
+  } finally {
+    release();
+  }
+}
 
 /** A tmux launcher seam — real impl spawns tmux; tests inject a recorder. */
 export interface TmuxLauncher {
@@ -194,13 +228,26 @@ export function buildAgentClaudeArgs(opts: {
  * Spawn a sandboxed agent session from a spec. Idempotent: an existing tmux
  * session is a no-op (returns `alreadyRunning: true`).
  *
- * Order: mint per-resource tokens → write MCP config → build claude argv →
- * sandbox-wrap → tmux launch with scrubbed env.
+ * Order: validate name → mint per-resource tokens → write MCP config → build
+ * claude argv → sandbox-wrap → tmux launch with scrubbed env.
+ *
+ * **Concurrency-safe.** The sandbox-runtime singleton's initialize→wrap window is
+ * serialized process-wide (see `withSpawnLock`), so concurrent `spawnAgent` calls
+ * don't clobber each other's sandbox config. Each produces an independent MCP
+ * config + wrapped argv; the spawned processes then run independently.
  */
 export async function spawnAgent(
   spec: AgentSpec,
   deps: SpawnAgentDeps,
 ): Promise<SpawnAgentResult> {
+  // SECURITY: the name lands UNESCAPED in a tmux `-t` target and a path segment;
+  // reject anything that isn't a strict slug BEFORE any fs/tmux side effect.
+  if (!AGENT_NAME_SLUG.test(spec.name)) {
+    throw new Error(
+      `spawnAgent: spec name "${spec.name}" must be a slug (alphanumeric, dash, underscore only)`,
+    );
+  }
+
   const session = sessionName(spec.name);
   const workspace = sessionWorkspace(deps.sessionsDir, spec.name);
 
@@ -230,9 +277,12 @@ export async function spawnAgent(
   //    session with a credential the manager couldn't actually grant (§4.3).
   const tokens: Record<string, MintResult> = {};
   const channelEntries: ChannelMcpEntry[] = [];
-  for (const channel of spec.channels) {
+  for (const rawChannel of spec.channels) {
+    const { name: channel, access } = normalizeChannel(rawChannel);
+    // A read-only channel mints `channel:read` only — the arm is woken + reads
+    // but cannot reply; a write channel mints `channel:read channel:write`.
     const minted = await mintScopedToken(
-      { scope: channelScope({ write: true }), audience: "channel" },
+      { scope: channelScope({ write: access === "write" }), audience: "channel" },
       mintDeps,
     );
     tokens[channel] = minted;
@@ -280,11 +330,13 @@ export async function spawnAgent(
   });
   mkdirSync(workspace, { recursive: true });
   const mcpConfigPath = join(workspace, ".mcp.json");
+  // `mode: 0o600` on the write is sufficient here — the file is always newly
+  // created per-launch under the per-session workspace, so there's no pre-existing
+  // looser-perms file to tighten (unlike registry.ts's read-modify-write).
   writeFileSync(mcpConfigPath, mcpConfigJson, { mode: 0o600 });
-  chmodSync(mcpConfigPath, 0o600);
 
   // 3. Build the claude argv, sandbox-wrap it, launch in tmux with scrubbed env.
-  const firstChannel = spec.channels[0]!;
+  const firstChannel = normalizeChannel(spec.channels[0]!).name;
   const claudeArgs = buildAgentClaudeArgs({
     mcpConfigPath,
     firstChannelEntryKey: `channel-${firstChannel}`,
@@ -300,14 +352,19 @@ export async function spawnAgent(
     ...(deps.vaultUrl ? { vaultOrigin: deps.vaultUrl } : {}),
   };
 
+  // Serialize the sandbox-runtime singleton's initialize→wrap window across
+  // concurrent spawns (the policy is baked into the argv at wrap, so only this
+  // window races). Outside the lock the spawned process runs independently.
   const sandbox = new Sandbox(deps.sandboxEngine);
-  const wrapped = await sandbox.wrap({
-    spec,
-    baseBinds,
-    egressBase,
-    command: shellJoin(claudeArgs),
-    ...(deps.ripgrep ? { ripgrep: deps.ripgrep } : {}),
-  });
+  const wrapped = await withSpawnLock(() =>
+    sandbox.wrap({
+      spec,
+      baseBinds,
+      egressBase,
+      command: shellJoin(claudeArgs),
+      ...(deps.ripgrep ? { ripgrep: deps.ripgrep } : {}),
+    }),
+  );
 
   // Layer the scrubbed agent env UNDER the sandbox wrapper's env (proxy vars,
   // sandbox markers from the engine win on conflict; CLAUDE_CODE_OAUTH_TOKEN +
@@ -360,6 +417,10 @@ function shellQuote(arg: string): string {
 export function realTmuxLauncher(spawnFn: typeof Bun.spawn = Bun.spawn): TmuxLauncher {
   return {
     async hasSession(name: string): Promise<boolean> {
+      // Read-only existence probe — it inherits the parent's full env, which is
+      // fine and intentional: it only checks whether a session exists and starts
+      // no child process. The scrubbed-env discipline applies to `newSession`
+      // (which actually launches the agent), not to this side-effect-free query.
       const proc = spawnFn(["tmux", "has-session", "-t", name], {
         stdout: "ignore",
         stderr: "ignore",

--- a/src/spawn-agent.ts
+++ b/src/spawn-agent.ts
@@ -1,0 +1,399 @@
+/**
+ * Spawn/scope command — graduate `scripts/launch-session.sh` into a real module
+ * (design §4). Given an agent spec:
+ *
+ *   1. Mint one scoped token PER resource via the hub mint API (attenuated to the
+ *      manager's own bearer): `channel:read[+write]` per channel, `vault:<name>:<verb>`
+ *      (optionally tag-scoped) for the vault — one token per `aud` (§4.2 step 1, §4.3).
+ *   2. Build the multi-entry strict MCP config from those tokens (§4.2 step 2).
+ *   3. Launch `claude` WRAPPED BY THE SANDBOX in a tmux session, with a scrubbed
+ *      env: inject the per-channel OAuth credential as `CLAUDE_CODE_OAUTH_TOKEN`,
+ *      and NEVER set `ANTHROPIC_API_KEY` (which would silently route the session
+ *      onto API billing, §6). `--strict-mcp-config` closes the MCP surface to
+ *      exactly the spec.
+ *
+ * The credential injected here is a passed-in param/placeholder for THIS stream;
+ * Stream 3 builds the real per-channel secret store (design §6, §4.1 credentialRef).
+ *
+ * Env-scrubbing follows runner's `buildChildEnv` instinct
+ * (`parachute-runner/src/spawn.ts`): pass only what claude needs, drop everything
+ * else — but UNLIKE runner, we deliberately do NOT pass `ANTHROPIC_API_KEY`
+ * through (runner is the API-key path; the channel session is the interactive
+ * subscription path).
+ */
+
+import { writeFileSync, mkdirSync, chmodSync } from "node:fs";
+import { join } from "node:path";
+import type { AgentSpec, BaseBinds } from "./sandbox/types.ts";
+import { Sandbox, type SandboxEngine, type WrappedCommand } from "./sandbox/index.ts";
+import type { EgressBaseInput } from "./sandbox/egress.ts";
+import {
+  buildAgentMcpConfigJson,
+  type ChannelMcpEntry,
+  type VaultMcpEntry,
+  type OtherMcpEntry,
+} from "./agent-mcp-config.ts";
+import {
+  mintScopedToken,
+  channelScope,
+  vaultScope,
+  type MintTokenDeps,
+  type MintResult,
+} from "./mint-token.ts";
+
+/** A tmux launcher seam — real impl spawns tmux; tests inject a recorder. */
+export interface TmuxLauncher {
+  /**
+   * Create a detached tmux session `name` that runs `argv` with `env` from `cwd`.
+   * Returns the spawned argv (for assertion). Must not block on the session.
+   */
+  newSession(opts: {
+    name: string;
+    argv: string[];
+    env: Record<string, string | undefined>;
+    cwd: string;
+  }): Promise<void>;
+  /** Whether a session by this name already exists (idempotency). */
+  hasSession(name: string): Promise<boolean>;
+}
+
+export interface SpawnAgentDeps {
+  /** Hub origin + manager bearer for minting (§4.3). */
+  hubOrigin: string;
+  managerBearer: string;
+  /** Daemon base URL the channel MCP endpoints live under. */
+  channelUrl: string;
+  /** Vault base URL (if the spec binds a vault). Defaults to hubOrigin. */
+  vaultUrl?: string;
+  /** Base for session workspaces (e.g. `~/.parachute/channel/sessions`). */
+  sessionsDir: string;
+  /**
+   * Read-only runtime/config binds the sandbox always grants (the claude config
+   * dir, etc.). Workspace is derived per-session under `sessionsDir`.
+   */
+  runtimeReadOnly: string[];
+  /**
+   * The Claude credential to inject as `CLAUDE_CODE_OAUTH_TOKEN`. For THIS stream
+   * a passed-in param/placeholder; Stream 3 resolves it from the per-channel
+   * secret store keyed by `spec.credentialRef`.
+   */
+  claudeOauthToken: string;
+  /** Sandbox engine override (tests inject a fake). */
+  sandboxEngine?: SandboxEngine;
+  /** tmux launcher (tests inject a recorder). */
+  tmux: TmuxLauncher;
+  /** fetch override for the mint client (tests). */
+  fetchFn?: typeof fetch;
+  /** Parent env to scrub from. Defaults to process.env. */
+  parentEnv?: Record<string, string | undefined>;
+  /** claude binary. Defaults to "claude" (resolved by the shell at run, not us). */
+  claudeBin?: string;
+  /**
+   * Optional ripgrep override threaded to the sandbox (macOS deny-path scan needs
+   * a real `rg` binary; pass one when the host has none on PATH).
+   */
+  ripgrep?: { command: string; args?: string[] };
+}
+
+export interface SpawnAgentResult {
+  /** tmux session name (`<spec.name>-agent`). */
+  session: string;
+  /** Per-session workspace dir. */
+  workspace: string;
+  /** The minted tokens, by resource key (channel name / `vault:<name>` / mcp name). */
+  tokens: Record<string, MintResult>;
+  /** The inline MCP config JSON written for the session. */
+  mcpConfigJson: string;
+  /** The sandbox-wrapped argv + env + config the session was launched with. */
+  wrapped: WrappedCommand;
+  /** Already-running? (idempotent no-op). */
+  alreadyRunning: boolean;
+}
+
+/** tmux session name for a spec — matches launch-session.sh's `<name>-agent`. */
+export function sessionName(specName: string): string {
+  return `${specName}-agent`;
+}
+
+/** Per-session workspace dir under the sessions base. */
+export function sessionWorkspace(sessionsDir: string, specName: string): string {
+  return join(sessionsDir, specName);
+}
+
+/**
+ * Build the scrubbed child env for the sandboxed claude. Mirrors runner's
+ * passthrough allowlist MINUS `ANTHROPIC_API_KEY` (and the `ANTHROPIC_*`/`CLAUDE_*`
+ * wildcards, which would re-admit it) — the channel session runs on the
+ * interactive subscription, so an API key must never leak in (§6). The injected
+ * `CLAUDE_CODE_OAUTH_TOKEN` is the session's auth.
+ *
+ * The sandbox engine's own env (proxy vars, sandbox markers) is layered on TOP of
+ * this by the wrap step; this is the base the wrapper extends.
+ */
+export function buildAgentChildEnv(
+  parentEnv: Record<string, string | undefined>,
+  claudeOauthToken: string,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  // Fundamentals + locale, like runner — but NOT ANTHROPIC_API_KEY / CLAUDE_API_KEY.
+  const passthrough = [
+    "PATH",
+    "HOME",
+    "USER",
+    "LOGNAME",
+    "SHELL",
+    "TERM",
+    "LANG",
+    "TZ",
+    "CLAUDE_CONFIG_DIR",
+    "XDG_CONFIG_HOME",
+    "XDG_DATA_HOME",
+    "XDG_CACHE_HOME",
+    "XDG_RUNTIME_DIR",
+  ];
+  for (const k of passthrough) {
+    const v = parentEnv[k];
+    if (typeof v === "string" && v.length > 0) out[k] = v;
+  }
+  // Pass through LC_* locale vars only. Deliberately NOT the broad ANTHROPIC_*/
+  // CLAUDE_* wildcards runner uses — those would re-admit ANTHROPIC_API_KEY and
+  // route the session onto metered API billing instead of the subscription.
+  for (const [k, v] of Object.entries(parentEnv)) {
+    if (typeof v === "string" && v.length > 0 && k.startsWith("LC_")) out[k] = v;
+  }
+  if (!out.PATH) out.PATH = "/usr/local/bin:/usr/bin:/bin";
+
+  // The interactive subscription credential (design §6). Explicitly the ONLY
+  // Claude auth var set; ANTHROPIC_API_KEY is intentionally absent.
+  out.CLAUDE_CODE_OAUTH_TOKEN = claudeOauthToken;
+  return out;
+}
+
+/**
+ * Build the `claude` invocation argv (pre-sandbox-wrap). Interactive `claude`
+ * (NOT `claude -p` — the session runs on the subscription, §1/§6) with the
+ * strict, multi-entry MCP config and the dev-channels flag for the first channel
+ * (the wake transport). `--strict-mcp-config` closes the MCP surface to the spec.
+ */
+export function buildAgentClaudeArgs(opts: {
+  mcpConfigPath: string;
+  firstChannelEntryKey: string;
+  claudeBin?: string;
+}): string[] {
+  const bin = opts.claudeBin ?? "claude";
+  return [
+    bin,
+    "--strict-mcp-config",
+    "--mcp-config",
+    opts.mcpConfigPath,
+    `--dangerously-load-development-channels=server:${opts.firstChannelEntryKey}`,
+  ];
+}
+
+/**
+ * Spawn a sandboxed agent session from a spec. Idempotent: an existing tmux
+ * session is a no-op (returns `alreadyRunning: true`).
+ *
+ * Order: mint per-resource tokens → write MCP config → build claude argv →
+ * sandbox-wrap → tmux launch with scrubbed env.
+ */
+export async function spawnAgent(
+  spec: AgentSpec,
+  deps: SpawnAgentDeps,
+): Promise<SpawnAgentResult> {
+  const session = sessionName(spec.name);
+  const workspace = sessionWorkspace(deps.sessionsDir, spec.name);
+
+  if (await deps.tmux.hasSession(session)) {
+    return {
+      session,
+      workspace,
+      tokens: {},
+      mcpConfigJson: "",
+      wrapped: { argv: [], env: {}, config: { network: { allowedDomains: [], deniedDomains: [] }, filesystem: { denyRead: [], allowWrite: [], denyWrite: [] } } },
+      alreadyRunning: true,
+    };
+  }
+
+  if (spec.channels.length === 0) {
+    throw new Error(`spawnAgent: spec "${spec.name}" declares no channels`);
+  }
+
+  const mintDeps: MintTokenDeps = {
+    hubOrigin: deps.hubOrigin,
+    managerBearer: deps.managerBearer,
+    ...(deps.fetchFn ? { fetchFn: deps.fetchFn } : {}),
+  };
+
+  // 1. Mint one token per resource (one aud each, attenuated). Any over-broad or
+  //    unauthorized scope fails here (the hub's canGrant), so we never launch a
+  //    session with a credential the manager couldn't actually grant (§4.3).
+  const tokens: Record<string, MintResult> = {};
+  const channelEntries: ChannelMcpEntry[] = [];
+  for (const channel of spec.channels) {
+    const minted = await mintScopedToken(
+      { scope: channelScope({ write: true }), audience: "channel" },
+      mintDeps,
+    );
+    tokens[channel] = minted;
+    channelEntries.push({ channel, token: minted.token });
+  }
+
+  let vaultArg: { url: string; entry: VaultMcpEntry } | undefined;
+  if (spec.vault) {
+    const v = spec.vault;
+    const minted = await mintScopedToken(
+      {
+        scope: vaultScope(v.name, v.access),
+        audience: `vault.${v.name}`,
+        ...(v.tags && v.tags.length > 0 ? { permissions: { scoped_tags: v.tags } } : {}),
+      },
+      mintDeps,
+    );
+    tokens[`vault:${v.name}`] = minted;
+    vaultArg = {
+      url: deps.vaultUrl ?? deps.hubOrigin,
+      entry: { name: v.name, token: minted.token },
+    };
+  }
+
+  const otherEntries: OtherMcpEntry[] = [];
+  for (const o of spec.otherMcps ?? []) {
+    let token: string | undefined;
+    if (o.scope) {
+      const minted = await mintScopedToken(
+        { scope: o.scope, ...(o.audience ? { audience: o.audience } : {}) },
+        mintDeps,
+      );
+      tokens[o.name] = minted;
+      token = minted.token;
+    }
+    otherEntries.push({ name: o.name, url: o.url, ...(token ? { token } : {}) });
+  }
+
+  // 2. Build the multi-entry strict MCP config + write it 0600 (it inlines tokens).
+  const mcpConfigJson = buildAgentMcpConfigJson({
+    channelUrl: deps.channelUrl,
+    channels: channelEntries,
+    ...(vaultArg ? { vault: vaultArg } : {}),
+    ...(otherEntries.length > 0 ? { otherMcps: otherEntries } : {}),
+  });
+  mkdirSync(workspace, { recursive: true });
+  const mcpConfigPath = join(workspace, ".mcp.json");
+  writeFileSync(mcpConfigPath, mcpConfigJson, { mode: 0o600 });
+  chmodSync(mcpConfigPath, 0o600);
+
+  // 3. Build the claude argv, sandbox-wrap it, launch in tmux with scrubbed env.
+  const firstChannel = spec.channels[0]!;
+  const claudeArgs = buildAgentClaudeArgs({
+    mcpConfigPath,
+    firstChannelEntryKey: `channel-${firstChannel}`,
+    ...(deps.claudeBin ? { claudeBin: deps.claudeBin } : {}),
+  });
+
+  const baseBinds: BaseBinds = {
+    workspace,
+    runtimeReadOnly: deps.runtimeReadOnly,
+  };
+  const egressBase: EgressBaseInput = {
+    hubOrigin: deps.hubOrigin,
+    ...(deps.vaultUrl ? { vaultOrigin: deps.vaultUrl } : {}),
+  };
+
+  const sandbox = new Sandbox(deps.sandboxEngine);
+  const wrapped = await sandbox.wrap({
+    spec,
+    baseBinds,
+    egressBase,
+    command: shellJoin(claudeArgs),
+    ...(deps.ripgrep ? { ripgrep: deps.ripgrep } : {}),
+  });
+
+  // Layer the scrubbed agent env UNDER the sandbox wrapper's env (proxy vars,
+  // sandbox markers from the engine win on conflict; CLAUDE_CODE_OAUTH_TOKEN +
+  // the passthrough fundamentals come from us). ANTHROPIC_API_KEY is absent.
+  const childEnv = buildAgentChildEnv(deps.parentEnv ?? process.env, deps.claudeOauthToken);
+  const launchEnv: Record<string, string | undefined> = { ...childEnv, ...wrapped.env };
+
+  await deps.tmux.newSession({
+    name: session,
+    argv: wrapped.argv,
+    env: launchEnv,
+    cwd: workspace,
+  });
+
+  return {
+    session,
+    workspace,
+    tokens,
+    mcpConfigJson,
+    wrapped,
+    alreadyRunning: false,
+  };
+}
+
+/**
+ * Minimal POSIX shell-quote for joining argv into the single command string the
+ * sandbox engine wraps (`wrapWithSandboxArgv` takes a command string). Quotes any
+ * arg containing shell-significant chars; safe for the controlled argv we build
+ * (claude bin, flags, a workspace-local config path).
+ */
+export function shellJoin(argv: string[]): string {
+  return argv.map(shellQuote).join(" ");
+}
+
+function shellQuote(arg: string): string {
+  if (arg.length > 0 && /^[A-Za-z0-9_@%+=:,./-]+$/.test(arg)) return arg;
+  // Single-quote, escaping embedded single quotes the POSIX way.
+  return `'${arg.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * The real tmux launcher — `tmux new-session -d` running the sandboxed argv. The
+ * env is applied via `tmux new-session`'s `-e KEY=VAL` (tmux ≥3.0) so the child
+ * inherits exactly the launch env (scrubbed agent env + sandbox proxy vars), not
+ * the operator's shell env. `argv` is the sandbox wrapper's argv (already
+ * `["/bin/bash","-c", "<env … sandbox-exec … claude …>"]` on macOS), so tmux
+ * runs it directly. Injected here (not used by tests, which use a recorder) so
+ * the module is a real command, not just a planner.
+ */
+export function realTmuxLauncher(spawnFn: typeof Bun.spawn = Bun.spawn): TmuxLauncher {
+  return {
+    async hasSession(name: string): Promise<boolean> {
+      const proc = spawnFn(["tmux", "has-session", "-t", name], {
+        stdout: "ignore",
+        stderr: "ignore",
+      });
+      const code = await proc.exited;
+      return code === 0;
+    },
+    async newSession(opts): Promise<void> {
+      const envArgs: string[] = [];
+      for (const [k, v] of Object.entries(opts.env)) {
+        if (typeof v === "string") envArgs.push("-e", `${k}=${v}`);
+      }
+      const argv = [
+        "tmux",
+        "new-session",
+        "-d",
+        "-s",
+        opts.name,
+        "-c",
+        opts.cwd,
+        "-x",
+        "220",
+        "-y",
+        "50",
+        ...envArgs,
+        "--",
+        ...opts.argv,
+      ];
+      const proc = spawnFn(argv, { stdout: "pipe", stderr: "pipe" });
+      const code = await proc.exited;
+      if (code !== 0) {
+        const err = await new Response(proc.stderr as ReadableStream<Uint8Array>).text();
+        throw new Error(`tmux new-session failed (exit ${code}): ${err.trim()}`);
+      }
+    },
+  };
+}

--- a/src/spawn-agent.ts
+++ b/src/spawn-agent.ts
@@ -12,8 +12,11 @@
  *      onto API billing, §6). `--strict-mcp-config` closes the MCP surface to
  *      exactly the spec.
  *
- * The credential injected here is a passed-in param/placeholder for THIS stream;
- * Stream 3 builds the real per-channel secret store (design §6, §4.1 credentialRef).
+ * The credential is resolved at launch from the per-channel secret store
+ * (`credentials.ts`, design §6): the spec's wake channel's per-channel override,
+ * falling back to the default/operator token, erroring when neither is set. The
+ * resolver is injectable (`deps.resolveClaudeToken`) so tests run hermetically
+ * without touching a real store.
  *
  * Env-scrubbing follows runner's `buildChildEnv` instinct
  * (`parachute-runner/src/spawn.ts`): pass only what claude needs, drop everything
@@ -41,6 +44,7 @@ import {
   type MintTokenDeps,
   type MintResult,
 } from "./mint-token.ts";
+import { resolveClaudeCredential } from "./credentials.ts";
 
 /**
  * Slug guard for `spec.name`. The name is used UNESCAPED as a tmux session
@@ -107,11 +111,15 @@ export interface SpawnAgentDeps {
    */
   runtimeReadOnly: string[];
   /**
-   * The Claude credential to inject as `CLAUDE_CODE_OAUTH_TOKEN`. For THIS stream
-   * a passed-in param/placeholder; Stream 3 resolves it from the per-channel
-   * secret store keyed by `spec.credentialRef`.
+   * Resolve the Claude OAuth token to inject as `CLAUDE_CODE_OAUTH_TOKEN`, given
+   * the spec's wake channel. Defaults to the real per-channel secret store
+   * (`credentials.ts` — channel override ?? default/operator ?? throw). Tests
+   * inject a stub so they never read a real store. The store throws
+   * `CredentialNotConfiguredError` when neither an override nor a default is set,
+   * which aborts the launch BEFORE any tmux session is created (no session ever
+   * runs without auth).
    */
-  claudeOauthToken: string;
+  resolveClaudeToken?: (channel: string) => string;
   /** Sandbox engine override (tests inject a fake). */
   sandboxEngine?: SandboxEngine;
   /** tmux launcher (tests inject a recorder). */
@@ -266,6 +274,16 @@ export async function spawnAgent(
     throw new Error(`spawnAgent: spec "${spec.name}" declares no channels`);
   }
 
+  // Resolve the Claude OAuth credential from the per-channel store keyed on the
+  // wake channel (the first channel — the one whose dev-channel flag the session
+  // launches under). A missing credential throws here (CredentialNotConfigured),
+  // BEFORE any mint or fs/tmux side effect, so a session never launches without
+  // auth. The token is read at spawn time so a rotate via the config API takes
+  // effect on the next spawn without a daemon restart.
+  const wakeChannel = normalizeChannel(spec.channels[0]!).name;
+  const resolveToken = deps.resolveClaudeToken ?? ((ch: string) => resolveClaudeCredential(ch));
+  const claudeOauthToken = resolveToken(wakeChannel);
+
   const mintDeps: MintTokenDeps = {
     hubOrigin: deps.hubOrigin,
     managerBearer: deps.managerBearer,
@@ -336,10 +354,11 @@ export async function spawnAgent(
   writeFileSync(mcpConfigPath, mcpConfigJson, { mode: 0o600 });
 
   // 3. Build the claude argv, sandbox-wrap it, launch in tmux with scrubbed env.
-  const firstChannel = normalizeChannel(spec.channels[0]!).name;
+  // `wakeChannel` (resolved above) is the first channel — the dev-channel flag's
+  // server name + the key the credential was resolved under.
   const claudeArgs = buildAgentClaudeArgs({
     mcpConfigPath,
-    firstChannelEntryKey: `channel-${firstChannel}`,
+    firstChannelEntryKey: `channel-${wakeChannel}`,
     ...(deps.claudeBin ? { claudeBin: deps.claudeBin } : {}),
   });
 
@@ -369,7 +388,7 @@ export async function spawnAgent(
   // Layer the scrubbed agent env UNDER the sandbox wrapper's env (proxy vars,
   // sandbox markers from the engine win on conflict; CLAUDE_CODE_OAUTH_TOKEN +
   // the passthrough fundamentals come from us). ANTHROPIC_API_KEY is absent.
-  const childEnv = buildAgentChildEnv(deps.parentEnv ?? process.env, deps.claudeOauthToken);
+  const childEnv = buildAgentChildEnv(deps.parentEnv ?? process.env, claudeOauthToken);
   const launchEnv: Record<string, string | undefined> = { ...childEnv, ...wrapped.env };
 
   await deps.tmux.newSession({

--- a/src/spawn-agent.ts
+++ b/src/spawn-agent.ts
@@ -22,7 +22,7 @@
  * subscription path).
  */
 
-import { writeFileSync, mkdirSync } from "node:fs";
+import { writeFileSync, mkdirSync, chmodSync } from "node:fs";
 import { join } from "node:path";
 import type { AgentSpec, BaseBinds } from "./sandbox/types.ts";
 import { normalizeChannel } from "./sandbox/types.ts";
@@ -406,13 +406,63 @@ function shellQuote(arg: string): string {
 }
 
 /**
- * The real tmux launcher — `tmux new-session -d` running the sandboxed argv. The
- * env is applied via `tmux new-session`'s `-e KEY=VAL` (tmux ≥3.0) so the child
- * inherits exactly the launch env (scrubbed agent env + sandbox proxy vars), not
- * the operator's shell env. `argv` is the sandbox wrapper's argv (already
- * `["/bin/bash","-c", "<env … sandbox-exec … claude …>"]` on macOS), so tmux
- * runs it directly. Injected here (not used by tests, which use a recorder) so
- * the module is a real command, not just a planner.
+ * Build the per-session **launch script** body for an already-sandbox-wrapped argv.
+ *
+ * Why a script and not inline argv: on macOS `wrapWithSandboxArgv` returns
+ * `["/bin/bash","-c","<command embedding the ~84 KB Seatbelt -p profile inline>"]`.
+ * Passing that ~84 KB string as a tmux argument exceeds tmux's per-argument /
+ * command buffer, so `tmux new-session -- /bin/bash -c <84KB>` fails. Instead we
+ * write the wrapped command to a file and have tmux run only the short
+ * `/bin/bash <script-path>` argv — the 84 KB profile lives in the file, never on
+ * the tmux command line.
+ *
+ * Two argv shapes are handled generally:
+ *  - macOS Seatbelt: `["/bin/bash","-c", cmd]` → the script body IS `cmd` (it
+ *    already embeds the sandbox-exec invocation + the claude command).
+ *  - General argv (e.g. Linux bubblewrap `["bwrap", ...args, "claude", ...]`) →
+ *    the body `exec`s the argv with POSIX quoting (reusing `shellJoin`).
+ *
+ * The injected secret (CLAUDE_CODE_OAUTH_TOKEN) is passed via the environment by
+ * `newSession` (`-e KEY=VAL`), NOT written into the script — so the launch script
+ * body is token-free.
+ */
+export function buildLaunchScript(argv: string[]): string {
+  const header = "#!/bin/bash\nset -euo pipefail\n";
+  // The canonical macOS shape: `/bin/bash -c "<cmd>"`. The command string already
+  // is a complete shell program (it embeds the sandbox-exec call and the claude
+  // invocation), so the script body is exactly that command.
+  if (argv.length === 3 && argv[0] === "/bin/bash" && argv[1] === "-c") {
+    return `${header}${argv[2]}\n`;
+  }
+  // General argv: exec it directly with proper quoting so a giant arg (or many
+  // args) stays in the file, not on the tmux command line. `exec` so the wrapped
+  // process replaces this shell (no extra PID, signals reach claude directly).
+  return `${header}exec ${shellJoin(argv)}\n`;
+}
+
+/** Per-session launch-script path under the session workspace (`cwd`). */
+function launchScriptPath(cwd: string): string {
+  return join(cwd, ".launch.sh");
+}
+
+/**
+ * The real tmux launcher — `tmux new-session -d` running the sandboxed argv via a
+ * per-session **launch script**. The env is applied via `tmux new-session`'s
+ * `-e KEY=VAL` (tmux ≥3.0) so the child inherits exactly the launch env (scrubbed
+ * agent env + sandbox proxy vars), not the operator's shell env.
+ *
+ * `argv` is the sandbox wrapper's argv (on macOS already
+ * `["/bin/bash","-c", "<sandbox-exec … claude …>"]` where the command embeds the
+ * ~84 KB Seatbelt `-p` profile inline). That string is far too large to pass as a
+ * tmux argument — `tmux new-session -- /bin/bash -c <84KB>` overruns tmux's
+ * command buffer and fails. So we write the wrapped command to a per-session
+ * launch script (`<workspace>/.launch.sh`, 0600) and hand tmux only the SHORT argv
+ * `/bin/bash <script-path>`; the 84 KB profile lives in the file, off the command
+ * line. See `buildLaunchScript` for how the two argv shapes are handled.
+ *
+ * The script carries NO secret: the OAuth credential is injected via `-e` into the
+ * env, not written into the script body. Injected here (not used by tests, which
+ * use a recorder) so the module is a real command, not just a planner.
  */
 export function realTmuxLauncher(spawnFn: typeof Bun.spawn = Bun.spawn): TmuxLauncher {
   return {
@@ -429,6 +479,17 @@ export function realTmuxLauncher(spawnFn: typeof Bun.spawn = Bun.spawn): TmuxLau
       return code === 0;
     },
     async newSession(opts): Promise<void> {
+      // Write the wrapped command to a per-session launch script so tmux receives
+      // a short argv (the ~84 KB macOS Seatbelt profile would overrun tmux's
+      // command buffer if passed inline). The script lives in the session
+      // workspace alongside .mcp.json, 0600 — it carries no secret (the OAuth
+      // token rides the env via `-e`, below).
+      const scriptPath = launchScriptPath(opts.cwd);
+      writeFileSync(scriptPath, buildLaunchScript(opts.argv), { mode: 0o600 });
+      // Defensive: guarantee 0600 even under a permissive umask (the file is
+      // freshly created per-launch, so there's no looser-perms predecessor).
+      chmodSync(scriptPath, 0o600);
+
       const envArgs: string[] = [];
       for (const [k, v] of Object.entries(opts.env)) {
         if (typeof v === "string") envArgs.push("-e", `${k}=${v}`);
@@ -447,7 +508,8 @@ export function realTmuxLauncher(spawnFn: typeof Bun.spawn = Bun.spawn): TmuxLau
         "50",
         ...envArgs,
         "--",
-        ...opts.argv,
+        "/bin/bash",
+        scriptPath,
       ];
       const proc = spawnFn(argv, { stdout: "pipe", stderr: "pipe" });
       const code = await proc.exited;

--- a/src/terminal-ui.ts
+++ b/src/terminal-ui.ts
@@ -1,0 +1,314 @@
+/**
+ * Static HTML for `/channel/terminal` — the in-page xterm.js terminal (design
+ * `design/2026-06-14-sandboxed-agent-sessions.md` §5).
+ *
+ * Single self-contained document: HTML + inline CSS + inline JS, no build step
+ * (same shape as `daemon.ts`'s chat UI + `admin-ui.ts`). xterm.js + the fit
+ * addon load from a pinned CDN — there's no bundler in this repo, and the
+ * existing UIs are all hand-written HTML strings, so a CDN import is the
+ * minimal, in-pattern way to ship xterm without adding a build step.
+ *
+ * What the page does:
+ *   1. Fetch the channel list (`<mount>/.parachute/config`) → a picker.
+ *   2. Fetch a hub-minted `channel:admin` Bearer (`<origin>/admin/channel-token`,
+ *      cookie-gated — the SAME token the chat + admin UIs use; the terminal is
+ *      operator-gated, so the operator's token is exactly what's needed).
+ *   3. Open a WebSocket to `<mount>/terminal/<channel>?token=…&cols=…&rows=…`
+ *      (the token rides as `?token=` — a browser can't set Authorization on
+ *      `new WebSocket()`). The daemon's upgrade gate validates channel:admin
+ *      BEFORE upgrading.
+ *   4. Relay xterm ↔ WS: xterm `onData` (keystrokes) → BINARY frames; pty output
+ *      (BINARY frames) → `term.write`; xterm `onResize` → a JSON control frame
+ *      `{type:"resize",cols,rows}`.
+ *   5. Reconnect: because the backend attaches to TMUX (not a raw pty), a dropped
+ *      socket just re-attaches to the live session with scrollback intact.
+ *
+ * Flow control (browser half of the §5.4 backpressure design): xterm's
+ * `FlowControl`-style high-watermark — we count bytes written to xterm and, past
+ * a watermark, the backend's own `getBufferedAmount` throttle is the primary
+ * guard; the browser side keeps the renderer from falling so far behind it
+ * stalls. The load-bearing flow control is server-side (terminal.ts); this is
+ * the cooperative browser half.
+ */
+
+// Pinned xterm.js + fit addon (CDN, no build step). Versions pinned for
+// reproducibility; SRI omitted to keep the single-file page simple (the page is
+// operator-only, same-origin behind the hub). xterm 5.x is the current line.
+const XTERM_VERSION = "5.3.0";
+const XTERM_FIT_VERSION = "0.10.0";
+
+export const TERMINAL_UI_HTML = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="referrer" content="no-referrer" />
+<title>parachute-channel · terminal</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@${XTERM_VERSION}/css/xterm.min.css" />
+<style>
+  :root {
+    --bg: #0f1115; --panel: #171a21; --line: #262b36; --fg: #e6e9ef;
+    --muted: #8b93a3; --accent: #4cc2a0; --danger: #e0796b;
+  }
+  * { box-sizing: border-box; }
+  html, body { height: 100%; margin: 0; }
+  body {
+    background: var(--bg); color: var(--fg);
+    font: 14px/1.5 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    display: flex; flex-direction: column; height: 100vh;
+  }
+  header {
+    display: flex; align-items: center; gap: 12px;
+    padding: 10px 16px; border-bottom: 1px solid var(--line); background: var(--panel);
+    flex: 0 0 auto;
+  }
+  header .brand { font-weight: 600; }
+  header .brand small { color: var(--muted); font-weight: 400; }
+  header select {
+    background: var(--bg); color: var(--fg);
+    border: 1px solid var(--line); border-radius: 6px; padding: 6px 10px; font: inherit;
+  }
+  header .spacer { margin-left: auto; }
+  #status { font-size: 12px; color: var(--muted); }
+  #status.live { color: var(--accent); }
+  #status.err { color: var(--danger); }
+  button {
+    background: var(--bg); color: var(--fg); border: 1px solid var(--line);
+    border-radius: 6px; padding: 6px 12px; font: inherit; cursor: pointer;
+  }
+  button:hover { border-color: var(--muted); }
+  button:disabled { opacity: .4; cursor: default; }
+  #term-wrap {
+    flex: 1 1 auto; min-height: 0; padding: 8px; background: #000;
+  }
+  #term { width: 100%; height: 100%; }
+  .notice {
+    padding: 8px 16px; font-size: 13px; color: var(--muted);
+    border-bottom: 1px solid var(--line); background: var(--panel);
+  }
+  .notice.err { color: var(--danger); }
+  .notice code { color: var(--fg); }
+</style>
+</head>
+<body>
+  <header>
+    <div class="brand">parachute-channel <small>· terminal</small></div>
+    <select id="channel" title="channel"></select>
+    <button id="reconnect" type="button" title="Re-attach to the tmux session">Reconnect</button>
+    <span class="spacer"></span>
+    <span id="status">connecting…</span>
+  </header>
+  <div id="notice" class="notice" hidden></div>
+  <div id="term-wrap"><div id="term"></div></div>
+
+  <script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@${XTERM_VERSION}/lib/xterm.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@${XTERM_FIT_VERSION}/lib/addon-fit.min.js"></script>
+<script>
+(function () {
+  var sel = document.getElementById("channel");
+  var statusEl = document.getElementById("status");
+  var noticeEl = document.getElementById("notice");
+  var reconnectBtn = document.getElementById("reconnect");
+  var termHost = document.getElementById("term");
+
+  // Served through the hub the page is /channel/terminal; locally it's
+  // /terminal. Derive the mount prefix so the WS + token URLs resolve under the
+  // same prefix (same shape as the chat UI's MOUNT).
+  var MOUNT = location.pathname.replace(/\\/terminal(\\/[^/]*)?\\/?$/, "");
+
+  if (typeof window.Terminal !== "function") {
+    showNotice("xterm.js failed to load (CDN blocked?). The terminal needs it. " +
+      "You can always attach on the host: <code>tmux attach -t &lt;channel&gt;-agent</code>.", true);
+    setStatus("xterm unavailable", "err");
+    return;
+  }
+
+  // --- xterm setup --------------------------------------------------------
+  var term = new window.Terminal({
+    cursorBlink: true,
+    fontFamily: 'ui-monospace, "SF Mono", Menlo, Monaco, "Cascadia Mono", monospace',
+    fontSize: 13,
+    scrollback: 5000,
+    theme: { background: "#000000", foreground: "#e6e9ef" },
+    // Cooperative flow control: xterm acks after writing; combined with the
+    // backend's getBufferedAmount throttle (terminal.ts §5.4) this keeps the
+    // renderer from stalling under a flood.
+    convertEol: false,
+  });
+  var fit = null;
+  try {
+    fit = new window.FitAddon.FitAddon();
+    term.loadAddon(fit);
+  } catch (_e) { fit = null; }
+  term.open(termHost);
+  doFit();
+
+  var ws = null;
+  var manualClose = false;
+  var reconnectTimer = null;
+  var enc = new TextEncoder();
+
+  function setStatus(text, cls) {
+    statusEl.textContent = text;
+    statusEl.className = cls || "";
+  }
+  function showNotice(html, isErr) {
+    noticeEl.innerHTML = html;
+    noticeEl.className = "notice" + (isErr ? " err" : "");
+    noticeEl.hidden = false;
+  }
+  function clearNotice() { noticeEl.hidden = true; noticeEl.innerHTML = ""; }
+
+  function currentChannel() { return sel.value; }
+
+  function doFit() {
+    if (!fit) return;
+    try { fit.fit(); } catch (_e) {}
+  }
+
+  // --- token (operator channel:admin, minted by the hub) ------------------
+  // The terminal WS is operator-gated on channel:admin. The hub mints that for
+  // the logged-in operator at <origin>/admin/channel-token (cookie-gated) — the
+  // same endpoint the chat + admin UIs use. We fetch it from the page origin
+  // (which IS the hub origin when served through the expose) and pass it as
+  // ?token= on the WebSocket URL (a browser can't set Authorization on
+  // new WebSocket()).
+  window.__token = null;
+  function fetchToken() {
+    return fetch(window.location.origin + "/admin/channel-token", { credentials: "include" })
+      .then(function (r) { if (!r.ok) throw new Error("token " + r.status); return r.json(); })
+      .then(function (j) { window.__token = (j && j.token) ? j.token : null; return window.__token; })
+      .catch(function (err) {
+        window.__token = null;
+        showNotice("Not authenticated — open this page through the hub portal, signed in " +
+          "as the operator. The terminal needs a <code>channel:admin</code> token (" + err + ").", true);
+        return null;
+      });
+  }
+
+  // --- WebSocket relay ----------------------------------------------------
+  function wsUrl(ch) {
+    var proto = location.protocol === "https:" ? "wss:" : "ws:";
+    var dims = "cols=" + term.cols + "&rows=" + term.rows;
+    var u = proto + "//" + location.host + MOUNT + "/terminal/" + encodeURIComponent(ch) + "?" + dims;
+    if (window.__token) u += "&token=" + encodeURIComponent(window.__token);
+    return u;
+  }
+
+  function connect() {
+    var ch = currentChannel();
+    if (!ch) { setStatus("no channel"); return; }
+    if (ws) { manualClose = true; try { ws.close(); } catch (_e) {} ws = null; }
+    manualClose = false;
+    clearNotice();
+    setStatus("connecting…");
+    doFit();
+    var socket = new WebSocket(wsUrl(ch));
+    socket.binaryType = "arraybuffer";
+    ws = socket;
+
+    socket.onopen = function () {
+      setStatus("● attached · " + ch, "live");
+      // Send the current geometry immediately so the pty matches the page.
+      sendResize();
+      term.focus();
+    };
+    socket.onmessage = function (ev) {
+      // BINARY = raw pty output. (The backend only ever sends binary; a text
+      // frame would be an out-of-band notice — render it as text.)
+      if (typeof ev.data === "string") { term.write(ev.data); return; }
+      term.write(new Uint8Array(ev.data));
+    };
+    socket.onclose = function (ev) {
+      if (socket !== ws) return; // superseded by a newer connect
+      ws = null;
+      if (manualClose) return;
+      if (ev.code === 1013) {
+        // Backend closed us for being too slow (terminal.ts MAX_QUEUE_BYTES).
+        setStatus("disconnected (too slow)", "err");
+        showNotice("The terminal fell too far behind and was disconnected. Reconnecting will " +
+          "re-attach to the live session (scrollback intact via tmux).", true);
+      } else if (ev.code === 1000) {
+        setStatus("session ended");
+        showNotice("The tmux session ended (or detached). Start a session with " +
+          "<code>./scripts/launch-session.sh &lt;channel&gt; &lt;channel&gt;</code>, then Reconnect.", false);
+        return; // don't auto-reconnect a deliberately-ended session
+      } else {
+        setStatus("reconnecting…", "err");
+      }
+      scheduleReconnect();
+    };
+    socket.onerror = function () {
+      // onclose follows; status is set there. Surface a hint only if we never
+      // opened (likely auth or no tmux session).
+      if (socket.readyState === WebSocket.CLOSED || socket.readyState === WebSocket.CONNECTING) {
+        // leave reconnect/backoff to onclose
+      }
+    };
+  }
+
+  function scheduleReconnect() {
+    if (reconnectTimer) return;
+    reconnectTimer = setTimeout(function () {
+      reconnectTimer = null;
+      // Refresh the (short-lived) token before re-attaching.
+      fetchToken().then(function () { connect(); });
+    }, 1500);
+  }
+
+  // xterm input (keystrokes / paste) → BINARY frame to the pty.
+  term.onData(function (data) {
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(enc.encode(data));
+    }
+  });
+
+  // Resize → a JSON CONTROL frame (distinct from the binary input frames).
+  function sendResize() {
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({ type: "resize", cols: term.cols, rows: term.rows }));
+    }
+  }
+  term.onResize(function () { sendResize(); });
+  window.addEventListener("resize", function () { doFit(); /* onResize fires sendResize */ });
+
+  reconnectBtn.addEventListener("click", function () {
+    if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
+    fetchToken().then(function () { connect(); });
+  });
+
+  sel.addEventListener("change", function () {
+    term.reset();
+    var url = new URL(window.location.href);
+    url.searchParams.set("channel", sel.value);
+    history.replaceState(null, "", url);
+    connect();
+  });
+
+  // --- boot: list channels, then token, then connect ----------------------
+  function loadChannelsAndConnect() {
+    return fetch(MOUNT + "/.parachute/config")
+      .then(function (r) { return r.json(); })
+      .then(function (cfg) {
+        var chans = (cfg.channels || []);
+        if (!chans.length) { setStatus("no channels configured"); return; }
+        var preselect = new URL(window.location.href).searchParams.get("channel");
+        // Also honor a channel baked into the path (/terminal/<channel>).
+        var pathCh = (location.pathname.match(/\\/terminal\\/([^/]+)/) || [])[1];
+        if (pathCh) preselect = decodeURIComponent(pathCh);
+        chans.forEach(function (c) {
+          var opt = document.createElement("option");
+          opt.value = c.name; opt.textContent = c.name + " (" + c.transport + ")";
+          if (c.name === preselect) opt.selected = true;
+          sel.appendChild(opt);
+        });
+        connect();
+      })
+      .catch(function (err) { setStatus("config load failed", "err"); showNotice("Could not load channels: " + err, true); });
+  }
+
+  fetchToken().then(loadChannelsAndConnect);
+})();
+</script>
+</body>
+</html>`;

--- a/src/terminal.test.ts
+++ b/src/terminal.test.ts
@@ -1,0 +1,487 @@
+/**
+ * In-page terminal tests — the WS↔pty relay (`createTerminalWsHandlers`,
+ * `parseControlFrame`, src/terminal.ts) + the daemon-side terminal upgrade gate
+ * (`authorizeTerminalUpgrade`, src/daemon.ts).
+ *
+ * The relay tests drive the handler set against a FAKE `ServerWebSocket` and the
+ * injectable `spawnTerminal` seam — no real tmux, no real pty, no `Bun.serve`.
+ * The fake socket exposes a settable `getBufferedAmount()` so we can simulate
+ * the hub's send-buffer filling under a flood and assert the flow-control
+ * contract (the load-bearing item): a flood PARKS in the daemon-side coalesce
+ * queue, the socket is NOT closed, and output resumes (drains) once the client
+ * catches up. The hub's blunt 8 MiB cap therefore never has to fire.
+ *
+ * The auth tests call the pure `authorizeTerminalUpgrade` directly, using the
+ * same sentinel-token `mock.module("./hub-jwt.ts")` harness daemon-config-api.
+ * test.ts uses — accept paths run without a live hub/JWKS; the no-token reject
+ * still hits the real short-circuit.
+ */
+import { describe, test, expect, mock } from "bun:test";
+import type { ServerWebSocket } from "bun";
+
+// Sentinel tokens → fixed scope sets. Mirrors daemon-config-api.test.ts so this
+// process-wide mock stays compatible. ADMIN_TOKEN carries channel:admin (==
+// SCOPE_TERMINAL); READ_TOKEN is under-scoped; anything else throws (bad token).
+const ADMIN_TOKEN = "test-admin-token"; // channel:admin (== SCOPE_TERMINAL)
+const READ_TOKEN = "test-read-token"; // channel:read only (insufficient)
+import { HubJwtError, looksLikeJwt } from "@openparachute/scope-guard";
+mock.module("./hub-jwt.ts", () => ({
+  CHANNEL_AUDIENCE: "channel",
+  async validateHubJwt(token: string) {
+    const base = { sub: "test", aud: "channel", jti: undefined, clientId: undefined, vaultScope: undefined };
+    if (token === ADMIN_TOKEN) return { ...base, scopes: ["channel:read", "channel:send", "channel:admin"] };
+    if (token === READ_TOKEN) return { ...base, scopes: ["channel:read"] };
+    throw new HubJwtError("issuer", "invalid token");
+  },
+  HubJwtError,
+  looksLikeJwt,
+  resetJwksCache() {},
+  resetRevocationCache() {},
+}));
+
+import {
+  createTerminalWsHandlers,
+  parseControlFrame,
+  HUB_WS_CAP_BYTES,
+  PAUSE_FRAC,
+  RESUME_FRAC,
+  type TerminalWsData,
+  type SpawnTerminalFn,
+  type SpawnedTerminal,
+  type BunTerminal,
+} from "./terminal.ts";
+import { authorizeTerminalUpgrade } from "./daemon.ts";
+import type { Channel } from "./registry.ts";
+
+// ===========================================================================
+// Fakes — a recording pty + a controllable ServerWebSocket.
+// ===========================================================================
+
+/** A fake pty that records writes/resizes and lets the test push pty output. */
+class FakePty implements BunTerminal {
+  writes: Uint8Array[] = [];
+  writeStrings: string[] = [];
+  resizes: Array<{ cols: number; rows: number }> = [];
+  closed = false;
+  /** Captured callbacks from the spawn opts — the test drives pty output via these. */
+  onData!: (bytes: Uint8Array) => void;
+  onExit!: () => void;
+
+  write(data: string | ArrayBufferView | ArrayBufferLike): number {
+    if (typeof data === "string") {
+      this.writeStrings.push(data);
+      return data.length;
+    }
+    const u8 = data instanceof Uint8Array ? data : new Uint8Array(data as ArrayBufferLike);
+    this.writes.push(u8);
+    return u8.byteLength;
+  }
+  resize(cols: number, rows: number): void {
+    this.resizes.push({ cols, rows });
+  }
+  close(): void {
+    this.closed = true;
+  }
+}
+
+interface FakeProc {
+  readonly exited: Promise<number>;
+  killed: boolean;
+  kill(signal?: number | string): void;
+}
+
+/** A fake ServerWebSocket: records sends/close, settable buffered depth. */
+class FakeWs {
+  data: TerminalWsData;
+  sent: Uint8Array[] = [];
+  closeCalls: Array<{ code?: number; reason?: string }> = [];
+  /** Test sets this to simulate the hub send-buffer depth. */
+  buffered = 0;
+
+  constructor(data: TerminalWsData) {
+    this.data = data;
+  }
+  send(bytes: Uint8Array | string): number {
+    if (typeof bytes === "string") {
+      this.sent.push(new TextEncoder().encode(bytes));
+      return bytes.length;
+    }
+    this.sent.push(bytes);
+    return bytes.byteLength;
+  }
+  getBufferedAmount(): number {
+    return this.buffered;
+  }
+  close(code?: number, reason?: string): void {
+    this.closeCalls.push({ code, reason });
+  }
+  get totalSentBytes(): number {
+    return this.sent.reduce((n, b) => n + b.byteLength, 0);
+  }
+}
+
+/** Build a fake-pty spawn seam; returns the seam + a handle on the created pty. */
+function makeSpawn(): { spawn: SpawnTerminalFn; ptyRef: { current?: FakePty }; procRef: { current?: FakeProc } } {
+  const ptyRef: { current?: FakePty } = {};
+  const procRef: { current?: FakeProc } = {};
+  const spawn: SpawnTerminalFn = (_session, opts) => {
+    const pty = new FakePty();
+    pty.onData = opts.onData;
+    pty.onExit = opts.onExit;
+    const proc: FakeProc = { exited: Promise.resolve(0), killed: false, kill() { this.killed = true; } };
+    ptyRef.current = pty;
+    procRef.current = proc;
+    return { terminal: pty, proc } as unknown as SpawnedTerminal;
+  };
+  return { spawn, ptyRef, procRef };
+}
+
+function wsData(over: Partial<TerminalWsData> = {}): TerminalWsData {
+  return { session: "eng-agent", channel: "eng", cols: 80, rows: 24, ...over };
+}
+
+/** Open a handler set + fake ws + fake pty, returning the lot for a test. */
+function setup(opts: { capBytes?: number } = {}) {
+  const { spawn, ptyRef, procRef } = makeSpawn();
+  const warnings: string[] = [];
+  const handlers = createTerminalWsHandlers({
+    spawnTerminal: spawn,
+    capBytes: opts.capBytes,
+    logger: { warn: (...a: unknown[]) => warnings.push(a.map(String).join(" ")) },
+  });
+  const ws = new FakeWs(wsData());
+  handlers.open(ws as unknown as ServerWebSocket<TerminalWsData>);
+  return { handlers, ws, pty: () => ptyRef.current!, proc: () => procRef.current!, warnings };
+}
+
+// Cast helper — drive a handler with the fake ws.
+const asWs = (ws: FakeWs) => ws as unknown as ServerWebSocket<TerminalWsData>;
+
+// ===========================================================================
+// parseControlFrame — unit cases
+// ===========================================================================
+describe("parseControlFrame", () => {
+  test("a valid resize frame parses + clamps", () => {
+    expect(parseControlFrame(JSON.stringify({ type: "resize", cols: 120, rows: 40 }))).toEqual({
+      type: "resize",
+      cols: 120,
+      rows: 40,
+    });
+  });
+
+  test("out-of-range dims clamp to [1, 9999]", () => {
+    expect(parseControlFrame(JSON.stringify({ type: "resize", cols: 0, rows: 999999 }))).toEqual({
+      type: "resize",
+      cols: 1,
+      rows: 9999,
+    });
+  });
+
+  test("malformed JSON → null (forwarded as input by the caller)", () => {
+    expect(parseControlFrame("{not json")).toBeNull();
+  });
+
+  test("a non-resize control type → null", () => {
+    expect(parseControlFrame(JSON.stringify({ type: "evil", cmd: "rm -rf /" }))).toBeNull();
+  });
+
+  test("resize with non-finite dims → null", () => {
+    expect(parseControlFrame(JSON.stringify({ type: "resize", cols: "80", rows: NaN }))).toBeNull();
+    expect(parseControlFrame(JSON.stringify({ type: "resize" }))).toBeNull();
+  });
+
+  test("a bare JSON scalar / array (not an object) → null", () => {
+    expect(parseControlFrame("42")).toBeNull();
+    expect(parseControlFrame("null")).toBeNull();
+    expect(parseControlFrame("[1,2,3]")).toBeNull();
+  });
+});
+
+// ===========================================================================
+// Relay — both directions
+// ===========================================================================
+describe("relay — pty ↔ ws", () => {
+  test("pty output → ws.send (binary), bytes preserved", () => {
+    const { ws, pty } = setup();
+    const chunk = new Uint8Array([0x68, 0x69]); // "hi"
+    pty().onData(chunk);
+    expect(ws.sent).toHaveLength(1);
+    expect(Array.from(ws.sent[0]!)).toEqual([0x68, 0x69]);
+  });
+
+  test("ws binary message → terminal.write (keystrokes to the pty)", () => {
+    const { handlers, ws, pty } = setup();
+    const keys = Buffer.from("ls\n");
+    handlers.message(asWs(ws), keys);
+    expect(pty().writes).toHaveLength(1);
+    expect(Buffer.from(pty().writes[0]!).toString()).toBe("ls\n");
+  });
+
+  test("a text frame that ISN'T a control frame is forwarded to the pty as input (fail-safe)", () => {
+    const { handlers, ws, pty } = setup();
+    handlers.message(asWs(ws), "plain text");
+    expect(pty().writeStrings).toEqual(["plain text"]);
+    expect(pty().resizes).toHaveLength(0);
+  });
+});
+
+// ===========================================================================
+// Control frame — resize
+// ===========================================================================
+describe("control frame — resize", () => {
+  test("a {type:resize} text frame → terminal.resize(cols, rows), NOT written as input", () => {
+    const { handlers, ws, pty } = setup();
+    handlers.message(asWs(ws), JSON.stringify({ type: "resize", cols: 100, rows: 30 }));
+    expect(pty().resizes).toEqual([{ cols: 100, rows: 30 }]);
+    expect(pty().writes).toHaveLength(0);
+    expect(pty().writeStrings).toHaveLength(0);
+  });
+});
+
+// ===========================================================================
+// THE load-bearing test — backpressure flood stays alive
+// ===========================================================================
+describe("backpressure — a flood parks in the queue, never closes the socket", () => {
+  // A tiny cap so the test floods it cheaply. pause @ 50% (500), resume @ 25% (250).
+  const CAP = 1000;
+
+  test("a huge burst while the socket buffer is high → paused + coalesced, socket NOT closed, hub cap never approached", () => {
+    const { ws, pty, proc } = setup({ capBytes: CAP });
+
+    // Simulate the hub's send buffer already full (over the pause mark) and never
+    // draining during the burst — exactly the "a build log floods xterm" case.
+    ws.buffered = CAP; // 1000 ≥ pauseAt(500)
+
+    // First chunk goes out, then the post-send buffered check trips pause.
+    pty().onData(new Uint8Array(64));
+    // Subsequent chunks while paused MUST queue, not send.
+    const FLOOD_CHUNK = new Uint8Array(64 * 1024); // 64 KiB each
+    for (let i = 0; i < 200; i++) pty().onData(FLOOD_CHUNK); // ~12.8 MiB of pty output
+
+    // The socket is ALIVE — no close (no 1011, no 1013), pty alive, proc alive.
+    expect(ws.closeCalls).toHaveLength(0);
+    expect(pty().closed).toBe(false);
+    expect(proc().killed).toBe(false);
+
+    // Our OWN buffered bytes (what the hub sees) never grew past the one chunk we
+    // sent before pausing — the flood parked daemon-side, NOT in the hub buffer.
+    // i.e. we never let the socket approach the 8 MiB hub cap.
+    expect(ws.totalSentBytes).toBeLessThanOrEqual(64);
+    expect(ws.totalSentBytes).toBeLessThan(HUB_WS_CAP_BYTES);
+  });
+
+  test("when the client drains, the queued flood is eventually delivered (resume)", () => {
+    const { handlers, ws, pty } = setup({ capBytes: CAP });
+
+    ws.buffered = CAP; // over pause mark
+    pty().onData(new Uint8Array(64)); // sent → then pause
+    // Queue a bounded flood (well under MAX_QUEUE_BYTES so it parks, not closes).
+    const N = 50;
+    const CHUNK = 64; // bytes
+    for (let i = 0; i < N; i++) pty().onData(new Uint8Array(CHUNK).fill(i));
+    expect(ws.closeCalls).toHaveLength(0);
+    const sentBeforeDrain = ws.sent.length;
+
+    // Client catches up: buffer empties. Bun fires drain repeatedly as it clears;
+    // drain flushes the queue while buffered stays under the pause mark.
+    ws.buffered = 0;
+    // A few drain cycles to flush the whole queue (flushQueue drains until empty
+    // or the pause mark; with buffered=0 it empties in one pass, but loop to be safe).
+    for (let i = 0; i < 5 && ws.sent.length < sentBeforeDrain + N; i++) {
+      handlers.drain(asWs(ws));
+    }
+
+    // Everything queued got delivered — the flood was buffered, not dropped.
+    expect(ws.sent.length).toBe(sentBeforeDrain + N);
+    expect(ws.closeCalls).toHaveLength(0);
+    // And the very last queued chunk arrived intact (content preserved through the queue).
+    const last = ws.sent[ws.sent.length - 1]!;
+    expect(last.byteLength).toBe(CHUNK);
+    expect(last[0]).toBe(N - 1);
+  });
+});
+
+// ===========================================================================
+// Hysteresis — pause @ 50%, resume only under 25%
+// ===========================================================================
+describe("hysteresis — pause @ PAUSE_FRAC, resume only under RESUME_FRAC", () => {
+  const CAP = 1000; // pauseAt = 500, resumeAt = 250
+
+  test("constants are 0.5 / 0.25 (the documented margins)", () => {
+    expect(PAUSE_FRAC).toBe(0.5);
+    expect(RESUME_FRAC).toBe(0.25);
+  });
+
+  test("does NOT pause while buffered stays under the pause mark", () => {
+    const { ws, pty } = setup({ capBytes: CAP });
+    ws.buffered = 400; // < pauseAt(500)
+    pty().onData(new Uint8Array(10));
+    pty().onData(new Uint8Array(10)); // still forwarded, not queued
+    expect(ws.sent).toHaveLength(2);
+    expect(ws.closeCalls).toHaveLength(0);
+  });
+
+  test("pauses at the 50% mark; a drain to BETWEEN resume(25%) and pause(50%) does NOT resume", () => {
+    const { handlers, ws, pty } = setup({ capBytes: CAP });
+    ws.buffered = 500; // == pauseAt → pause after the send
+    pty().onData(new Uint8Array(10));
+    // Now paused: a new pty chunk queues rather than sends.
+    pty().onData(new Uint8Array(10));
+    expect(ws.sent).toHaveLength(1); // only the first went out
+
+    // Drain partway — buffer at 300 (still > resumeAt 250). Queue flushes only if
+    // under the pause mark (300 < 500 so it flushes), but we stay PAUSED for live
+    // forwarding because we're not yet under the resume mark.
+    ws.buffered = 300;
+    handlers.drain(asWs(ws));
+    // A fresh live chunk should STILL queue (paused), proving no premature resume.
+    const sentAfterDrain = ws.sent.length;
+    pty().onData(new Uint8Array(10));
+    expect(ws.sent.length).toBe(sentAfterDrain); // still paused → queued, not sent
+  });
+
+  test("resumes only once buffered falls under the 25% mark (and the queue is empty)", () => {
+    const { handlers, ws, pty } = setup({ capBytes: CAP });
+    ws.buffered = 600; // pause
+    pty().onData(new Uint8Array(10));
+    pty().onData(new Uint8Array(10)); // queued
+
+    // Drain fully under the resume mark → drain flushes the queue + resumes.
+    ws.buffered = 100; // < resumeAt(250)
+    handlers.drain(asWs(ws));
+    // Now resumed: a new live chunk forwards immediately.
+    const before = ws.sent.length;
+    pty().onData(new Uint8Array(10));
+    expect(ws.sent.length).toBe(before + 1);
+  });
+});
+
+// ===========================================================================
+// 1013 — a hopelessly-stuck client is shed
+// ===========================================================================
+describe("stuck client — closed 1013 when the queue blows past MAX_QUEUE_BYTES", () => {
+  // Keep the hub cap tiny so we pause immediately; the queue cap (16 MiB) is the
+  // line under test. Flood past 16 MiB while the socket never drains.
+  const CAP = 1000;
+
+  test(">16 MiB queued while the socket stays full → close(1013), pty + viewer torn down", () => {
+    const { ws, pty, proc, warnings } = setup({ capBytes: CAP });
+    ws.buffered = CAP; // perpetually over the pause mark → everything queues
+    pty().onData(new Uint8Array(64)); // first send trips pause
+
+    // 17 MiB in 1 MiB chunks — crosses the 16 MiB MAX_QUEUE_BYTES line.
+    const MiB = new Uint8Array(1024 * 1024);
+    for (let i = 0; i < 17; i++) pty().onData(MiB);
+
+    const closed1013 = ws.closeCalls.find((c) => c.code === 1013);
+    expect(closed1013).toBeDefined();
+    expect(pty().closed).toBe(true); // pty closed
+    expect(proc().killed).toBe(true); // viewer process killed
+    expect(warnings.some((w) => w.includes("too far behind") || w.includes("too slow"))).toBe(true);
+  });
+});
+
+// ===========================================================================
+// Lifecycle — pty exit + client close tear down the viewer (session lives on)
+// ===========================================================================
+describe("lifecycle — teardown", () => {
+  test("pty exit closes the socket with a clean 1000 (session ended)", () => {
+    const { ws, pty, proc } = setup();
+    pty().onExit();
+    expect(ws.closeCalls.some((c) => c.code === 1000)).toBe(true);
+    expect(pty().closed).toBe(true);
+    expect(proc().killed).toBe(true);
+  });
+
+  test("client close releases the pty + kills the viewer proc (idempotent)", () => {
+    const { handlers, ws, pty, proc } = setup();
+    handlers.close(asWs(ws));
+    expect(pty().closed).toBe(true);
+    expect(proc().killed).toBe(true);
+    // Idempotent — a second close is a no-op (no throw, no double behavior change).
+    expect(() => handlers.close(asWs(ws))).not.toThrow();
+  });
+});
+
+// ===========================================================================
+// Daemon-side terminal auth — authorizeTerminalUpgrade (pure fn)
+// ===========================================================================
+describe("authorizeTerminalUpgrade — operator-gated channel:admin", () => {
+  function channels(names: string[] = ["eng"]): Map<string, Channel> {
+    const m = new Map<string, Channel>();
+    for (const name of names) {
+      m.set(name, { name, transport: {} as Channel["transport"], entry: { name, transport: "vault" } });
+    }
+    return m;
+  }
+  function req(query = ""): { req: Request; url: URL } {
+    const url = new URL(`http://127.0.0.1/terminal/eng${query}`);
+    return { req: new Request(url, { headers: { upgrade: "websocket" } }), url };
+  }
+
+  test("missing token → reject (401), no session leaked", async () => {
+    const { req: r, url } = req();
+    const d = await authorizeTerminalUpgrade(r, url, channels(), "eng");
+    expect(d.ok).toBe(false);
+    if (!d.ok) expect(d.response.status).toBe(401);
+  });
+
+  test("bad/expired token → reject (401)", async () => {
+    const { req: r, url } = req("?token=garbage-not-a-real-jwt");
+    const d = await authorizeTerminalUpgrade(r, url, channels(), "eng");
+    expect(d.ok).toBe(false);
+    if (!d.ok) expect(d.response.status).toBe(401);
+  });
+
+  test("under-scoped token (channel:read, not channel:admin) → reject (403)", async () => {
+    const { req: r, url } = req(`?token=${READ_TOKEN}`);
+    const d = await authorizeTerminalUpgrade(r, url, channels(), "eng");
+    expect(d.ok).toBe(false);
+    if (!d.ok) expect(d.response.status).toBe(403);
+  });
+
+  test("valid channel:admin token → ok, with the right tmux session + geometry", async () => {
+    const { req: r, url } = req(`?token=${ADMIN_TOKEN}&cols=120&rows=40`);
+    const d = await authorizeTerminalUpgrade(r, url, channels(), "eng");
+    expect(d.ok).toBe(true);
+    if (d.ok) {
+      expect(d.channel).toBe("eng");
+      expect(d.session).toBe("eng-agent"); // <name>-agent (launch-session.sh:38)
+      expect(d.cols).toBe(120);
+      expect(d.rows).toBe(40);
+    }
+  });
+
+  test("geometry defaults (80×24) when cols/rows absent or out-of-range", async () => {
+    const { req: r, url } = req(`?token=${ADMIN_TOKEN}&cols=0&rows=abc`);
+    const d = await authorizeTerminalUpgrade(r, url, channels(), "eng");
+    expect(d.ok).toBe(true);
+    if (d.ok) {
+      expect(d.cols).toBe(80);
+      expect(d.rows).toBe(24);
+    }
+  });
+
+  test("unknown channel → reject (404), even with a valid admin token (no traversal / no session)", async () => {
+    const url = new URL(`http://127.0.0.1/terminal/ghost?token=${ADMIN_TOKEN}`);
+    const r = new Request(url, { headers: { upgrade: "websocket" } });
+    const d = await authorizeTerminalUpgrade(r, url, channels(["eng"]), "ghost");
+    expect(d.ok).toBe(false);
+    if (!d.ok) expect(d.response.status).toBe(404);
+  });
+
+  test("a path-traversal-shaped channel name is treated as an unknown channel → 404 (no escape)", async () => {
+    const weird = "../../etc";
+    const url = new URL(`http://127.0.0.1/terminal/${encodeURIComponent(weird)}?token=${ADMIN_TOKEN}`);
+    const r = new Request(url, { headers: { upgrade: "websocket" } });
+    const d = await authorizeTerminalUpgrade(r, url, channels(["eng"]), weird);
+    expect(d.ok).toBe(false);
+    if (!d.ok) expect(d.response.status).toBe(404);
+  });
+});
+
+// Touch HUB_WS_CAP_BYTES so the import is load-bearing if the relationship to the
+// hub cap ever drifts (the constant mirrors the hub's DEFAULT_MAX_BUFFERED_BYTES).
+test("HUB_WS_CAP_BYTES mirrors the hub's 8 MiB cap", () => {
+  expect(HUB_WS_CAP_BYTES).toBe(8 * 1024 * 1024);
+});

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -1,0 +1,442 @@
+/**
+ * In-page terminal backend for parachute-channel (design
+ * `design/2026-06-14-sandboxed-agent-sessions.md` §5).
+ *
+ * Bridges a browser xterm.js terminal ↔ the channel daemon's own Bun WebSocket
+ * server ↔ a session's tmux pane. The pty is **Bun's native terminal**
+ * (`new Bun.Terminal({...})` + `Bun.spawn({ terminal })`), spawned to run
+ * `tmux attach -t <name>-agent` — the SAME tmux session `scripts/launch-session.sh`
+ * creates (session name `<name>-agent`, `launch-session.sh:38`). Attaching to
+ * tmux (not a raw pty) is what makes a dropped WS re-attach to the LIVE session
+ * with scrollback intact (§5.4 reconnect): the session keeps running in tmux
+ * regardless of who is watching.
+ *
+ * THE LOAD-BEARING DESIGN ITEM — backpressure (§5.4, R1). The hub's WS bridge
+ * (`parachute-hub/src/ws-bridge.ts`) enforces a fixed 8 MiB buffered-bytes cap
+ * that closes BOTH sides on overflow and is NOT per-connection tunable. A
+ * terminal legitimately floods it (a big build log, `yes`, `cat` of a large
+ * file). The bridge is a blind pipe with no flow-control hook, so the flow
+ * control MUST live here: the channel daemon holds the upstream end of the
+ * terminal socket as a `ServerWebSocket` and so has `ws.getBufferedAmount()`
+ * natively. We watch our OWN send-buffer depth and PAUSE reading from the pty
+ * (Bun.Terminal supports this implicitly — we stop forwarding its `data` and
+ * coalesce into a bounded queue) when buffered bytes climb toward a safe
+ * fraction of the cap, resuming when the client drains (the `drain` handler).
+ * Net effect: a flood NEVER lets a single terminal's buffered bytes approach
+ * 8 MiB, so the hub's blunt cap is a safety net that never fires in normal use.
+ *
+ * Frame protocol (§5.5):
+ *   - BINARY frames are raw pty bytes, both directions (input keystrokes
+ *     client→pty, output bytes pty→client) — the terminal's natural stream.
+ *   - TEXT frames are JSON CONTROL frames, disambiguated by being valid JSON
+ *     with a `type` field. The only one in v1 is
+ *     `{ "type": "resize", "cols": <n>, "rows": <n> }` → `terminal.resize`.
+ *   Raw input that happens to be a text frame is impossible in practice
+ *   (xterm sends keystrokes as binary), but we fail safe: a text frame that
+ *   does NOT parse as a control object is forwarded to the pty as input.
+ *
+ * Auth is NOT in this module — it runs in the daemon's upgrade gate (operator-
+ * grade `channel:admin`, token via `?token=`, BEFORE `server.upgrade`). By the
+ * time `open()` runs the socket is already authorized. This module owns the
+ * pty↔WS relay + flow control only.
+ */
+
+import type { ServerWebSocket } from "bun";
+
+/**
+ * The hub WS bridge's hard cap (`DEFAULT_MAX_BUFFERED_BYTES`,
+ * `parachute-hub/src/ws-bridge.ts:55`). Mirrored here as the ceiling our flow
+ * control must stay UNDER — if our buffered bytes ever reach this, the hub
+ * closes both sides. Kept as a named constant so the relationship to the hub is
+ * explicit and a future hub bump is a one-line change here.
+ */
+export const HUB_WS_CAP_BYTES = 8 * 1024 * 1024;
+
+/**
+ * Pause reading the pty when our socket's buffered bytes climb past this
+ * fraction of the hub cap; resume when they fall back under {@link RESUME_FRAC}.
+ * 0.5 / 0.25 leaves a wide margin below the 8 MiB ceiling so a burst that
+ * arrives between two backpressure checks still can't reach it. The gap between
+ * the two fractions is hysteresis — it stops us flapping pause/resume on every
+ * frame near the threshold.
+ */
+export const PAUSE_FRAC = 0.5;
+export const RESUME_FRAC = 0.25;
+
+/**
+ * Cap on bytes we'll hold in the per-connection coalesce queue while paused.
+ * The queue exists so a brief pause doesn't drop pty output; but a client that
+ * NEVER drains can't make us buffer unboundedly in the daemon either. If the
+ * queue exceeds this while the socket is also full, the client is hopelessly
+ * behind — we close it (1013, "try again later") rather than OOM the daemon.
+ * Generous (16 MiB) so only a truly stuck client trips it.
+ */
+export const MAX_QUEUE_BYTES = 16 * 1024 * 1024;
+
+/** Per-connection state attached to `ws.data` for a terminal socket. */
+export interface TerminalWsData {
+  /** The tmux session this socket attaches to (`<name>-agent`). */
+  readonly session: string;
+  /** The channel name (for logging / future per-channel policy). */
+  readonly channel: string;
+  /** Initial terminal geometry from the upgrade query (xterm's first fit). */
+  readonly cols: number;
+  readonly rows: number;
+  /** Internal relay state — attached by `open()`, owned by this module. */
+  _term?: TerminalState;
+}
+
+/** A control frame the client sends over a TEXT frame. */
+type ControlFrame = { type: "resize"; cols: number; rows: number };
+
+interface TerminalState {
+  /** The Bun pty running `tmux attach`. */
+  terminal: BunTerminal;
+  proc: { readonly exited: Promise<number>; kill(signal?: number | string): void };
+  /** Coalesced pty output waiting while the socket is over the pause mark. */
+  queue: Uint8Array[];
+  queuedBytes: number;
+  /** True while we're holding pty output because the socket buffer is high. */
+  paused: boolean;
+  /** Set once teardown started — makes close idempotent across the pty/WS races. */
+  closed: boolean;
+}
+
+/**
+ * The slice of `Bun.Terminal` this module uses. Declared structurally so tests
+ * can inject a fake without spawning a real pty (and so the module doesn't hard-
+ * depend on the global `Bun` shape at type-check time across Bun versions).
+ */
+export interface BunTerminal {
+  // Accept the broad input shape Bun's `Terminal.write` takes, plus a plain
+  // `Uint8Array` — the WS `message` callback hands us a `Buffer` (a Uint8Array
+  // subclass whose backing buffer types as `ArrayBufferLike`), so the param is
+  // widened to `string | ArrayBufferView | ArrayBufferLike` to take it without
+  // a cast at every call site.
+  write(data: string | ArrayBufferView | ArrayBufferLike): number;
+  resize(cols: number, rows: number): void;
+  close(): void;
+}
+
+/** What `spawnTerminal` returns — the pty plus the child's exit promise. */
+export interface SpawnedTerminal {
+  terminal: BunTerminal;
+  proc: { readonly exited: Promise<number>; kill(signal?: number | string): void };
+}
+
+/**
+ * Spawn a Bun pty attached to a tmux session. Injectable so the relay can be
+ * unit-tested against a fake pty (no tmux, no real subprocess). The default
+ * implementation runs `tmux attach -t <session>` inside a fresh `Bun.Terminal`,
+ * wiring its `data` callback to `onData` (pty output) and `exit` to `onExit`.
+ *
+ * `tmux attach` (not a raw shell) is deliberate: the session is owned by tmux,
+ * so this pty is just a *viewer*. Dropping it leaves the session alive; a
+ * reconnect re-attaches with scrollback. `-t <session>` targets the exact
+ * session `launch-session.sh` made (`<name>-agent`).
+ */
+export type SpawnTerminalFn = (
+  session: string,
+  opts: {
+    cols: number;
+    rows: number;
+    onData: (bytes: Uint8Array) => void;
+    onExit: () => void;
+  },
+) => SpawnedTerminal;
+
+/** Default pty spawn — the real `Bun.Terminal` + `tmux attach`. */
+export const defaultSpawnTerminal: SpawnTerminalFn = (session, opts) => {
+  // `Bun.Terminal` is the native pty (verified present with write/resize/
+  // setRawMode/data/exit on channel's pinned Bun 1.3.13 — see the design's R2
+  // version-floor note; the floor is met). The `data` callback IS the pty
+  // output stream; `exit` fires when the pty closes (tmux detach / session
+  // gone). We do NOT setRawMode here — tmux owns the inner pty's mode; this
+  // outer viewer pty passes bytes through untouched.
+  const TerminalCtor = (globalThis as { Bun?: { Terminal?: new (o: unknown) => BunTerminal } })
+    .Bun?.Terminal;
+  if (!TerminalCtor) {
+    throw new Error(
+      "Bun.Terminal is unavailable — the in-page terminal needs Bun ≥ 1.3.13 " +
+        "(with the native pty API). Upgrade Bun, or use `tmux attach -t <name>-agent` on the host.",
+    );
+  }
+  const terminal = new TerminalCtor({
+    cols: opts.cols,
+    rows: opts.rows,
+    name: "xterm-256color",
+    data: (_t: unknown, bytes: Uint8Array) => opts.onData(bytes),
+    exit: () => opts.onExit(),
+  });
+  // `tmux attach -t <session>` — attach this viewer pty to the live session.
+  const proc = (
+    globalThis as {
+      Bun: { spawn: (cmd: string[], o: unknown) => SpawnedTerminal["proc"] };
+    }
+  ).Bun.spawn(["tmux", "attach", "-t", session], {
+    terminal,
+    // No env scrub here — this pty runs `tmux attach`, which only TALKS to the
+    // already-running tmux server; it never starts the Claude session (that's
+    // the sandboxed spawn path, §4). The session's own isolation is upstream.
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  return { terminal, proc };
+};
+
+/**
+ * Parse a TEXT frame as a control frame. Returns the control object, or null
+ * if it isn't one (so the caller forwards the bytes to the pty as input — fail
+ * safe). Only `resize` exists in v1; an unknown `type` is treated as not-a-
+ * control-frame and forwarded (forward-compat: a future client control frame
+ * an old daemon doesn't know just reaches the pty harmlessly as input bytes,
+ * which tmux/the shell ignores or echoes — never a crash).
+ */
+export function parseControlFrame(text: string): ControlFrame | null {
+  let obj: unknown;
+  try {
+    obj = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  if (!obj || typeof obj !== "object") return null;
+  const o = obj as Record<string, unknown>;
+  if (o.type === "resize" && Number.isFinite(o.cols) && Number.isFinite(o.rows)) {
+    // Clamp to sane bounds — a malicious/buggy client can't ask for a 0×0 or a
+    // 100000-column pty (ioctl winsize is u16; out-of-range is rejected/garbage).
+    const cols = clampDim(o.cols as number);
+    const rows = clampDim(o.rows as number);
+    return { type: "resize", cols, rows };
+  }
+  return null;
+}
+
+/** Clamp a terminal dimension to [1, 9999] (winsize is a u16). */
+function clampDim(n: number): number {
+  const v = Math.floor(n);
+  if (!Number.isFinite(v) || v < 1) return 1;
+  if (v > 9999) return 9999;
+  return v;
+}
+
+/**
+ * Build the Bun.serve `websocket` handler set for terminal sockets. One handler
+ * object serves every terminal connection; per-connection state lives on
+ * `ws.data._term`. Pure over its deps so tests drive it with a fake pty + a
+ * fake `ServerWebSocket`.
+ *
+ * Backpressure contract (the load-bearing part): every pty→client write checks
+ * `ws.getBufferedAmount()`. Past {@link PAUSE_FRAC} of the hub cap we stop
+ * forwarding pty output (it accumulates in a bounded coalesce queue); Bun's
+ * `drain` callback fires when the socket buffer empties, where we flush the
+ * queue and, once under {@link RESUME_FRAC}, resume live forwarding. A flood
+ * therefore parks in our queue (bounded, daemon-side) instead of the hub's
+ * buffer — the hub cap never trips.
+ */
+export function createTerminalWsHandlers(
+  deps: {
+    spawnTerminal?: SpawnTerminalFn;
+    /** Override the hub cap (tests use a tiny value). */
+    capBytes?: number;
+    logger?: Pick<Console, "warn">;
+  } = {},
+) {
+  const spawn = deps.spawnTerminal ?? defaultSpawnTerminal;
+  const cap = deps.capBytes ?? HUB_WS_CAP_BYTES;
+  const pauseAt = cap * PAUSE_FRAC;
+  const resumeAt = cap * RESUME_FRAC;
+  const logger = deps.logger ?? console;
+
+  /** Tear both pty + socket down exactly once. */
+  function teardown(
+    ws: ServerWebSocket<TerminalWsData>,
+    state: TerminalState,
+    code: number,
+    reason: string,
+  ): void {
+    if (state.closed) return;
+    state.closed = true;
+    try {
+      state.terminal.close();
+    } catch {
+      // pty already closed — best-effort.
+    }
+    try {
+      // Kill the `tmux attach` viewer process (detaches; the session lives on).
+      state.proc.kill();
+    } catch {
+      // already exited.
+    }
+    try {
+      ws.close(code, reason);
+    } catch {
+      // already closing.
+    }
+  }
+
+  /**
+   * Forward one pty output chunk to the client, applying flow control. If the
+   * socket is already over the pause mark we queue instead of sending; a queue
+   * that overflows {@link MAX_QUEUE_BYTES} means the client is hopelessly
+   * behind → close it (rather than buffer unboundedly in the daemon).
+   */
+  function forwardOrQueue(
+    ws: ServerWebSocket<TerminalWsData>,
+    state: TerminalState,
+    bytes: Uint8Array,
+  ): void {
+    if (state.closed) return;
+    if (state.paused) {
+      enqueue(ws, state, bytes);
+      return;
+    }
+    // `send` returns the byte count, -1 on backpressure, 0 if dropped. We don't
+    // branch on it directly — we read the authoritative buffered depth right
+    // after and decide pause from THAT (one source of truth).
+    ws.send(bytes);
+    if (ws.getBufferedAmount() >= pauseAt) {
+      state.paused = true;
+    }
+  }
+
+  function enqueue(
+    ws: ServerWebSocket<TerminalWsData>,
+    state: TerminalState,
+    bytes: Uint8Array,
+  ): void {
+    state.queue.push(bytes);
+    state.queuedBytes += bytes.byteLength;
+    if (state.queuedBytes > MAX_QUEUE_BYTES) {
+      logger.warn(
+        `[terminal] client for tmux "${ws.data.session}" is too far behind ` +
+          `(queued ${state.queuedBytes} bytes) — closing to protect the daemon`,
+      );
+      teardown(ws, state, 1013, "terminal consumer too slow");
+    }
+  }
+
+  /** Drain the coalesce queue into the socket until it fills again or empties. */
+  function flushQueue(ws: ServerWebSocket<TerminalWsData>, state: TerminalState): void {
+    while (state.queue.length > 0 && !state.closed) {
+      // Stop early if sending would push us back over the pause mark — leave the
+      // rest queued for the next drain.
+      if (ws.getBufferedAmount() >= pauseAt) return;
+      const chunk = state.queue.shift()!;
+      state.queuedBytes -= chunk.byteLength;
+      ws.send(chunk);
+    }
+  }
+
+  return {
+    /**
+     * A connection was accepted (auth already passed in the daemon's upgrade
+     * gate). Spawn the pty attached to the tmux session and start relaying.
+     */
+    open(ws: ServerWebSocket<TerminalWsData>) {
+      const data = ws.data;
+      const state: TerminalState = {
+        terminal: undefined as unknown as BunTerminal,
+        proc: undefined as unknown as TerminalState["proc"],
+        queue: [],
+        queuedBytes: 0,
+        paused: false,
+        closed: false,
+      };
+      data._term = state;
+
+      let spawned: SpawnedTerminal;
+      try {
+        spawned = spawn(data.session, {
+          cols: data.cols,
+          rows: data.rows,
+          onData: (bytes) => forwardOrQueue(ws, state, bytes),
+          // The pty closed (tmux detached / session gone). Tear the socket down
+          // with a clean code so the browser shows "session ended", not an error.
+          onExit: () => teardown(ws, state, 1000, "terminal session ended"),
+        });
+      } catch (err) {
+        logger.warn(
+          `[terminal] failed to attach to tmux session "${data.session}": ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+        try {
+          ws.close(1011, "failed to attach terminal session");
+        } catch {
+          /* already closing */
+        }
+        return;
+      }
+      state.terminal = spawned.terminal;
+      state.proc = spawned.proc;
+    },
+
+    /**
+     * A frame from the client. BINARY = raw pty input (keystrokes). TEXT =
+     * a JSON control frame (resize) — or, fail-safe, raw input if it doesn't
+     * parse as one.
+     */
+    message(ws: ServerWebSocket<TerminalWsData>, message: string | Buffer) {
+      const state = ws.data._term;
+      if (!state || state.closed || !state.terminal) return;
+      if (typeof message === "string") {
+        const ctrl = parseControlFrame(message);
+        if (ctrl) {
+          try {
+            state.terminal.resize(ctrl.cols, ctrl.rows);
+          } catch {
+            // pty gone mid-resize — the close/exit path handles teardown.
+          }
+          return;
+        }
+        // Not a control frame — forward as input (fail safe; see parseControlFrame).
+        try {
+          state.terminal.write(message);
+        } catch {
+          /* pty gone */
+        }
+        return;
+      }
+      // Binary input → straight to the pty.
+      try {
+        state.terminal.write(message);
+      } catch {
+        /* pty gone */
+      }
+    },
+
+    /**
+     * The socket's send buffer emptied (Bun fires this after backpressure
+     * clears). Flush our coalesce queue, then — once under the resume mark —
+     * resume live pty forwarding.
+     */
+    drain(ws: ServerWebSocket<TerminalWsData>) {
+      const state = ws.data._term;
+      if (!state || state.closed) return;
+      flushQueue(ws, state);
+      if (state.paused && ws.getBufferedAmount() <= resumeAt && state.queue.length === 0) {
+        state.paused = false;
+      }
+    },
+
+    /** The client (or the relay) closed — tear down the pty + viewer process. */
+    close(ws: ServerWebSocket<TerminalWsData>) {
+      const state = ws.data._term;
+      if (!state) return;
+      // Don't recurse into ws.close (we're already in the close callback); just
+      // release the pty + viewer process.
+      if (state.closed) return;
+      state.closed = true;
+      try {
+        state.terminal?.close();
+      } catch {
+        /* already closed */
+      }
+      try {
+        state.proc?.kill();
+      } catch {
+        /* already exited */
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Phase 1: sandboxed agent sessions

This is the **single mergeable Phase-1 PR**. It is the four individually-reviewed component PRs **merged + integration-tested** on one branch off `main`:

| Component | PR | Branch |
|---|---|---|
| Core — sandbox adapter + agent-spec + spawn/scope (sandbox-runtime) | **#48** | `ag-agents-phase1` |
| Full-tier cloud-init + deploy-tiers doc | **#49** | `ag-agents-deploy` |
| Per-channel Claude OAuth secret storage + spawn wiring | **#50** | `ag-agents-creds` |
| In-page xterm.js terminal over the WS bridge | **#51** | `ag-agents-terminal` |

**Merging THIS PR lands all of Phase 1.** The four component PRs are kept open for their per-part review trail and are closeable on merge (their commits are all included here).

The merge order was core → creds → terminal → deploy. All four composed with **zero conflicts** (`daemon.ts` ort-merged cleanly across creds + terminal, as the component reviewer predicted). One review nit was folded into the terminal branch first: the unused `SpawnTerminalFn` type import in `daemon.ts` was removed (also pushed to #51).

### What ships

- **Sandbox abstraction** — a `Sandbox` over `@anthropic-ai/sandbox-runtime` (Seatbelt on macOS, bubblewrap on Linux). Per-spec config: a non-removable egress base (Anthropic API + hub/vault origin) plus additive declared hosts; a private per-session rw workspace plus additive declared binds; reads scoped to binds, not broad.
- **Agent-spec + spawn/scope** — `spawnAgent(spec, deps)`: validate name (strict slug, no tmux/path injection) → mint one **per-resource, single-audience** hub token each (channel:read / +write; vault scoped, optional scoped_tags) → write the multi-entry **strict** MCP config 0600 → build the `claude` argv (`--strict-mcp-config`, interactive subscription, not `claude -p`) → Seatbelt-wrap → tmux launch with a **scrubbed** env. Idempotent on an existing session. Spawn serialized process-wide (the sandbox-runtime singleton's init→wrap window).
- **Per-channel Claude OAuth secret storage** — `credentials.json` (0600), per-channel override ?? default/operator ?? throw-before-any-side-effect. Resolved at spawn time (rotate takes effect next spawn, no restart). Injected as `CLAUDE_CODE_OAUTH_TOKEN`; `ANTHROPIC_API_KEY` is deliberately scrubbed so a session runs on the subscription, never metered API.
- **In-page terminal** — xterm.js over the WS bridge, attaching to the session's tmux pane. **Operator-gated on `channel:admin`** (a connecting session holds only read/write, never admin → a session can never open a terminal onto itself or another). Flow-control: a flood parks in the daemon-side coalesce queue and drains, so the hub's 8 MiB WS cap never fires.
- **Full-tier deploy** — provider-agnostic `deploy/cloud-init-full.yaml` + `deploy/README.md` (deploy tiers).
- **Operator CLI** — `scripts/spawn-agent.ts` ("graduate `launch-session.sh` into a real command"). `spawnAgent` shipped as a tested library with no caller; this is the thin command that invokes it with the REAL deps (operator-token manager bearer → hub mint, real `Sandbox` engine, `realTmuxLauncher`, real per-channel `resolveClaudeCredential`). Flags mirror `launch-session.sh`'s ergonomics, generalized to the spec: `--channel <name>[:read|write]` (repeatable; first = wake channel), `--vault <name>:<read|write>[:tag1,tag2]`, `--egress <hosts>`, `--mount <hostPath:mountPath:ro|rw[:shared]>`, `--help`. On success prints the tmux session, the resolved **per-aud** scopes, the MCP entry keys, and `tmux attach` + the web-terminal URL; on a missing Claude credential prints the exact creds-API curl and exits non-zero before any mint/tmux side effect. **Integration-only** — it depends on `credentials.ts` (the #50 creds feature, absent from core #48), so it rides this branch, not core.

### Integration test — proves they compose

On the merged branch, after a single `bun install`:

- `bun test src/` → **348 pass / 0 fail**, 949 expect() calls, 23 files. (The union of all four branches' tests plus the CLI arg-parser test, green.)
- `bun run typecheck` → only the **2 pre-existing `bridge.ts` TS2589** errors (type-instantiation-depth), confirmed unchanged by Phase 1 — `bridge.ts` is untouched on every branch. No new type errors.

### End-to-end stub-token smoke (what it proved)

A real spawn run on macOS (fresh `PARACHUTE_HOME`, stub `claude` that dumps argv+env, fake mint hub, dedicated tmux socket) proved end-to-end:

- the **N-entry strict MCP config** is written **0600** with the correct **per-aud** tokens — wake channel `channel:read channel:write`, read-only channel `channel:read` only, vault `vault:default:read`;
- the **per-channel credential resolves** and is injected as `CLAUDE_CODE_OAUTH_TOKEN`; **`ANTHROPIC_API_KEY` is absent** in the sandboxed process (confirmed from the dumped child env);
- the command is wrapped by **real Seatbelt** (the launched argv[0] is the sandbox wrapper, not the bare bin) and runs in a **real tmux session**;
- `authorizeTerminalUpgrade` **accepts** an operator `channel:admin` token for the session and **rejects** a session-level (`channel:read`/`write`) token (403).

A real-world finding the smoke surfaced: the Seatbelt-wrapped argv carries an ~84 KB profile arg that exceeds tmux's per-arg buffer — a production launcher must use a launch-script indirection (the smoke does; tracked as a launcher note, not a Phase-1 blocker).

### Dependency

Depends on the design-doc PR **#47** (`design/2026-06-14-sandboxed-agent-sessions.md`). #47 can merge independently — it's docs-only.

### Known follow-ups (not blockers)

- **Resource limits gap** — `@anthropic-ai/sandbox-runtime` exposes no cgroup/CPU/memory knob; per-session resource caps need a host-side wrapper, later.
- **CDN-SRI** — the terminal page loads xterm.js from a CDN without subresource-integrity; an acknowledged operator-only future-hardening nit.
- **Two live smokes** (below) need Aaron's real token / a real box.

### How to test the spawn CLI locally

Three commands — set the operator Claude credential, spawn, watch. Requires a running hub (for the loopback `~/.parachute/operator.token` mint), the channel daemon, and an existing channel `<ch>` (in `~/.parachute/channel/channels.json` or via `/channel/admin`).

```bash
# 1. Set the operator Claude credential (get the token via `claude setup-token`).
#    Needs a channel:admin JWT — mint one: parachute auth mint-token --scope "channel:admin"
curl -X POST http://127.0.0.1:1941/api/credentials/claude \
  -H "authorization: Bearer $(parachute auth mint-token --scope 'channel:admin')" \
  -H 'content-type: application/json' \
  -d '{"token":"<oat_… from claude setup-token>"}'

# 2. Spawn a sandboxed session scoped to channel <ch> + read-only vault.
bun scripts/spawn-agent.ts demo --channel <ch> --vault default:read

# 3. Watch it — attach to the tmux pane, or open the web terminal the spawn printed.
tmux attach -t demo-agent          # detach: Ctrl-b then d
#   or the web terminal URL the CLI prints (…/terminal?session=demo-agent)
```

The CLI prints the session name, the resolved per-aud scopes, the MCP entry keys, and both watch hints. `--help` shows the full flag set. Re-running for an existing session is an idempotent no-op. If the Claude credential isn't set, step 2 fails with the exact step-1 curl and exits non-zero (no session launched).

### Two one-command live smokes for Aaron

**(a) Live interactive Claude auth in-sandbox from an injected OAuth token:**
1. Set the per-channel secret via the creds API (the config API endpoint added in #50), e.g. `POST` the channel's Claude OAuth token to the daemon's credentials endpoint for channel `<ch>`.
2. Spawn an agent scoped to `<ch>`: it should authenticate with **no `/login`** (the injected `CLAUDE_CODE_OAUTH_TOKEN` carries the subscription) and reply on the channel.
3. Confirm: the session posts a reply to `<ch>` and `tmux` shows it ran `claude` (interactive), not `claude -p`.

**(b) Live VPS boot via the full-tier cloud-init:**
1. Boot a DO/Hetzner box with `deploy/cloud-init-full.yaml` as user-data.
2. Confirm hub + vault + channel come up supervised and the box is reachable per `deploy/README.md`.

---

DO NOT auto-merge — Aaron merges. Component PRs #48–#51 are retained for their review trail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
