### PR TITLE
fix(agents): open network by default + reset sandbox singleton per spawn

### DIFF
--- a/src/agents-ui.ts
+++ b/src/agents-ui.ts
@@ -115,7 +115,6 @@ export const AGENTS_UI_HTML = `<!doctype html>
   .scopes { margin: 8px 0 0; font-size: 12px; color: var(--muted); }
   .muted { color: var(--muted); }
   .empty { color: var(--muted); font-size: 13px; padding: 8px 2px; }
-  .warnbox { color: var(--warn); font-size: 12px; }
 </style>
 </head>
 <body>
@@ -219,16 +218,16 @@ export const AGENTS_UI_HTML = `<!doctype html>
           <div>
             <label for="net-mode">Network</label>
             <select id="net-mode">
-              <option value="restricted" selected>Restricted — Anthropic API + hub/vault + listed hosts</option>
-              <option value="open">Open — allow ALL network (trusted sessions only)</option>
+              <option value="open" selected>Open — full network access (default)</option>
+              <option value="restricted">Restricted — only Anthropic API + hub/vault + listed hosts</option>
             </select>
-            <div id="egress-wrap" style="margin-top:8px;">
+            <div id="egress-wrap" style="display:none; margin-top:8px;">
               <label for="egress">Additional allowed hosts (comma-separated)</label>
               <input type="text" id="egress" placeholder="registry.npmjs.org, github.com" autocomplete="off" />
             </div>
-            <div id="open-warn" class="warnbox" style="display:none; margin-top:8px;">
-              ⚠ Open network removes egress confinement — anything the session can reach, it can send to.
-              Use only for sessions you trust.
+            <div id="open-warn" class="muted" style="display:none; font-size:12px; margin-top:8px;">
+              Open is the default — the session reaches the network like any local process (it's still
+              filesystem-sandboxed). Choose Restricted to confine egress when a session handles untrusted input.
             </div>
           </div>
 
@@ -413,11 +412,13 @@ export const AGENTS_UI_HTML = `<!doctype html>
 
   // Network mode toggle: show host list only when restricted; warn when open.
   var netMode = document.getElementById("net-mode");
-  netMode.addEventListener("change", function () {
+  function syncNetMode() {
     var open = netMode.value === "open";
     document.getElementById("egress-wrap").style.display = open ? "none" : "";
     document.getElementById("open-warn").style.display = open ? "" : "none";
-  });
+  }
+  netMode.addEventListener("change", syncNetMode);
+  syncNetMode(); // default is open → show the note, hide the hosts field
 
   function collectSpec() {
     var wake = chanEl.value;

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -128,6 +128,24 @@ export class Sandbox {
       ...(input.allowPty !== undefined ? { allowPty: input.allowPty } : {}),
       ...(input.ripgrep ? { ripgrep: input.ripgrep } : {}),
     });
+    // Reset the process-global singleton BEFORE re-initializing. Without this, a
+    // prior spawn's network config leaks into this wrap: most visibly, an OPEN
+    // (no-proxy) session inherits a prior RESTRICTED session's `HTTP(S)_PROXY` env
+    // (baked into the wrapped argv), so claude routes to a now-wrong/absent proxy
+    // and dies with "An unknown error occurred (Unexpected)". Reset → initialize →
+    // wrap runs inside the caller's spawn lock, so each spawn produces a wrap that
+    // reflects ONLY its own config. (Caveat: because the singleton's host proxies
+    // are global, resetting here tears down a concurrently-running RESTRICTED
+    // session's proxy on the next spawn — a known v1 limitation of the singleton
+    // backend; OPEN sessions use no proxy and are unaffected. The escalation rung
+    // §3.4 is a per-session backend that removes this.)
+    try {
+      await this.engine.reset();
+    } catch {
+      // Any reset error is ignored: on the first-ever wrap there's nothing to tear
+      // down, and a later teardown fault must not block the (re-)initialize that
+      // follows. The fresh initialize() below re-establishes a clean state regardless.
+    }
     await this.engine.initialize(config);
     const { argv, env } = await this.engine.wrapWithSandboxArgv(input.command);
     return { argv, env, config };

--- a/src/sandbox/sandbox.test.ts
+++ b/src/sandbox/sandbox.test.ts
@@ -12,18 +12,22 @@ function fakeEngine(): SandboxEngine & {
   initializedWith: SandboxRuntimeConfig | null;
   wrappedCommands: string[];
   resets: number;
+  calls: string[];
 } {
   const rec = {
     initializedWith: null as SandboxRuntimeConfig | null,
     wrappedCommands: [] as string[],
     resets: 0,
+    calls: [] as string[],
     isSupportedPlatform: () => true,
     isSandboxingEnabled: () => true,
     async initialize(cfg: SandboxRuntimeConfig) {
       rec.initializedWith = cfg;
+      rec.calls.push("initialize");
     },
     async wrapWithSandboxArgv(command: string) {
       rec.wrappedCommands.push(command);
+      rec.calls.push("wrap");
       return {
         argv: ["/bin/bash", "-c", `SANDBOXED ${command}`],
         env: { SANDBOX_RUNTIME: "1", HTTP_PROXY: "http://localhost:9999" },
@@ -31,6 +35,7 @@ function fakeEngine(): SandboxEngine & {
     },
     async reset() {
       rec.resets += 1;
+      rec.calls.push("reset");
     },
   };
   return rec;
@@ -70,6 +75,51 @@ describe("Sandbox adapter", () => {
     expect(wrapped.argv[2]).toContain("SANDBOXED claude");
     expect(wrapped.env.SANDBOX_RUNTIME).toBe("1");
     expect(wrapped.config).toBe(engine.initializedWith!);
+  });
+
+  test("wrap() RESETS the singleton before initializing (no stale proxy/config leak across spawns)", async () => {
+    const engine = fakeEngine();
+    const sandbox = new Sandbox(engine);
+    await sandbox.wrap({
+      spec: SPEC,
+      baseBinds: BASE_BINDS,
+      egressBase: EGRESS_BASE,
+      command: "claude",
+    });
+    // The order matters: reset → initialize → wrap. Without the leading reset, a
+    // prior spawn's network config (e.g. HTTP_PROXY from a restricted session)
+    // leaks into this wrap and an open session routes to a dead proxy → dies.
+    expect(engine.calls).toEqual(["reset", "initialize", "wrap"]);
+  });
+
+  test("a RESTRICTED spawn's proxy env does NOT leak into a later OPEN spawn (the real-bug scenario)", async () => {
+    // A leak-MODELING engine, mirroring the real singleton: `initialize` turns the
+    // proxy on iff the config has an allowlist (restricted); `wrap` emits HTTP_PROXY
+    // iff the proxy is on; `reset` turns it off. Without the reset-before-init in
+    // Sandbox.wrap, the proxy would still be on from the restricted spawn and leak
+    // into the open spawn's env — exactly the live failure.
+    let proxyOn = false;
+    const engine: SandboxEngine = {
+      isSupportedPlatform: () => true,
+      isSandboxingEnabled: () => true,
+      async initialize(cfg: SandboxRuntimeConfig) {
+        if ((cfg.network as { allowedDomains?: string[] }).allowedDomains) proxyOn = true;
+      },
+      async wrapWithSandboxArgv(command: string) {
+        return { argv: ["/bin/bash", "-c", command], env: proxyOn ? { HTTP_PROXY: "http://localhost:1" } : {} };
+      },
+      async reset() {
+        proxyOn = false;
+      },
+    };
+    const sandbox = new Sandbox(engine);
+    // 1) restricted spawn → proxy on, HTTP_PROXY present.
+    const restricted = await sandbox.wrap({ spec: { name: "r", channels: ["c"] }, baseBinds: BASE_BINDS, egressBase: EGRESS_BASE, command: "claude" });
+    expect(restricted.env.HTTP_PROXY).toBeDefined();
+    // 2) open spawn right after → the per-wrap reset clears the proxy, so NO stale
+    //    HTTP_PROXY leaks in (the bug: claude would route to the dead proxy + die).
+    const open = await sandbox.wrap({ spec: { name: "o", channels: ["c"], egressUnrestricted: true }, baseBinds: BASE_BINDS, egressBase: EGRESS_BASE, command: "claude" });
+    expect(open.env.HTTP_PROXY).toBeUndefined();
   });
 
   test("reset() tears the engine down", async () => {


### PR DESCRIPTION
From operator feedback: "not sure super-restrictive egress is right; it failed even on egress=open."

## 1. Open-egress sessions were dying (the bug)
The `@anthropic-ai/sandbox-runtime` `SandboxManager` is a **process-global singleton**. In the long-lived daemon, a prior **Restricted** spawn (which starts a host egress proxy) leaked its `HTTP(S)_PROXY` env into a later **Open** spawn's wrapped argv — so the open session routed to an absent proxy and claude died ("An unknown error occurred"). A fresh process (test harness) never saw it; the daemon did.

**Fix** (`sandbox/index.ts`): `Sandbox.wrap()` calls `engine.reset()` (guarded) before `initialize()`, inside the caller's spawn lock — every wrap reflects ONLY its own spec. Verified live: restricted→open→open all survive; the open launch script carries zero proxy env.

Caveat (commented): the singleton's host proxies are global, so a reset tears down a concurrently-running **Restricted** session's proxy on the next spawn — a v1 limitation of the single-backend model. **Open** sessions use no proxy and are unaffected (and Open is now the default), so concurrent multi-agent works for the default path. The §3.4 per-session backend removes this later.

## 2. Default network → Open
Egress confinement is the load-bearing control for sessions handling **untrusted/foreign input**, not for the operator's own trusted spawns — so it shouldn't be the default for an owner-operated tool. The page now defaults to **Open** (full network, still filesystem-sandboxed); **Restricted** is an explicit opt-in ("for sessions that handle untrusted input") that reveals the additional-allowed-hosts field.

Note: the **CLI** (`scripts/spawn-agent.ts`) intentionally keeps restricted-default + `--egress-all` opt-in — scripted invocations should be explicit. (Flagging the UI/CLI asymmetry so it's not "fixed" by accident.)

## Tests
sandbox.test.ts: the reset→initialize→wrap ordering guard PLUS a two-call leak-model test (restricted spawn then open spawn → asserts no stale `HTTP_PROXY` in the open wrap — the exact bug). Full suite 398 pass; typecheck clean (2 pre-existing bridge.ts TS2589s aside). Reviewer LGTM, no criticals (nits folded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)