### PR TITLE
fix(agents): stabilize the sandbox — one isolation knob + a private seeded HOME

### DIFF
--- a/scripts/spawn-agent.ts
+++ b/scripts/spawn-agent.ts
@@ -62,8 +62,10 @@ Flags:
                                   The FIRST channel is the wake channel.
   --vault <name>:<read|write>[:tag1,tag2]
                                   optional vault MCP scope (+ optional tag-scope).
-  --egress <host,host,...>        optional additive egress allowlist (beyond the base).
-  --egress-all                    open the network entirely (allow ALL egress; trusted sessions only).
+  --confined                      isolate for UNTRUSTED input: scoped reads (home denied) +
+                                  egress restricted to the base + --egress hosts.
+                                  Default is "trusted": broad reads + open network.
+  --egress <host,host,...>        additive egress allowlist (only used with --confined).
   --mount <hostPath:mountPath:ro|rw[:shared]>
                                   filesystem mount (repeatable; optional).
   --help                          show this help.
@@ -177,7 +179,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
   const channels: AgentChannelSpec[] = [];
   let vault: AgentVaultSpec | undefined;
   const egress: string[] = [];
-  let egressUnrestricted = false;
+  let confined = false;
   const mounts: AgentMount[] = [];
 
   for (let i = 0; i < argv.length; i++) {
@@ -205,8 +207,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
         i++;
         break;
       }
-      case "--egress-all": {
-        egressUnrestricted = true;
+      case "--confined": {
+        confined = true;
         break;
       }
       case "--mount": {
@@ -231,8 +233,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
 
   const spec: AgentSpec = { name, channels };
   if (vault) spec.vault = vault;
-  if (egressUnrestricted) spec.egressUnrestricted = true;
-  else if (egress.length > 0) spec.egress = egress;
+  if (confined) spec.isolation = "confined";
+  if (egress.length > 0) spec.egress = egress;
   if (mounts.length > 0) spec.mounts = mounts;
   return { help: false, spec };
 }

--- a/src/agents-ui.ts
+++ b/src/agents-ui.ts
@@ -216,18 +216,20 @@ export const AGENTS_UI_HTML = `<!doctype html>
           </div>
 
           <div>
-            <label for="net-mode">Network</label>
+            <label for="net-mode">Isolation</label>
             <select id="net-mode">
-              <option value="open" selected>Open — full network access (default)</option>
-              <option value="restricted">Restricted — only Anthropic API + hub/vault + listed hosts</option>
+              <option value="trusted" selected>Trusted — full read + open network (default)</option>
+              <option value="confined">Confined — scoped reads + restricted network (untrusted input)</option>
             </select>
             <div id="egress-wrap" style="display:none; margin-top:8px;">
               <label for="egress">Additional allowed hosts (comma-separated)</label>
               <input type="text" id="egress" placeholder="registry.npmjs.org, github.com" autocomplete="off" />
             </div>
             <div id="open-warn" class="muted" style="display:none; font-size:12px; margin-top:8px;">
-              Open is the default — the session reaches the network like any local process (it's still
-              filesystem-sandboxed). Choose Restricted to confine egress when a session handles untrusted input.
+              Trusted is the default for your own agents — the session reads the system + your files and
+              reaches the network like any local process (it still gets a private writable home and can't
+              write outside its workspace). Choose Confined for an agent that handles untrusted input:
+              its reads are scoped to its workspace and its network is restricted.
             </div>
           </div>
 
@@ -410,15 +412,16 @@ export const AGENTS_UI_HTML = `<!doctype html>
   }
   document.getElementById("add-mount").addEventListener("click", function () { mountRow(); });
 
-  // Network mode toggle: show host list only when restricted; warn when open.
+  // Isolation toggle: show the additional-hosts field only when Confined; show the
+  // explainer note when Trusted (the default).
   var netMode = document.getElementById("net-mode");
   function syncNetMode() {
-    var open = netMode.value === "open";
-    document.getElementById("egress-wrap").style.display = open ? "none" : "";
-    document.getElementById("open-warn").style.display = open ? "" : "none";
+    var trusted = netMode.value === "trusted";
+    document.getElementById("egress-wrap").style.display = trusted ? "none" : "";
+    document.getElementById("open-warn").style.display = trusted ? "" : "none";
   }
   netMode.addEventListener("change", syncNetMode);
-  syncNetMode(); // default is open → show the note, hide the hosts field
+  syncNetMode(); // default is trusted → show the note, hide the hosts field
 
   function collectSpec() {
     var wake = chanEl.value;
@@ -440,12 +443,12 @@ export const AGENTS_UI_HTML = `<!doctype html>
       spec.vault = v;
     }
 
-    if (netMode.value === "open") {
-      spec.egressUnrestricted = true;
-    } else {
+    if (netMode.value === "confined") {
+      spec.isolation = "confined";
       var egress = document.getElementById("egress").value.split(",").map(function (h) { return h.trim(); }).filter(Boolean);
       if (egress.length) spec.egress = egress;
     }
+    // else: trusted (default) — no isolation field; broad reads + open network.
 
     var mounts = [];
     document.querySelectorAll("#mounts-rows .mrow").forEach(function (row) {
@@ -477,7 +480,8 @@ export const AGENTS_UI_HTML = `<!doctype html>
           r.tokens.forEach(function (t) { lines.push("  " + t.resource + " → " + t.scope); });
         }
         if (r.mcpServers && r.mcpServers.length) lines.push("MCP servers: " + r.mcpServers.join(", "));
-        lines.push("network: " + (r.egressUnrestricted ? "OPEN (all hosts)" : ((r.egress || []).join(", ") || "base only")));
+        lines.push("isolation: " + (r.isolation || "trusted") +
+          (r.isolation === "confined" ? " (egress: " + ((r.egress || []).join(", ") || "base only") + ")" : " (full read + open network)"));
       }
       showMsg(msg, lines.join("\\n"), false);
       loadAgents();

--- a/src/agents.test.ts
+++ b/src/agents.test.ts
@@ -139,13 +139,14 @@ describe("buildSpecFromBody", () => {
       buildSpecFromBody({ name: "a", channels: ["c"], mounts: [{ hostPath: "/h", mountPath: "/m", mode: "x" }] }),
     ).toThrow(/mode/);
   });
-  test("egressUnrestricted is accepted and overrides per-host egress", () => {
-    const spec = buildSpecFromBody({ name: "a", channels: ["c"], egressUnrestricted: true, egress: ["x.com"] });
-    expect(spec.egressUnrestricted).toBe(true);
-    expect(spec.egress).toBeUndefined(); // allow-all is strictly broader
+  test("isolation defaults to trusted (omitted) and accepts 'confined' + egress", () => {
+    expect(buildSpecFromBody({ name: "a", channels: ["c"] }).isolation).toBeUndefined(); // default = trusted
+    const spec = buildSpecFromBody({ name: "a", channels: ["c"], isolation: "confined", egress: ["x.com"] });
+    expect(spec.isolation).toBe("confined");
+    expect(spec.egress).toEqual(["x.com"]); // additive hosts kept (used under confined)
   });
-  test("rejects a non-boolean egressUnrestricted", () => {
-    expect(() => buildSpecFromBody({ name: "a", channels: ["c"], egressUnrestricted: "yes" })).toThrow(/egressUnrestricted/);
+  test("rejects an invalid isolation value", () => {
+    expect(() => buildSpecFromBody({ name: "a", channels: ["c"], isolation: "loose" })).toThrow(/isolation/);
   });
   test("rejects relative mount paths (must be absolute)", () => {
     expect(() =>
@@ -182,23 +183,23 @@ describe("redactSpawnResult", () => {
     ]);
     expect(red.mcpServers).toEqual(["channel-aaron", "vault-default"]);
     expect(red.egress).toEqual(["api.anthropic.com:443"]);
-    expect(red.egressUnrestricted).toBe(false);
+    expect(red.isolation).toBe("confined"); // allowedDomains present → confined
     // The smoking gun: no token VALUE appears anywhere in the serialized result.
     const wire = JSON.stringify(red);
     expect(wire).not.toContain("SECRET-CHANNEL-TOKEN");
     expect(wire).not.toContain("SECRET-VAULT-TOKEN");
   });
-  test("an unrestricted-network result (no allowedDomains) → egressUnrestricted true, egress []", () => {
-    const unrestricted: SpawnAgentResult = {
+  test("a trusted result (no allowedDomains) → isolation 'trusted', egress []", () => {
+    const trusted: SpawnAgentResult = {
       ...result,
       wrapped: {
         ...result.wrapped,
-        // allow-all: allowedDomains absent (the runtime's no-restriction shape).
+        // trusted: allowedDomains absent (the runtime's no-restriction shape).
         config: { network: { deniedDomains: [] }, filesystem: { denyRead: [], allowWrite: [], denyWrite: [] } } as unknown as SpawnAgentResult["wrapped"]["config"],
       },
     };
-    const red = redactSpawnResult(unrestricted);
-    expect(red.egressUnrestricted).toBe(true);
+    const red = redactSpawnResult(trusted);
+    expect(red.isolation).toBe("trusted");
     expect(red.egress).toEqual([]);
   });
 });

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -82,10 +82,10 @@ export interface RedactedSpawnResult {
   tokens: RedactedToken[];
   /** The MCP server entry keys wired into the session (names only). */
   mcpServers: string[];
-  /** Egress allowlist baked into the sandbox (empty when unrestricted). */
+  /** Isolation posture the session launched under. */
+  isolation: "trusted" | "confined";
+  /** Egress allowlist baked into the sandbox (empty when trusted/open). */
   egress: string[];
-  /** True when the session runs with NO network restriction (allow-all). */
-  egressUnrestricted: boolean;
 }
 
 /** The spawn/list/kill operations the daemon routes call. Injectable for tests. */
@@ -221,11 +221,11 @@ export function buildSpecFromBody(body: unknown): AgentSpec {
     spec.vault = parseVaultEntry(b.vault);
   }
 
-  if (b.egressUnrestricted !== undefined && b.egressUnrestricted !== null) {
-    if (typeof b.egressUnrestricted !== "boolean") {
-      throw new SpawnRequestError("body.egressUnrestricted must be a boolean");
+  if (b.isolation !== undefined && b.isolation !== null) {
+    if (b.isolation !== "trusted" && b.isolation !== "confined") {
+      throw new SpawnRequestError('body.isolation must be "trusted" or "confined"');
     }
-    if (b.egressUnrestricted) spec.egressUnrestricted = true;
+    spec.isolation = b.isolation;
   }
 
   if (b.egress !== undefined && b.egress !== null) {
@@ -238,8 +238,9 @@ export function buildSpecFromBody(body: unknown): AgentSpec {
         return h.trim();
       })
       .filter((h) => h.length > 0);
-    // egressUnrestricted is strictly broader; ignore per-host egress when set.
-    if (egress.length > 0 && !spec.egressUnrestricted) spec.egress = egress;
+    // Additional allowed hosts — only take effect under `isolation: "confined"`
+    // (trusted = fully open network); harmless to carry otherwise.
+    if (egress.length > 0) spec.egress = egress;
   }
 
   if (b.mounts !== undefined && b.mounts !== null) {
@@ -354,7 +355,7 @@ export function redactSpawnResult(result: SpawnAgentResult): RedactedSpawnResult
   } catch {
     mcpServers = [];
   }
-  // allowedDomains is absent when the session runs unrestricted (allow-all).
+  // allowedDomains is present only in CONFINED mode (trusted omits it = open net).
   const allowed = result.wrapped.config.network.allowedDomains as string[] | undefined;
   return {
     session: result.session,
@@ -362,8 +363,8 @@ export function redactSpawnResult(result: SpawnAgentResult): RedactedSpawnResult
     alreadyRunning: result.alreadyRunning,
     tokens,
     mcpServers,
+    isolation: allowed === undefined ? "trusted" : "confined",
     egress: allowed ?? [],
-    egressUnrestricted: allowed === undefined,
   };
 }
 

--- a/src/sandbox/config.test.ts
+++ b/src/sandbox/config.test.ts
@@ -9,9 +9,28 @@ const BASE_BINDS: BaseBinds = {
 };
 const EGRESS_BASE: EgressBaseInput = { hubOrigin: "https://hub.example.com" };
 
+// These cases exercise the CONFINED posture (scoped reads + egress floor), so the
+// helper defaults to it; a spread `p` can override (e.g. to test trusted).
 function specOf(p: Partial<AgentSpec> = {}): AgentSpec {
-  return { name: "arm", channels: ["ch"], ...p };
+  return { name: "arm", channels: ["ch"], isolation: "confined", ...p };
 }
+
+describe("buildSandboxConfig — trusted (default) posture", () => {
+  test("trusted: NO read deny (broad) + NO allowedDomains (open network), writes still confined", () => {
+    const cfg = buildSandboxConfig({
+      spec: { name: "arm", channels: ["ch"] }, // no isolation → trusted default
+      baseBinds: BASE_BINDS,
+      egressBase: EGRESS_BASE,
+      platform: "darwin",
+    });
+    // Broad reads: no home-tree deny.
+    expect(cfg.filesystem.denyRead).toEqual([]);
+    // Open network: allowedDomains omitted entirely (runtime = no restriction).
+    expect((cfg.network as { allowedDomains?: string[] }).allowedDomains).toBeUndefined();
+    // Writes are STILL confined to the workspace even when trusted.
+    expect(cfg.filesystem.allowWrite).toContain("/state/sessions/arm");
+  });
+});
 
 describe("buildSandboxConfig — spec → SandboxRuntimeConfig", () => {
   test("network: deny-by-default + base floor present, deniedDomains empty", () => {

--- a/src/sandbox/config.ts
+++ b/src/sandbox/config.ts
@@ -56,17 +56,22 @@ export function currentSandboxPlatform(): SandboxPlatform {
 export function buildSandboxConfig(input: BuildSandboxConfigInput): SandboxRuntimeConfig {
   const platform = input.platform ?? currentSandboxPlatform();
 
-  const fs = composeFilesystemView(input.baseBinds, input.spec.mounts, platform);
+  // The single isolation knob (default "trusted") sets BOTH read scope + egress.
+  const confined = input.spec.isolation === "confined";
 
-  // Network: by default the non-removable base unioned with the spec's additions.
-  // When the spec opts into `egressUnrestricted`, we OMIT `allowedDomains` entirely
-  // — the sandbox-runtime treats an absent allowedDomains as "no network
-  // restriction" (verified: present-but-empty = block all; absent = allow all).
-  // The cast is because the runtime's TS type marks allowedDomains required while
-  // its runtime honors the absent case as the documented allow-all path.
-  const network: SandboxRuntimeConfig["network"] = input.spec.egressUnrestricted
-    ? ({ deniedDomains: [] } as unknown as SandboxRuntimeConfig["network"])
-    : { allowedDomains: composeEgressAllowlist(input.egressBase, input.spec.egress), deniedDomains: [] };
+  // Reads are scoped only when confined; trusted = broad reads (claude's own
+  // runtime never collides with a deny — the stability win). Writes are confined
+  // to the workspace in both.
+  const fs = composeFilesystemView(input.baseBinds, input.spec.mounts, platform, confined);
+
+  // Network: trusted = OPEN (omit `allowedDomains` — the runtime treats an absent
+  // allowedDomains as "no restriction"; verified: present-but-empty = block all,
+  // absent = allow all). confined = the non-removable base UNIONed with the spec's
+  // additions. The cast is because the runtime's TS type marks allowedDomains
+  // required while its runtime honors the absent case as the documented allow-all.
+  const network: SandboxRuntimeConfig["network"] = confined
+    ? { allowedDomains: composeEgressAllowlist(input.egressBase, input.spec.egress), deniedDomains: [] }
+    : ({ deniedDomains: [] } as unknown as SandboxRuntimeConfig["network"]);
 
   const config: SandboxRuntimeConfig = {
     network,

--- a/src/sandbox/live-seatbelt.test.ts
+++ b/src/sandbox/live-seatbelt.test.ts
@@ -64,7 +64,7 @@ afterEach(() => {
 d("LIVE Seatbelt — network egress", () => {
   test("positive control: the harness can run a trivial sandboxed command", async () => {
     workspace = mkdtempSync(join(tmpdir(), "sbx-live-pos-"));
-    const spec: AgentSpec = { name: "pos", channels: ["c"], egress: [] };
+    const spec: AgentSpec = { name: "pos", channels: ["c"], isolation: "confined", egress: [] };
     const cfg = buildSandboxConfig({
       spec,
       baseBinds: { workspace, runtimeReadOnly: [] },
@@ -79,7 +79,7 @@ d("LIVE Seatbelt — network egress", () => {
   test("DENIED: curl to a host NOT in the allowlist is blocked", async () => {
     workspace = mkdtempSync(join(tmpdir(), "sbx-live-deny-"));
     // Allowlist the base only (anthropic + the loopback hub). example.com is NOT on it.
-    const spec: AgentSpec = { name: "deny", channels: ["c"], egress: [] };
+    const spec: AgentSpec = { name: "deny", channels: ["c"], isolation: "confined", egress: [] };
     const cfg = buildSandboxConfig({
       spec,
       baseBinds: { workspace, runtimeReadOnly: [] },
@@ -99,7 +99,7 @@ d("LIVE Seatbelt — network egress", () => {
 
   test("a spec that adds an egress host gets that host on the allowlist (additive)", async () => {
     workspace = mkdtempSync(join(tmpdir(), "sbx-live-add-"));
-    const spec: AgentSpec = { name: "add", channels: ["c"], egress: ["example.com"] };
+    const spec: AgentSpec = { name: "add", channels: ["c"], isolation: "confined", egress: ["example.com"] };
     const cfg = buildSandboxConfig({
       spec,
       baseBinds: { workspace, runtimeReadOnly: [] },
@@ -122,7 +122,7 @@ d("LIVE Seatbelt — filesystem read confinement", () => {
     const secretFile = join(secretDir, "secret.txt");
     writeFileSync(secretFile, "TOPSECRET-do-not-read");
     try {
-      const spec: AgentSpec = { name: "read", channels: ["c"], egress: [] };
+      const spec: AgentSpec = { name: "read", channels: ["c"], isolation: "confined", egress: [] };
       const cfg = buildSandboxConfig({
         spec,
         baseBinds: { workspace, runtimeReadOnly: [] },
@@ -154,7 +154,7 @@ d("LIVE Seatbelt — filesystem read confinement", () => {
     const secretFile = join(secretDir, "home-secret.txt");
     writeFileSync(secretFile, "HOME-TOPSECRET-do-not-read");
     try {
-      const spec: AgentSpec = { name: "homeread", channels: ["c"], egress: [] };
+      const spec: AgentSpec = { name: "homeread", channels: ["c"], isolation: "confined", egress: [] };
       // buildSandboxConfig with platform "darwin" → denyRead:["/Users"],
       // allowRead:[workspace]. We pass the config THROUGH unmodified.
       const cfg = buildSandboxConfig({
@@ -187,7 +187,7 @@ d("LIVE Seatbelt — filesystem read confinement", () => {
     workspace = mkdtempSync(join(tmpdir(), "sbx-live-read-ok-"));
     const f = join(workspace, "inside.txt");
     writeFileSync(f, "READABLE-inside-workspace");
-    const spec: AgentSpec = { name: "readok", channels: ["c"], egress: [] };
+    const spec: AgentSpec = { name: "readok", channels: ["c"], isolation: "confined", egress: [] };
     const cfg = buildSandboxConfig({
       spec,
       baseBinds: { workspace, runtimeReadOnly: [] },
@@ -204,7 +204,7 @@ d("LIVE Seatbelt — filesystem read confinement", () => {
     const outsideDir = mkdtempSync(join(tmpdir(), "sbx-live-outside-"));
     const target = join(outsideDir, "should-not-exist.txt");
     try {
-      const spec: AgentSpec = { name: "write", channels: ["c"], egress: [] };
+      const spec: AgentSpec = { name: "write", channels: ["c"], isolation: "confined", egress: [] };
       const cfg = buildSandboxConfig({
         spec,
         baseBinds: { workspace, runtimeReadOnly: [] },
@@ -223,7 +223,7 @@ d("LIVE Seatbelt — filesystem read confinement", () => {
   test("ALLOWED: writing INSIDE the workspace succeeds", async () => {
     workspace = mkdtempSync(join(tmpdir(), "sbx-live-write-ok-"));
     const target = join(workspace, "out.txt");
-    const spec: AgentSpec = { name: "writeok", channels: ["c"], egress: [] };
+    const spec: AgentSpec = { name: "writeok", channels: ["c"], isolation: "confined", egress: [] };
     const cfg = buildSandboxConfig({
       spec,
       baseBinds: { workspace, runtimeReadOnly: [] },

--- a/src/sandbox/mounts.ts
+++ b/src/sandbox/mounts.ts
@@ -58,6 +58,7 @@ export function composeFilesystemView(
   base: BaseBinds,
   mounts: readonly AgentMount[] | undefined,
   platform: SandboxPlatform,
+  scopedReads = true,
 ): FilesystemView {
   const declared = mounts ?? [];
 
@@ -70,6 +71,17 @@ export function composeFilesystemView(
     if (m.mode === "rw") writePaths.push(m.hostPath);
   }
 
+  // WRITES are confined in BOTH postures (workspace + rw mounts) — the agent
+  // never escapes its workspace or corrupts the operator's files, regardless of
+  // read scope. READS depend on the posture:
+  //   - scopedReads (confined): deny the home tree, re-allow the read surface
+  //     within it (workspace + runtime/config + mounts). The isolation control.
+  //   - broad (trusted, the default for owner-operated agents): no deny — claude
+  //     reads its binary, the system, and the operator's files freely, so its own
+  //     runtime never collides with a deny. (System paths are readable in both.)
+  if (!scopedReads) {
+    return { denyRead: [], allowRead: [], allowWrite: dedupePreserveOrder(writePaths), denyWrite: [] };
+  }
   return {
     denyRead: [homeTreeDenyRoot(platform)],
     allowRead: dedupePreserveOrder(readPaths),

--- a/src/sandbox/sandbox.test.ts
+++ b/src/sandbox/sandbox.test.ts
@@ -41,9 +41,12 @@ function fakeEngine(): SandboxEngine & {
   return rec;
 }
 
+// CONFINED so the config-shape assertions (allowedDomains floor, /Users deny)
+// apply; trusted is the default elsewhere and covered in config.test.ts.
 const SPEC: AgentSpec = {
   name: "arm",
   channels: ["ch"],
+  isolation: "confined",
   egress: ["registry.npmjs.org"],
   mounts: [{ hostPath: "/proj", mountPath: "/work", mode: "rw" }],
 };
@@ -92,12 +95,12 @@ describe("Sandbox adapter", () => {
     expect(engine.calls).toEqual(["reset", "initialize", "wrap"]);
   });
 
-  test("a RESTRICTED spawn's proxy env does NOT leak into a later OPEN spawn (the real-bug scenario)", async () => {
+  test("a CONFINED spawn's proxy env does NOT leak into a later TRUSTED spawn (the real-bug scenario)", async () => {
     // A leak-MODELING engine, mirroring the real singleton: `initialize` turns the
-    // proxy on iff the config has an allowlist (restricted); `wrap` emits HTTP_PROXY
+    // proxy on iff the config has an allowlist (confined); `wrap` emits HTTP_PROXY
     // iff the proxy is on; `reset` turns it off. Without the reset-before-init in
-    // Sandbox.wrap, the proxy would still be on from the restricted spawn and leak
-    // into the open spawn's env — exactly the live failure.
+    // Sandbox.wrap, the proxy would still be on from the confined spawn and leak
+    // into the trusted spawn's env — exactly the live failure.
     let proxyOn = false;
     const engine: SandboxEngine = {
       isSupportedPlatform: () => true,
@@ -113,13 +116,14 @@ describe("Sandbox adapter", () => {
       },
     };
     const sandbox = new Sandbox(engine);
-    // 1) restricted spawn → proxy on, HTTP_PROXY present.
-    const restricted = await sandbox.wrap({ spec: { name: "r", channels: ["c"] }, baseBinds: BASE_BINDS, egressBase: EGRESS_BASE, command: "claude" });
-    expect(restricted.env.HTTP_PROXY).toBeDefined();
-    // 2) open spawn right after → the per-wrap reset clears the proxy, so NO stale
-    //    HTTP_PROXY leaks in (the bug: claude would route to the dead proxy + die).
-    const open = await sandbox.wrap({ spec: { name: "o", channels: ["c"], egressUnrestricted: true }, baseBinds: BASE_BINDS, egressBase: EGRESS_BASE, command: "claude" });
-    expect(open.env.HTTP_PROXY).toBeUndefined();
+    // 1) confined spawn → allowlist present → proxy on, HTTP_PROXY present.
+    const confined = await sandbox.wrap({ spec: { name: "r", channels: ["c"], isolation: "confined" }, baseBinds: BASE_BINDS, egressBase: EGRESS_BASE, command: "claude" });
+    expect(confined.env.HTTP_PROXY).toBeDefined();
+    // 2) trusted spawn right after (the default) → the per-wrap reset clears the
+    //    proxy, so NO stale HTTP_PROXY leaks in (the bug: claude would route to the
+    //    dead proxy + die).
+    const trusted = await sandbox.wrap({ spec: { name: "o", channels: ["c"] }, baseBinds: BASE_BINDS, egressBase: EGRESS_BASE, command: "claude" });
+    expect(trusted.env.HTTP_PROXY).toBeUndefined();
   });
 
   test("reset() tears the engine down", async () => {
@@ -134,11 +138,11 @@ describe("Sandbox adapter", () => {
     expect(new Sandbox(engine).isSupportedPlatform()).toBe(true);
   });
 
-  test("SECURITY: a spec omitting egress still gets the base floor in the engine config", async () => {
+  test("SECURITY: a confined spec omitting egress still gets the base floor in the engine config", async () => {
     const engine = fakeEngine();
     const sandbox = new Sandbox(engine);
     await sandbox.wrap({
-      spec: { name: "x", channels: ["c"] }, // no egress declared
+      spec: { name: "x", channels: ["c"], isolation: "confined" }, // confined, no egress declared
       baseBinds: BASE_BINDS,
       egressBase: EGRESS_BASE,
       command: "claude",

--- a/src/sandbox/types.ts
+++ b/src/sandbox/types.ts
@@ -111,23 +111,36 @@ export interface AgentSpec {
   /** Additional MCP servers, by URL. */
   otherMcps?: OtherMcpSpec[];
   /**
-   * Network egress — ADDITIVE to a minimal non-removable base of
-   * `{ the Anthropic API host(s), the hub/vault origin }` (design §4.4). A
-   * weaver-style arm declares `[]` (base only); a code-building arm opens
-   * exactly the package/source hosts it needs.
+   * Isolation posture — the single knob that sets BOTH the read scope and the
+   * network egress, matched to the trust gradient:
+   *
+   *   - `"trusted"` (DEFAULT): the operator's own self-spawned agent on a flat
+   *     trust gradient. Reads are BROAD (the runtime default — claude reads its
+   *     binary, the system, the operator's files without per-path binds) and the
+   *     network is OPEN. Writes are still confined to the per-session workspace
+   *     (which holds the agent's private HOME), so it can't corrupt the operator's
+   *     real config or escape its workspace. This is what makes the sandbox STABLE
+   *     for running claude — claude's own runtime never collides with a deny.
+   *
+   *   - `"confined"`: for an agent fed FOREIGN/untrusted input. Reads are SCOPED
+   *     (home tree denied, re-allowed to workspace + the claude runtime + declared
+   *     mounts) and egress is RESTRICTED to the non-removable base
+   *     (`{ Anthropic API, hub/vault }`) UNIONed with `egress[]`. The real
+   *     isolation surface — only turn it on when the agent processes input you
+   *     don't trust.
+   *
+   * Defaults to `"trusted"` (owner-operated). The per-session writable HOME +
+   * temp + onboarding seed are provided in BOTH postures (claude must always be
+   * able to run); `isolation` only governs reach BEYOND claude's own runtime.
+   */
+  isolation?: "trusted" | "confined";
+  /**
+   * Network egress hosts ADDITIVE to the non-removable base — only meaningful
+   * under `isolation: "confined"` (in `"trusted"` the network is fully open, so
+   * this is ignored). A confined code-building agent opens exactly the
+   * package/source hosts it needs here.
    */
   egress?: string[];
-  /**
-   * Open the network entirely — allow ALL egress, ignoring `egress[]` and the
-   * base allowlist (the sandbox runs with no network restriction; filesystem
-   * isolation is unchanged). This is the operator's explicit, deliberate choice
-   * for a TRUSTED session where the convenience of unrestricted network outweighs
-   * the exfiltration surface ("I know how this is contained"). Egress is the
-   * load-bearing control for a session fed FOREIGN-authored input (design §3.3),
-   * so this must never be the default and must be an explicit per-spawn opt-in.
-   * Mutually overrides `egress` (allow-all is strictly broader).
-   */
-  egressUnrestricted?: boolean;
   /**
    * Filesystem mounts — ADDITIVE to the default private per-session workspace
    * (rw) + the implicit runtime/claude-config (ro). Reads are scoped to declared

--- a/src/spawn-agent-cli.test.ts
+++ b/src/spawn-agent-cli.test.ts
@@ -80,10 +80,11 @@ describe("parseArgs — name + channels + vault + egress + mounts → the right 
     expect(spec!.channels[1]).toEqual({ name: "second" });
   });
 
-  test("--egress-all sets egressUnrestricted and overrides --egress", () => {
-    const { spec } = parseArgs(["a", "--channel", "c", "--egress", "x.com", "--egress-all"]);
-    expect(spec!.egressUnrestricted).toBe(true);
-    expect(spec!.egress).toBeUndefined(); // allow-all is strictly broader
+  test("default is trusted (no isolation field); --confined sets it + keeps --egress", () => {
+    expect(parseArgs(["a", "--channel", "c"]).spec!.isolation).toBeUndefined(); // default trusted
+    const { spec } = parseArgs(["a", "--channel", "c", "--egress", "x.com", "--confined"]);
+    expect(spec!.isolation).toBe("confined");
+    expect(spec!.egress).toEqual(["x.com"]); // additive hosts kept (used under confined)
   });
 });
 

--- a/src/spawn-agent.test.ts
+++ b/src/spawn-agent.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, readFileSync, statSync } from "node:fs";
+import { mkdtempSync, rmSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -8,6 +8,7 @@ import {
   buildAgentClaudeArgs,
   buildLaunchScript,
   realTmuxLauncher,
+  seedAgentHome,
   sessionName,
   shellJoin,
   type SpawnAgentDeps,
@@ -157,6 +158,8 @@ describe("buildAgentClaudeArgs", () => {
     expect(argv).toContain("--mcp-config");
     expect(argv).toContain("/ws/.mcp.json");
     expect(argv).toContain("--dangerously-load-development-channels=server:channel-aaron-dev");
+    // Autonomous: no human answers tool prompts; the sandbox is the containment.
+    expect(argv).toContain("--dangerously-skip-permissions");
     // NOT headless: no `-p`.
     expect(argv).not.toContain("-p");
   });
@@ -166,6 +169,80 @@ describe("shellJoin", () => {
   test("leaves safe args bare, quotes args with spaces", () => {
     expect(shellJoin(["claude", "--mcp-config", "/a/b.json"])).toBe("claude --mcp-config /a/b.json");
     expect(shellJoin(["echo", "a b"])).toBe("echo 'a b'");
+  });
+});
+
+describe("seedAgentHome — the per-session writable HOME (stability keystone)", () => {
+  test("seeds from the operator config (inherits first-run state), strips projects+oauthAccount, trusts the workspace", () => {
+    const ws = mkdtempSync(join(tmpdir(), "seed-home-"));
+    const opDir = mkdtempSync(join(tmpdir(), "seed-op-"));
+    const opPath = join(opDir, ".claude.json");
+    // A realistic operator config: completed first-run flags + history + account.
+    writeFileSync(opPath, JSON.stringify({
+      hasCompletedOnboarding: true,
+      theme: "dark",
+      numStartups: 536,
+      sonnet45MigrationComplete: true,
+      oauthAccount: { email: "op@example.com", secret: "DO-NOT-COPY" },
+      projects: { "/some/other/proj": { hasTrustDialogAccepted: true } },
+    }));
+    try {
+      const env = seedAgentHome(ws, { mcpServers: ["channel-uni-dev", "vault-default"], operatorConfigPath: opPath });
+      // Config + temp are redirected to per-session dirs INSIDE the workspace.
+      // (HOME is deliberately NOT overridden — claude finds its real install there.)
+      expect(env.HOME).toBeUndefined();
+      expect(env.CLAUDE_CONFIG_DIR).toBe(join(ws, "home", ".claude"));
+      expect(env.TMPDIR).toBe(join(ws, "tmp"));
+      expect(env.CLAUDE_CODE_TMPDIR).toBe(join(ws, "tmp"));
+      const seed = JSON.parse(readFileSync(join(ws, "home", ".claude", ".claude.json"), "utf8")) as Record<string, unknown>;
+      // Inherits the operator's completed first-run state (onboarding, theme, migrations).
+      expect(seed.hasCompletedOnboarding).toBe(true);
+      expect(seed.theme).toBe("dark");
+      expect(seed.sonnet45MigrationComplete).toBe(true);
+      // Strips the account; replaces project history with ONLY this workspace, trusted.
+      expect(seed.oauthAccount).toBeUndefined();
+      const projects = seed.projects as Record<string, { hasTrustDialogAccepted: boolean; hasCompletedProjectOnboarding: boolean }>;
+      expect(Object.keys(projects)).toEqual([ws]);
+      expect(projects[ws]!.hasTrustDialogAccepted).toBe(true);
+      expect(projects[ws]!.hasCompletedProjectOnboarding).toBe(true);
+      // Our configured MCP servers are pre-approved (no "trust this MCP server" prompt).
+      expect((projects[ws] as { enabledMcpjsonServers?: string[] }).enabledMcpjsonServers).toEqual([
+        "channel-uni-dev",
+        "vault-default",
+      ]);
+    } finally {
+      rmSync(ws, { recursive: true, force: true });
+      rmSync(opDir, { recursive: true, force: true });
+    }
+  });
+
+  test("falls back to the minimal seed when the operator has no config", () => {
+    const ws = mkdtempSync(join(tmpdir(), "seed-home-noop-"));
+    try {
+      seedAgentHome(ws, { operatorConfigPath: join(ws, "does-not-exist.json") });
+      const seed = JSON.parse(readFileSync(join(ws, "home", ".claude", ".claude.json"), "utf8")) as {
+        hasCompletedOnboarding: boolean;
+        projects: Record<string, { hasTrustDialogAccepted: boolean }>;
+      };
+      expect(seed.hasCompletedOnboarding).toBe(true);
+      expect(seed.projects[ws]!.hasTrustDialogAccepted).toBe(true);
+    } finally {
+      rmSync(ws, { recursive: true, force: true });
+    }
+  });
+
+  test("idempotent — an existing seed is left as-is (claude owns it after first boot)", () => {
+    const ws = mkdtempSync(join(tmpdir(), "seed-home-idem-"));
+    const noop = join(ws, "no-operator.json");
+    try {
+      seedAgentHome(ws, { operatorConfigPath: noop });
+      const path = join(ws, "home", ".claude", ".claude.json");
+      writeFileSync(path, JSON.stringify({ hasCompletedOnboarding: true, mine: true }));
+      seedAgentHome(ws, { operatorConfigPath: noop }); // second call must not clobber
+      expect(JSON.parse(readFileSync(path, "utf8")).mine).toBe(true);
+    } finally {
+      rmSync(ws, { recursive: true, force: true });
+    }
   });
 });
 
@@ -180,6 +257,7 @@ describe("spawnAgent — full wiring with stubs (no real token)", () => {
       name: "aaron-dev",
       channels: ["aaron-dev"],
       vault: { name: "default", access: "read", tags: ["#channel-message"] },
+      isolation: "confined", // exercise the egress floor + scoped reads (step 6)
     };
     const res = await spawnAgent(spec, baseDeps({ tmux, sandboxEngine: engine }));
 

--- a/src/spawn-agent.ts
+++ b/src/spawn-agent.ts
@@ -192,6 +192,7 @@ export function buildAgentChildEnv(
     "XDG_CONFIG_HOME",
     "XDG_DATA_HOME",
     "XDG_CACHE_HOME",
+    "XDG_STATE_HOME",
     "XDG_RUNTIME_DIR",
   ];
   for (const k of passthrough) {
@@ -230,7 +231,8 @@ export function buildAgentChildEnv(
  * `oauthAccount` is dropped (the agent authenticates via CLAUDE_CODE_OAUTH_TOKEN).
  * If the operator has no config, fall back to the two flags that gate the prompts.
  *
- * Returns the env overrides (HOME + CLAUDE_CONFIG_DIR + XDG_* + the temp vars) to
+ * Returns the env overrides (CLAUDE_CONFIG_DIR + XDG_* + the temp vars — NOT HOME,
+ * which is deliberately left as the operator's so claude finds its real install) to
  * layer LAST over the launch env so they win over the inherited + engine env.
  * Idempotent: an existing seed is left as-is (claude owns it after first boot).
  * `operatorConfigPath` is injectable for tests.

--- a/src/spawn-agent.ts
+++ b/src/spawn-agent.ts
@@ -25,7 +25,8 @@
  * subscription path).
  */
 
-import { writeFileSync, mkdirSync, chmodSync } from "node:fs";
+import { writeFileSync, mkdirSync, chmodSync, existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { join } from "node:path";
 import type { AgentSpec, BaseBinds } from "./sandbox/types.ts";
 import { normalizeChannel } from "./sandbox/types.ts";
@@ -212,10 +213,125 @@ export function buildAgentChildEnv(
 }
 
 /**
+ * Create the agent's PRIVATE, WRITABLE HOME inside its workspace and seed it so
+ * claude starts straight into a usable session — no onboarding flow, no per-folder
+ * trust prompt — and so ALL of claude's config/cache/log/lock/temp writes land
+ * here instead of EPERM-ing against the operator's (read-only, shared) real home.
+ *
+ * This is the keystone of a STABLE sandbox: claude always has a home it can fully
+ * read AND write, decoupled from the operator's ~/.claude (so concurrent agents
+ * never race/corrupt it).
+ *
+ * The seed is based on the operator's REAL `~/.claude.json` so the agent inherits
+ * a fully-COMPLETED first run — onboarding, theme, and every version-migration
+ * flag — which is robust to claude's evolving first-run sub-steps (chasing them
+ * one-by-one is exactly the fragility this avoids). We then strip the heavy /
+ * private bits: `projects` is REPLACED with just this workspace (pre-trusted), and
+ * `oauthAccount` is dropped (the agent authenticates via CLAUDE_CODE_OAUTH_TOKEN).
+ * If the operator has no config, fall back to the two flags that gate the prompts.
+ *
+ * Returns the env overrides (HOME + CLAUDE_CONFIG_DIR + XDG_* + the temp vars) to
+ * layer LAST over the launch env so they win over the inherited + engine env.
+ * Idempotent: an existing seed is left as-is (claude owns it after first boot).
+ * `operatorConfigPath` is injectable for tests.
+ */
+export function seedAgentHome(
+  workspace: string,
+  opts: { mcpServers?: string[]; operatorConfigPath?: string } = {},
+): Record<string, string> {
+  const mcpServerNames = opts.mcpServers ?? [];
+  const operatorConfigPath = opts.operatorConfigPath ?? join(homedir(), ".claude.json");
+  const home = join(workspace, "home");
+  const claudeDir = join(home, ".claude");
+  const tmp = join(workspace, "tmp");
+  mkdirSync(claudeDir, { recursive: true });
+  mkdirSync(tmp, { recursive: true });
+  // claude reads its primary config from `$CLAUDE_CONFIG_DIR/.claude.json` when
+  // CLAUDE_CONFIG_DIR is set (which we set below, to claudeDir) — NOT
+  // `$HOME/.claude.json`. Seed THERE. Only seed if absent — after first boot
+  // claude owns this file.
+  const seedPath = join(claudeDir, ".claude.json");
+  if (!existsSync(seedPath)) {
+    let base: Record<string, unknown> = {};
+    try {
+      if (existsSync(operatorConfigPath)) {
+        base = JSON.parse(readFileSync(operatorConfigPath, "utf-8")) as Record<string, unknown>;
+      }
+    } catch {
+      base = {}; // unreadable/garbage operator config → minimal seed
+    }
+    delete base.oauthAccount; // don't copy the operator's account into the agent home
+    const seed = {
+      ...base,
+      hasCompletedOnboarding: true,
+      // Replace the operator's project history with ONLY this workspace, pre-trusted
+      // AND with our own configured MCP servers pre-approved (claude otherwise
+      // prompts "New MCP server found in this project" for the workspace .mcp.json
+      // we wrote — these are operator-configured, not foreign, so pre-approve them).
+      projects: {
+        [workspace]: {
+          hasTrustDialogAccepted: true,
+          hasCompletedProjectOnboarding: true,
+          enabledMcpjsonServers: mcpServerNames,
+          enableAllProjectMcpServers: true,
+        },
+      },
+    };
+    writeFileSync(seedPath, JSON.stringify(seed, null, 2) + "\n", { mode: 0o600 });
+  }
+  // settings.json: pre-suppress the "are you sure?" meta-prompt that
+  // `--dangerously-skip-permissions` shows on first use (the operator's own config
+  // sets this too). Without it, skip-permissions just trades one prompt for another.
+  const settingsPath = join(claudeDir, "settings.json");
+  if (!existsSync(settingsPath)) {
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({ skipDangerousModePermissionPrompt: true }, null, 2) + "\n",
+      { mode: 0o600 },
+    );
+  }
+  // NOTE: we deliberately do NOT override HOME. claude resolves its own install
+  // relative to $HOME (`$HOME/.local/...`); leaving HOME as the operator's means
+  // claude finds its real install (no "setup issue", no per-spawn self-reinstall).
+  // All of claude's WRITES are redirected to the per-session dirs below
+  // (CLAUDE_CONFIG_DIR + XDG + temp), so it never EPERMs on the operator's
+  // read-only home and concurrent agents don't share mutable config.
+  return {
+    CLAUDE_CONFIG_DIR: claudeDir,
+    XDG_CONFIG_HOME: join(home, ".config"),
+    XDG_DATA_HOME: join(home, ".local", "share"),
+    XDG_CACHE_HOME: join(home, ".cache"),
+    XDG_STATE_HOME: join(home, ".local", "state"),
+    XDG_RUNTIME_DIR: join(home, ".run"),
+    // claude's `/tmp/claude-<uid>` scratch dir follows CLAUDE_CODE_TMPDIR; TMPDIR/
+    // TMP/TEMP cover everything else. All inside the writable workspace, so claude
+    // never EPERMs on temp (the "could not start" death) regardless of read scope.
+    TMPDIR: tmp,
+    CLAUDE_CODE_TMPDIR: tmp,
+    TMP: tmp,
+    TEMP: tmp,
+    // An ephemeral sandboxed agent shouldn't auto-update itself — it would download
+    // a fresh claude into the per-session data dir on every spawn (bandwidth + disk
+    // for nothing; the agent is gone when the session ends). This narrow flag
+    // disables ONLY the updater — unlike CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC,
+    // which also disables the channels feature we depend on.
+    DISABLE_AUTOUPDATER: "1",
+  };
+}
+
+/**
  * Build the `claude` invocation argv (pre-sandbox-wrap). Interactive `claude`
  * (NOT `claude -p` — the session runs on the subscription, §1/§6) with the
  * strict, multi-entry MCP config and the dev-channels flag for the first channel
  * (the wake transport). `--strict-mcp-config` closes the MCP surface to the spec.
+ *
+ * `--dangerously-skip-permissions`: a spawned agent runs AUTONOMOUSLY — there is no
+ * human at the terminal to answer claude's in-app permission / dev-channels
+ * confirmation prompts, and the OS sandbox (+ scoped reads / egress when confined)
+ * is the real containment, so claude's own prompts are redundant friction. Skipping
+ * them is what lets the agent reach a usable state hands-off. (The meta "are you
+ * sure" for this flag is pre-suppressed via the seeded settings.json — see
+ * seedAgentHome.)
  */
 export function buildAgentClaudeArgs(opts: {
   mcpConfigPath: string;
@@ -225,6 +341,7 @@ export function buildAgentClaudeArgs(opts: {
   const bin = opts.claudeBin ?? "claude";
   return [
     bin,
+    "--dangerously-skip-permissions",
     "--strict-mcp-config",
     "--mcp-config",
     opts.mcpConfigPath,
@@ -385,30 +502,28 @@ export async function spawnAgent(
     }),
   );
 
-  // A writable per-session temp dir INSIDE the workspace (the workspace is the
-  // sandbox's one writable region). claude needs a writable TMPDIR to start — its
-  // default (`/tmp/claude-<uid>/…`) is OUTSIDE the workspace, which the sandbox
-  // DENIES, so without this claude dies immediately with
-  // "Claude Code could not start: EPERM … mkdir '/tmp/claude-<uid>/…'". Pointing
-  // TMPDIR (+ the claude-specific + the generic TMP/TEMP) at this dir keeps all of
-  // claude's scratch writes within the allowed workspace.
-  const sessionTmp = join(workspace, "tmp");
-  mkdirSync(sessionTmp, { recursive: true });
+  // The agent's private, writable, pre-seeded HOME + temp dirs (the stability
+  // keystone — see seedAgentHome). Everything claude reads/writes about itself
+  // lives here, inside the workspace (the sandbox's writable region). The MCP
+  // server names (from the config we just wrote) are pre-approved in the seed so
+  // claude doesn't prompt to trust the project's .mcp.json.
+  const mcpServerNames = Object.keys(
+    (JSON.parse(mcpConfigJson) as { mcpServers?: Record<string, unknown> }).mcpServers ?? {},
+  );
+  const homeEnv = seedAgentHome(workspace, { mcpServers: mcpServerNames });
 
   // Layer the scrubbed agent env UNDER the sandbox wrapper's env: the engine's
   // proxy vars / sandbox markers win over our childEnv on conflict;
   // CLAUDE_CODE_OAUTH_TOKEN + the passthrough fundamentals come from us;
-  // ANTHROPIC_API_KEY is absent. EXCEPTION: the temp vars are layered LAST so they
-  // override even the engine's own TMPDIR (which points at a non-writable path
-  // under our scoped-read policy — the cause of the "could not start" death).
+  // ANTHROPIC_API_KEY is absent. EXCEPTION: the HOME/config/temp vars are layered
+  // LAST so they override even the engine's own (e.g. its non-writable TMPDIR) —
+  // pointing claude at its private writable home is what stops the EPERM /
+  // "could not start" deaths.
   const childEnv = buildAgentChildEnv(deps.parentEnv ?? process.env, claudeOauthToken);
   const launchEnv: Record<string, string | undefined> = {
     ...childEnv,
     ...wrapped.env,
-    TMPDIR: sessionTmp,
-    CLAUDE_CODE_TMPDIR: sessionTmp,
-    TMP: sessionTmp,
-    TEMP: sessionTmp,
+    ...homeEnv,
   };
 
   await deps.tmux.newSession({

--- a/src/spawn-deps.test.ts
+++ b/src/spawn-deps.test.ts
@@ -34,16 +34,21 @@ describe("resolveSpawnDeps", () => {
     expect(() => resolveSpawnDeps()).toThrow(SpawnDepsError);
   });
 
-  test("binds ~/.claude.json read-only (skip-onboarding regression guard)", () => {
+  test("binds the claude binary (confined reads) but NOT the operator's ~/.claude", () => {
     tmp = mkdtempSync(join(tmpdir(), "spawn-deps-"));
     process.env.PARACHUTE_HOME = tmp;
     writeFileSync(join(tmp, "operator.token"), "fake-operator-bearer");
     const deps = resolveSpawnDeps();
-    // The config FILE at the home root must be bound — this is the fix for the
-    // onboarding-connectivity death under restricted egress.
-    expect(deps.runtimeReadOnly).toContain(resolve(homedir(), ".claude.json"));
-    // And the config DIR.
-    const dir = process.env.CLAUDE_CONFIG_DIR ?? resolve(homedir(), ".claude");
-    expect(deps.runtimeReadOnly).toContain(dir);
+    // The agent's config/onboarding now lives in its own per-session HOME
+    // (seedAgentHome), so we no longer expose the operator's real config.
+    expect(deps.runtimeReadOnly).not.toContain(resolve(homedir(), ".claude.json"));
+    expect(deps.runtimeReadOnly).not.toContain(resolve(homedir(), ".claude"));
+    // The claude BINARY is still bound (needed under confined/scoped reads) when
+    // resolvable on PATH — and claudeBin is set to its absolute path.
+    const bin = Bun.which("claude");
+    if (bin) {
+      expect(deps.claudeBin).toBe(bin);
+      expect(deps.runtimeReadOnly).toContain(bin);
+    }
   });
 });

--- a/src/spawn-deps.ts
+++ b/src/spawn-deps.ts
@@ -71,27 +71,6 @@ function resolveChannelUrl(): string {
 }
 
 /**
- * Claude runtime/config paths bound read-only so the sandboxed `claude` runs:
- *   - the config DIR (`~/.claude` or $CLAUDE_CONFIG_DIR) — skills, plugins, settings;
- *   - the config FILE `~/.claude.json` (at the home ROOT, a sibling of the dir).
- *
- * Binding `~/.claude.json` is load-bearing: without it claude can't see that it's
- * already onboarded, so it runs FIRST-RUN SETUP, whose connectivity check is FATAL
- * under the restricted egress proxy → the tmux session dies instantly with
- * "An unknown error occurred (Unexpected)". With it bound, claude skips onboarding
- * and starts cleanly under both restricted and open network. Bound READ-ONLY: a
- * session can read the operator's claude config (it runs on the operator's claude
- * credential anyway) but never mutate it for future sessions.
- */
-function claudeConfigReads(): string[] {
-  const dir = process.env.CLAUDE_CONFIG_DIR ?? resolve(homedir(), ".claude");
-  const reads = [dir, resolve(homedir(), ".claude.json")];
-  // If CLAUDE_CONFIG_DIR is set, newer claude keeps its config json under it too.
-  if (process.env.CLAUDE_CONFIG_DIR) reads.push(join(process.env.CLAUDE_CONFIG_DIR, ".claude.json"));
-  return reads;
-}
-
-/**
  * Resolve the `claude` binary to an ABSOLUTE path and the read binds the sandbox
  * needs to actually exec it.
  *
@@ -158,11 +137,14 @@ export function resolveSpawnDeps(): SpawnAgentDeps {
   // bare "claude" on PATH (correct when claude is outside the home tree).
   const claude = resolveClaudeBin();
 
-  // The runtime/config paths the sandboxed `claude` must read: its config dir +
-  // config file (skip-onboarding, see claudeConfigReads) + (when resolved) the
-  // binary itself and its install dir. System paths (/usr,/lib,/opt) stay
-  // readable; the per-session workspace (rw) is added by spawnAgent under sessionsDir.
-  const runtimeReadOnly = [...claudeConfigReads(), ...(claude?.reads ?? [])];
+  // Read binds the sandboxed `claude` needs in CONFINED (scoped-read) mode: the
+  // claude BINARY + its install dir (commonly under the home tree, which confined
+  // mode denies). The agent's config/onboarding now lives in its own per-session
+  // HOME (seedAgentHome) under the workspace — re-allowed there — so we no longer
+  // bind (or expose) the operator's real ~/.claude. In TRUSTED mode reads are
+  // broad and these binds are harmless no-ops. System paths (/usr,/lib,/opt) stay
+  // readable; the per-session workspace (rw) is added by spawnAgent.
+  const runtimeReadOnly = [...(claude?.reads ?? [])];
 
   return {
     hubOrigin: getHubOrigin(),


### PR DESCRIPTION
## Why

The sandboxed `claude` was fragile. Getting an agent to a usable state meant chasing a cascade of first-run gates one by one — onboarding, theme picker, per-folder trust, MCP approval, the skip-perms confirm — plus EPERM deaths on temp, a per-spawn self-reinstall, and a leaky two-axis egress model. Aaron: *"lets figure out a more stable situation for our sandboxing causing errors like this."* This replaces the whack-a-mole with two structural changes.

## What

**1. One isolation knob, matched to the trust gradient** (replaces `egress[]` + `egressUnrestricted`):

| posture | reads | network | writes |
|---|---|---|---|
| `trusted` (**default**) | broad | open | confined to workspace |
| `confined` (foreign input) | scoped (home denied, re-allowed to workspace + claude runtime + mounts) | base floor ∪ `egress[]` | confined to workspace |

Trusted is the owner-operated default: claude's own runtime never collides with a deny, so it just works. Confined is the real isolation surface — opt-in, for an agent processing untrusted input. **Writes are confined to the per-session workspace in both** — the agent can never corrupt the operator's files or escape its workspace.

**2. A private, writable, pre-seeded HOME per session** (`seedAgentHome` — the keystone). claude gets its own `<workspace>/home/.claude` with config/cache/log/temp redirected there (`CLAUDE_CONFIG_DIR` + `XDG_*` + `TMPDIR`). The seed is derived from the operator's real `~/.claude.json` so it inherits a **fully-completed first run** (robust to claude's evolving first-run sub-steps — the fragility this avoids), with `oauthAccount` stripped and `projects` replaced by just this workspace (pre-trusted, MCP servers pre-approved). HOME is deliberately **not** overridden so claude still finds its real install; `DISABLE_AUTOUPDATER=1` stops the per-spawn reinstall.

**Autonomy.** A spawned agent has no human at the terminal, so it launches `--dangerously-skip-permissions`. The OS sandbox (+ scoped reads/egress when confined) is the real containment; the meta confirm is pre-suppressed via the seeded `settings.json`. The per-spawn singleton `reset()` (no proxy leak across spawns) stays.

## Surface changes
- **CLI**: `--egress-all` → `--confined`
- **Web UI**: "Network: Open/Restricted" → "Isolation: Trusted/Confined"
- **API**: request `egressUnrestricted` → `isolation`; result `egressUnrestricted` → `isolation`

## Verification
- 404 tests pass; typecheck clean (the 2 pre-existing `bridge.ts` TS2589s aside).
- Playwright-verified through the **hub-proxied browser path** (not just the daemon): trusted spawn reaches a fully clean startup — no setup issue, no auto-install, channels active, autonomous. Confined spawn works (shows a minor "1 setup issue: MCP · /doctor" notice under restricted egress — claude still functions; tracked as a follow-up).

## Residual / follow-ups
- The dev-channels warning is a single per-session keypress (not persistable — it's claude's per-invocation flag), so a launched agent still needs one "1" press to arm the wake channel. Flagging for awareness; can be scripted as a follow-up.
- Confined mode's "1 setup issue: MCP" notice (likely an MCP host outside the egress floor) — benign, follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)