### PR TITLE
fix(agents): give the sandboxed claude a writable TMPDIR (was dying 'could not start')

### DIFF
--- a/src/spawn-agent.test.ts
+++ b/src/spawn-agent.test.ts
@@ -63,7 +63,9 @@ function fakeEngine(): SandboxEngine & { initializedWith: SandboxRuntimeConfig |
       // Emulate the real shape: a bash -c wrapper carrying the command + proxy env.
       return {
         argv: ["/bin/bash", "-c", `SBX ${command}`],
-        env: { SANDBOX_RUNTIME: "1", HTTPS_PROXY: "http://localhost:5555" },
+        // Include a TMPDIR the engine would set — spawnAgent must OVERRIDE it with
+        // a workspace-writable path (the override regression guard below).
+        env: { SANDBOX_RUNTIME: "1", HTTPS_PROXY: "http://localhost:5555", TMPDIR: "/tmp/claude" },
       };
     },
     async reset() {},
@@ -200,6 +202,17 @@ describe("spawnAgent — full wiring with stubs (no real token)", () => {
     // ...and the sandbox proxy env layered on top.
     expect(launch.env.SANDBOX_RUNTIME).toBe("1");
     expect(launch.env.HTTPS_PROXY).toBe("http://localhost:5555");
+
+    // 3b. TMPDIR (+ claude-specific + generic) point at a WRITABLE dir inside the
+    // workspace, OVERRIDING the sandbox engine's own TMPDIR — without this claude
+    // can't create its scratch dir and dies "Claude Code could not start: EPERM".
+    const wsTmp = join(res.workspace, "tmp");
+    expect(launch.env.TMPDIR).toBe(wsTmp);
+    expect(launch.env.CLAUDE_CODE_TMPDIR).toBe(wsTmp);
+    expect(launch.env.TMP).toBe(wsTmp);
+    expect(launch.env.TEMP).toBe(wsTmp);
+    // ...and the dir is actually created on disk (writable, where the child looks).
+    expect(statSync(wsTmp).isDirectory()).toBe(true);
 
     // 4. The MCP config has the right entries with DISTINCT tokens (one per aud).
     const parsed = JSON.parse(res.mcpConfigJson) as {

--- a/src/spawn-agent.ts
+++ b/src/spawn-agent.ts
@@ -385,11 +385,31 @@ export async function spawnAgent(
     }),
   );
 
-  // Layer the scrubbed agent env UNDER the sandbox wrapper's env (proxy vars,
-  // sandbox markers from the engine win on conflict; CLAUDE_CODE_OAUTH_TOKEN +
-  // the passthrough fundamentals come from us). ANTHROPIC_API_KEY is absent.
+  // A writable per-session temp dir INSIDE the workspace (the workspace is the
+  // sandbox's one writable region). claude needs a writable TMPDIR to start — its
+  // default (`/tmp/claude-<uid>/…`) is OUTSIDE the workspace, which the sandbox
+  // DENIES, so without this claude dies immediately with
+  // "Claude Code could not start: EPERM … mkdir '/tmp/claude-<uid>/…'". Pointing
+  // TMPDIR (+ the claude-specific + the generic TMP/TEMP) at this dir keeps all of
+  // claude's scratch writes within the allowed workspace.
+  const sessionTmp = join(workspace, "tmp");
+  mkdirSync(sessionTmp, { recursive: true });
+
+  // Layer the scrubbed agent env UNDER the sandbox wrapper's env: the engine's
+  // proxy vars / sandbox markers win over our childEnv on conflict;
+  // CLAUDE_CODE_OAUTH_TOKEN + the passthrough fundamentals come from us;
+  // ANTHROPIC_API_KEY is absent. EXCEPTION: the temp vars are layered LAST so they
+  // override even the engine's own TMPDIR (which points at a non-writable path
+  // under our scoped-read policy — the cause of the "could not start" death).
   const childEnv = buildAgentChildEnv(deps.parentEnv ?? process.env, claudeOauthToken);
-  const launchEnv: Record<string, string | undefined> = { ...childEnv, ...wrapped.env };
+  const launchEnv: Record<string, string | undefined> = {
+    ...childEnv,
+    ...wrapped.env,
+    TMPDIR: sessionTmp,
+    CLAUDE_CODE_TMPDIR: sessionTmp,
+    TMP: sessionTmp,
+    TEMP: sessionTmp,
+  };
 
   await deps.tmux.newSession({
     name: session,


### PR DESCRIPTION
The last blocker in the "spawn from the web" chain. Web-spawned sessions appeared in the running list for a moment, then vanished.

## Root cause (captured from claude's stderr under a pty)
```
Claude Code could not start: EPERM: operation not permitted,
mkdir '/tmp/claude-<uid>/claude-<uid>'
```
claude needs a writable temp dir, but the sandbox confines writes to the per-session workspace. claude's default `/tmp/claude-<uid>/…` is outside it → mkdir denied → claude exits. (It renders its TUI first, which is why the session flickered into the list before dying.)

## Fix (`src/spawn-agent.ts`)
Create `<workspace>/tmp` (inside the one writable region) and point `TMPDIR` + `CLAUDE_CODE_TMPDIR` + `TMP` + `TEMP` at it, layered **after** the sandbox engine's env so they override the engine's own (non-writable) `TMPDIR`. The engine's proxy sockets are baked into the argv at wrap time, not the child's `TMPDIR`, so the override is safe.

Verified end-to-end: a web spawn now survives indefinitely — claude reaches its interactive TUI (trust prompt), shows in `/api/agents`, claude process running.

Diagnosed deterministically with a `script` pty capture (tmux signalling was too flaky to read reliably).

## Tests
`spawn-agent.test.ts`: the fake engine now emits an adversarial `TMPDIR=/tmp/claude`; the test asserts all four temp vars in the launch env resolve to `<workspace>/tmp` (proving the override) and that the dir exists on disk. Full suite 396 pass; typecheck clean (2 pre-existing `bridge.ts` TS2589s aside). Reviewer LGTM, no criticals (2 nits folded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)