### PR TITLE
feat(agents): web spawn/list/kill surface — operate sandboxed agents through the browser

### DIFF
--- a/scripts/spawn-agent.ts
+++ b/scripts/spawn-agent.ts
@@ -34,17 +34,12 @@
  *   CLAUDE_CONFIG_DIR          claude config dir bound read-only into the sandbox (default ~/.claude).
  */
 
-import { existsSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { resolve, join } from "node:path";
 import {
   spawnAgent,
-  realTmuxLauncher,
   type SpawnAgentDeps,
 } from "../src/spawn-agent.ts";
-import { CredentialNotConfiguredError, resolveClaudeCredential } from "../src/credentials.ts";
-import { defaultStateDir } from "../src/registry.ts";
-import { getHubOrigin } from "../src/hub-jwt.ts";
+import { CredentialNotConfiguredError } from "../src/credentials.ts";
+import { resolveSpawnDeps } from "../src/spawn-deps.ts";
 import { channelEntryKey, vaultEntryKey } from "../src/agent-mcp-config.ts";
 import { MintError } from "../src/mint-token.ts";
 import type {
@@ -53,9 +48,6 @@ import type {
   AgentVaultSpec,
   AgentMount,
 } from "../src/sandbox/types.ts";
-
-const DEFAULT_CHANNEL_PORT = 1941;
-const DEFAULT_VAULT_URL = "http://127.0.0.1:1940";
 
 const USAGE = `spawn-agent — launch a sandboxed Claude Code agent session
 
@@ -239,78 +231,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
 }
 
 // ---------------------------------------------------------------------------
-// Real-dep resolution (only reached on the actual run, not in unit tests).
+// Run-time helpers (only reached on the actual run, not in unit tests).
 // ---------------------------------------------------------------------------
-
-/** Base for `operator.token` — `$PARACHUTE_HOME` else `~/.parachute`. */
-function parachuteHome(): string {
-  return process.env.PARACHUTE_HOME ?? resolve(homedir(), ".parachute");
-}
-
-/**
- * The spawn-manager's OWN bearer — `~/.parachute/operator.token`, the local
- * operator credential the hub attenuates child mints against (same file vault's
- * `readOperatorToken` reads). Mirrors launch-session.sh leaning on the operator's
- * logged-in `parachute auth mint-token`; here we present the operator bearer to
- * the hub directly so the mint runs in-process with no shell-out.
- */
-function readManagerBearer(): string | null {
-  try {
-    const path = resolve(parachuteHome(), "operator.token");
-    if (!existsSync(path)) return null;
-    const raw = readFileSync(path, "utf-8").trim();
-    return raw.length > 0 ? raw : null;
-  } catch {
-    return null;
-  }
-}
-
-/** Default channel daemon base URL: PARACHUTE_CHANNEL_URL, else loopback:<port>. */
-function resolveChannelUrl(): string {
-  const explicit = process.env.PARACHUTE_CHANNEL_URL?.replace(/\/$/, "");
-  if (explicit) return explicit;
-  const port = parseInt(process.env.PARACHUTE_CHANNEL_PORT ?? "", 10) || DEFAULT_CHANNEL_PORT;
-  return `http://127.0.0.1:${port}`;
-}
-
-/** Claude config dir bound read-only so the sandboxed session can read its config. */
-function claudeConfigDir(): string {
-  return process.env.CLAUDE_CONFIG_DIR ?? resolve(homedir(), ".claude");
-}
-
-/** Build the real SpawnAgentDeps from the environment. */
-function realDeps(): SpawnAgentDeps {
-  const managerBearer = readManagerBearer();
-  if (!managerBearer) {
-    throw new ArgError(
-      `no operator token at ${resolve(parachuteHome(), "operator.token")} — the manager bearer the\n` +
-        `hub attenuates child mints against. Log in / provision the hub so the operator token exists\n` +
-        `(it's what \`parachute auth mint-token\` uses), then re-run.`,
-    );
-  }
-
-  const stateDir = defaultStateDir();
-  const sessionsDir = join(stateDir, "sessions");
-  const vaultUrl = process.env.PARACHUTE_VAULT_URL?.replace(/\/$/, "") || DEFAULT_VAULT_URL;
-
-  return {
-    hubOrigin: getHubOrigin(),
-    managerBearer,
-    channelUrl: resolveChannelUrl(),
-    vaultUrl,
-    sessionsDir,
-    // The claude config dir is the one runtime path the sandboxed `claude` must
-    // read (system paths /usr,/lib stay readable; the home tree is denied). The
-    // per-session workspace (rw) is added by spawnAgent under sessionsDir.
-    runtimeReadOnly: [claudeConfigDir()],
-    // The real per-channel Claude OAuth resolver (channel override ?? default ?? throw).
-    resolveClaudeToken: (channel: string) => resolveClaudeCredential(channel, stateDir),
-    // The real tmux launcher (writes the per-session launch script, runs tmux).
-    tmux: realTmuxLauncher(),
-    // sandboxEngine omitted → spawnAgent's `new Sandbox()` uses the real, pinned,
-    // library-linked engine.
-  };
-}
 
 /** Format a per-aud scope summary line for each minted token. */
 function scopeLines(result: Awaited<ReturnType<typeof spawnAgent>>): string[] {
@@ -341,7 +263,7 @@ async function main(): Promise<number> {
 
   let deps: SpawnAgentDeps;
   try {
-    deps = realDeps();
+    deps = resolveSpawnDeps();
   } catch (err) {
     process.stderr.write(`error: ${err instanceof Error ? err.message : String(err)}\n`);
     return 1;

--- a/src/agents-ui.ts
+++ b/src/agents-ui.ts
@@ -1,0 +1,523 @@
+/**
+ * Static HTML for `/channel/agents` — the in-page agent management surface
+ * (design `design/2026-06-14-sandboxed-agent-sessions.md` §4/§5; the web spawn
+ * flow Aaron asked for: "this needs to work through the web interface since
+ * that's really the default way of operating").
+ *
+ * Self-contained document (HTML + inline CSS + inline JS, no build step — the
+ * same shape as `terminal-ui.ts` and `daemon.ts`'s chat UI). It drives the
+ * daemon's `channel:admin`-gated JSON API:
+ *
+ *   - GET    /api/credentials/claude   → credential status (default set? overrides?)
+ *   - POST   /api/credentials/claude   → set the default operator Claude token
+ *   - POST   /api/credentials/claude/:channel  → per-channel override
+ *   - DELETE /api/credentials/claude/:channel  → remove an override
+ *   - GET    /api/agents               → list running agent sessions
+ *   - POST   /api/agents               → spawn a sandboxed agent from a spec
+ *   - DELETE /api/agents/:name         → kill a session
+ *   - GET    /.parachute/config        → channel list (prefills the spawn form)
+ *
+ * Auth: the page loads OPEN (like /ui, /admin, /terminal) and then fetches a
+ * hub-minted `channel:admin` Bearer from `<origin>/admin/channel-token`
+ * (cookie-gated — the operator's logged-in portal session), attaching it to every
+ * /api call. A launched session is the most powerful thing this module does, so
+ * the whole surface is operator-gated on `channel:admin` — the SAME gate the
+ * terminal uses.
+ *
+ * Token hygiene mirrors the rest of the module: the Claude OAuth token the
+ * operator pastes is POSTed once and never read back (the status endpoint returns
+ * names/presence only); the spawn result shows scopes/audiences but never the
+ * minted token values.
+ */
+
+export const AGENTS_UI_HTML = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="referrer" content="no-referrer" />
+<title>parachute-channel · agents</title>
+<style>
+  :root {
+    --bg: #0f1115; --panel: #171a21; --line: #262b36; --fg: #e6e9ef;
+    --muted: #8b93a3; --accent: #4cc2a0; --danger: #e0796b; --warn: #d9b25f;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; }
+  body {
+    background: var(--bg); color: var(--fg);
+    font: 14px/1.5 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    padding-bottom: 48px;
+  }
+  header {
+    display: flex; align-items: center; gap: 12px;
+    padding: 12px 20px; border-bottom: 1px solid var(--line); background: var(--panel);
+    position: sticky; top: 0; z-index: 5;
+  }
+  header .brand { font-weight: 600; }
+  header .brand small { color: var(--muted); font-weight: 400; }
+  header .spacer { margin-left: auto; }
+  #status { font-size: 12px; color: var(--muted); }
+  #status.live { color: var(--accent); }
+  #status.err { color: var(--danger); }
+  main { max-width: 920px; margin: 0 auto; padding: 20px; display: grid; gap: 20px; }
+  section {
+    background: var(--panel); border: 1px solid var(--line); border-radius: 10px; padding: 16px 18px;
+  }
+  section h2 { margin: 0 0 4px; font-size: 15px; }
+  section p.hint { margin: 0 0 14px; color: var(--muted); font-size: 13px; }
+  label { display: block; font-size: 12px; color: var(--muted); margin: 0 0 4px; }
+  input[type=text], input[type=password], select, textarea {
+    width: 100%; background: var(--bg); color: var(--fg);
+    border: 1px solid var(--line); border-radius: 6px; padding: 8px 10px; font: inherit;
+  }
+  textarea { resize: vertical; min-height: 56px; }
+  .row { display: flex; gap: 10px; align-items: flex-end; flex-wrap: wrap; }
+  .row > .grow { flex: 1 1 160px; }
+  .grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+  button {
+    background: var(--bg); color: var(--fg); border: 1px solid var(--line);
+    border-radius: 6px; padding: 8px 14px; font: inherit; cursor: pointer;
+  }
+  button:hover { border-color: var(--muted); }
+  button:disabled { opacity: .4; cursor: default; }
+  button.primary { background: var(--accent); color: #06140f; border-color: var(--accent); font-weight: 600; }
+  button.danger { color: var(--danger); border-color: #3a2a2a; }
+  button.danger:hover { border-color: var(--danger); }
+  button.ghost { padding: 4px 9px; font-size: 12px; }
+  .pill { display: inline-block; padding: 2px 8px; border-radius: 999px; font-size: 11px; border: 1px solid var(--line); }
+  .pill.on { color: var(--accent); border-color: #244; }
+  .pill.off { color: var(--warn); border-color: #443; }
+  .pill.attached { color: var(--accent); border-color: #244; }
+  .pill.detached { color: var(--muted); }
+  table { width: 100%; border-collapse: collapse; font-size: 13px; }
+  th, td { text-align: left; padding: 8px 10px; border-bottom: 1px solid var(--line); vertical-align: middle; }
+  th { color: var(--muted); font-weight: 500; font-size: 12px; }
+  td.actions { text-align: right; white-space: nowrap; }
+  td.actions a, td.actions button { margin-left: 6px; }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  .channels-rows { display: grid; gap: 8px; margin-bottom: 8px; }
+  .channels-rows .crow { display: flex; gap: 8px; align-items: center; }
+  .channels-rows .crow input { flex: 1 1 auto; }
+  .channels-rows .crow select { flex: 0 0 130px; }
+  .mounts-rows { display: grid; gap: 8px; margin-bottom: 8px; }
+  .mounts-rows .mrow { display: flex; gap: 8px; align-items: center; }
+  .mounts-rows .mrow input { flex: 1 1 auto; }
+  .mounts-rows .mrow select { flex: 0 0 90px; }
+  .msg { margin-top: 12px; padding: 10px 12px; border-radius: 8px; font-size: 13px; display: none; white-space: pre-wrap; }
+  .msg.ok { display: block; background: #11241d; color: var(--accent); border: 1px solid #244; }
+  .msg.err { display: block; background: #241313; color: var(--danger); border: 1px solid #3a2a2a; }
+  code { color: var(--fg); background: #0b0d11; padding: 1px 5px; border-radius: 4px; font-size: 12px; }
+  details summary { cursor: pointer; color: var(--muted); font-size: 13px; }
+  .scopes { margin: 8px 0 0; font-size: 12px; color: var(--muted); }
+  .scopes div { font-family: ui-monospace, Menlo, monospace; }
+  .muted { color: var(--muted); }
+  .empty { color: var(--muted); font-size: 13px; padding: 8px 2px; }
+</style>
+</head>
+<body>
+  <header>
+    <div class="brand">parachute-channel <small>· agents</small></div>
+    <span class="spacer"></span>
+    <span id="status">connecting…</span>
+  </header>
+
+  <main>
+    <!-- Claude credential -->
+    <section id="cred-section">
+      <h2>Claude credential</h2>
+      <p class="hint">A launched session runs on a Claude subscription token from
+        <code>claude setup-token</code> (the 1-year headless auth) — injected per session, never your CLI login.
+        Set a default once; override per channel if needed.</p>
+      <div class="row">
+        <span>Default credential: <span id="cred-default" class="pill off">checking…</span></span>
+        <span class="spacer"></span>
+      </div>
+      <div id="cred-overrides" class="scopes"></div>
+      <details style="margin-top:12px;">
+        <summary>Set / rotate a credential</summary>
+        <div style="margin-top:10px;" class="grid2">
+          <div>
+            <label for="cred-channel">Scope (blank = default/operator)</label>
+            <input type="text" id="cred-channel" placeholder="channel name, or blank for default" />
+          </div>
+          <div>
+            <label for="cred-token">Token (oat_… from <code>claude setup-token</code>)</label>
+            <input type="password" id="cred-token" placeholder="oat_…" autocomplete="off" />
+          </div>
+        </div>
+        <div class="row" style="margin-top:10px;">
+          <button id="cred-save" class="primary" type="button">Save credential</button>
+          <span class="muted" style="font-size:12px;">The token is stored 0600 and never shown again.</span>
+        </div>
+      </details>
+      <div id="cred-msg" class="msg"></div>
+    </section>
+
+    <!-- Spawn -->
+    <section id="spawn-section">
+      <h2>Spawn an agent</h2>
+      <p class="hint">Launches a sandboxed Claude Code session in tmux, scoped to the channels (and optional vault)
+        you declare. Network egress is deny-by-default beyond the Anthropic API + your hub/vault; filesystem reads
+        are scoped to the workspace + declared mounts.</p>
+      <div class="grid2">
+        <div>
+          <label for="spawn-name">Name (slug)</label>
+          <input type="text" id="spawn-name" placeholder="e.g. aaron" autocomplete="off" />
+        </div>
+        <div>
+          <label>Channels <span class="muted">(first = wake channel)</span></label>
+          <div id="channels-rows" class="channels-rows"></div>
+          <button id="add-channel" class="ghost" type="button">+ channel</button>
+        </div>
+      </div>
+
+      <details style="margin-top:14px;">
+        <summary>Vault binding (optional)</summary>
+        <div class="grid2" style="margin-top:10px;">
+          <div>
+            <label for="vault-name">Vault name</label>
+            <input type="text" id="vault-name" placeholder="e.g. default (blank = no vault)" autocomplete="off" />
+          </div>
+          <div>
+            <label for="vault-access">Access</label>
+            <select id="vault-access">
+              <option value="read">read</option>
+              <option value="write">write</option>
+              <option value="admin">admin</option>
+            </select>
+          </div>
+        </div>
+        <div style="margin-top:10px;">
+          <label for="vault-tags">Tag scope (optional, comma-separated)</label>
+          <input type="text" id="vault-tags" placeholder="e.g. #channel-message" autocomplete="off" />
+        </div>
+      </details>
+
+      <details style="margin-top:12px;">
+        <summary>Network egress (optional)</summary>
+        <div style="margin-top:10px;">
+          <label for="egress">Additional allowed hosts (comma-separated, beyond the base)</label>
+          <input type="text" id="egress" placeholder="e.g. registry.npmjs.org, github.com" autocomplete="off" />
+        </div>
+      </details>
+
+      <details style="margin-top:12px;">
+        <summary>Filesystem mounts (optional)</summary>
+        <div id="mounts-rows" class="mounts-rows" style="margin-top:10px;"></div>
+        <button id="add-mount" class="ghost" type="button">+ mount</button>
+      </details>
+
+      <div class="row" style="margin-top:16px;">
+        <button id="spawn-go" class="primary" type="button">Spawn agent</button>
+        <span class="muted" id="spawn-note" style="font-size:12px;"></span>
+      </div>
+      <div id="spawn-msg" class="msg"></div>
+    </section>
+
+    <!-- Running agents -->
+    <section id="agents-section">
+      <div class="row" style="margin-bottom:10px;">
+        <h2 style="margin:0;">Running agents</h2>
+        <span class="spacer"></span>
+        <button id="refresh" class="ghost" type="button">Refresh</button>
+      </div>
+      <div id="agents-table"></div>
+    </section>
+  </main>
+
+<script>
+(function () {
+  // Served through the hub the page is /channel/agents; locally it's /agents.
+  // Derive the mount prefix so the API + token URLs resolve under the same prefix
+  // (same shape as the terminal + chat UIs).
+  var MOUNT = location.pathname.replace(/\\/agents\\/?$/, "");
+  var statusEl = document.getElementById("status");
+  var TOKEN = null;
+
+  function setStatus(text, cls) { statusEl.textContent = text; statusEl.className = cls || ""; }
+  function esc(s) {
+    return String(s == null ? "" : s).replace(/[&<>"]/g, function (c) {
+      return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c];
+    });
+  }
+  function showMsg(el, text, isErr) {
+    // textContent (NOT innerHTML) — server/result strings (session, workspace,
+    // scopes, egress, error messages) flow through here, so this deliberately
+    // avoids needing esc(): the browser never parses them as HTML.
+    el.textContent = text;
+    el.className = "msg " + (isErr ? "err" : "ok");
+  }
+  function clearMsg(el) { el.textContent = ""; el.className = "msg"; }
+
+  // --- token (operator channel:admin, minted by the hub) ------------------
+  function fetchToken() {
+    return fetch(location.origin + "/admin/channel-token", { credentials: "include" })
+      .then(function (r) { if (!r.ok) throw new Error("token " + r.status); return r.json(); })
+      .then(function (j) { TOKEN = (j && j.token) ? j.token : null; return TOKEN; })
+      .catch(function (err) {
+        TOKEN = null;
+        setStatus("not authenticated", "err");
+        throw err;
+      });
+  }
+
+  // Authed fetch against the daemon API. Retries ONCE on a 401 with a fresh token
+  // (the channel:admin token is short-lived).
+  function api(path, opts, _retried) {
+    opts = opts || {};
+    var headers = Object.assign({}, opts.headers || {});
+    if (TOKEN) headers["authorization"] = "Bearer " + TOKEN;
+    if (opts.body && !headers["content-type"]) headers["content-type"] = "application/json";
+    return fetch(MOUNT + path, Object.assign({}, opts, { headers: headers })).then(function (r) {
+      if (r.status === 401 && !_retried) {
+        return fetchToken().then(function () { return api(path, opts, true); });
+      }
+      return r;
+    });
+  }
+  function apiJson(path, opts) {
+    return api(path, opts).then(function (r) {
+      return r.json().catch(function () { return {}; }).then(function (j) {
+        if (!r.ok) { var e = new Error((j && (j.message || j.error)) || ("HTTP " + r.status)); e.status = r.status; throw e; }
+        return j;
+      });
+    });
+  }
+
+  // --- credential status --------------------------------------------------
+  function loadCreds() {
+    return apiJson("/api/credentials/claude").then(function (j) {
+      var dflt = document.getElementById("cred-default");
+      dflt.textContent = j.defaultSet ? "set" : "not set";
+      dflt.className = "pill " + (j.defaultSet ? "on" : "off");
+      var ov = document.getElementById("cred-overrides");
+      if (j.channels && j.channels.length) {
+        ov.innerHTML = "<div style='margin-top:8px;'>Per-channel overrides:</div>" +
+          j.channels.map(function (c) {
+            return "<div style='margin-top:4px;'>" + esc(c) +
+              " <button class='ghost danger' data-cred-rm='" + esc(c) + "' type='button'>remove</button></div>";
+          }).join("");
+        ov.querySelectorAll("[data-cred-rm]").forEach(function (btn) {
+          btn.addEventListener("click", function () { removeCred(btn.getAttribute("data-cred-rm")); });
+        });
+      } else {
+        ov.innerHTML = "";
+      }
+      updateSpawnNote(j.defaultSet, j.channels || []);
+      return j;
+    }).catch(function (err) {
+      document.getElementById("cred-default").textContent = "unknown (" + err.message + ")";
+    });
+  }
+
+  function updateSpawnNote(defaultSet, overrides) {
+    var note = document.getElementById("spawn-note");
+    if (!defaultSet && (!overrides || !overrides.length)) {
+      note.textContent = "⚠ no Claude credential set — spawn will fail until you set one above.";
+      note.style.color = "var(--warn)";
+    } else {
+      note.textContent = "";
+    }
+  }
+
+  document.getElementById("cred-save").addEventListener("click", function () {
+    var msg = document.getElementById("cred-msg");
+    clearMsg(msg);
+    var channel = document.getElementById("cred-channel").value.trim();
+    var token = document.getElementById("cred-token").value;
+    if (!token) { showMsg(msg, "Paste a token first.", true); return; }
+    var path = channel ? "/api/credentials/claude/" + encodeURIComponent(channel) : "/api/credentials/claude";
+    apiJson(path, { method: "POST", body: JSON.stringify({ token: token }) }).then(function () {
+      document.getElementById("cred-token").value = "";
+      showMsg(msg, channel ? ("Saved override for channel \\"" + channel + "\\".") : "Saved default credential.", false);
+      loadCreds();
+    }).catch(function (err) { showMsg(msg, "Failed: " + err.message, true); });
+  });
+
+  function removeCred(channel) {
+    var msg = document.getElementById("cred-msg");
+    clearMsg(msg);
+    apiJson("/api/credentials/claude/" + encodeURIComponent(channel), { method: "DELETE" }).then(function () {
+      showMsg(msg, "Removed override for \\"" + channel + "\\".", false);
+      loadCreds();
+    }).catch(function (err) { showMsg(msg, "Failed: " + err.message, true); });
+  }
+
+  // --- spawn form: channel + mount rows -----------------------------------
+  var knownChannels = [];
+  function channelRow(value, access) {
+    var div = document.createElement("div");
+    div.className = "crow";
+    var list = knownChannels.map(function (c) { return "<option value='" + esc(c) + "'>"; }).join("");
+    div.innerHTML =
+      "<input type='text' class='ch-name' placeholder='channel name' list='known-channels' value='" + esc(value || "") + "' />" +
+      "<select class='ch-access'>" +
+        "<option value='write'" + (access === "read" ? "" : " selected") + ">read+write</option>" +
+        "<option value='read'" + (access === "read" ? " selected" : "") + ">read only</option>" +
+      "</select>" +
+      "<button class='ghost' type='button' title='remove'>✕</button>";
+    div.querySelector("button").addEventListener("click", function () { div.remove(); });
+    document.getElementById("channels-rows").appendChild(div);
+    return div;
+  }
+  document.getElementById("add-channel").addEventListener("click", function () { channelRow("", "write"); });
+
+  function mountRow() {
+    var div = document.createElement("div");
+    div.className = "mrow";
+    div.innerHTML =
+      "<input type='text' class='mt-host' placeholder='host path (/abs/path)' />" +
+      "<input type='text' class='mt-mount' placeholder='mount path (/abs/path)' />" +
+      "<select class='mt-mode'><option value='ro'>ro</option><option value='rw'>rw</option></select>" +
+      "<button class='ghost' type='button' title='remove'>✕</button>";
+    div.querySelector("button").addEventListener("click", function () { div.remove(); });
+    document.getElementById("mounts-rows").appendChild(div);
+    return div;
+  }
+  document.getElementById("add-mount").addEventListener("click", function () { mountRow(); });
+
+  function collectSpec() {
+    var name = document.getElementById("spawn-name").value.trim();
+    if (!name) throw new Error("name is required");
+    var channels = [];
+    document.querySelectorAll("#channels-rows .crow").forEach(function (row) {
+      var n = row.querySelector(".ch-name").value.trim();
+      if (!n) return;
+      channels.push({ name: n, access: row.querySelector(".ch-access").value });
+    });
+    if (!channels.length) throw new Error("at least one channel is required (the first is the wake channel)");
+    var spec = { name: name, channels: channels };
+
+    var vn = document.getElementById("vault-name").value.trim();
+    if (vn) {
+      var v = { name: vn, access: document.getElementById("vault-access").value };
+      var tags = document.getElementById("vault-tags").value.split(",").map(function (t) { return t.trim(); }).filter(Boolean);
+      if (tags.length) v.tags = tags;
+      spec.vault = v;
+    }
+
+    var egress = document.getElementById("egress").value.split(",").map(function (h) { return h.trim(); }).filter(Boolean);
+    if (egress.length) spec.egress = egress;
+
+    var mounts = [];
+    document.querySelectorAll("#mounts-rows .mrow").forEach(function (row) {
+      var host = row.querySelector(".mt-host").value.trim();
+      var mount = row.querySelector(".mt-mount").value.trim();
+      if (!host || !mount) return;
+      mounts.push({ hostPath: host, mountPath: mount, mode: row.querySelector(".mt-mode").value });
+    });
+    if (mounts.length) spec.mounts = mounts;
+    return spec;
+  }
+
+  document.getElementById("spawn-go").addEventListener("click", function () {
+    var msg = document.getElementById("spawn-msg");
+    clearMsg(msg);
+    var spec;
+    try { spec = collectSpec(); } catch (e) { showMsg(msg, e.message, true); return; }
+    var btn = document.getElementById("spawn-go");
+    btn.disabled = true; btn.textContent = "Spawning…";
+    apiJson("/api/agents", { method: "POST", body: JSON.stringify(spec) }).then(function (r) {
+      var lines = [];
+      if (r.alreadyRunning) {
+        lines.push("Session \\"" + r.session + "\\" is already running (no-op).");
+      } else {
+        lines.push("Launched \\"" + r.session + "\\".");
+        lines.push("workspace: " + r.workspace);
+        if (r.tokens && r.tokens.length) {
+          lines.push("scopes:");
+          r.tokens.forEach(function (t) { lines.push("  " + t.resource + " → " + t.scope); });
+        }
+        if (r.mcpServers && r.mcpServers.length) lines.push("MCP servers: " + r.mcpServers.join(", "));
+        if (r.egress && r.egress.length) lines.push("egress: " + r.egress.join(", "));
+      }
+      showMsg(msg, lines.join("\\n"), false);
+      loadAgents();
+    }).catch(function (err) {
+      showMsg(msg, "Spawn failed: " + err.message, true);
+    }).then(function () {
+      btn.disabled = false; btn.textContent = "Spawn agent";
+    });
+  });
+
+  // --- running agents list ------------------------------------------------
+  function terminalUrl(channel) {
+    return MOUNT + "/terminal?channel=" + encodeURIComponent(channel);
+  }
+  function loadAgents() {
+    return apiJson("/api/agents").then(function (j) {
+      var host = document.getElementById("agents-table");
+      var agents = j.agents || [];
+      if (!agents.length) {
+        host.innerHTML = "<div class='empty'>No agent sessions running. Spawn one above.</div>";
+        return;
+      }
+      var rows = agents.map(function (a) {
+        var att = a.attached
+          ? "<span class='pill attached'>attached</span>"
+          : "<span class='pill detached'>idle</span>";
+        return "<tr>" +
+          "<td><strong>" + esc(a.name) + "</strong></td>" +
+          "<td><code>" + esc(a.session) + "</code></td>" +
+          "<td>" + att + "</td>" +
+          "<td class='actions'>" +
+            "<a href='" + esc(terminalUrl(a.name)) + "' target='_blank' rel='noopener'>terminal ↗</a>" +
+            "<button class='ghost danger' data-kill='" + esc(a.name) + "' type='button'>kill</button>" +
+          "</td></tr>";
+      }).join("");
+      host.innerHTML = "<table><thead><tr><th>Agent</th><th>tmux session</th><th>State</th><th></th></tr></thead><tbody>" +
+        rows + "</tbody></table>";
+      host.querySelectorAll("[data-kill]").forEach(function (btn) {
+        btn.addEventListener("click", function () { killAgent(btn.getAttribute("data-kill")); });
+      });
+    }).catch(function (err) {
+      document.getElementById("agents-table").innerHTML = "<div class='empty'>Could not load agents: " + esc(err.message) + "</div>";
+    });
+  }
+
+  function killAgent(name) {
+    // name is a server-enforced slug (alphanumeric/dash/underscore, agents.ts),
+    // so it carries no HTML/JS-special chars in the confirm string; it's
+    // encodeURI'd into the request path regardless.
+    if (!confirm("Kill agent \\"" + name + "\\"? This ends its tmux session.")) return;
+    apiJson("/api/agents/" + encodeURIComponent(name), { method: "DELETE" }).then(function () {
+      loadAgents();
+    }).catch(function (err) { alert("Kill failed: " + err.message); });
+  }
+
+  document.getElementById("refresh").addEventListener("click", function () { loadAgents(); });
+
+  // --- channels (prefill the spawn form) ----------------------------------
+  function loadChannels() {
+    return fetch(MOUNT + "/.parachute/config").then(function (r) { return r.json(); }).then(function (cfg) {
+      knownChannels = (cfg.channels || []).map(function (c) { return c.name; });
+      var dl = document.getElementById("known-channels");
+      dl.innerHTML = knownChannels.map(function (c) { return "<option value='" + esc(c) + "'>"; }).join("");
+      // Seed one channel row (prefilled with the first known channel, if any).
+      if (!document.querySelector("#channels-rows .crow")) {
+        channelRow(knownChannels[0] || "", "write");
+      }
+    }).catch(function () { channelRow("", "write"); });
+  }
+
+  // --- boot ---------------------------------------------------------------
+  setStatus("authenticating…");
+  fetchToken().then(function () {
+    setStatus("● ready", "live");
+    return Promise.all([loadChannels(), loadCreds(), loadAgents()]);
+  }).then(function () {
+    // Poll the running list so kills/exits elsewhere reflect here.
+    setInterval(loadAgents, 5000);
+  }).catch(function (err) {
+    setStatus("not authenticated", "err");
+    var msg = document.getElementById("spawn-msg");
+    showMsg(msg, "Open this page through the hub portal, signed in as the operator. " +
+      "The agents surface needs a channel:admin token (" + err.message + ").", true);
+  });
+})();
+</script>
+<datalist id="known-channels"></datalist>
+</body>
+</html>`;

--- a/src/agents.test.ts
+++ b/src/agents.test.ts
@@ -1,0 +1,511 @@
+/**
+ * Tests for the web agent-management layer (`src/agents.ts`) + the daemon's
+ * `/agents` page and `/api/agents` routes (`src/daemon.ts`).
+ *
+ * Three layers:
+ *   1. Pure functions — no hub, no tmux: `parseTmuxSessions`,
+ *      `agentInfoFromSessions`, `buildSpecFromBody` (valid + every error),
+ *      `redactSpawnResult` (proves token values never leak).
+ *   2. `createRealAgentOps` list/kill with an injected `TmuxAdmin` recorder.
+ *   3. The daemon routes through the REAL fetch handler, with `validateHubJwt`
+ *      mocked (so a known token carries `channel:admin`) and a STUB `AgentOps`
+ *      injected — verifying the gate, the body→spec→spawn wiring, the redaction,
+ *      and every error→status mapping, without a hub, a sandbox, or tmux.
+ */
+
+import { describe, test, expect, mock } from "bun:test";
+// Re-export the REAL error class + helper in the mock below so this process-wide
+// `mock.module` doesn't break hub-jwt.test.ts's assertions on the genuine shapes
+// (same discipline daemon-config-api.test.ts keeps).
+import { HubJwtError, looksLikeJwt } from "@openparachute/scope-guard";
+
+const ADMIN_TOKEN = "test-admin-token"; // channel:admin (the operator gate)
+const READ_TOKEN = "test-read-token"; // channel:read only (insufficient)
+mock.module("./hub-jwt.ts", () => ({
+  CHANNEL_AUDIENCE: "channel",
+  async validateHubJwt(token: string) {
+    const base = { sub: "test", aud: "channel", jti: undefined, clientId: undefined, vaultScope: undefined };
+    if (token === ADMIN_TOKEN) return { ...base, scopes: ["channel:read", "channel:send", "channel:admin"] };
+    if (token === READ_TOKEN) return { ...base, scopes: ["channel:read"] };
+    throw new HubJwtError("issuer", "invalid token");
+  },
+  HubJwtError,
+  looksLikeJwt,
+  resetJwksCache() {},
+  resetRevocationCache() {},
+}));
+
+import {
+  parseTmuxSessions,
+  agentInfoFromSessions,
+  buildSpecFromBody,
+  redactSpawnResult,
+  createRealAgentOps,
+  SpawnRequestError,
+  type AgentOps,
+  type TmuxAdmin,
+} from "./agents.ts";
+import { createFetchHandler } from "./daemon.ts";
+import { ClientRegistry } from "./routing.ts";
+import { HttpUiTransport } from "./transports/http-ui.ts";
+import { CredentialNotConfiguredError } from "./credentials.ts";
+import { SpawnDepsError } from "./spawn-deps.ts";
+import { MintError } from "./mint-token.ts";
+import type { Channel } from "./registry.ts";
+import type { SpawnAgentResult } from "./spawn-agent.ts";
+
+const adminAuth = { authorization: "Bearer " + ADMIN_TOKEN } as const;
+const readAuth = { authorization: "Bearer " + READ_TOKEN } as const;
+
+// ===========================================================================
+// 1. Pure functions
+// ===========================================================================
+describe("parseTmuxSessions", () => {
+  test("parses `<name> <attachedCount>` lines; attached>0 → true", () => {
+    const out = parseTmuxSessions("aaron-agent 1\nweaver-agent 0\nmisc 2\n");
+    expect(out).toEqual([
+      { name: "aaron-agent", attached: true },
+      { name: "weaver-agent", attached: false },
+      { name: "misc", attached: true },
+    ]);
+  });
+  test("empty / blank input → empty list", () => {
+    expect(parseTmuxSessions("")).toEqual([]);
+    expect(parseTmuxSessions("\n  \n")).toEqual([]);
+  });
+});
+
+describe("agentInfoFromSessions", () => {
+  test("keeps only *-agent sessions, strips the suffix, sorts by name", () => {
+    const infos = agentInfoFromSessions(
+      [
+        { name: "weaver-agent", attached: false },
+        { name: "scratch", attached: true }, // not an agent session — dropped
+        { name: "aaron-agent", attached: true },
+      ],
+      "/tmp/sessions",
+    );
+    expect(infos.map((i) => i.name)).toEqual(["aaron", "weaver"]);
+    expect(infos[0]).toMatchObject({ name: "aaron", session: "aaron-agent", attached: true });
+    expect(infos[0]!.workspace).toBe("/tmp/sessions/aaron");
+    // hasWorkspace is false for a non-existent dir (no .mcp.json on disk).
+    expect(infos[0]!.hasWorkspace).toBe(false);
+  });
+  test("a bare `-agent` (empty slug) is dropped", () => {
+    expect(agentInfoFromSessions([{ name: "-agent", attached: false }], "/tmp/s")).toEqual([]);
+  });
+});
+
+describe("buildSpecFromBody", () => {
+  test("minimal valid body (one channel, defaults to write)", () => {
+    const spec = buildSpecFromBody({ name: "aaron", channels: ["aaron"] });
+    expect(spec).toEqual({ name: "aaron", channels: ["aaron"] });
+  });
+  test("full body — channels (object form), vault+tags, egress, mounts", () => {
+    const spec = buildSpecFromBody({
+      name: "weaver",
+      channels: [{ name: "weave", access: "read" }, { name: "out" }],
+      vault: { name: "default", access: "read", tags: ["#channel-message", " "] },
+      egress: ["registry.npmjs.org", "  "],
+      mounts: [{ hostPath: "/data", mountPath: "/data", mode: "ro", shared: "corpus" }],
+    });
+    expect(spec.channels).toEqual([{ name: "weave", access: "read" }, { name: "out" }]);
+    expect(spec.vault).toEqual({ name: "default", access: "read", tags: ["#channel-message"] });
+    expect(spec.egress).toEqual(["registry.npmjs.org"]); // blank trimmed out
+    expect(spec.mounts).toEqual([{ hostPath: "/data", mountPath: "/data", mode: "ro", shared: "corpus" }]);
+  });
+  test("rejects a non-object body", () => {
+    expect(() => buildSpecFromBody(null)).toThrow(SpawnRequestError);
+    expect(() => buildSpecFromBody("x")).toThrow(/must be a JSON object/);
+  });
+  test("rejects a missing / non-slug name", () => {
+    expect(() => buildSpecFromBody({ channels: ["a"] })).toThrow(/body.name/);
+    expect(() => buildSpecFromBody({ name: "bad name", channels: ["a"] })).toThrow(/slug/);
+    expect(() => buildSpecFromBody({ name: "../escape", channels: ["a"] })).toThrow(/slug/);
+  });
+  test("rejects empty / missing channels", () => {
+    expect(() => buildSpecFromBody({ name: "a", channels: [] })).toThrow(/non-empty array/);
+    expect(() => buildSpecFromBody({ name: "a" })).toThrow(/non-empty array/);
+  });
+  test("rejects a bad channel access / shape", () => {
+    expect(() => buildSpecFromBody({ name: "a", channels: [{ name: "c", access: "admin" }] })).toThrow(/access/);
+    expect(() => buildSpecFromBody({ name: "a", channels: [123] })).toThrow(/string or/);
+  });
+  test("rejects a bad vault access", () => {
+    expect(() => buildSpecFromBody({ name: "a", channels: ["c"], vault: { name: "v", access: "x" } })).toThrow(/vault.access/);
+  });
+  test("rejects a bad mount mode", () => {
+    expect(() =>
+      buildSpecFromBody({ name: "a", channels: ["c"], mounts: [{ hostPath: "/h", mountPath: "/m", mode: "x" }] }),
+    ).toThrow(/mode/);
+  });
+  test("rejects relative mount paths (must be absolute)", () => {
+    expect(() =>
+      buildSpecFromBody({ name: "a", channels: ["c"], mounts: [{ hostPath: "rel", mountPath: "/m", mode: "ro" }] }),
+    ).toThrow(/hostPath must be an absolute path/);
+    expect(() =>
+      buildSpecFromBody({ name: "a", channels: ["c"], mounts: [{ hostPath: "/h", mountPath: "rel", mode: "ro" }] }),
+    ).toThrow(/mountPath must be an absolute path/);
+  });
+});
+
+describe("redactSpawnResult", () => {
+  const result: SpawnAgentResult = {
+    session: "aaron-agent",
+    workspace: "/s/aaron",
+    alreadyRunning: false,
+    tokens: {
+      aaron: { jti: "j1", token: "SECRET-CHANNEL-TOKEN", expiresAt: "2026-07-01T00:00:00Z", scope: "channel:read channel:write" },
+      "vault:default": { jti: "j2", token: "SECRET-VAULT-TOKEN", expiresAt: "2026-07-01T00:00:00Z", scope: "vault:default:read" },
+    },
+    mcpConfigJson: JSON.stringify({ mcpServers: { "channel-aaron": {}, "vault-default": {} } }),
+    wrapped: {
+      argv: ["/bin/bash", "-c", "..."],
+      env: {},
+      config: { network: { allowedDomains: ["api.anthropic.com:443"], deniedDomains: [] }, filesystem: { denyRead: [], allowWrite: [], denyWrite: [] } },
+    },
+  };
+  test("surfaces scopes + mcp servers + egress, NEVER the token values", () => {
+    const red = redactSpawnResult(result);
+    expect(red.session).toBe("aaron-agent");
+    expect(red.tokens).toEqual([
+      { resource: "aaron", scope: "channel:read channel:write", expiresAt: "2026-07-01T00:00:00Z" },
+      { resource: "vault:default", scope: "vault:default:read", expiresAt: "2026-07-01T00:00:00Z" },
+    ]);
+    expect(red.mcpServers).toEqual(["channel-aaron", "vault-default"]);
+    expect(red.egress).toEqual(["api.anthropic.com:443"]);
+    // The smoking gun: no token VALUE appears anywhere in the serialized result.
+    const wire = JSON.stringify(red);
+    expect(wire).not.toContain("SECRET-CHANNEL-TOKEN");
+    expect(wire).not.toContain("SECRET-VAULT-TOKEN");
+  });
+});
+
+// ===========================================================================
+// 2. createRealAgentOps list/kill with an injected tmux admin
+// ===========================================================================
+describe("createRealAgentOps — list + kill", () => {
+  function recorder(sessions: { name: string; attached: boolean }[]): { tmux: TmuxAdmin; killed: string[] } {
+    const killed: string[] = [];
+    const tmux: TmuxAdmin = {
+      async listSessions() {
+        return sessions;
+      },
+      async killSession(name: string) {
+        killed.push(name);
+        return sessions.some((s) => s.name === name);
+      },
+    };
+    return { tmux, killed };
+  }
+
+  test("list maps tmux sessions to agent infos under the sessions dir", async () => {
+    const { tmux } = recorder([{ name: "aaron-agent", attached: true }, { name: "other", attached: false }]);
+    const ops = createRealAgentOps({ tmux, sessionsDirPath: "/tmp/s" });
+    const list = await ops.list();
+    expect(list.map((a) => a.name)).toEqual(["aaron"]);
+  });
+
+  test("kill targets `<name>-agent` and reports whether it existed", async () => {
+    const { tmux, killed } = recorder([{ name: "aaron-agent", attached: false }]);
+    const ops = createRealAgentOps({ tmux, sessionsDirPath: "/tmp/s" });
+    expect(await ops.kill("aaron")).toEqual({ killed: true });
+    expect(killed).toEqual(["aaron-agent"]);
+    expect(await ops.kill("ghost")).toEqual({ killed: false });
+  });
+
+  test("kill rejects a non-slug name before touching tmux", async () => {
+    const { tmux, killed } = recorder([]);
+    const ops = createRealAgentOps({ tmux, sessionsDirPath: "/tmp/s" });
+    await expect(ops.kill("../escape")).rejects.toThrow(SpawnRequestError);
+    expect(killed).toEqual([]);
+  });
+});
+
+// ===========================================================================
+// 3. The daemon routes (real handler, mocked JWT, stub AgentOps)
+// ===========================================================================
+function buildServer(agentOps?: Partial<AgentOps>) {
+  const registry = new ClientRegistry();
+  const transport = new HttpUiTransport({ channel: "ui1" });
+  const channels = new Map<string, Channel>([
+    ["ui1", { name: "ui1", transport, entry: { name: "ui1", transport: "http-ui" } }],
+  ]);
+  void transport.start({ channel: "ui1", emit: () => {}, emitPermissionVerdict: () => {} });
+  const ops: AgentOps = {
+    async spawn() {
+      throw new Error("spawn not stubbed");
+    },
+    async list() {
+      return [];
+    },
+    async kill() {
+      return { killed: false };
+    },
+    ...agentOps,
+  };
+  const srv = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    idleTimeout: 0,
+    fetch: createFetchHandler(channels, registry, { agentOps: ops }),
+  });
+  return { srv, base: `http://127.0.0.1:${srv.port}` };
+}
+
+describe("GET /agents — the management page (loads open)", () => {
+  test("returns the HTML page with no token", async () => {
+    const { srv, base } = buildServer();
+    try {
+      const res = await fetch(`${base}/agents`);
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("text/html");
+      const html = await res.text();
+      expect(html).toContain("parachute-channel");
+      expect(html).toContain("Spawn an agent");
+    } finally {
+      srv.stop(true);
+    }
+  });
+});
+
+describe("/api/agents — operator-gated on channel:admin", () => {
+  test("GET with no token → 401", async () => {
+    const { srv, base } = buildServer();
+    try {
+      const res = await fetch(`${base}/api/agents`);
+      expect(res.status).toBe(401);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("GET with channel:read (insufficient) → 403", async () => {
+    const { srv, base } = buildServer();
+    try {
+      const res = await fetch(`${base}/api/agents`, { headers: readAuth });
+      expect(res.status).toBe(403);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("GET with channel:admin → 200 + the agent list", async () => {
+    const { srv, base } = buildServer({
+      async list() {
+        return [
+          { name: "aaron", session: "aaron-agent", attached: true, workspace: "/s/aaron", hasWorkspace: true },
+        ];
+      },
+    });
+    try {
+      const res = await fetch(`${base}/api/agents`, { headers: adminAuth });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { agents: { name: string }[] };
+      expect(body.agents).toHaveLength(1);
+      expect(body.agents[0]!.name).toBe("aaron");
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("POST with no token → 401 (and spawn is never called)", async () => {
+    let spawned = false;
+    const { srv, base } = buildServer({
+      async spawn() {
+        spawned = true;
+        throw new Error("unreachable");
+      },
+    });
+    try {
+      const res = await fetch(`${base}/api/agents`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "x", channels: ["x"] }),
+      });
+      expect(res.status).toBe(401);
+      expect(spawned).toBe(false);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("POST with admin token + valid spec → 200 redacted result (no token values)", async () => {
+    const { srv, base } = buildServer({
+      async spawn(spec) {
+        return {
+          session: spec.name + "-agent",
+          workspace: "/s/" + spec.name,
+          alreadyRunning: false,
+          tokens: { [spec.name]: { jti: "j", token: "LEAKME", expiresAt: "2026-07-01T00:00:00Z", scope: "channel:read channel:write" } },
+          mcpConfigJson: JSON.stringify({ mcpServers: { ["channel-" + spec.name]: {} } }),
+          wrapped: {
+            argv: [],
+            env: {},
+            config: { network: { allowedDomains: ["api.anthropic.com:443"], deniedDomains: [] }, filesystem: { denyRead: [], allowWrite: [], denyWrite: [] } },
+          },
+        } satisfies SpawnAgentResult;
+      },
+    });
+    try {
+      const res = await fetch(`${base}/api/agents`, {
+        method: "POST",
+        headers: { ...adminAuth, "content-type": "application/json" },
+        body: JSON.stringify({ name: "aaron", channels: ["aaron"] }),
+      });
+      expect(res.status).toBe(200);
+      const text = await res.text();
+      expect(text).not.toContain("LEAKME");
+      const body = JSON.parse(text) as { session: string; tokens: { scope: string }[]; mcpServers: string[] };
+      expect(body.session).toBe("aaron-agent");
+      expect(body.tokens[0]!.scope).toBe("channel:read channel:write");
+      expect(body.mcpServers).toEqual(["channel-aaron"]);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("POST with admin token + bad spec → 400 (spawn never called)", async () => {
+    let spawned = false;
+    const { srv, base } = buildServer({
+      async spawn() {
+        spawned = true;
+        throw new Error("unreachable");
+      },
+    });
+    try {
+      const res = await fetch(`${base}/api/agents`, {
+        method: "POST",
+        headers: { ...adminAuth, "content-type": "application/json" },
+        body: JSON.stringify({ name: "aaron" }), // no channels
+      });
+      expect(res.status).toBe(400);
+      expect(spawned).toBe(false);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("spawn throws CredentialNotConfiguredError → 400 with the fix", async () => {
+    const { srv, base } = buildServer({
+      async spawn() {
+        throw new CredentialNotConfiguredError("aaron");
+      },
+    });
+    try {
+      const res = await fetch(`${base}/api/agents`, {
+        method: "POST",
+        headers: { ...adminAuth, "content-type": "application/json" },
+        body: JSON.stringify({ name: "aaron", channels: ["aaron"] }),
+      });
+      expect(res.status).toBe(400);
+      expect(((await res.json()) as { error: string }).error).toContain("no Claude credential");
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("spawn throws SpawnDepsError (no operator token) → 503", async () => {
+    const { srv, base } = buildServer({
+      async spawn() {
+        throw new SpawnDepsError("no operator token");
+      },
+    });
+    try {
+      const res = await fetch(`${base}/api/agents`, {
+        method: "POST",
+        headers: { ...adminAuth, "content-type": "application/json" },
+        body: JSON.stringify({ name: "aaron", channels: ["aaron"] }),
+      });
+      expect(res.status).toBe(503);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("spawn throws MintError → forwards the hub status", async () => {
+    const { srv, base } = buildServer({
+      async spawn() {
+        throw new MintError("over-broad scope", 403, "forbidden");
+      },
+    });
+    try {
+      const res = await fetch(`${base}/api/agents`, {
+        method: "POST",
+        headers: { ...adminAuth, "content-type": "application/json" },
+        body: JSON.stringify({ name: "aaron", channels: ["aaron"] }),
+      });
+      expect(res.status).toBe(403);
+      expect(((await res.json()) as { error: string }).error).toContain("mint failed");
+    } finally {
+      srv.stop(true);
+    }
+  });
+});
+
+describe("DELETE /api/agents/:name", () => {
+  test("no token → 401 (kill never called)", async () => {
+    let killed = false;
+    const { srv, base } = buildServer({
+      async kill() {
+        killed = true;
+        return { killed: true };
+      },
+    });
+    try {
+      const res = await fetch(`${base}/api/agents/aaron`, { method: "DELETE" });
+      expect(res.status).toBe(401);
+      expect(killed).toBe(false);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("channel:read (insufficient) → 403 (kill never called)", async () => {
+    let killed = false;
+    const { srv, base } = buildServer({
+      async kill() {
+        killed = true;
+        return { killed: true };
+      },
+    });
+    try {
+      const res = await fetch(`${base}/api/agents/aaron`, { method: "DELETE", headers: readAuth });
+      expect(res.status).toBe(403);
+      expect(killed).toBe(false);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("admin token → 200 { killed }", async () => {
+    const { srv, base } = buildServer({
+      async kill(name) {
+        expect(name).toBe("aaron");
+        return { killed: true };
+      },
+    });
+    try {
+      const res = await fetch(`${base}/api/agents/aaron`, { method: "DELETE", headers: adminAuth });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { ok: boolean; name: string; killed: boolean };
+      expect(body).toEqual({ ok: true, name: "aaron", killed: true });
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("kill's SpawnRequestError (bad slug) → 400", async () => {
+    const { srv, base } = buildServer({
+      async kill() {
+        throw new SpawnRequestError("bad slug");
+      },
+    });
+    try {
+      const res = await fetch(`${base}/api/agents/whatever`, { method: "DELETE", headers: adminAuth });
+      expect(res.status).toBe(400);
+    } finally {
+      srv.stop(true);
+    }
+  });
+});

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -1,0 +1,392 @@
+/**
+ * Agent management operations — the daemon-facing layer behind the web spawn UI
+ * (`POST/GET/DELETE /api/agents`) and the management page (`src/agents-ui.ts`).
+ *
+ * This is the SAME launch path the operator CLI (`scripts/spawn-agent.ts`) uses —
+ * it builds an {@link AgentSpec} and calls {@link spawnAgent} with the real deps
+ * ({@link resolveSpawnDeps}). The web is just another caller; every least-
+ * privilege decision still lives in `spawnAgent`/`sandbox/*`. The web flow adds
+ * three things the CLI didn't need:
+ *
+ *   1. {@link buildSpecFromBody} — turn an untrusted JSON request body into a
+ *      validated {@link AgentSpec} (or a {@link SpawnRequestError} mapped to 400).
+ *   2. {@link redactSpawnResult} — surface scopes/audiences per resource but
+ *      NEVER the minted token values (the result carries them; the wire must not).
+ *   3. list + kill over the live tmux sessions ({@link AgentOps}).
+ *
+ * The tmux side is behind a small injectable seam ({@link TmuxAdmin}) so the
+ * list/kill logic is unit-testable without a real tmux server.
+ */
+
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import type {
+  AgentSpec,
+  AgentChannel,
+  AgentVaultSpec,
+  AgentMount,
+} from "./sandbox/types.ts";
+import {
+  spawnAgent,
+  sessionName,
+  sessionWorkspace,
+  type SpawnAgentResult,
+  type SpawnAgentDeps,
+} from "./spawn-agent.ts";
+import { resolveSpawnDeps, sessionsDir as defaultSessionsDir } from "./spawn-deps.ts";
+
+/** The `-agent` suffix tmux sessions launched by `spawnAgent` carry. */
+const AGENT_SESSION_SUFFIX = "-agent";
+
+/** Same slug shape `spawnAgent` enforces — validated early so a bad name 400s. */
+const AGENT_NAME_SLUG = /^[a-z0-9_-]+$/i;
+
+/** A malformed spawn request body — the caller maps `.message` to a 400. */
+export class SpawnRequestError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SpawnRequestError";
+  }
+}
+
+/** One running (or recently-launched) agent session, as the page lists them. */
+export interface AgentInfo {
+  /** Agent slug (the tmux session name minus the `-agent` suffix). */
+  name: string;
+  /** tmux session name (`<name>-agent`). */
+  session: string;
+  /** Whether a client is currently attached to the tmux session. */
+  attached: boolean;
+  /** Per-session workspace dir (may not exist if the session predates this build). */
+  workspace: string;
+  /** Whether the session's workspace (with its .mcp.json) is present on disk. */
+  hasWorkspace: boolean;
+}
+
+/** A redacted mint summary — scope + audience + expiry, NEVER the token value. */
+export interface RedactedToken {
+  /** Resource key (channel name / `vault:<name>` / other-mcp name). */
+  resource: string;
+  /** The granted scope string. */
+  scope: string;
+  /** ISO expiry. */
+  expiresAt: string;
+}
+
+/** The redacted spawn result the web endpoint returns (no token values). */
+export interface RedactedSpawnResult {
+  session: string;
+  workspace: string;
+  alreadyRunning: boolean;
+  /** One entry per minted resource — scope/expiry only, token redacted. */
+  tokens: RedactedToken[];
+  /** The MCP server entry keys wired into the session (names only). */
+  mcpServers: string[];
+  /** Egress allowlist baked into the sandbox (host:port domains). */
+  egress: string[];
+}
+
+/** The spawn/list/kill operations the daemon routes call. Injectable for tests. */
+export interface AgentOps {
+  /** Launch a sandboxed agent session from a validated spec. */
+  spawn(spec: AgentSpec): Promise<SpawnAgentResult>;
+  /** List the live agent tmux sessions. */
+  list(): Promise<AgentInfo[]>;
+  /** Kill an agent session by name (returns whether one existed). */
+  kill(name: string): Promise<{ killed: boolean }>;
+}
+
+/** A tmux admin seam — real impl shells out to tmux; tests inject a recorder. */
+export interface TmuxAdmin {
+  /** List sessions as `{ name, attached }`. Empty when no tmux server runs. */
+  listSessions(): Promise<{ name: string; attached: boolean }[]>;
+  /** Kill a session by exact name; returns whether it existed. */
+  killSession(name: string): Promise<boolean>;
+}
+
+/**
+ * Parse `tmux list-sessions -F '#{session_name} #{session_attached}'` stdout into
+ * `{ name, attached }[]`. Each line is `<name> <attachedCount>`; attached>0 → true.
+ * Robust to blank trailing lines. Pure — the real probe + this parser are split so
+ * the parse is unit-tested without a tmux server.
+ */
+export function parseTmuxSessions(stdout: string): { name: string; attached: boolean }[] {
+  const out: { name: string; attached: boolean }[] = [];
+  for (const line of stdout.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    // Split on the LAST space so a (disallowed-but-defensive) spaced name still
+    // parses its trailing attached count.
+    const idx = trimmed.lastIndexOf(" ");
+    if (idx < 0) {
+      out.push({ name: trimmed, attached: false });
+      continue;
+    }
+    const name = trimmed.slice(0, idx);
+    const attachedRaw = trimmed.slice(idx + 1);
+    out.push({ name, attached: parseInt(attachedRaw, 10) > 0 });
+  }
+  return out;
+}
+
+/**
+ * Map raw tmux sessions to {@link AgentInfo}, keeping only `*-agent` sessions and
+ * stripping the suffix to the agent slug. Pure over its inputs (the sessions list
+ * + the sessions dir) so it's unit-testable.
+ */
+export function agentInfoFromSessions(
+  sessions: { name: string; attached: boolean }[],
+  sessionsDirPath: string,
+): AgentInfo[] {
+  const agents: AgentInfo[] = [];
+  for (const s of sessions) {
+    if (!s.name.endsWith(AGENT_SESSION_SUFFIX)) continue;
+    const name = s.name.slice(0, -AGENT_SESSION_SUFFIX.length);
+    if (name.length === 0) continue;
+    const workspace = sessionWorkspace(sessionsDirPath, name);
+    agents.push({
+      name,
+      session: s.name,
+      attached: s.attached,
+      workspace,
+      hasWorkspace: existsSync(join(workspace, ".mcp.json")),
+    });
+  }
+  agents.sort((a, b) => a.name.localeCompare(b.name));
+  return agents;
+}
+
+/** The real tmux admin — shells out via Bun.spawn. */
+export function realTmuxAdmin(spawnFn: typeof Bun.spawn = Bun.spawn): TmuxAdmin {
+  return {
+    async listSessions() {
+      const proc = spawnFn(
+        ["tmux", "list-sessions", "-F", "#{session_name} #{session_attached}"],
+        { stdout: "pipe", stderr: "pipe" },
+      );
+      const code = await proc.exited;
+      // tmux exits non-zero with "no server running" when there are zero sessions
+      // — that's an empty list, not an error.
+      if (code !== 0) return [];
+      const stdout = await new Response(proc.stdout as ReadableStream<Uint8Array>).text();
+      return parseTmuxSessions(stdout);
+    },
+    async killSession(name: string) {
+      const proc = spawnFn(["tmux", "kill-session", "-t", name], {
+        stdout: "ignore",
+        stderr: "ignore",
+      });
+      const code = await proc.exited;
+      return code === 0;
+    },
+  };
+}
+
+/**
+ * Build a validated {@link AgentSpec} from an untrusted JSON request body. Throws
+ * {@link SpawnRequestError} on any malformed field — the daemon maps it to a 400.
+ * Mirrors the CLI's parse semantics (channels default to write; the first channel
+ * is the wake channel) but over JSON rather than flags.
+ *
+ * Accepts channels as either `["name"]` (write) or `[{ name, access }]`. The
+ * `spawnAgent` slug guard is the authority on the name, but we check it here too
+ * so a bad name fails before any dep resolution / mint side effect.
+ */
+export function buildSpecFromBody(body: unknown): AgentSpec {
+  if (!body || typeof body !== "object") {
+    throw new SpawnRequestError("request body must be a JSON object");
+  }
+  const b = body as Record<string, unknown>;
+
+  const name = b.name;
+  if (typeof name !== "string" || name.length === 0) {
+    throw new SpawnRequestError("body.name (non-empty string) is required");
+  }
+  if (!AGENT_NAME_SLUG.test(name)) {
+    throw new SpawnRequestError(
+      `body.name "${name}" must be a slug (alphanumeric, dash, underscore only)`,
+    );
+  }
+
+  if (!Array.isArray(b.channels) || b.channels.length === 0) {
+    throw new SpawnRequestError("body.channels must be a non-empty array (the first is the wake channel)");
+  }
+  const channels: AgentChannel[] = b.channels.map((raw, i) => parseChannelEntry(raw, i));
+
+  const spec: AgentSpec = { name, channels };
+
+  if (b.vault !== undefined && b.vault !== null) {
+    spec.vault = parseVaultEntry(b.vault);
+  }
+
+  if (b.egress !== undefined && b.egress !== null) {
+    if (!Array.isArray(b.egress)) {
+      throw new SpawnRequestError("body.egress must be an array of host strings");
+    }
+    const egress = b.egress
+      .map((h) => {
+        if (typeof h !== "string") throw new SpawnRequestError("body.egress entries must be strings");
+        return h.trim();
+      })
+      .filter((h) => h.length > 0);
+    if (egress.length > 0) spec.egress = egress;
+  }
+
+  if (b.mounts !== undefined && b.mounts !== null) {
+    if (!Array.isArray(b.mounts)) {
+      throw new SpawnRequestError("body.mounts must be an array");
+    }
+    const mounts = b.mounts.map((raw, i) => parseMountEntry(raw, i));
+    if (mounts.length > 0) spec.mounts = mounts;
+  }
+
+  return spec;
+}
+
+function parseChannelEntry(raw: unknown, i: number): AgentChannel {
+  if (typeof raw === "string") {
+    if (raw.length === 0) throw new SpawnRequestError(`body.channels[${i}] is an empty string`);
+    return raw;
+  }
+  if (!raw || typeof raw !== "object") {
+    throw new SpawnRequestError(`body.channels[${i}] must be a string or { name, access }`);
+  }
+  const c = raw as Record<string, unknown>;
+  if (typeof c.name !== "string" || c.name.length === 0) {
+    throw new SpawnRequestError(`body.channels[${i}].name (non-empty string) is required`);
+  }
+  if (c.access !== undefined && c.access !== "read" && c.access !== "write") {
+    throw new SpawnRequestError(`body.channels[${i}].access must be "read" or "write"`);
+  }
+  return c.access === undefined
+    ? { name: c.name }
+    : { name: c.name, access: c.access as "read" | "write" };
+}
+
+function parseVaultEntry(raw: unknown): AgentVaultSpec {
+  if (!raw || typeof raw !== "object") {
+    throw new SpawnRequestError("body.vault must be { name, access, tags? }");
+  }
+  const v = raw as Record<string, unknown>;
+  if (typeof v.name !== "string" || v.name.length === 0) {
+    throw new SpawnRequestError("body.vault.name (non-empty string) is required");
+  }
+  if (v.access !== "read" && v.access !== "write" && v.access !== "admin") {
+    throw new SpawnRequestError('body.vault.access must be "read", "write", or "admin"');
+  }
+  const spec: AgentVaultSpec = { name: v.name, access: v.access as "read" | "write" | "admin" };
+  if (v.tags !== undefined && v.tags !== null) {
+    if (!Array.isArray(v.tags)) throw new SpawnRequestError("body.vault.tags must be an array of strings");
+    const tags = v.tags
+      .map((t) => {
+        if (typeof t !== "string") throw new SpawnRequestError("body.vault.tags entries must be strings");
+        return t.trim();
+      })
+      .filter((t) => t.length > 0);
+    if (tags.length > 0) spec.tags = tags;
+  }
+  return spec;
+}
+
+function parseMountEntry(raw: unknown, i: number): AgentMount {
+  if (!raw || typeof raw !== "object") {
+    throw new SpawnRequestError(`body.mounts[${i}] must be { hostPath, mountPath, mode, shared? }`);
+  }
+  const m = raw as Record<string, unknown>;
+  if (typeof m.hostPath !== "string" || m.hostPath.length === 0) {
+    throw new SpawnRequestError(`body.mounts[${i}].hostPath (non-empty string) is required`);
+  }
+  if (typeof m.mountPath !== "string" || m.mountPath.length === 0) {
+    throw new SpawnRequestError(`body.mounts[${i}].mountPath (non-empty string) is required`);
+  }
+  // Require ABSOLUTE paths. The sandbox engine is the authoritative confinement,
+  // but a relative `hostPath` would resolve against the session's cwd in
+  // surprising ways — make the trust boundary explicit with a clean 400 here
+  // rather than a confusing sandbox behavior downstream.
+  if (!m.hostPath.startsWith("/")) {
+    throw new SpawnRequestError(`body.mounts[${i}].hostPath must be an absolute path (start with "/")`);
+  }
+  if (!m.mountPath.startsWith("/")) {
+    throw new SpawnRequestError(`body.mounts[${i}].mountPath must be an absolute path (start with "/")`);
+  }
+  if (m.mode !== "ro" && m.mode !== "rw") {
+    throw new SpawnRequestError(`body.mounts[${i}].mode must be "ro" or "rw"`);
+  }
+  const mount: AgentMount = {
+    hostPath: m.hostPath,
+    mountPath: m.mountPath,
+    mode: m.mode as "ro" | "rw",
+  };
+  if (m.shared !== undefined && m.shared !== null) {
+    if (typeof m.shared !== "string" || m.shared.length === 0) {
+      throw new SpawnRequestError(`body.mounts[${i}].shared must be a non-empty string`);
+    }
+    mount.shared = m.shared;
+  }
+  return mount;
+}
+
+/**
+ * Redact a {@link SpawnAgentResult} for the wire: scopes + audiences + expiries
+ * per resource, the MCP server names, and the egress allowlist — but NEVER the
+ * minted token values (the result inlines them; the response must not).
+ */
+export function redactSpawnResult(result: SpawnAgentResult): RedactedSpawnResult {
+  const tokens: RedactedToken[] = Object.entries(result.tokens).map(([resource, minted]) => ({
+    resource,
+    scope: minted.scope,
+    expiresAt: minted.expiresAt,
+  }));
+  let mcpServers: string[] = [];
+  try {
+    const parsed = JSON.parse(result.mcpConfigJson || "{}") as { mcpServers?: Record<string, unknown> };
+    mcpServers = Object.keys(parsed.mcpServers ?? {});
+  } catch {
+    mcpServers = [];
+  }
+  return {
+    session: result.session,
+    workspace: result.workspace,
+    alreadyRunning: result.alreadyRunning,
+    tokens,
+    mcpServers,
+    egress: result.wrapped.config.network.allowedDomains,
+  };
+}
+
+/**
+ * Build the real {@link AgentOps} from the environment — `spawn` calls
+ * {@link spawnAgent} with {@link resolveSpawnDeps} (resolved lazily PER spawn so a
+ * credential/token set via the API takes effect without a daemon restart), `list`
+ * + `kill` go through the real tmux admin. `depsFactory` + `tmux` are injectable
+ * so tests exercise the routes without a hub, a sandbox, or a tmux server.
+ */
+export function createRealAgentOps(opts?: {
+  depsFactory?: () => SpawnAgentDeps;
+  tmux?: TmuxAdmin;
+  sessionsDirPath?: string;
+}): AgentOps {
+  const depsFactory = opts?.depsFactory ?? resolveSpawnDeps;
+  const tmux = opts?.tmux ?? realTmuxAdmin();
+  const dir = opts?.sessionsDirPath ?? defaultSessionsDir();
+  return {
+    async spawn(spec) {
+      // Deps resolved per-spawn so a credential rotate / operator-token change is
+      // picked up live (dynamic-read discipline) — and so a missing operator token
+      // surfaces as a clean error at spawn time, not at daemon boot.
+      return spawnAgent(spec, depsFactory());
+    },
+    async list() {
+      return agentInfoFromSessions(await tmux.listSessions(), dir);
+    },
+    async kill(name) {
+      if (!AGENT_NAME_SLUG.test(name)) {
+        throw new SpawnRequestError(
+          `agent name "${name}" must be a slug (alphanumeric, dash, underscore only)`,
+        );
+      }
+      const killed = await tmux.killSession(sessionName(name));
+      return { killed };
+    },
+  };
+}

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -74,6 +74,17 @@ import {
   type TerminalWsData,
 } from "./terminal.ts";
 import { TERMINAL_UI_HTML } from "./terminal-ui.ts";
+import { AGENTS_UI_HTML } from "./agents-ui.ts";
+import {
+  createRealAgentOps,
+  buildSpecFromBody,
+  redactSpawnResult,
+  SpawnRequestError,
+  type AgentOps,
+} from "./agents.ts";
+import { SpawnDepsError } from "./spawn-deps.ts";
+import { CredentialNotConfiguredError } from "./credentials.ts";
+import { MintError } from "./mint-token.ts";
 import { validateHubJwt } from "./hub-jwt.ts";
 import {
   handleProtectedResource,
@@ -697,7 +708,12 @@ function clampQueryDim(raw: string | null, fallback: number): number {
 export function createFetchHandler(
   channels: Map<string, Channel>,
   registry: ClientRegistry,
+  opts?: { agentOps?: AgentOps },
 ): (req: Request, server?: { upgrade: (req: Request, opts: { data: TerminalWsData }) => boolean }) => Promise<Response> {
+  // Spawn/list/kill operations behind the web agents surface. Lazily defaulted to
+  // the real ops (resolve-deps + real tmux); tests inject a stub so the routes are
+  // exercised without a hub, a sandbox, or a tmux server. Built once per handler.
+  const agentOps: AgentOps = opts?.agentOps ?? createRealAgentOps();
   /** Resolve the transport for a channel name, or null on miss. */
   function transportFor(channel: string | undefined): Transport | null {
     if (!channel) return null;
@@ -789,6 +805,17 @@ export function createFetchHandler(
     // gated. Served by the daemon (spans every channel via a picker).
     if (req.method === "GET" && (url.pathname === "/terminal" || termMatch)) {
       return new Response(TERMINAL_UI_HTML, {
+        headers: { "content-type": "text/html; charset=utf-8" },
+      });
+    }
+
+    // Agent management page (the web spawn/list/kill surface, design §4/§5) —
+    // `/agents`. Loads OPEN (like /ui, /admin, /terminal) so it can bootstrap its
+    // hub-minted channel:admin token; the `/api/agents` + `/api/credentials/*`
+    // calls it makes are what `requireScope` gates. Served by the daemon (spans
+    // every channel via the spawn form + the running-agents list).
+    if (req.method === "GET" && url.pathname === "/agents") {
+      return new Response(AGENTS_UI_HTML, {
         headers: { "content-type": "text/html; charset=utf-8" },
       });
     }
@@ -1040,6 +1067,81 @@ export function createFetchHandler(
         return json({ error: `failed to write credentials.json: ${(err as Error).message}` }, 500);
       }
       return json({ ok: true, scope: "channel", channel });
+    }
+
+    // ---------------------------------------------------------------------
+    // Agent management API (the web spawn/list/kill surface, design §4/§5) —
+    // the SAME least-privilege launch path as the operator CLI
+    // (`scripts/spawn-agent.ts`), driven from the browser. Operator-gated on
+    // `channel:admin` (a launched session is the most powerful thing this module
+    // does, so the whole surface uses the same gate as the terminal).
+    //
+    //   GET    /api/agents          → list running agent tmux sessions (no secrets)
+    //   POST   /api/agents          { name, channels, vault?, egress?, mounts? } → spawn
+    //   DELETE /api/agents/:name    → kill the session
+    //
+    // Externally hub strips `/channel`, so these are `<hub>/channel/api/agents`.
+    // The spawn response surfaces scopes/audiences but NEVER the minted token
+    // values (redactSpawnResult); the launch resolves its deps lazily so a
+    // credential set via the creds API takes effect without a daemon restart.
+    // ---------------------------------------------------------------------
+    if (url.pathname === "/api/agents" && (req.method === "GET" || req.method === "POST")) {
+      const denied = await requireScope(req, url, SCOPE_ADMIN);
+      if (denied) return denied;
+
+      if (req.method === "GET") {
+        try {
+          return json({ agents: await agentOps.list() });
+        } catch (err) {
+          return json({ error: `failed to list agents: ${(err as Error).message}` }, 500);
+        }
+      }
+
+      // POST — spawn a sandboxed agent from a spec.
+      let spawnBody: unknown;
+      try {
+        spawnBody = await req.json();
+      } catch {
+        return json({ error: "invalid JSON body" }, 400);
+      }
+      let spec;
+      try {
+        spec = buildSpecFromBody(spawnBody);
+      } catch (err) {
+        if (err instanceof SpawnRequestError) return json({ error: err.message }, 400);
+        throw err;
+      }
+      try {
+        const result = await agentOps.spawn(spec);
+        return json(redactSpawnResult(result));
+      } catch (err) {
+        // A missing operator token (no manager bearer) → 503: the daemon can't
+        // mint child tokens until the hub is provisioned.
+        if (err instanceof SpawnDepsError) return json({ error: err.message }, 503);
+        // A missing Claude credential → 400 with the fix (set it via the creds API
+        // / the page's credential form).
+        if (err instanceof CredentialNotConfiguredError) return json({ error: err.message }, 400);
+        // An over-broad / refused mint (the hub's canGrant) → surface the hub's status.
+        if (err instanceof MintError) {
+          return json({ error: `token mint failed: ${err.message}` }, err.status >= 400 && err.status < 600 ? err.status : 502);
+        }
+        // A bad slug (spawnAgent's guard) or any other launch fault.
+        return json({ error: (err as Error).message }, 400);
+      }
+    }
+
+    const agentMatch = url.pathname.match(/^\/api\/agents\/([^/]+)$/);
+    if (agentMatch && req.method === "DELETE") {
+      const denied = await requireScope(req, url, SCOPE_ADMIN);
+      if (denied) return denied;
+      const name = decodeURIComponent(agentMatch[1]!);
+      try {
+        const { killed } = await agentOps.kill(name);
+        return json({ ok: true, name, killed });
+      } catch (err) {
+        if (err instanceof SpawnRequestError) return json({ error: err.message }, 400);
+        return json({ error: `failed to kill agent: ${(err as Error).message}` }, 500);
+      }
     }
 
     // ---------------------------------------------------------------------
@@ -1531,6 +1633,16 @@ function main(): void {
       // gives, but declaring it explicitly future-proofs against a later `uis`
       // declaration accidentally gating the terminal at hub-users. Design §5.3.
       uis: {
+        // The web spawn/list/kill surface — the DEFAULT way to operate (spawn an
+        // agent, scope it, watch it). audience "surface" so the hub passes it
+        // through; channel owns admission end-to-end (operator-grade channel:admin,
+        // enforced on every /api/agents call). Design §4/§5.
+        agents: {
+          displayName: "Agents",
+          tagline: "Spawn, scope, and watch sandboxed Claude Code sessions.",
+          path: "/channel/agents",
+          audience: "surface",
+        },
         terminal: {
           displayName: "Terminal",
           tagline: "Attach to a session's live tmux pane in the browser.",

--- a/src/spawn-deps.ts
+++ b/src/spawn-deps.ts
@@ -1,0 +1,125 @@
+/**
+ * Resolve the REAL {@link SpawnAgentDeps} from the environment — the hub origin,
+ * the manager bearer (`~/.parachute/operator.token`), the channel/vault URLs, the
+ * sessions dir, the read-only runtime binds, the per-channel Claude-credential
+ * resolver, and the real tmux launcher.
+ *
+ * This is the one place the spawn side-effects get their concrete wiring, shared
+ * by BOTH callers that launch a real session:
+ *   - the operator CLI (`scripts/spawn-agent.ts`), and
+ *   - the daemon's web spawn endpoint (`POST /api/agents`, daemon.ts).
+ *
+ * Keeping it in `src/` (not the CLI script) lets the daemon import it without
+ * reaching across into `scripts/`, and means the CLI and the web flow resolve
+ * EXACTLY the same deps — a session launched from the page is byte-for-byte the
+ * same least-privilege launch as one from the terminal.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve, join } from "node:path";
+import {
+  realTmuxLauncher,
+  type SpawnAgentDeps,
+} from "./spawn-agent.ts";
+import { resolveClaudeCredential } from "./credentials.ts";
+import { defaultStateDir } from "./registry.ts";
+import { getHubOrigin } from "./hub-jwt.ts";
+
+const DEFAULT_CHANNEL_PORT = 1941;
+const DEFAULT_VAULT_URL = "http://127.0.0.1:1940";
+
+/**
+ * No operator token on disk — the manager bearer the hub attenuates child mints
+ * against is missing, so no session can be launched. Carries an actionable
+ * message; callers map it to a clean CLI error or a 503 JSON body.
+ */
+export class SpawnDepsError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SpawnDepsError";
+  }
+}
+
+/** Base for `operator.token` — `$PARACHUTE_HOME` else `~/.parachute`. */
+function parachuteHome(): string {
+  return process.env.PARACHUTE_HOME ?? resolve(homedir(), ".parachute");
+}
+
+/**
+ * The spawn-manager's OWN bearer — `~/.parachute/operator.token`, the local
+ * operator credential the hub attenuates child mints against (the same file
+ * vault's `readOperatorToken` reads). Returns null when absent/empty.
+ */
+function readManagerBearer(): string | null {
+  try {
+    const path = resolve(parachuteHome(), "operator.token");
+    if (!existsSync(path)) return null;
+    const raw = readFileSync(path, "utf-8").trim();
+    return raw.length > 0 ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Default channel daemon base URL: PARACHUTE_CHANNEL_URL, else loopback:<port>. */
+function resolveChannelUrl(): string {
+  const explicit = process.env.PARACHUTE_CHANNEL_URL?.replace(/\/$/, "");
+  if (explicit) return explicit;
+  const port = parseInt(process.env.PARACHUTE_CHANNEL_PORT ?? "", 10) || DEFAULT_CHANNEL_PORT;
+  return `http://127.0.0.1:${port}`;
+}
+
+/** Claude config dir bound read-only so the sandboxed session can read its config. */
+function claudeConfigDir(): string {
+  return process.env.CLAUDE_CONFIG_DIR ?? resolve(homedir(), ".claude");
+}
+
+/** Absolute path to the operator token file (for error messages). */
+export function operatorTokenPath(): string {
+  return resolve(parachuteHome(), "operator.token");
+}
+
+/**
+ * Build the real {@link SpawnAgentDeps} from the environment. Throws
+ * {@link SpawnDepsError} when the operator token is missing (no manager bearer →
+ * no mint → no launch). Pure aside from reading the env + the token file; the
+ * returned deps carry the real mint client, sandbox engine, and tmux launcher.
+ */
+export function resolveSpawnDeps(): SpawnAgentDeps {
+  const managerBearer = readManagerBearer();
+  if (!managerBearer) {
+    throw new SpawnDepsError(
+      `no operator token at ${operatorTokenPath()} — the manager bearer the hub attenuates ` +
+        `child mints against. Log in / provision the hub so the operator token exists ` +
+        `(it's what \`parachute auth mint-token\` uses), then retry.`,
+    );
+  }
+
+  const stateDir = defaultStateDir();
+  const sessionsDir = join(stateDir, "sessions");
+  const vaultUrl = process.env.PARACHUTE_VAULT_URL?.replace(/\/$/, "") || DEFAULT_VAULT_URL;
+
+  return {
+    hubOrigin: getHubOrigin(),
+    managerBearer,
+    channelUrl: resolveChannelUrl(),
+    vaultUrl,
+    sessionsDir,
+    // The claude config dir is the one runtime path the sandboxed `claude` must
+    // read (system paths /usr,/lib stay readable; the home tree is denied). The
+    // per-session workspace (rw) is added by spawnAgent under sessionsDir.
+    runtimeReadOnly: [claudeConfigDir()],
+    // The real per-channel Claude OAuth resolver (channel override ?? default ?? throw).
+    resolveClaudeToken: (channel: string) => resolveClaudeCredential(channel, stateDir),
+    // The real tmux launcher (writes the per-session launch script, runs tmux).
+    tmux: realTmuxLauncher(),
+    // sandboxEngine omitted → spawnAgent's `new Sandbox()` uses the real, pinned,
+    // library-linked engine.
+  };
+}
+
+/** The sessions dir the agent ops enumerate workspaces under. */
+export function sessionsDir(): string {
+  return join(defaultStateDir(), "sessions");
+}


### PR DESCRIPTION
## What

Phase 1 shipped agent spawning as **CLI-only** (`scripts/spawn-agent.ts`) and the in-page terminal as **watch-only**. The default way of operating Parachute is the web interface, so this adds the management surface: spawn, scope, watch, and kill sandboxed Claude Code sessions entirely from the browser.

## How

- **`src/agents.ts`** — the daemon-facing spawn/list/kill layer over the **same least-privilege launch path** as the CLI:
  - `buildSpecFromBody` validates an untrusted JSON body → `AgentSpec` (slug guard before any side effect; absolute-path mounts; trimmed egress/tags).
  - `redactSpawnResult` surfaces scopes/audiences/expiry but **never** the minted token values.
  - a `TmuxAdmin` seam lists + kills `*-agent` sessions. `AgentOps` is injectable for hermetic tests.
- **`src/spawn-deps.ts`** — shared `resolveSpawnDeps()` extracted from the CLI so the web flow and the CLI resolve **byte-for-byte the same deps**. The CLI now imports it (no duplicated dep-resolution to drift).
- **`src/agents-ui.ts`** — a self-contained `/channel/agents` page (no build step, same shape as the terminal page): credential status + set/rotate, a spawn form (name · channels w/ access · optional vault+tags · egress · mounts), and a live running-agents list with per-row **terminal ↗** + **kill**.
- **`src/daemon.ts`** — routes `GET /agents` (page), `GET/POST /api/agents`, `DELETE /api/agents/:name`, all operator-gated on `channel:admin` (the same gate as the terminal). Deps resolve **lazily per spawn** so a credential set via the creds API takes effect with no daemon restart. Errors map cleanly: bad spec → 400, no Claude cred → 400, no operator token → 503, refused mint → the hub's status. Self-registers the surface as `uis.agents` (audience: surface).

## Security

- **Token redaction**: proven by test — the full spawn response is serialized and asserted to contain no token value. `mcpConfigJson` (which inlines bearers) is parsed only for server-name keys; `CLAUDE_CODE_OAUTH_TOKEN` lives in `wrapped.env`, never in the redacted result.
- **Auth**: every `/api/agents*` + `/api/credentials/claude*` route gates on `channel:admin` first (negative tests cover no-token 401 and read-scope 403). The page loads open to bootstrap a hub-minted token — same pattern as `/admin` and `/terminal`.
- **Injection/traversal**: slug guard (`/^[a-z0-9_-]+$/i`) enforced before any tmux/fs side effect in both spawn and kill; tmux invoked as a literal argv array (no shell).

## Tests

`src/agents.test.ts` — 31 tests: pure validators/redaction, list/kill ops, and every route (auth gate, body→spec→spawn wiring, the redaction "no token on the wire" proof, and each error→status mapping). Full suite **377 pass**; typecheck clean aside from the 2 pre-existing `bridge.ts` TS2589s.

Reviewed by an independent reviewer subagent (LGTM, no criticals; two nits — absolute-path mount validation + the DELETE read-scope 403 test — folded inline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)