### PR TITLE
fix(terminal): set TERM for tmux attach (pane showed 'does not support clear')

### DIFF
--- a/src/terminal.test.ts
+++ b/src/terminal.test.ts
@@ -41,6 +41,7 @@ mock.module("./hub-jwt.ts", () => ({
 
 import {
   createTerminalWsHandlers,
+  tmuxAttachEnv,
   parseControlFrame,
   HUB_WS_CAP_BYTES,
   PAUSE_FRAC,
@@ -400,6 +401,21 @@ describe("lifecycle — teardown", () => {
     expect(proc().killed).toBe(true);
     // Idempotent — a second close is a no-op (no throw, no double behavior change).
     expect(() => handlers.close(asWs(ws))).not.toThrow();
+  });
+});
+
+// ===========================================================================
+// tmuxAttachEnv — TERM wiring for the `tmux attach` viewer
+// ===========================================================================
+describe("tmuxAttachEnv — forces a real TERM so `tmux attach` finds terminfo", () => {
+  test("sets TERM=xterm-256color (else tmux aborts 'does not support clear')", () => {
+    expect(tmuxAttachEnv({ PATH: "/usr/bin" }).TERM).toBe("xterm-256color");
+  });
+  test("preserves the inherited env + overrides a stale/empty TERM", () => {
+    const env = tmuxAttachEnv({ PATH: "/usr/bin", HOME: "/home/op", TERM: "" });
+    expect(env.PATH).toBe("/usr/bin");
+    expect(env.HOME).toBe("/home/op");
+    expect(env.TERM).toBe("xterm-256color"); // empty/missing TERM is the daemon's reality
   });
 });
 

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -145,6 +145,20 @@ export type SpawnTerminalFn = (
   },
 ) => SpawnedTerminal;
 
+/**
+ * The env for the `tmux attach` viewer process: the inherited env with TERM
+ * forced to a real terminfo entry matching the pty (`xterm-256color`). The daemon
+ * runs under launchd/systemd with NO TERM, so without this `tmux attach` can't
+ * find terminfo and aborts "open terminal failed: terminal does not support
+ * clear" — the WS attaches but the pane shows only that error. Pure + exported so
+ * the wiring is unit-testable without fighting Bun's readonly globals.
+ */
+export function tmuxAttachEnv(
+  parentEnv: Record<string, string | undefined> = process.env,
+): Record<string, string | undefined> {
+  return { ...parentEnv, TERM: "xterm-256color" };
+}
+
 /** Default pty spawn — the real `Bun.Terminal` + `tmux attach`. */
 export const defaultSpawnTerminal: SpawnTerminalFn = (session, opts) => {
   // `Bun.Terminal` is the native pty (verified present with write/resize/
@@ -175,9 +189,11 @@ export const defaultSpawnTerminal: SpawnTerminalFn = (session, opts) => {
     }
   ).Bun.spawn(["tmux", "attach", "-t", session], {
     terminal,
-    // No env scrub here — this pty runs `tmux attach`, which only TALKS to the
-    // already-running tmux server; it never starts the Claude session (that's
-    // the sandboxed spawn path, §4). The session's own isolation is upstream.
+    // TERM forced to a real terminfo entry (see tmuxAttachEnv) so `tmux attach`
+    // doesn't abort "does not support clear". No further scrub: this pty only
+    // TALKS to the already-running tmux server; it never starts the Claude session
+    // (that's the sandboxed spawn path, §4).
+    env: tmuxAttachEnv(),
     stdout: "ignore",
     stderr: "ignore",
   });


### PR DESCRIPTION
With the hub WS bridge fixed ([hub#661]), the in-page terminal upgrades + attaches — but the pane rendered only:
```
open terminal failed: terminal does not support clear
```
The daemon runs under launchd/systemd with **no `TERM`**, so the `tmux attach` viewer inherited an empty TERM, couldn't resolve terminfo, and aborted before drawing.

**Fix:** force `TERM=xterm-256color` (matching the `Bun.Terminal` pty) on the attach env, via a pure exported `tmuxAttachEnv()` helper.

**Verified end-to-end with Playwright** (real chromium → hub → channel → tmux → claude): the pane renders claude's live TUI (workspace + trust prompt + tmux status bar), status holds `● attached`, no reconnect loop.

Tests: `terminal.test.ts` asserts `tmuxAttachEnv` forces TERM + preserves the inherited env. Full suite **400 pass**; typecheck clean (2 pre-existing bridge.ts TS2589s aside).

🤖 Generated with [Claude Code](https://claude.com/claude-code)