### PR TITLE
fix(agents): make web-spawned sessions run + integrate the UX

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,8 @@
         "@anthropic-ai/sandbox-runtime": "0.0.54",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@openparachute/scope-guard": "^0.4.0",
+        "@xterm/addon-fit": "0.10.0",
+        "@xterm/xterm": "5.5.0",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -31,6 +33,10 @@
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
     "@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
+
+    "@xterm/addon-fit": ["@xterm/addon-fit@0.10.0", "", { "peerDependencies": { "@xterm/xterm": "^5.0.0" } }, "sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ=="],
+
+    "@xterm/xterm": ["@xterm/xterm@5.5.0", "", {}, "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
   "dependencies": {
     "@anthropic-ai/sandbox-runtime": "0.0.54",
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@openparachute/scope-guard": "^0.4.0"
+    "@openparachute/scope-guard": "^0.4.0",
+    "@xterm/addon-fit": "0.10.0",
+    "@xterm/xterm": "5.5.0"
   },
   "peerDependencies": {
     "typescript": "^5"

--- a/scripts/spawn-agent.ts
+++ b/scripts/spawn-agent.ts
@@ -63,6 +63,7 @@ Flags:
   --vault <name>:<read|write>[:tag1,tag2]
                                   optional vault MCP scope (+ optional tag-scope).
   --egress <host,host,...>        optional additive egress allowlist (beyond the base).
+  --egress-all                    open the network entirely (allow ALL egress; trusted sessions only).
   --mount <hostPath:mountPath:ro|rw[:shared]>
                                   filesystem mount (repeatable; optional).
   --help                          show this help.
@@ -176,6 +177,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
   const channels: AgentChannelSpec[] = [];
   let vault: AgentVaultSpec | undefined;
   const egress: string[] = [];
+  let egressUnrestricted = false;
   const mounts: AgentMount[] = [];
 
   for (let i = 0; i < argv.length; i++) {
@@ -203,6 +205,10 @@ export function parseArgs(argv: string[]): ParsedArgs {
         i++;
         break;
       }
+      case "--egress-all": {
+        egressUnrestricted = true;
+        break;
+      }
       case "--mount": {
         mounts.push(parseMount(takeValue(argv, i, "--mount")));
         i++;
@@ -225,7 +231,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
 
   const spec: AgentSpec = { name, channels };
   if (vault) spec.vault = vault;
-  if (egress.length > 0) spec.egress = egress;
+  if (egressUnrestricted) spec.egressUnrestricted = true;
+  else if (egress.length > 0) spec.egress = egress;
   if (mounts.length > 0) spec.mounts = mounts;
   return { help: false, spec };
 }

--- a/src/admin-ui.ts
+++ b/src/admin-ui.ts
@@ -146,6 +146,11 @@ export function renderAdminPage(mount = ""): string {
         </div>
         <h1>Manage channels</h1>
         <p class="subtitle">Add and remove the channels your Claude Code sessions talk over. Each channel is bound to one transport.</p>
+        <p class="subtitle" style="margin-top:6px;">
+          <a id="nav-agents" href="#">Agents →</a> spawn &amp; watch sandboxed sessions ·
+          <a id="nav-chat" href="#">Chat</a> ·
+          <a id="nav-terminal" href="#">Terminal</a>
+        </p>
       </header>
 
       <div id="status-banner" class="banner" hidden></div>
@@ -563,6 +568,15 @@ const PAGE_SCRIPT = String.raw`
   // prefix and the /api/channels URL under it.
   var MOUNT = window.__CHANNEL_MOUNT__ || "";
   var API_URL = window.__CHANNEL_API_URL__ || "/api/channels";
+
+  // Wire the header nav links to the sibling surfaces under the same mount.
+  (function wireNav() {
+    var map = { "nav-agents": "/agents", "nav-chat": "/ui", "nav-terminal": "/terminal" };
+    Object.keys(map).forEach(function (id) {
+      var a = document.getElementById(id);
+      if (a) a.href = MOUNT + map[id];
+    });
+  })();
 
   // --- Auth: a channel:admin Bearer minted by the hub --------------------
   // The channel config API (/api/channels) requires a hub JWT with

--- a/src/agents-ui.ts
+++ b/src/agents-ui.ts
@@ -9,25 +9,22 @@
  * daemon's `channel:admin`-gated JSON API:
  *
  *   - GET    /api/credentials/claude   → credential status (default set? overrides?)
- *   - POST   /api/credentials/claude   → set the default operator Claude token
- *   - POST   /api/credentials/claude/:channel  → per-channel override
- *   - DELETE /api/credentials/claude/:channel  → remove an override
+ *   - POST   /api/credentials/claude[/:channel]  → set default / per-channel token
+ *   - DELETE /api/credentials/claude/:channel    → remove an override
  *   - GET    /api/agents               → list running agent sessions
  *   - POST   /api/agents               → spawn a sandboxed agent from a spec
  *   - DELETE /api/agents/:name         → kill a session
- *   - GET    /.parachute/config        → channel list (prefills the spawn form)
+ *   - GET    /api/vaults               → installed vault instances (the picker)
+ *   - GET    /.parachute/config        → channel list (the picker)
  *
- * Auth: the page loads OPEN (like /ui, /admin, /terminal) and then fetches a
- * hub-minted `channel:admin` Bearer from `<origin>/admin/channel-token`
- * (cookie-gated — the operator's logged-in portal session), attaching it to every
- * /api call. A launched session is the most powerful thing this module does, so
- * the whole surface is operator-gated on `channel:admin` — the SAME gate the
- * terminal uses.
+ * UX: the DEFAULT flow is one-agent-one-channel — pick a channel, the agent name
+ * auto-fills from it, click Spawn. Everything else (extra channels, vault binding,
+ * network mode, mounts) lives under "Advanced" for the dynamic cases.
  *
- * Token hygiene mirrors the rest of the module: the Claude OAuth token the
- * operator pastes is POSTed once and never read back (the status endpoint returns
- * names/presence only); the spawn result shows scopes/audiences but never the
- * minted token values.
+ * Auth: loads OPEN (like /ui, /admin, /terminal), then fetches a hub-minted
+ * `channel:admin` Bearer from `<origin>/admin/channel-token` and attaches it to
+ * every /api call. Token hygiene: the pasted Claude token is POSTed once and never
+ * read back; the spawn result shows scopes but never minted token values.
  */
 
 export const AGENTS_UI_HTML = `<!doctype html>
@@ -50,17 +47,20 @@ export const AGENTS_UI_HTML = `<!doctype html>
     padding-bottom: 48px;
   }
   header {
-    display: flex; align-items: center; gap: 12px;
+    display: flex; align-items: center; gap: 14px;
     padding: 12px 20px; border-bottom: 1px solid var(--line); background: var(--panel);
     position: sticky; top: 0; z-index: 5;
   }
   header .brand { font-weight: 600; }
   header .brand small { color: var(--muted); font-weight: 400; }
+  header nav { display: flex; gap: 12px; }
+  header nav a { color: var(--muted); text-decoration: none; font-size: 13px; }
+  header nav a:hover { color: var(--fg); text-decoration: underline; }
   header .spacer { margin-left: auto; }
   #status { font-size: 12px; color: var(--muted); }
   #status.live { color: var(--accent); }
   #status.err { color: var(--danger); }
-  main { max-width: 920px; margin: 0 auto; padding: 20px; display: grid; gap: 20px; }
+  main { max-width: 940px; margin: 0 auto; padding: 20px; display: grid; gap: 20px; }
   section {
     background: var(--panel); border: 1px solid var(--line); border-radius: 10px; padding: 16px 18px;
   }
@@ -71,10 +71,10 @@ export const AGENTS_UI_HTML = `<!doctype html>
     width: 100%; background: var(--bg); color: var(--fg);
     border: 1px solid var(--line); border-radius: 6px; padding: 8px 10px; font: inherit;
   }
-  textarea { resize: vertical; min-height: 56px; }
   .row { display: flex; gap: 10px; align-items: flex-end; flex-wrap: wrap; }
   .row > .grow { flex: 1 1 160px; }
   .grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+  .grid3 { display: grid; grid-template-columns: 1.4fr 1fr 1.2fr; gap: 12px; }
   button {
     background: var(--bg); color: var(--fg); border: 1px solid var(--line);
     border-radius: 6px; padding: 8px 14px; font: inherit; cursor: pointer;
@@ -97,28 +97,35 @@ export const AGENTS_UI_HTML = `<!doctype html>
   td.actions a, td.actions button { margin-left: 6px; }
   a { color: var(--accent); text-decoration: none; }
   a:hover { text-decoration: underline; }
-  .channels-rows { display: grid; gap: 8px; margin-bottom: 8px; }
-  .channels-rows .crow { display: flex; gap: 8px; align-items: center; }
-  .channels-rows .crow input { flex: 1 1 auto; }
-  .channels-rows .crow select { flex: 0 0 130px; }
-  .mounts-rows { display: grid; gap: 8px; margin-bottom: 8px; }
-  .mounts-rows .mrow { display: flex; gap: 8px; align-items: center; }
+  details { margin-top: 14px; border-top: 1px solid var(--line); padding-top: 12px; }
+  details summary { cursor: pointer; color: var(--muted); font-size: 13px; user-select: none; }
+  details[open] summary { color: var(--fg); margin-bottom: 12px; }
+  .sub { display: grid; gap: 12px; }
+  .extra-channels { display: grid; gap: 8px; }
+  .extra-channels .crow, .mounts-rows .mrow { display: flex; gap: 8px; align-items: center; }
+  .extra-channels .crow select.ch-name { flex: 1 1 auto; }
+  .extra-channels .crow select.ch-access { flex: 0 0 130px; }
+  .mounts-rows { display: grid; gap: 8px; }
   .mounts-rows .mrow input { flex: 1 1 auto; }
   .mounts-rows .mrow select { flex: 0 0 90px; }
   .msg { margin-top: 12px; padding: 10px 12px; border-radius: 8px; font-size: 13px; display: none; white-space: pre-wrap; }
   .msg.ok { display: block; background: #11241d; color: var(--accent); border: 1px solid #244; }
   .msg.err { display: block; background: #241313; color: var(--danger); border: 1px solid #3a2a2a; }
   code { color: var(--fg); background: #0b0d11; padding: 1px 5px; border-radius: 4px; font-size: 12px; }
-  details summary { cursor: pointer; color: var(--muted); font-size: 13px; }
   .scopes { margin: 8px 0 0; font-size: 12px; color: var(--muted); }
-  .scopes div { font-family: ui-monospace, Menlo, monospace; }
   .muted { color: var(--muted); }
   .empty { color: var(--muted); font-size: 13px; padding: 8px 2px; }
+  .warnbox { color: var(--warn); font-size: 12px; }
 </style>
 </head>
 <body>
   <header>
     <div class="brand">parachute-channel <small>· agents</small></div>
+    <nav>
+      <a id="nav-chat" href="#">Chat</a>
+      <a id="nav-terminal" href="#">Terminal</a>
+      <a id="nav-config" href="#">Config</a>
+    </nav>
     <span class="spacer"></span>
     <span id="status">connecting…</span>
   </header>
@@ -128,28 +135,29 @@ export const AGENTS_UI_HTML = `<!doctype html>
     <section id="cred-section">
       <h2>Claude credential</h2>
       <p class="hint">A launched session runs on a Claude subscription token from
-        <code>claude setup-token</code> (the 1-year headless auth) — injected per session, never your CLI login.
+        <code>claude setup-token</code> — injected per session, never your CLI login.
         Set a default once; override per channel if needed.</p>
       <div class="row">
         <span>Default credential: <span id="cred-default" class="pill off">checking…</span></span>
-        <span class="spacer"></span>
       </div>
       <div id="cred-overrides" class="scopes"></div>
-      <details style="margin-top:12px;">
+      <details>
         <summary>Set / rotate a credential</summary>
-        <div style="margin-top:10px;" class="grid2">
-          <div>
-            <label for="cred-channel">Scope (blank = default/operator)</label>
-            <input type="text" id="cred-channel" placeholder="channel name, or blank for default" />
+        <div class="sub">
+          <div class="grid2">
+            <div>
+              <label for="cred-channel">Scope (blank = default/operator)</label>
+              <input type="text" id="cred-channel" placeholder="channel name, or blank for default" />
+            </div>
+            <div>
+              <label for="cred-token">Token (oat_… from <code>claude setup-token</code>)</label>
+              <input type="password" id="cred-token" placeholder="oat_…" autocomplete="off" />
+            </div>
           </div>
-          <div>
-            <label for="cred-token">Token (oat_… from <code>claude setup-token</code>)</label>
-            <input type="password" id="cred-token" placeholder="oat_…" autocomplete="off" />
+          <div class="row">
+            <button id="cred-save" class="primary" type="button">Save credential</button>
+            <span class="muted" style="font-size:12px;">Stored 0600, never shown again.</span>
           </div>
-        </div>
-        <div class="row" style="margin-top:10px;">
-          <button id="cred-save" class="primary" type="button">Save credential</button>
-          <span class="muted" style="font-size:12px;">The token is stored 0600 and never shown again.</span>
         </div>
       </details>
       <div id="cred-msg" class="msg"></div>
@@ -158,55 +166,78 @@ export const AGENTS_UI_HTML = `<!doctype html>
     <!-- Spawn -->
     <section id="spawn-section">
       <h2>Spawn an agent</h2>
-      <p class="hint">Launches a sandboxed Claude Code session in tmux, scoped to the channels (and optional vault)
-        you declare. Network egress is deny-by-default beyond the Anthropic API + your hub/vault; filesystem reads
-        are scoped to the workspace + declared mounts.</p>
-      <div class="grid2">
+      <p class="hint">Launches a sandboxed Claude Code session in tmux, wired to a channel.
+        The common case is one agent per channel — pick a channel and spawn. Open Advanced for
+        extra channels, a vault, network, or mounts.</p>
+
+      <div class="grid3">
         <div>
-          <label for="spawn-name">Name (slug)</label>
-          <input type="text" id="spawn-name" placeholder="e.g. aaron" autocomplete="off" />
+          <label for="spawn-channel">Channel <span class="muted">(wake)</span></label>
+          <select id="spawn-channel"></select>
         </div>
         <div>
-          <label>Channels <span class="muted">(first = wake channel)</span></label>
-          <div id="channels-rows" class="channels-rows"></div>
-          <button id="add-channel" class="ghost" type="button">+ channel</button>
+          <label for="spawn-access">Access</label>
+          <select id="spawn-access">
+            <option value="write" selected>read+write</option>
+            <option value="read">read only</option>
+          </select>
+        </div>
+        <div>
+          <label for="spawn-name">Agent name</label>
+          <input type="text" id="spawn-name" placeholder="(defaults to channel)" autocomplete="off" />
         </div>
       </div>
 
-      <details style="margin-top:14px;">
-        <summary>Vault binding (optional)</summary>
-        <div class="grid2" style="margin-top:10px;">
+      <details id="advanced">
+        <summary>Advanced — extra channels, vault, network, mounts</summary>
+        <div class="sub">
           <div>
-            <label for="vault-name">Vault name</label>
-            <input type="text" id="vault-name" placeholder="e.g. default (blank = no vault)" autocomplete="off" />
+            <label>Additional channels <span class="muted">(beyond the wake channel above)</span></label>
+            <div id="extra-channels" class="extra-channels"></div>
+            <button id="add-channel" class="ghost" type="button" style="margin-top:8px;">+ channel</button>
           </div>
+
+          <div class="grid3">
+            <div>
+              <label for="vault-name">Vault</label>
+              <select id="vault-name"><option value="">(no vault)</option></select>
+            </div>
+            <div>
+              <label for="vault-access">Vault access</label>
+              <select id="vault-access">
+                <option value="read">read</option>
+                <option value="write">write</option>
+                <option value="admin">admin</option>
+              </select>
+            </div>
+            <div>
+              <label for="vault-tags">Tag scope (optional)</label>
+              <input type="text" id="vault-tags" placeholder="#channel-message, …" autocomplete="off" />
+            </div>
+          </div>
+
           <div>
-            <label for="vault-access">Access</label>
-            <select id="vault-access">
-              <option value="read">read</option>
-              <option value="write">write</option>
-              <option value="admin">admin</option>
+            <label for="net-mode">Network</label>
+            <select id="net-mode">
+              <option value="restricted" selected>Restricted — Anthropic API + hub/vault + listed hosts</option>
+              <option value="open">Open — allow ALL network (trusted sessions only)</option>
             </select>
+            <div id="egress-wrap" style="margin-top:8px;">
+              <label for="egress">Additional allowed hosts (comma-separated)</label>
+              <input type="text" id="egress" placeholder="registry.npmjs.org, github.com" autocomplete="off" />
+            </div>
+            <div id="open-warn" class="warnbox" style="display:none; margin-top:8px;">
+              ⚠ Open network removes egress confinement — anything the session can reach, it can send to.
+              Use only for sessions you trust.
+            </div>
+          </div>
+
+          <div>
+            <label>Filesystem mounts</label>
+            <div id="mounts-rows" class="mounts-rows"></div>
+            <button id="add-mount" class="ghost" type="button" style="margin-top:8px;">+ mount</button>
           </div>
         </div>
-        <div style="margin-top:10px;">
-          <label for="vault-tags">Tag scope (optional, comma-separated)</label>
-          <input type="text" id="vault-tags" placeholder="e.g. #channel-message" autocomplete="off" />
-        </div>
-      </details>
-
-      <details style="margin-top:12px;">
-        <summary>Network egress (optional)</summary>
-        <div style="margin-top:10px;">
-          <label for="egress">Additional allowed hosts (comma-separated, beyond the base)</label>
-          <input type="text" id="egress" placeholder="e.g. registry.npmjs.org, github.com" autocomplete="off" />
-        </div>
-      </details>
-
-      <details style="margin-top:12px;">
-        <summary>Filesystem mounts (optional)</summary>
-        <div id="mounts-rows" class="mounts-rows" style="margin-top:10px;"></div>
-        <button id="add-mount" class="ghost" type="button">+ mount</button>
       </details>
 
       <div class="row" style="margin-top:16px;">
@@ -229,12 +260,17 @@ export const AGENTS_UI_HTML = `<!doctype html>
 
 <script>
 (function () {
-  // Served through the hub the page is /channel/agents; locally it's /agents.
-  // Derive the mount prefix so the API + token URLs resolve under the same prefix
-  // (same shape as the terminal + chat UIs).
+  // Served through the hub the page is /channel/agents; locally /agents. Derive
+  // the mount prefix so API + token + nav URLs resolve under the same prefix.
   var MOUNT = location.pathname.replace(/\\/agents\\/?$/, "");
   var statusEl = document.getElementById("status");
   var TOKEN = null;
+  var knownChannels = [];
+
+  // Wire nav links under the same mount.
+  document.getElementById("nav-chat").href = MOUNT + "/ui";
+  document.getElementById("nav-terminal").href = MOUNT + "/terminal";
+  document.getElementById("nav-config").href = MOUNT + "/admin";
 
   function setStatus(text, cls) { statusEl.textContent = text; statusEl.className = cls || ""; }
   function esc(s) {
@@ -243,9 +279,8 @@ export const AGENTS_UI_HTML = `<!doctype html>
     });
   }
   function showMsg(el, text, isErr) {
-    // textContent (NOT innerHTML) — server/result strings (session, workspace,
-    // scopes, egress, error messages) flow through here, so this deliberately
-    // avoids needing esc(): the browser never parses them as HTML.
+    // textContent (NOT innerHTML) — server/result strings flow through here, so
+    // this deliberately avoids needing esc(): the browser never parses them as HTML.
     el.textContent = text;
     el.className = "msg " + (isErr ? "err" : "ok");
   }
@@ -256,15 +291,9 @@ export const AGENTS_UI_HTML = `<!doctype html>
     return fetch(location.origin + "/admin/channel-token", { credentials: "include" })
       .then(function (r) { if (!r.ok) throw new Error("token " + r.status); return r.json(); })
       .then(function (j) { TOKEN = (j && j.token) ? j.token : null; return TOKEN; })
-      .catch(function (err) {
-        TOKEN = null;
-        setStatus("not authenticated", "err");
-        throw err;
-      });
+      .catch(function (err) { TOKEN = null; setStatus("not authenticated", "err"); throw err; });
   }
 
-  // Authed fetch against the daemon API. Retries ONCE on a 401 with a fresh token
-  // (the channel:admin token is short-lived).
   function api(path, opts, _retried) {
     opts = opts || {};
     var headers = Object.assign({}, opts.headers || {});
@@ -302,9 +331,7 @@ export const AGENTS_UI_HTML = `<!doctype html>
         ov.querySelectorAll("[data-cred-rm]").forEach(function (btn) {
           btn.addEventListener("click", function () { removeCred(btn.getAttribute("data-cred-rm")); });
         });
-      } else {
-        ov.innerHTML = "";
-      }
+      } else { ov.innerHTML = ""; }
       updateSpawnNote(j.defaultSet, j.channels || []);
       return j;
     }).catch(function (err) {
@@ -315,11 +342,9 @@ export const AGENTS_UI_HTML = `<!doctype html>
   function updateSpawnNote(defaultSet, overrides) {
     var note = document.getElementById("spawn-note");
     if (!defaultSet && (!overrides || !overrides.length)) {
-      note.textContent = "⚠ no Claude credential set — spawn will fail until you set one above.";
+      note.textContent = "⚠ no Claude credential set — set one above before spawning.";
       note.style.color = "var(--warn)";
-    } else {
-      note.textContent = "";
-    }
+    } else { note.textContent = ""; }
   }
 
   document.getElementById("cred-save").addEventListener("click", function () {
@@ -331,7 +356,7 @@ export const AGENTS_UI_HTML = `<!doctype html>
     var path = channel ? "/api/credentials/claude/" + encodeURIComponent(channel) : "/api/credentials/claude";
     apiJson(path, { method: "POST", body: JSON.stringify({ token: token }) }).then(function () {
       document.getElementById("cred-token").value = "";
-      showMsg(msg, channel ? ("Saved override for channel \\"" + channel + "\\".") : "Saved default credential.", false);
+      showMsg(msg, channel ? ("Saved override for channel " + channel + ".") : "Saved default credential.", false);
       loadCreds();
     }).catch(function (err) { showMsg(msg, "Failed: " + err.message, true); });
   });
@@ -340,29 +365,38 @@ export const AGENTS_UI_HTML = `<!doctype html>
     var msg = document.getElementById("cred-msg");
     clearMsg(msg);
     apiJson("/api/credentials/claude/" + encodeURIComponent(channel), { method: "DELETE" }).then(function () {
-      showMsg(msg, "Removed override for \\"" + channel + "\\".", false);
+      showMsg(msg, "Removed override for " + channel + ".", false);
       loadCreds();
     }).catch(function (err) { showMsg(msg, "Failed: " + err.message, true); });
   }
 
-  // --- spawn form: channel + mount rows -----------------------------------
-  var knownChannels = [];
-  function channelRow(value, access) {
+  // --- spawn form ---------------------------------------------------------
+  function channelOptions(selected) {
+    return knownChannels.map(function (c) {
+      return "<option value='" + esc(c) + "'" + (c === selected ? " selected" : "") + ">" + esc(c) + "</option>";
+    }).join("");
+  }
+
+  // Auto-fill the name from the chosen wake channel until the operator edits it.
+  var nameEdited = false;
+  var nameEl = document.getElementById("spawn-name");
+  var chanEl = document.getElementById("spawn-channel");
+  nameEl.addEventListener("input", function () { nameEdited = true; });
+  chanEl.addEventListener("change", function () {
+    if (!nameEdited) nameEl.value = chanEl.value;
+  });
+
+  function extraChannelRow() {
     var div = document.createElement("div");
     div.className = "crow";
-    var list = knownChannels.map(function (c) { return "<option value='" + esc(c) + "'>"; }).join("");
     div.innerHTML =
-      "<input type='text' class='ch-name' placeholder='channel name' list='known-channels' value='" + esc(value || "") + "' />" +
-      "<select class='ch-access'>" +
-        "<option value='write'" + (access === "read" ? "" : " selected") + ">read+write</option>" +
-        "<option value='read'" + (access === "read" ? " selected" : "") + ">read only</option>" +
-      "</select>" +
+      "<select class='ch-name'>" + channelOptions("") + "</select>" +
+      "<select class='ch-access'><option value='write'>read+write</option><option value='read'>read only</option></select>" +
       "<button class='ghost' type='button' title='remove'>✕</button>";
     div.querySelector("button").addEventListener("click", function () { div.remove(); });
-    document.getElementById("channels-rows").appendChild(div);
-    return div;
+    document.getElementById("extra-channels").appendChild(div);
   }
-  document.getElementById("add-channel").addEventListener("click", function () { channelRow("", "write"); });
+  document.getElementById("add-channel").addEventListener("click", function () { extraChannelRow(); });
 
   function mountRow() {
     var div = document.createElement("div");
@@ -374,23 +408,30 @@ export const AGENTS_UI_HTML = `<!doctype html>
       "<button class='ghost' type='button' title='remove'>✕</button>";
     div.querySelector("button").addEventListener("click", function () { div.remove(); });
     document.getElementById("mounts-rows").appendChild(div);
-    return div;
   }
   document.getElementById("add-mount").addEventListener("click", function () { mountRow(); });
 
+  // Network mode toggle: show host list only when restricted; warn when open.
+  var netMode = document.getElementById("net-mode");
+  netMode.addEventListener("change", function () {
+    var open = netMode.value === "open";
+    document.getElementById("egress-wrap").style.display = open ? "none" : "";
+    document.getElementById("open-warn").style.display = open ? "" : "none";
+  });
+
   function collectSpec() {
-    var name = document.getElementById("spawn-name").value.trim();
-    if (!name) throw new Error("name is required");
-    var channels = [];
-    document.querySelectorAll("#channels-rows .crow").forEach(function (row) {
-      var n = row.querySelector(".ch-name").value.trim();
+    var wake = chanEl.value;
+    if (!wake) throw new Error("pick a channel");
+    var name = nameEl.value.trim() || wake;
+    var channels = [{ name: wake, access: document.getElementById("spawn-access").value }];
+    document.querySelectorAll("#extra-channels .crow").forEach(function (row) {
+      var n = row.querySelector(".ch-name").value;
       if (!n) return;
       channels.push({ name: n, access: row.querySelector(".ch-access").value });
     });
-    if (!channels.length) throw new Error("at least one channel is required (the first is the wake channel)");
     var spec = { name: name, channels: channels };
 
-    var vn = document.getElementById("vault-name").value.trim();
+    var vn = document.getElementById("vault-name").value;
     if (vn) {
       var v = { name: vn, access: document.getElementById("vault-access").value };
       var tags = document.getElementById("vault-tags").value.split(",").map(function (t) { return t.trim(); }).filter(Boolean);
@@ -398,8 +439,12 @@ export const AGENTS_UI_HTML = `<!doctype html>
       spec.vault = v;
     }
 
-    var egress = document.getElementById("egress").value.split(",").map(function (h) { return h.trim(); }).filter(Boolean);
-    if (egress.length) spec.egress = egress;
+    if (netMode.value === "open") {
+      spec.egressUnrestricted = true;
+    } else {
+      var egress = document.getElementById("egress").value.split(",").map(function (h) { return h.trim(); }).filter(Boolean);
+      if (egress.length) spec.egress = egress;
+    }
 
     var mounts = [];
     document.querySelectorAll("#mounts-rows .mrow").forEach(function (row) {
@@ -422,16 +467,16 @@ export const AGENTS_UI_HTML = `<!doctype html>
     apiJson("/api/agents", { method: "POST", body: JSON.stringify(spec) }).then(function (r) {
       var lines = [];
       if (r.alreadyRunning) {
-        lines.push("Session \\"" + r.session + "\\" is already running (no-op).");
+        lines.push("Session " + r.session + " is already running (no-op).");
       } else {
-        lines.push("Launched \\"" + r.session + "\\".");
+        lines.push("Launched " + r.session + ".");
         lines.push("workspace: " + r.workspace);
         if (r.tokens && r.tokens.length) {
           lines.push("scopes:");
           r.tokens.forEach(function (t) { lines.push("  " + t.resource + " → " + t.scope); });
         }
         if (r.mcpServers && r.mcpServers.length) lines.push("MCP servers: " + r.mcpServers.join(", "));
-        if (r.egress && r.egress.length) lines.push("egress: " + r.egress.join(", "));
+        lines.push("network: " + (r.egressUnrestricted ? "OPEN (all hosts)" : ((r.egress || []).join(", ") || "base only")));
       }
       showMsg(msg, lines.join("\\n"), false);
       loadAgents();
@@ -443,9 +488,7 @@ export const AGENTS_UI_HTML = `<!doctype html>
   });
 
   // --- running agents list ------------------------------------------------
-  function terminalUrl(channel) {
-    return MOUNT + "/terminal?channel=" + encodeURIComponent(channel);
-  }
+  function terminalUrl(channel) { return MOUNT + "/terminal?channel=" + encodeURIComponent(channel); }
   function loadAgents() {
     return apiJson("/api/agents").then(function (j) {
       var host = document.getElementById("agents-table");
@@ -455,9 +498,7 @@ export const AGENTS_UI_HTML = `<!doctype html>
         return;
       }
       var rows = agents.map(function (a) {
-        var att = a.attached
-          ? "<span class='pill attached'>attached</span>"
-          : "<span class='pill detached'>idle</span>";
+        var att = a.attached ? "<span class='pill attached'>attached</span>" : "<span class='pill detached'>idle</span>";
         return "<tr>" +
           "<td><strong>" + esc(a.name) + "</strong></td>" +
           "<td><code>" + esc(a.session) + "</code></td>" +
@@ -478,46 +519,50 @@ export const AGENTS_UI_HTML = `<!doctype html>
   }
 
   function killAgent(name) {
-    // name is a server-enforced slug (alphanumeric/dash/underscore, agents.ts),
-    // so it carries no HTML/JS-special chars in the confirm string; it's
-    // encodeURI'd into the request path regardless.
-    if (!confirm("Kill agent \\"" + name + "\\"? This ends its tmux session.")) return;
+    // name is a server-enforced slug (alphanumeric/dash/underscore, agents.ts), so
+    // it carries no HTML/JS-special chars in the confirm string; encodeURI'd anyway.
+    if (!confirm("Kill agent " + name + "? This ends its tmux session.")) return;
     apiJson("/api/agents/" + encodeURIComponent(name), { method: "DELETE" }).then(function () {
       loadAgents();
     }).catch(function (err) { alert("Kill failed: " + err.message); });
   }
-
   document.getElementById("refresh").addEventListener("click", function () { loadAgents(); });
 
-  // --- channels (prefill the spawn form) ----------------------------------
+  // --- pickers: channels + vaults -----------------------------------------
   function loadChannels() {
     return fetch(MOUNT + "/.parachute/config").then(function (r) { return r.json(); }).then(function (cfg) {
       knownChannels = (cfg.channels || []).map(function (c) { return c.name; });
-      var dl = document.getElementById("known-channels");
-      dl.innerHTML = knownChannels.map(function (c) { return "<option value='" + esc(c) + "'>"; }).join("");
-      // Seed one channel row (prefilled with the first known channel, if any).
-      if (!document.querySelector("#channels-rows .crow")) {
-        channelRow(knownChannels[0] || "", "write");
-      }
-    }).catch(function () { channelRow("", "write"); });
+      chanEl.innerHTML = knownChannels.length
+        ? channelOptions(knownChannels[0])
+        : "<option value=''>(no channels — add one in Config)</option>";
+      if (knownChannels.length && !nameEdited) nameEl.value = knownChannels[0];
+    }).catch(function () {
+      chanEl.innerHTML = "<option value=''>(channel list failed)</option>";
+    });
+  }
+  function loadVaults() {
+    return apiJson("/api/vaults").then(function (j) {
+      var vaults = j.vaults || [];
+      var sel = document.getElementById("vault-name");
+      sel.innerHTML = "<option value=''>(no vault)</option>" +
+        vaults.map(function (v) { return "<option value='" + esc(v) + "'>" + esc(v) + "</option>"; }).join("");
+    }).catch(function () { /* leave the (no vault) default */ });
   }
 
   // --- boot ---------------------------------------------------------------
   setStatus("authenticating…");
   fetchToken().then(function () {
     setStatus("● ready", "live");
-    return Promise.all([loadChannels(), loadCreds(), loadAgents()]);
+    return Promise.all([loadChannels(), loadVaults(), loadCreds(), loadAgents()]);
   }).then(function () {
-    // Poll the running list so kills/exits elsewhere reflect here.
     setInterval(loadAgents, 5000);
   }).catch(function (err) {
     setStatus("not authenticated", "err");
-    var msg = document.getElementById("spawn-msg");
-    showMsg(msg, "Open this page through the hub portal, signed in as the operator. " +
+    showMsg(document.getElementById("spawn-msg"),
+      "Open this page through the hub portal, signed in as the operator. " +
       "The agents surface needs a channel:admin token (" + err.message + ").", true);
   });
 })();
 </script>
-<datalist id="known-channels"></datalist>
 </body>
 </html>`;

--- a/src/agents.test.ts
+++ b/src/agents.test.ts
@@ -139,6 +139,14 @@ describe("buildSpecFromBody", () => {
       buildSpecFromBody({ name: "a", channels: ["c"], mounts: [{ hostPath: "/h", mountPath: "/m", mode: "x" }] }),
     ).toThrow(/mode/);
   });
+  test("egressUnrestricted is accepted and overrides per-host egress", () => {
+    const spec = buildSpecFromBody({ name: "a", channels: ["c"], egressUnrestricted: true, egress: ["x.com"] });
+    expect(spec.egressUnrestricted).toBe(true);
+    expect(spec.egress).toBeUndefined(); // allow-all is strictly broader
+  });
+  test("rejects a non-boolean egressUnrestricted", () => {
+    expect(() => buildSpecFromBody({ name: "a", channels: ["c"], egressUnrestricted: "yes" })).toThrow(/egressUnrestricted/);
+  });
   test("rejects relative mount paths (must be absolute)", () => {
     expect(() =>
       buildSpecFromBody({ name: "a", channels: ["c"], mounts: [{ hostPath: "rel", mountPath: "/m", mode: "ro" }] }),
@@ -174,10 +182,24 @@ describe("redactSpawnResult", () => {
     ]);
     expect(red.mcpServers).toEqual(["channel-aaron", "vault-default"]);
     expect(red.egress).toEqual(["api.anthropic.com:443"]);
+    expect(red.egressUnrestricted).toBe(false);
     // The smoking gun: no token VALUE appears anywhere in the serialized result.
     const wire = JSON.stringify(red);
     expect(wire).not.toContain("SECRET-CHANNEL-TOKEN");
     expect(wire).not.toContain("SECRET-VAULT-TOKEN");
+  });
+  test("an unrestricted-network result (no allowedDomains) → egressUnrestricted true, egress []", () => {
+    const unrestricted: SpawnAgentResult = {
+      ...result,
+      wrapped: {
+        ...result.wrapped,
+        // allow-all: allowedDomains absent (the runtime's no-restriction shape).
+        config: { network: { deniedDomains: [] }, filesystem: { denyRead: [], allowWrite: [], denyWrite: [] } } as unknown as SpawnAgentResult["wrapped"]["config"],
+      },
+    };
+    const red = redactSpawnResult(unrestricted);
+    expect(red.egressUnrestricted).toBe(true);
+    expect(red.egress).toEqual([]);
   });
 });
 
@@ -437,6 +459,29 @@ describe("/api/agents — operator-gated on channel:admin", () => {
       });
       expect(res.status).toBe(403);
       expect(((await res.json()) as { error: string }).error).toContain("mint failed");
+    } finally {
+      srv.stop(true);
+    }
+  });
+});
+
+describe("GET /api/vaults", () => {
+  test("no token → 401", async () => {
+    const { srv, base } = buildServer();
+    try {
+      expect((await fetch(`${base}/api/vaults`)).status).toBe(401);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("admin token → 200 with a vaults array", async () => {
+    const { srv, base } = buildServer();
+    try {
+      const res = await fetch(`${base}/api/vaults`, { headers: adminAuth });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { vaults: unknown };
+      expect(Array.isArray(body.vaults)).toBe(true);
     } finally {
       srv.stop(true);
     }

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -82,8 +82,10 @@ export interface RedactedSpawnResult {
   tokens: RedactedToken[];
   /** The MCP server entry keys wired into the session (names only). */
   mcpServers: string[];
-  /** Egress allowlist baked into the sandbox (host:port domains). */
+  /** Egress allowlist baked into the sandbox (empty when unrestricted). */
   egress: string[];
+  /** True when the session runs with NO network restriction (allow-all). */
+  egressUnrestricted: boolean;
 }
 
 /** The spawn/list/kill operations the daemon routes call. Injectable for tests. */
@@ -219,6 +221,13 @@ export function buildSpecFromBody(body: unknown): AgentSpec {
     spec.vault = parseVaultEntry(b.vault);
   }
 
+  if (b.egressUnrestricted !== undefined && b.egressUnrestricted !== null) {
+    if (typeof b.egressUnrestricted !== "boolean") {
+      throw new SpawnRequestError("body.egressUnrestricted must be a boolean");
+    }
+    if (b.egressUnrestricted) spec.egressUnrestricted = true;
+  }
+
   if (b.egress !== undefined && b.egress !== null) {
     if (!Array.isArray(b.egress)) {
       throw new SpawnRequestError("body.egress must be an array of host strings");
@@ -229,7 +238,8 @@ export function buildSpecFromBody(body: unknown): AgentSpec {
         return h.trim();
       })
       .filter((h) => h.length > 0);
-    if (egress.length > 0) spec.egress = egress;
+    // egressUnrestricted is strictly broader; ignore per-host egress when set.
+    if (egress.length > 0 && !spec.egressUnrestricted) spec.egress = egress;
   }
 
   if (b.mounts !== undefined && b.mounts !== null) {
@@ -344,13 +354,16 @@ export function redactSpawnResult(result: SpawnAgentResult): RedactedSpawnResult
   } catch {
     mcpServers = [];
   }
+  // allowedDomains is absent when the session runs unrestricted (allow-all).
+  const allowed = result.wrapped.config.network.allowedDomains as string[] | undefined;
   return {
     session: result.session,
     workspace: result.workspace,
     alreadyRunning: result.alreadyRunning,
     tokens,
     mcpServers,
-    egress: result.wrapped.config.network.allowedDomains,
+    egress: allowed ?? [],
+    egressUnrestricted: allowed === undefined,
   };
 }
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -22,7 +22,7 @@ import { mkdirSync, readFileSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 import { timingSafeEqual } from "node:crypto";
-import { upsertService } from "./services-manifest.ts";
+import { upsertService, listVaultNames } from "./services-manifest.ts";
 
 /** Constant-time webhook-secret compare. Length check first (a length mismatch
  *  is never equal); timingSafeEqual on equal-length buffers avoids the
@@ -74,6 +74,7 @@ import {
   type TerminalWsData,
 } from "./terminal.ts";
 import { TERMINAL_UI_HTML } from "./terminal-ui.ts";
+import { serveTerminalAsset } from "./terminal-assets.ts";
 import { AGENTS_UI_HTML } from "./agents-ui.ts";
 import {
   createRealAgentOps,
@@ -798,6 +799,17 @@ export function createFetchHandler(
       return authJson({ error: "websocket upgrade failed" }, 400);
     }
 
+    // Terminal renderer assets (xterm.js + addon-fit + css) served SAME-ORIGIN
+    // (design §5; replaces the CDN load that broke behind strict networks/CSP).
+    // Public like the page itself — these are vendored static JS/CSS, no secrets.
+    // Must run BEFORE the `/terminal/<channel>` page match (this is a 2-segment
+    // path the single-segment termMatch wouldn't catch, but keep it explicit).
+    const assetMatch = url.pathname.match(/^\/terminal\/assets\/([^/]+)$/);
+    if (req.method === "GET" && assetMatch) {
+      const served = serveTerminalAsset(decodeURIComponent(assetMatch[1]!));
+      return served ?? json({ error: "not found" }, 404);
+    }
+
     // Terminal view (the xterm.js page) — `/terminal` or `/terminal/<channel>`
     // as a plain GET (no upgrade) serves the page; the page then opens the WS to
     // `/terminal/<channel>`. Loads OPEN (like /ui and /admin) so it can bootstrap
@@ -1142,6 +1154,15 @@ export function createFetchHandler(
         if (err instanceof SpawnRequestError) return json({ error: err.message }, 400);
         return json({ error: `failed to kill agent: ${(err as Error).message}` }, 500);
       }
+    }
+
+    // Installed vault instances (for the agents page's vault picker) — derived
+    // from the vault module's registered `/vault/<name>` paths in services.json.
+    // No secrets; channel:admin-gated to match the rest of the agents surface.
+    if (url.pathname === "/api/vaults" && req.method === "GET") {
+      const denied = await requireScope(req, url, SCOPE_ADMIN);
+      if (denied) return denied;
+      return json({ vaults: listVaultNames() });
     }
 
     // ---------------------------------------------------------------------

--- a/src/sandbox/config.ts
+++ b/src/sandbox/config.ts
@@ -56,14 +56,20 @@ export function currentSandboxPlatform(): SandboxPlatform {
 export function buildSandboxConfig(input: BuildSandboxConfigInput): SandboxRuntimeConfig {
   const platform = input.platform ?? currentSandboxPlatform();
 
-  const allowedDomains = composeEgressAllowlist(input.egressBase, input.spec.egress);
   const fs = composeFilesystemView(input.baseBinds, input.spec.mounts, platform);
 
+  // Network: by default the non-removable base unioned with the spec's additions.
+  // When the spec opts into `egressUnrestricted`, we OMIT `allowedDomains` entirely
+  // — the sandbox-runtime treats an absent allowedDomains as "no network
+  // restriction" (verified: present-but-empty = block all; absent = allow all).
+  // The cast is because the runtime's TS type marks allowedDomains required while
+  // its runtime honors the absent case as the documented allow-all path.
+  const network: SandboxRuntimeConfig["network"] = input.spec.egressUnrestricted
+    ? ({ deniedDomains: [] } as unknown as SandboxRuntimeConfig["network"])
+    : { allowedDomains: composeEgressAllowlist(input.egressBase, input.spec.egress), deniedDomains: [] };
+
   const config: SandboxRuntimeConfig = {
-    network: {
-      allowedDomains,
-      deniedDomains: [],
-    },
+    network,
     filesystem: {
       denyRead: fs.denyRead,
       allowRead: fs.allowRead,

--- a/src/sandbox/types.ts
+++ b/src/sandbox/types.ts
@@ -118,6 +118,17 @@ export interface AgentSpec {
    */
   egress?: string[];
   /**
+   * Open the network entirely — allow ALL egress, ignoring `egress[]` and the
+   * base allowlist (the sandbox runs with no network restriction; filesystem
+   * isolation is unchanged). This is the operator's explicit, deliberate choice
+   * for a TRUSTED session where the convenience of unrestricted network outweighs
+   * the exfiltration surface ("I know how this is contained"). Egress is the
+   * load-bearing control for a session fed FOREIGN-authored input (design §3.3),
+   * so this must never be the default and must be an explicit per-spawn opt-in.
+   * Mutually overrides `egress` (allow-all is strictly broader).
+   */
+  egressUnrestricted?: boolean;
+  /**
    * Filesystem mounts — ADDITIVE to the default private per-session workspace
    * (rw) + the implicit runtime/claude-config (ro). Reads are scoped to declared
    * binds, NOT broad (design §4.5).

--- a/src/services-manifest.test.ts
+++ b/src/services-manifest.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect } from "bun:test";
 import { mkdtempSync, readFileSync, writeFileSync, existsSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { resolveManifestPath, upsertService, type ServiceEntry } from "./services-manifest.ts";
+import { resolveManifestPath, upsertService, listVaultNames, type ServiceEntry } from "./services-manifest.ts";
 
 function tmp(): string {
   return join(mkdtempSync(join(tmpdir(), "pc-manifest-")), "services.json");
@@ -78,5 +78,29 @@ describe("upsertService", () => {
     expect(() => upsertService(CHANNEL, path)).toThrow(/malformed/);
     expect(existsSync(path)).toBe(true); // original left intact
     expect(JSON.parse(readFileSync(path, "utf8"))).toEqual({ not_services: true }); // content untouched
+  });
+});
+
+describe("listVaultNames", () => {
+  test("extracts vault names from the vault module's /vault/<name> paths, default first", () => {
+    const path = tmp();
+    writeFileSync(path, JSON.stringify({ services: [
+      { name: "parachute-vault", port: 1940, paths: ["/vault/boulder", "/vault/default", "/vault/techne"], health: "x", version: "1" },
+      { name: "parachute-channel", port: 1941, paths: ["/channel"], health: "x", version: "1" },
+    ] }));
+    expect(listVaultNames(path)).toEqual(["default", "boulder", "techne"]);
+  });
+
+  test("dedupes across services and ignores non-vault paths", () => {
+    const path = tmp();
+    writeFileSync(path, JSON.stringify({ services: [
+      { name: "a", port: 1, paths: ["/vault/x", "/other"], health: "x", version: "1" },
+      { name: "b", port: 2, paths: ["/vault/x", "/vault/y"], health: "x", version: "1" },
+    ] }));
+    expect(listVaultNames(path).sort()).toEqual(["x", "y"]);
+  });
+
+  test("returns [] when the manifest is absent or unreadable", () => {
+    expect(listVaultNames(join(tmpdir(), "does-not-exist-" + Math.floor(performance.now()), "services.json"))).toEqual([]);
   });
 });

--- a/src/services-manifest.ts
+++ b/src/services-manifest.ts
@@ -49,6 +49,35 @@ function readManifest(path: string): ServicesManifest {
 }
 
 /**
+ * List the vault instance names installed on this host, from the vault module's
+ * registered `paths` (`/vault/<name>` → `<name>`). Used by the agents page's vault
+ * picker so an operator chooses from real vaults instead of typing a name blind.
+ * Best-effort: returns `[]` if the manifest is absent/unreadable (the picker then
+ * falls back to free text). Deduped + sorted; `default` floated first if present.
+ */
+export function listVaultNames(path: string = resolveManifestPath()): string[] {
+  let manifest: ServicesManifest;
+  try {
+    manifest = readManifest(path);
+  } catch {
+    return [];
+  }
+  const names = new Set<string>();
+  for (const svc of manifest.services) {
+    for (const p of svc.paths ?? []) {
+      // `paths` are operator-registered route prefixes, not URLs — take the literal
+      // segment (no decodeURIComponent: a stray %2F could synthesize a slash-bearing
+      // vault name, and real vault names are plain slugs).
+      const m = /^\/vault\/([^/]+)/.exec(p);
+      if (m && m[1]) names.add(m[1]);
+    }
+  }
+  const sorted = [...names].sort((a, b) => a.localeCompare(b));
+  // Float "default" to the front — it's the conventional primary vault.
+  return sorted.sort((a, b) => (a === "default" ? -1 : b === "default" ? 1 : 0));
+}
+
+/**
  * Idempotent upsert of a service entry. Merges into any existing row rather
  * than replacing it — preserves hub-stamped fields the module doesn't own.
  * Atomic write: stages to a tmp file, then renames over the target so a crash

--- a/src/spawn-agent-cli.test.ts
+++ b/src/spawn-agent-cli.test.ts
@@ -79,6 +79,12 @@ describe("parseArgs — name + channels + vault + egress + mounts → the right 
     expect(spec!.channels[0]).toEqual({ name: "first" });
     expect(spec!.channels[1]).toEqual({ name: "second" });
   });
+
+  test("--egress-all sets egressUnrestricted and overrides --egress", () => {
+    const { spec } = parseArgs(["a", "--channel", "c", "--egress", "x.com", "--egress-all"]);
+    expect(spec!.egressUnrestricted).toBe(true);
+    expect(spec!.egress).toBeUndefined(); // allow-all is strictly broader
+  });
 });
 
 describe("parseArgs — --help short-circuits", () => {

--- a/src/spawn-deps.test.ts
+++ b/src/spawn-deps.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Tests for `resolveSpawnDeps` (`src/spawn-deps.ts`) — the real-dep resolver
+ * shared by the CLI and the web spawn endpoint.
+ *
+ * The load-bearing regression guard here is the claude config binding: the
+ * sandboxed `claude` MUST get `~/.claude.json` bound read-only, or it runs
+ * first-run onboarding whose connectivity check is FATAL under the restricted
+ * egress proxy and the tmux session dies instantly ("An unknown error occurred").
+ * That bug shipped once; this test ensures the binding stays.
+ */
+
+import { describe, test, expect, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir, homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { resolveSpawnDeps, SpawnDepsError } from "./spawn-deps.ts";
+
+const savedHome = process.env.PARACHUTE_HOME;
+let tmp: string | undefined;
+
+afterEach(() => {
+  if (savedHome === undefined) delete process.env.PARACHUTE_HOME;
+  else process.env.PARACHUTE_HOME = savedHome;
+  if (tmp) {
+    try { rmSync(tmp, { recursive: true, force: true }); } catch {}
+    tmp = undefined;
+  }
+});
+
+describe("resolveSpawnDeps", () => {
+  test("throws SpawnDepsError when there's no operator token", () => {
+    tmp = mkdtempSync(join(tmpdir(), "spawn-deps-empty-"));
+    process.env.PARACHUTE_HOME = tmp; // no operator.token inside
+    expect(() => resolveSpawnDeps()).toThrow(SpawnDepsError);
+  });
+
+  test("binds ~/.claude.json read-only (skip-onboarding regression guard)", () => {
+    tmp = mkdtempSync(join(tmpdir(), "spawn-deps-"));
+    process.env.PARACHUTE_HOME = tmp;
+    writeFileSync(join(tmp, "operator.token"), "fake-operator-bearer");
+    const deps = resolveSpawnDeps();
+    // The config FILE at the home root must be bound — this is the fix for the
+    // onboarding-connectivity death under restricted egress.
+    expect(deps.runtimeReadOnly).toContain(resolve(homedir(), ".claude.json"));
+    // And the config DIR.
+    const dir = process.env.CLAUDE_CONFIG_DIR ?? resolve(homedir(), ".claude");
+    expect(deps.runtimeReadOnly).toContain(dir);
+  });
+});

--- a/src/spawn-deps.ts
+++ b/src/spawn-deps.ts
@@ -15,9 +15,9 @@
  * same least-privilege launch as one from the terminal.
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { homedir } from "node:os";
-import { resolve, join } from "node:path";
+import { resolve, join, dirname } from "node:path";
 import {
   realTmuxLauncher,
   type SpawnAgentDeps,
@@ -70,9 +70,62 @@ function resolveChannelUrl(): string {
   return `http://127.0.0.1:${port}`;
 }
 
-/** Claude config dir bound read-only so the sandboxed session can read its config. */
-function claudeConfigDir(): string {
-  return process.env.CLAUDE_CONFIG_DIR ?? resolve(homedir(), ".claude");
+/**
+ * Claude runtime/config paths bound read-only so the sandboxed `claude` runs:
+ *   - the config DIR (`~/.claude` or $CLAUDE_CONFIG_DIR) — skills, plugins, settings;
+ *   - the config FILE `~/.claude.json` (at the home ROOT, a sibling of the dir).
+ *
+ * Binding `~/.claude.json` is load-bearing: without it claude can't see that it's
+ * already onboarded, so it runs FIRST-RUN SETUP, whose connectivity check is FATAL
+ * under the restricted egress proxy → the tmux session dies instantly with
+ * "An unknown error occurred (Unexpected)". With it bound, claude skips onboarding
+ * and starts cleanly under both restricted and open network. Bound READ-ONLY: a
+ * session can read the operator's claude config (it runs on the operator's claude
+ * credential anyway) but never mutate it for future sessions.
+ */
+function claudeConfigReads(): string[] {
+  const dir = process.env.CLAUDE_CONFIG_DIR ?? resolve(homedir(), ".claude");
+  const reads = [dir, resolve(homedir(), ".claude.json")];
+  // If CLAUDE_CONFIG_DIR is set, newer claude keeps its config json under it too.
+  if (process.env.CLAUDE_CONFIG_DIR) reads.push(join(process.env.CLAUDE_CONFIG_DIR, ".claude.json"));
+  return reads;
+}
+
+/**
+ * Resolve the `claude` binary to an ABSOLUTE path and the read binds the sandbox
+ * needs to actually exec it.
+ *
+ * Why this matters: the scoped-read policy DENIES the whole home tree (`/Users`)
+ * and re-allows only declared binds (mounts.ts §4.5). The claude CLI commonly
+ * installs UNDER the home tree (`~/.local/bin/claude` → `~/.local/share/claude/
+ * versions/<v>`), so without binding it the sandboxed launch fails with
+ * `claude: command not found` and the tmux session dies instantly. Relying on
+ * PATH alone is also fragile — the supervised daemon's PATH may differ from a
+ * login shell. So we resolve the absolute path (via the daemon's PATH) and bind
+ * the symlink + its realpath + the install dir read-only.
+ *
+ * Returns `null` when `claude` isn't found on the daemon's PATH — the caller
+ * falls back to the bare `"claude"` (PATH lookup at run) and binds nothing, which
+ * is correct when claude lives OUTSIDE the home tree (e.g. `/opt/homebrew/bin`,
+ * already readable) and the only honest option when it can't be located at all.
+ */
+function resolveClaudeBin(): { bin: string; reads: string[] } | null {
+  const sym = Bun.which("claude");
+  if (!sym) return null;
+  const reads = new Set<string>([sym]);
+  try {
+    const real = realpathSync(sym);
+    reads.add(real);
+    // The install dir + its parent — a versioned install keeps sibling files at
+    // `…/versions/<v>` under `…/share/claude`; binding both covers what the
+    // binary loads at runtime. Outside the home tree these are no-ops (already
+    // readable), so this is safe regardless of install layout.
+    reads.add(dirname(real));
+    reads.add(dirname(dirname(real)));
+  } catch {
+    // realpath failed (broken symlink?) — bind just the symlink we found.
+  }
+  return { bin: sym, reads: [...reads] };
 }
 
 /** Absolute path to the operator token file (for error messages). */
@@ -100,20 +153,31 @@ export function resolveSpawnDeps(): SpawnAgentDeps {
   const sessionsDir = join(stateDir, "sessions");
   const vaultUrl = process.env.PARACHUTE_VAULT_URL?.replace(/\/$/, "") || DEFAULT_VAULT_URL;
 
+  // Resolve the claude binary + the read binds it needs inside the sandbox (the
+  // home tree is denied, and claude commonly lives under it). null → fall back to
+  // bare "claude" on PATH (correct when claude is outside the home tree).
+  const claude = resolveClaudeBin();
+
+  // The runtime/config paths the sandboxed `claude` must read: its config dir +
+  // config file (skip-onboarding, see claudeConfigReads) + (when resolved) the
+  // binary itself and its install dir. System paths (/usr,/lib,/opt) stay
+  // readable; the per-session workspace (rw) is added by spawnAgent under sessionsDir.
+  const runtimeReadOnly = [...claudeConfigReads(), ...(claude?.reads ?? [])];
+
   return {
     hubOrigin: getHubOrigin(),
     managerBearer,
     channelUrl: resolveChannelUrl(),
     vaultUrl,
     sessionsDir,
-    // The claude config dir is the one runtime path the sandboxed `claude` must
-    // read (system paths /usr,/lib stay readable; the home tree is denied). The
-    // per-session workspace (rw) is added by spawnAgent under sessionsDir.
-    runtimeReadOnly: [claudeConfigDir()],
+    runtimeReadOnly,
     // The real per-channel Claude OAuth resolver (channel override ?? default ?? throw).
     resolveClaudeToken: (channel: string) => resolveClaudeCredential(channel, stateDir),
     // The real tmux launcher (writes the per-session launch script, runs tmux).
     tmux: realTmuxLauncher(),
+    // Absolute claude path so the sandbox doesn't depend on PATH resolution at run
+    // (and matches the bound binary). Omitted → spawnAgent defaults to "claude".
+    ...(claude ? { claudeBin: claude.bin } : {}),
     // sandboxEngine omitted → spawnAgent's `new Sandbox()` uses the real, pinned,
     // library-linked engine.
   };

--- a/src/terminal-assets.test.ts
+++ b/src/terminal-assets.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Tests for same-origin terminal asset serving (`src/terminal-assets.ts`) — the
+ * fix for "xterm.js failed to load (CDN blocked?)". Proves the vendored xterm JS +
+ * CSS resolve from the installed packages and serve with the right content-type,
+ * and that an unknown asset name is a clean miss (the daemon 404s it).
+ */
+
+import { describe, test, expect } from "bun:test";
+import { serveTerminalAsset, TERMINAL_ASSET_NAMES } from "./terminal-assets.ts";
+
+describe("serveTerminalAsset", () => {
+  test("serves xterm.js as JavaScript with a real body", async () => {
+    const res = serveTerminalAsset("xterm.js");
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(200);
+    expect(res!.headers.get("content-type")).toContain("javascript");
+    const body = await res!.text();
+    // The UMD bundle defines the Terminal global — a non-trivial body proves the
+    // file resolved from the package (not an empty/placeholder response).
+    expect(body.length).toBeGreaterThan(1000);
+    expect(body).toContain("Terminal");
+  });
+
+  test("serves xterm.css as CSS", async () => {
+    const res = serveTerminalAsset("xterm.css");
+    expect(res!.status).toBe(200);
+    expect(res!.headers.get("content-type")).toContain("css");
+    expect((await res!.text()).length).toBeGreaterThan(100);
+  });
+
+  test("serves addon-fit.js", async () => {
+    const res = serveTerminalAsset("addon-fit.js");
+    expect(res!.status).toBe(200);
+    expect(res!.headers.get("content-type")).toContain("javascript");
+  });
+
+  test("sets an immutable cache header (version-pinned)", () => {
+    const res = serveTerminalAsset("xterm.js");
+    expect(res!.headers.get("cache-control")).toContain("immutable");
+  });
+
+  test("an unknown asset name → null (caller 404s)", () => {
+    expect(serveTerminalAsset("evil.js")).toBeNull();
+    expect(serveTerminalAsset("../../etc/passwd")).toBeNull();
+  });
+
+  test("the known names are the three xterm assets", () => {
+    expect(TERMINAL_ASSET_NAMES.sort()).toEqual(["addon-fit.js", "xterm.css", "xterm.js"]);
+  });
+});

--- a/src/terminal-assets.ts
+++ b/src/terminal-assets.ts
@@ -1,0 +1,79 @@
+/**
+ * Serve the vendored xterm.js assets SAME-ORIGIN (design §5; fixes the "xterm.js
+ * failed to load — CDN blocked?" failure).
+ *
+ * The terminal page originally loaded xterm + the fit addon from a public CDN
+ * (jsdelivr). That breaks whenever the operator's network or the hub's CSP blocks
+ * the CDN — and an operator-only terminal that silently won't load is a
+ * showstopper. So we vendor `@xterm/xterm` + `@xterm/addon-fit` as dependencies
+ * and serve their dist files from the daemon at `/terminal/assets/<file>`: no
+ * third-party origin, no CSP `script-src` widening (the bundle is `'self'`), works
+ * offline / behind strict networks.
+ *
+ * The files are resolved from the installed packages (works under both the
+ * bun-linked checkout and an npm install — they're real deps) and read+cached on
+ * first request. Version-pinned in package.json, so the responses are immutable.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+/** The asset routes the terminal page loads, mapped to package-relative files. */
+interface AssetSpec {
+  /** Package specifier whose dir anchors the file. */
+  pkg: string;
+  /** File path relative to the package root. */
+  rel: string;
+  /** Content-Type to serve. */
+  type: string;
+}
+
+const ASSETS: Record<string, AssetSpec> = {
+  "xterm.js": { pkg: "@xterm/xterm/package.json", rel: "lib/xterm.js", type: "text/javascript; charset=utf-8" },
+  "xterm.css": { pkg: "@xterm/xterm/package.json", rel: "css/xterm.css", type: "text/css; charset=utf-8" },
+  "addon-fit.js": { pkg: "@xterm/addon-fit/package.json", rel: "lib/addon-fit.js", type: "text/javascript; charset=utf-8" },
+};
+
+/** Cache of read file bodies (text — xterm js/css are all text), by asset name. */
+const bodyCache = new Map<string, string>();
+
+/** Resolve an asset's absolute path from its package root (works linked + installed). */
+function assetPath(spec: AssetSpec): string {
+  // Bun.resolveSync resolves the package's own package.json (always exported), and
+  // we join the known dist-relative path — robust to packages whose `exports` map
+  // doesn't expose deep subpaths directly.
+  const pkgRoot = dirname(Bun.resolveSync(spec.pkg, import.meta.dir));
+  return join(pkgRoot, spec.rel);
+}
+
+/**
+ * Serve a terminal asset by name (the segment after `/terminal/assets/`), or
+ * null if the name isn't a known asset (caller 404s). Read-once + cached;
+ * immutable cache headers since the version is pinned.
+ */
+export function serveTerminalAsset(name: string): Response | null {
+  const spec = ASSETS[name];
+  if (!spec) return null;
+  let body = bodyCache.get(name);
+  if (body === undefined) {
+    try {
+      body = readFileSync(assetPath(spec), "utf8");
+    } catch (err) {
+      return new Response(
+        `/* terminal asset "${name}" unavailable: ${(err as Error).message} */`,
+        { status: 500, headers: { "content-type": spec.type } },
+      );
+    }
+    bodyCache.set(name, body);
+  }
+  return new Response(body, {
+    headers: {
+      "content-type": spec.type,
+      // Version-pinned in package.json → safe to cache hard.
+      "cache-control": "public, max-age=31536000, immutable",
+    },
+  });
+}
+
+/** The known asset names (for routing/tests). */
+export const TERMINAL_ASSET_NAMES = Object.keys(ASSETS);

--- a/src/terminal-ui.ts
+++ b/src/terminal-ui.ts
@@ -3,39 +3,25 @@
  * `design/2026-06-14-sandboxed-agent-sessions.md` §5).
  *
  * Single self-contained document: HTML + inline CSS + inline JS, no build step
- * (same shape as `daemon.ts`'s chat UI + `admin-ui.ts`). xterm.js + the fit
- * addon load from a pinned CDN — there's no bundler in this repo, and the
- * existing UIs are all hand-written HTML strings, so a CDN import is the
- * minimal, in-pattern way to ship xterm without adding a build step.
+ * (same shape as `daemon.ts`'s chat UI + `admin-ui.ts`). xterm.js + the fit addon
+ * are served SAME-ORIGIN by the daemon (`/terminal/assets/*`, see
+ * `terminal-assets.ts`) — NOT from a CDN. The original CDN load broke whenever the
+ * operator's network or the hub's CSP blocked jsdelivr; vendoring + same-origin
+ * serving fixes that ("xterm.js failed to load — CDN blocked?").
  *
  * What the page does:
- *   1. Fetch the channel list (`<mount>/.parachute/config`) → a picker.
- *   2. Fetch a hub-minted `channel:admin` Bearer (`<origin>/admin/channel-token`,
- *      cookie-gated — the SAME token the chat + admin UIs use; the terminal is
- *      operator-gated, so the operator's token is exactly what's needed).
- *   3. Open a WebSocket to `<mount>/terminal/<channel>?token=…&cols=…&rows=…`
- *      (the token rides as `?token=` — a browser can't set Authorization on
- *      `new WebSocket()`). The daemon's upgrade gate validates channel:admin
- *      BEFORE upgrading.
- *   4. Relay xterm ↔ WS: xterm `onData` (keystrokes) → BINARY frames; pty output
- *      (BINARY frames) → `term.write`; xterm `onResize` → a JSON control frame
- *      `{type:"resize",cols,rows}`.
- *   5. Reconnect: because the backend attaches to TMUX (not a raw pty), a dropped
- *      socket just re-attaches to the live session with scrollback intact.
- *
- * Flow control (browser half of the §5.4 backpressure design): xterm's
- * `FlowControl`-style high-watermark — we count bytes written to xterm and, past
- * a watermark, the backend's own `getBufferedAmount` throttle is the primary
- * guard; the browser side keeps the renderer from falling so far behind it
- * stalls. The load-bearing flow control is server-side (terminal.ts); this is
- * the cooperative browser half.
+ *   1. Compute the mount prefix, then dynamically load the same-origin xterm
+ *      assets (CSS + JS), THEN boot — the `<script src>`/`<link>` can't be static
+ *      because their correct URL depends on the runtime mount prefix.
+ *   2. Fetch the channel list (`<mount>/.parachute/config`) → a picker.
+ *   3. Fetch a hub-minted `channel:admin` Bearer (`<origin>/admin/channel-token`).
+ *   4. Open a WebSocket to `<mount>/terminal/<channel>?token=…&cols=…&rows=…`.
+ *      The daemon's upgrade gate validates channel:admin BEFORE upgrading.
+ *   5. Relay xterm ↔ WS: keystrokes → BINARY frames; pty output (BINARY) →
+ *      `term.write`; resize → a JSON control frame `{type:"resize",cols,rows}`.
+ *   6. Reconnect: the backend attaches to TMUX, so a dropped socket re-attaches to
+ *      the live session with scrollback intact.
  */
-
-// Pinned xterm.js + fit addon (CDN, no build step). Versions pinned for
-// reproducibility; SRI omitted to keep the single-file page simple (the page is
-// operator-only, same-origin behind the hub). xterm 5.x is the current line.
-const XTERM_VERSION = "5.3.0";
-const XTERM_FIT_VERSION = "0.10.0";
 
 export const TERMINAL_UI_HTML = `<!doctype html>
 <html lang="en">
@@ -44,7 +30,6 @@ export const TERMINAL_UI_HTML = `<!doctype html>
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <meta name="referrer" content="no-referrer" />
 <title>parachute-channel · terminal</title>
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@${XTERM_VERSION}/css/xterm.min.css" />
 <style>
   :root {
     --bg: #0f1115; --panel: #171a21; --line: #262b36; --fg: #e6e9ef;
@@ -64,6 +49,8 @@ export const TERMINAL_UI_HTML = `<!doctype html>
   }
   header .brand { font-weight: 600; }
   header .brand small { color: var(--muted); font-weight: 400; }
+  header nav a { color: var(--muted); text-decoration: none; font-size: 13px; margin-right: 4px; }
+  header nav a:hover { color: var(--fg); text-decoration: underline; }
   header select {
     background: var(--bg); color: var(--fg);
     border: 1px solid var(--line); border-radius: 6px; padding: 6px 10px; font: inherit;
@@ -93,16 +80,15 @@ export const TERMINAL_UI_HTML = `<!doctype html>
 <body>
   <header>
     <div class="brand">parachute-channel <small>· terminal</small></div>
+    <nav><a id="nav-agents" href="#">← Agents</a></nav>
     <select id="channel" title="channel"></select>
     <button id="reconnect" type="button" title="Re-attach to the tmux session">Reconnect</button>
     <span class="spacer"></span>
-    <span id="status">connecting…</span>
+    <span id="status">loading…</span>
   </header>
   <div id="notice" class="notice" hidden></div>
   <div id="term-wrap"><div id="term"></div></div>
 
-  <script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@${XTERM_VERSION}/lib/xterm.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@${XTERM_FIT_VERSION}/lib/addon-fit.min.js"></script>
 <script>
 (function () {
   var sel = document.getElementById("channel");
@@ -112,16 +98,57 @@ export const TERMINAL_UI_HTML = `<!doctype html>
   var termHost = document.getElementById("term");
 
   // Served through the hub the page is /channel/terminal; locally it's
-  // /terminal. Derive the mount prefix so the WS + token URLs resolve under the
-  // same prefix (same shape as the chat UI's MOUNT).
+  // /terminal. Derive the mount prefix so the WS + token + asset URLs resolve
+  // under the same prefix (same shape as the chat UI's MOUNT).
   var MOUNT = location.pathname.replace(/\\/terminal(\\/[^/]*)?\\/?$/, "");
 
-  if (typeof window.Terminal !== "function") {
-    showNotice("xterm.js failed to load (CDN blocked?). The terminal needs it. " +
-      "You can always attach on the host: <code>tmux attach -t &lt;channel&gt;-agent</code>.", true);
-    setStatus("xterm unavailable", "err");
-    return;
+  // Wire the nav link to the agents page under the same mount.
+  document.getElementById("nav-agents").href = MOUNT + "/agents";
+
+  function setStatus(text, cls) { statusEl.textContent = text; statusEl.className = cls || ""; }
+  function showNotice(html, isErr) {
+    noticeEl.innerHTML = html;
+    noticeEl.className = "notice" + (isErr ? " err" : "");
+    noticeEl.hidden = false;
   }
+  function clearNotice() { noticeEl.hidden = true; noticeEl.innerHTML = ""; }
+
+  // --- same-origin asset loading ------------------------------------------
+  // xterm CSS + JS are served by the daemon at <mount>/terminal/assets/* (NOT a
+  // CDN). Their correct URL depends on MOUNT, so we inject them at runtime, then
+  // boot once xterm is defined.
+  function loadAssets(cb) {
+    var base = MOUNT + "/terminal/assets/";
+    var link = document.createElement("link");
+    link.rel = "stylesheet"; link.href = base + "xterm.css";
+    document.head.appendChild(link);
+    loadScript(base + "xterm.js", function () {
+      loadScript(base + "addon-fit.js", cb);
+    });
+  }
+  function loadScript(src, cb) {
+    var s = document.createElement("script");
+    s.src = src;
+    s.onload = cb;
+    s.onerror = function () {
+      setStatus("xterm unavailable", "err");
+      showNotice("Failed to load the terminal renderer from <code>" + src + "</code>. " +
+        "You can always attach on the host: <code>tmux attach -t &lt;channel&gt;-agent</code>.", true);
+    };
+    document.head.appendChild(s);
+  }
+
+  setStatus("loading renderer…");
+  loadAssets(boot);
+
+  function boot() {
+    if (typeof window.Terminal !== "function") {
+      setStatus("xterm unavailable", "err");
+      showNotice("The terminal renderer didn't initialize. " +
+        "You can always attach on the host: <code>tmux attach -t &lt;channel&gt;-agent</code>.", true);
+      return;
+    }
+    setStatus("connecting…");
 
   // --- xterm setup --------------------------------------------------------
   var term = new window.Terminal({
@@ -130,9 +157,6 @@ export const TERMINAL_UI_HTML = `<!doctype html>
     fontSize: 13,
     scrollback: 5000,
     theme: { background: "#000000", foreground: "#e6e9ef" },
-    // Cooperative flow control: xterm acks after writing; combined with the
-    // backend's getBufferedAmount throttle (terminal.ts §5.4) this keeps the
-    // renderer from stalling under a flood.
     convertEol: false,
   });
   var fit = null;
@@ -148,17 +172,6 @@ export const TERMINAL_UI_HTML = `<!doctype html>
   var reconnectTimer = null;
   var enc = new TextEncoder();
 
-  function setStatus(text, cls) {
-    statusEl.textContent = text;
-    statusEl.className = cls || "";
-  }
-  function showNotice(html, isErr) {
-    noticeEl.innerHTML = html;
-    noticeEl.className = "notice" + (isErr ? " err" : "");
-    noticeEl.hidden = false;
-  }
-  function clearNotice() { noticeEl.hidden = true; noticeEl.innerHTML = ""; }
-
   function currentChannel() { return sel.value; }
 
   function doFit() {
@@ -167,12 +180,6 @@ export const TERMINAL_UI_HTML = `<!doctype html>
   }
 
   // --- token (operator channel:admin, minted by the hub) ------------------
-  // The terminal WS is operator-gated on channel:admin. The hub mints that for
-  // the logged-in operator at <origin>/admin/channel-token (cookie-gated) — the
-  // same endpoint the chat + admin UIs use. We fetch it from the page origin
-  // (which IS the hub origin when served through the expose) and pass it as
-  // ?token= on the WebSocket URL (a browser can't set Authorization on
-  // new WebSocket()).
   window.__token = null;
   function fetchToken() {
     return fetch(window.location.origin + "/admin/channel-token", { credentials: "include" })
@@ -209,49 +216,38 @@ export const TERMINAL_UI_HTML = `<!doctype html>
 
     socket.onopen = function () {
       setStatus("● attached · " + ch, "live");
-      // Send the current geometry immediately so the pty matches the page.
       sendResize();
       term.focus();
     };
     socket.onmessage = function (ev) {
-      // BINARY = raw pty output. (The backend only ever sends binary; a text
-      // frame would be an out-of-band notice — render it as text.)
       if (typeof ev.data === "string") { term.write(ev.data); return; }
       term.write(new Uint8Array(ev.data));
     };
     socket.onclose = function (ev) {
-      if (socket !== ws) return; // superseded by a newer connect
+      if (socket !== ws) return;
       ws = null;
       if (manualClose) return;
       if (ev.code === 1013) {
-        // Backend closed us for being too slow (terminal.ts MAX_QUEUE_BYTES).
         setStatus("disconnected (too slow)", "err");
         showNotice("The terminal fell too far behind and was disconnected. Reconnecting will " +
           "re-attach to the live session (scrollback intact via tmux).", true);
       } else if (ev.code === 1000) {
         setStatus("session ended");
-        showNotice("The tmux session ended (or detached). Start a session with " +
-          "<code>./scripts/launch-session.sh &lt;channel&gt; &lt;channel&gt;</code>, then Reconnect.", false);
-        return; // don't auto-reconnect a deliberately-ended session
+        showNotice("The tmux session ended (or detached). Spawn a session from the " +
+          "<a href='" + MOUNT + "/agents'>Agents</a> page, then Reconnect.", false);
+        return;
       } else {
         setStatus("reconnecting…", "err");
       }
       scheduleReconnect();
     };
-    socket.onerror = function () {
-      // onclose follows; status is set there. Surface a hint only if we never
-      // opened (likely auth or no tmux session).
-      if (socket.readyState === WebSocket.CLOSED || socket.readyState === WebSocket.CONNECTING) {
-        // leave reconnect/backoff to onclose
-      }
-    };
+    socket.onerror = function () {};
   }
 
   function scheduleReconnect() {
     if (reconnectTimer) return;
     reconnectTimer = setTimeout(function () {
       reconnectTimer = null;
-      // Refresh the (short-lived) token before re-attaching.
       fetchToken().then(function () { connect(); });
     }, 1500);
   }
@@ -270,7 +266,7 @@ export const TERMINAL_UI_HTML = `<!doctype html>
     }
   }
   term.onResize(function () { sendResize(); });
-  window.addEventListener("resize", function () { doFit(); /* onResize fires sendResize */ });
+  window.addEventListener("resize", function () { doFit(); });
 
   reconnectBtn.addEventListener("click", function () {
     if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
@@ -293,9 +289,8 @@ export const TERMINAL_UI_HTML = `<!doctype html>
         var chans = (cfg.channels || []);
         if (!chans.length) { setStatus("no channels configured"); return; }
         var preselect = new URL(window.location.href).searchParams.get("channel");
-        // Also honor a channel baked into the path (/terminal/<channel>).
         var pathCh = (location.pathname.match(/\\/terminal\\/([^/]+)/) || [])[1];
-        if (pathCh) preselect = decodeURIComponent(pathCh);
+        if (pathCh && pathCh !== "assets") preselect = decodeURIComponent(pathCh);
         chans.forEach(function (c) {
           var opt = document.createElement("option");
           opt.value = c.name; opt.textContent = c.name + " (" + c.transport + ")";
@@ -308,6 +303,7 @@ export const TERMINAL_UI_HTML = `<!doctype html>
   }
 
   fetchToken().then(loadChannelsAndConnect);
+  } // end boot()
 })();
 </script>
 </body>


### PR DESCRIPTION
Follow-up to the web agent-spawn surface (#53), fixing real-use feedback.

## Showstoppers (both fixed + verified end-to-end)

**Spawned sessions died instantly.** Live diagnosis found two causes, both in how the sandbox sees a daemon-launched `claude`:
- `claude` installs under the home tree (`~/.local/bin` → `~/.local/share/claude`), which the scoped-read policy DENIES → `claude: command not found` → session dies. Fix: resolve claude's absolute path + bind the binary/install-dir read-only.
- `~/.claude.json` (at the home **root**, not the bound `~/.claude` dir) wasn't readable → claude ran **first-run onboarding**, whose connectivity check is fatal under the restricted egress proxy → `An unknown error occurred (Unexpected)`. Fix: bind `~/.claude.json` read-only so claude skips onboarding.

Verified: a web spawn now **survives, lists, and runs claude** under the default restricted egress.

**Terminal wouldn't load** (`xterm.js failed to load — CDN blocked?`). Vendored `@xterm/xterm` + `@xterm/addon-fit`; the daemon serves them **same-origin** (`/terminal/assets/*`); the terminal page loads them at runtime under the mount prefix. No CDN, no CSP widening, works offline.

## UX (the agents page)
- **One-agent-one-channel default**: pick a channel (a real `<select>` — fixes the datalist that hid other options until cleared), the name auto-fills, click Spawn. Extra channels / vault / network / mounts move under **Advanced**.
- **Vault picker**: `<select>` of installed vaults via new `GET /api/vaults` (derived from the vault module's `/vault/<name>` paths), not blind text.
- **Network mode**: **Restricted** (default) vs **Open — allow ALL network** (`spec.egressUnrestricted` → the sandbox runs with no network restriction; verified: omitting `allowedDomains` = allow-all, `[]` = block-all). One click for trusted sessions, with a warning. `--egress-all` CLI flag for parity.
- **Integration**: nav links across Agents ↔ Chat ↔ Terminal ↔ Config; the Config (admin) page now links to Agents (it had no path to the surface).

## Security
- The new read binds (`~/.claude.json`, claude install dir) are **read-only** — a session reads the operator's claude config (it runs on the operator's credential anyway) but can't mutate it.
- `egressUnrestricted` is never the default; per-host `egress` and allow-all can't mix; `redactSpawnResult` reports the mode truthfully.
- `serveTerminalAsset` is a fixed allowlist (path-traversal-safe by construction); `/api/vaults` is `channel:admin`-gated.

## Tests
+`spawn-deps.test.ts` (the `~/.claude.json` binding regression guard), +`terminal-assets.test.ts`, +`egressUnrestricted`/vault-list/`/api/vaults`/redaction cases. **Full suite 396 pass**; typecheck clean (2 pre-existing `bridge.ts` TS2589s aside). Independent reviewer pass (LGTM, no criticals; folded 2 nits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)