### PR TITLE
fix(agents): terminal attaches to an agent (fixes connecting/reconnecting loop)

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -39,7 +39,7 @@ import { resolveSpawnDeps, sessionsDir as defaultSessionsDir } from "./spawn-dep
 const AGENT_SESSION_SUFFIX = "-agent";
 
 /** Same slug shape `spawnAgent` enforces — validated early so a bad name 400s. */
-const AGENT_NAME_SLUG = /^[a-z0-9_-]+$/i;
+export const AGENT_NAME_SLUG = /^[a-z0-9_-]+$/i;
 
 /** A malformed spawn request body — the caller maps `.message` to a 400. */
 export class SpawnRequestError extends Error {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -81,6 +81,7 @@ import {
   buildSpecFromBody,
   redactSpawnResult,
   SpawnRequestError,
+  AGENT_NAME_SLUG,
   type AgentOps,
 } from "./agents.ts";
 import { SpawnDepsError } from "./spawn-deps.ts";
@@ -639,34 +640,40 @@ function json(data: unknown, status = 200): Response {
  * Auth: OPERATOR-GATED on `channel:admin` (`SCOPE_TERMINAL`). The token rides in
  * as a `?token=` query param (browsers can't set Authorization on
  * `new WebSocket()`), so `allowQueryParam: true`. The no-token path
- * short-circuits to 401 before any JWKS fetch (testable offline). The channel
- * must exist (a terminal onto an unknown channel is a 404, never an enumeration
- * oracle — but this endpoint is operator-only behind the admin scope, so a plain
- * 404 is fine).
+ * short-circuits to 401 before any JWKS fetch (testable offline).
  *
- * Returns either `{ ok: true, ... }` with the tmux session name (`<name>-agent`,
- * matching `scripts/launch-session.sh:38`) + the client's requested geometry, or
- * `{ ok: false, response }` carrying the deny Response the caller returns as-is.
+ * The path segment is an AGENT name — the tmux session is `<name>-agent`. An agent
+ * has its OWN name (chosen at spawn), which is NOT necessarily a configured
+ * channel (the 1:1 channel↔session assumption from the launch-session.sh era no
+ * longer holds — an operator can name an agent anything). So we DON'T require the
+ * name to be a known channel; we slug-guard it (it lands UNESCAPED in a tmux `-t`
+ * target) and let the attach handle a non-existent session — `tmux attach` to a
+ * missing session fails cleanly and the relay closes 1000 ("session ended"), no
+ * reconnect loop. Operator-only behind channel:admin, so there's no enumeration
+ * concern. (`channels` is no longer consulted; kept in the signature for the
+ * stable call shape.)
+ *
+ * Returns either `{ ok: true, ... }` with the tmux session name (`<name>-agent`)
+ * + the client's requested geometry, or `{ ok: false, response }` carrying the
+ * deny Response the caller returns as-is.
  */
 export async function authorizeTerminalUpgrade(
   req: Request,
   url: URL,
-  channels: Map<string, Channel>,
-  channelName: string,
+  _channels: Map<string, Channel>,
+  agentName: string,
 ): Promise<
   | { ok: true; channel: string; session: string; cols: number; rows: number }
   | { ok: false; response: Response }
 > {
-  if (!channels.has(channelName)) {
+  // Slug-guard: the name lands unescaped in a tmux `-t <session>` target and the
+  // session string `<name>-agent`. Reject anything that isn't a strict slug.
+  if (!AGENT_NAME_SLUG.test(agentName)) {
     return {
       ok: false,
       response: authJson(
-        {
-          error: `unknown channel "${channelName}" — known channels: ${
-            [...channels.keys()].join(", ") || "(none)"
-          }`,
-        },
-        404,
+        { error: `invalid agent name "${agentName}" (alphanumeric, dash, underscore only)` },
+        400,
       ),
     };
   }
@@ -675,12 +682,12 @@ export async function authorizeTerminalUpgrade(
   const denied = await requireScope(req, url, SCOPE_TERMINAL, true);
   if (denied) return { ok: false, response: denied };
 
-  // tmux session name convention: `<name>-agent` (launch-session.sh:38). Attach
-  // a viewer pty to THIS session; the session itself is created by the launcher.
-  const session = `${channelName}-agent`;
+  // tmux session name convention: `<name>-agent`. Attach a viewer pty to THIS
+  // session; the session itself is created by the spawn path.
+  const session = `${agentName}-agent`;
   const cols = clampQueryDim(url.searchParams.get("cols"), 80);
   const rows = clampQueryDim(url.searchParams.get("rows"), 24);
-  return { ok: true, channel: channelName, session, cols, rows };
+  return { ok: true, channel: agentName, session, cols, rows };
 }
 
 /** Is this request a WebSocket upgrade? (case-insensitive `Upgrade: websocket`). */
@@ -761,7 +768,7 @@ export function createFetchHandler(
     const url = new URL(req.url);
 
     // -------------------------------------------------------------------
-    // Terminal WebSocket upgrade — `/terminal/<channel>` (design §5).
+    // Terminal WebSocket upgrade — `/terminal/<agent>` (design §5).
     //
     // The in-page xterm.js terminal attaches to the channel's tmux session
     // (`<channel>-agent`) via Bun's native pty. Externally this is

--- a/src/terminal-ui.ts
+++ b/src/terminal-ui.ts
@@ -81,7 +81,7 @@ export const TERMINAL_UI_HTML = `<!doctype html>
   <header>
     <div class="brand">parachute-channel <small>· terminal</small></div>
     <nav><a id="nav-agents" href="#">← Agents</a></nav>
-    <select id="channel" title="channel"></select>
+    <select id="channel" title="agent session"></select>
     <button id="reconnect" type="button" title="Re-attach to the tmux session">Reconnect</button>
     <span class="spacer"></span>
     <span id="status">loading…</span>
@@ -276,33 +276,59 @@ export const TERMINAL_UI_HTML = `<!doctype html>
   sel.addEventListener("change", function () {
     term.reset();
     var url = new URL(window.location.href);
-    url.searchParams.set("channel", sel.value);
+    url.searchParams.set("agent", sel.value);
+    url.searchParams.delete("channel"); // migrate the legacy param name
     history.replaceState(null, "", url);
     connect();
   });
 
-  // --- boot: list channels, then token, then connect ----------------------
-  function loadChannelsAndConnect() {
-    return fetch(MOUNT + "/.parachute/config")
-      .then(function (r) { return r.json(); })
-      .then(function (cfg) {
-        var chans = (cfg.channels || []);
-        if (!chans.length) { setStatus("no channels configured"); return; }
-        var preselect = new URL(window.location.href).searchParams.get("channel");
-        var pathCh = (location.pathname.match(/\\/terminal\\/([^/]+)/) || [])[1];
-        if (pathCh && pathCh !== "assets") preselect = decodeURIComponent(pathCh);
-        chans.forEach(function (c) {
+  // --- boot: list running AGENTS, then connect ----------------------------
+  // The terminal attaches to an AGENT's tmux session (name-agent), so the picker
+  // lists running agents (operator-gated /api/agents), NOT channels — an agent has
+  // its own name, which isn't necessarily a configured channel.
+  function authedFetch(path) {
+    var headers = {};
+    if (window.__token) headers["authorization"] = "Bearer " + window.__token;
+    return fetch(MOUNT + path, { headers: headers });
+  }
+  function requestedAgent() {
+    var u = new URL(window.location.href);
+    var p = u.searchParams.get("agent") || u.searchParams.get("channel") || "";
+    var pathA = (location.pathname.match(/\\/terminal\\/([^/]+)/) || [])[1];
+    if (pathA && pathA !== "assets") p = decodeURIComponent(pathA);
+    return p;
+  }
+  function loadAgentsAndConnect() {
+    return authedFetch("/api/agents")
+      .then(function (r) { if (!r.ok) throw new Error("agents " + r.status); return r.json(); })
+      .then(function (j) {
+        var names = (j.agents || []).map(function (a) { return a.name; });
+        var want = requestedAgent();
+        // Keep the requested agent selectable even if the list is momentarily
+        // stale (e.g. just spawned) — the upgrade validates the session at attach.
+        if (want && names.indexOf(want) < 0) names.unshift(want);
+        if (!names.length) {
+          setStatus("no agents running");
+          showNotice("No agent sessions running. Spawn one on the " +
+            "<a href='" + MOUNT + "/agents'>Agents</a> page, then reload.", false);
+          return;
+        }
+        names.forEach(function (n) {
           var opt = document.createElement("option");
-          opt.value = c.name; opt.textContent = c.name + " (" + c.transport + ")";
-          if (c.name === preselect) opt.selected = true;
+          opt.value = n; opt.textContent = n;
+          if (n === want) opt.selected = true;
           sel.appendChild(opt);
         });
         connect();
       })
-      .catch(function (err) { setStatus("config load failed", "err"); showNotice("Could not load channels: " + err, true); });
+      .catch(function (err) {
+        setStatus("agent list failed", "err");
+        showNotice("Could not load agents (" + err + "). Open this page through the hub " +
+          "portal signed in as the operator.", true);
+      });
   }
 
-  fetchToken().then(loadChannelsAndConnect);
+  fetchToken().then(loadAgentsAndConnect);
   } // end boot()
 })();
 </script>

--- a/src/terminal.test.ts
+++ b/src/terminal.test.ts
@@ -462,21 +462,24 @@ describe("authorizeTerminalUpgrade — operator-gated channel:admin", () => {
     }
   });
 
-  test("unknown channel → reject (404), even with a valid admin token (no traversal / no session)", async () => {
-    const url = new URL(`http://127.0.0.1/terminal/ghost?token=${ADMIN_TOKEN}`);
+  test("an agent name that isn't a configured channel is ACCEPTED → its session (agents have own names)", async () => {
+    // The terminal attaches to an AGENT (tmux <name>-agent), not a channel — so a
+    // valid-slug name that isn't in the channel map is accepted (a non-existent
+    // session just fails to attach downstream with a clean 1000, no 404 here).
+    const url = new URL(`http://127.0.0.1/terminal/weaver?token=${ADMIN_TOKEN}`);
     const r = new Request(url, { headers: { upgrade: "websocket" } });
-    const d = await authorizeTerminalUpgrade(r, url, channels(["eng"]), "ghost");
-    expect(d.ok).toBe(false);
-    if (!d.ok) expect(d.response.status).toBe(404);
+    const d = await authorizeTerminalUpgrade(r, url, channels(["eng"]), "weaver");
+    expect(d.ok).toBe(true);
+    if (d.ok) expect(d.session).toBe("weaver-agent");
   });
 
-  test("a path-traversal-shaped channel name is treated as an unknown channel → 404 (no escape)", async () => {
+  test("a path-traversal-shaped name is rejected by the slug guard → 400 (no escape into tmux -t)", async () => {
     const weird = "../../etc";
     const url = new URL(`http://127.0.0.1/terminal/${encodeURIComponent(weird)}?token=${ADMIN_TOKEN}`);
     const r = new Request(url, { headers: { upgrade: "websocket" } });
     const d = await authorizeTerminalUpgrade(r, url, channels(["eng"]), weird);
     expect(d.ok).toBe(false);
-    if (!d.ok) expect(d.response.status).toBe(404);
+    if (!d.ok) expect(d.response.status).toBe(400);
   });
 });
 


### PR DESCRIPTION
The in-page terminal flashed **connecting↔reconnecting** for any agent whose name isn't a configured channel.

## Root cause
The WS upgrade gate (`authorizeTerminalUpgrade`) required the URL path segment to be a known **channel** (`channels.has(name)` → 404) — a leftover from when sessions were 1:1 with channels. Agents now have their own names (the tmux session is `<agentName>-agent`), so a custom-named agent 404'd the upgrade ("Expected 101 status code" → close 1002 → the page's reconnect path). Default-named agents (name == channel) happened to work, which masked it.

## Fixes
- **`daemon.ts` `authorizeTerminalUpgrade`**: the segment is an **agent** name, not a channel. Drop the channel-membership check; slug-guard the name (it lands unescaped in `tmux -t` + the `<name>-agent` session string) → 400 on a bad name; otherwise accept and let attach handle a missing session (clean 1000 "session ended", no loop). Still operator-gated on `channel:admin`.
- **`terminal-ui.ts`**: the picker now lists **running agents** (`/api/agents`, authed) instead of channels, since you attach to an agent's session. Honors `?agent=`/`?channel=`/path preselect; keeps a just-spawned agent selectable.
- **`agents.ts`**: export `AGENT_NAME_SLUG` (shared by the gate).

## Verified live
A custom-named agent's terminal now upgrades (101), streams pty output, and stays open; `/api/agents` feeds the picker.

## Security
Slug guard (`/^[a-z0-9_-]+$/i`) before auth — no tmux/path injection into `<name>-agent`. Operator-only (`channel:admin`) throughout; a non-existent session fails to attach cleanly (no enumeration oracle). Reviewer confirmed.

Tests updated: a non-channel slug name → accepted as `<name>-agent`; a traversal-shaped name → 400. Full suite 398 pass; typecheck clean (2 pre-existing bridge.ts TS2589s aside). Reviewer LGTM, no criticals (2 clarity nits folded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)