### PR TITLE
fix(agents): split isolation into two orthogonal boundaries — scoped reads + open net by default

### DIFF
--- a/scripts/spawn-agent.ts
+++ b/scripts/spawn-agent.ts
@@ -62,10 +62,12 @@ Flags:
                                   The FIRST channel is the wake channel.
   --vault <name>:<read|write>[:tag1,tag2]
                                   optional vault MCP scope (+ optional tag-scope).
-  --confined                      isolate for UNTRUSTED input: scoped reads (home denied) +
-                                  egress restricted to the base + --egress hosts.
-                                  Default is "trusted": broad reads + open network.
-  --egress <host,host,...>        additive egress allowlist (only used with --confined).
+  --full-read                     give the agent FULL read access to your disk.
+                                  Default: reads are sandboxed to the workspace
+                                  (your home tree, incl. operator.token, is unreadable).
+  --restricted                    restrict network egress to the base + --egress hosts
+                                  (for UNTRUSTED input). Default: open (full internet).
+  --egress <host,host,...>        additive egress allowlist (only used with --restricted).
   --mount <hostPath:mountPath:ro|rw[:shared]>
                                   filesystem mount (repeatable; optional).
   --help                          show this help.
@@ -179,7 +181,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
   const channels: AgentChannelSpec[] = [];
   let vault: AgentVaultSpec | undefined;
   const egress: string[] = [];
-  let confined = false;
+  let fullRead = false;
+  let restricted = false;
   const mounts: AgentMount[] = [];
 
   for (let i = 0; i < argv.length; i++) {
@@ -207,8 +210,12 @@ export function parseArgs(argv: string[]): ParsedArgs {
         i++;
         break;
       }
-      case "--confined": {
-        confined = true;
+      case "--full-read": {
+        fullRead = true;
+        break;
+      }
+      case "--restricted": {
+        restricted = true;
         break;
       }
       case "--mount": {
@@ -233,7 +240,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
 
   const spec: AgentSpec = { name, channels };
   if (vault) spec.vault = vault;
-  if (confined) spec.isolation = "confined";
+  if (fullRead) spec.filesystem = "full";
+  if (restricted) spec.network = "restricted";
   if (egress.length > 0) spec.egress = egress;
   if (mounts.length > 0) spec.mounts = mounts;
   return { help: false, spec };

--- a/src/agents-ui.ts
+++ b/src/agents-ui.ts
@@ -216,20 +216,33 @@ export const AGENTS_UI_HTML = `<!doctype html>
           </div>
 
           <div>
-            <label for="net-mode">Isolation</label>
+            <label for="fs-mode">Filesystem</label>
+            <select id="fs-mode">
+              <option value="workspace" selected>Sandboxed to its workspace (default) — can't read your files or secrets</option>
+              <option value="full">Full read access — can read your whole disk (use with care)</option>
+            </select>
+            <div id="fs-warn" class="muted" style="display:none; font-size:12px; margin-top:8px;">
+              Default: the agent reads only its own workspace + mounts + the claude runtime. Your home
+              tree (including <code>~/.parachute/operator.token</code>, SSH keys, other projects) is
+              unreadable. Writes are always confined to the workspace. Switch to Full read only when an
+              agent genuinely needs to see across your disk and you trust it not to leak.
+            </div>
+          </div>
+
+          <div>
+            <label for="net-mode">Network</label>
             <select id="net-mode">
-              <option value="trusted" selected>Trusted — full read + open network (default)</option>
-              <option value="confined">Confined — scoped reads + restricted network (untrusted input)</option>
+              <option value="open" selected>Open — full internet (default)</option>
+              <option value="restricted">Restricted — Anthropic + hub/vault + listed hosts only (untrusted input)</option>
             </select>
             <div id="egress-wrap" style="display:none; margin-top:8px;">
               <label for="egress">Additional allowed hosts (comma-separated)</label>
               <input type="text" id="egress" placeholder="registry.npmjs.org, github.com" autocomplete="off" />
             </div>
-            <div id="open-warn" class="muted" style="display:none; font-size:12px; margin-top:8px;">
-              Trusted is the default for your own agents — the session reads the system + your files and
-              reaches the network like any local process (it still gets a private writable home and can't
-              write outside its workspace). Choose Confined for an agent that handles untrusted input:
-              its reads are scoped to its workspace and its network is restricted.
+            <div id="net-note" class="muted" style="display:none; font-size:12px; margin-top:8px;">
+              Open is safe as the default because the workspace filesystem sandbox already keeps your
+              secrets unreadable — open network can't exfiltrate what the agent can't see. Choose
+              Restricted to also bound where an agent fed untrusted input can reach.
             </div>
           </div>
 
@@ -412,16 +425,24 @@ export const AGENTS_UI_HTML = `<!doctype html>
   }
   document.getElementById("add-mount").addEventListener("click", function () { mountRow(); });
 
-  // Isolation toggle: show the additional-hosts field only when Confined; show the
-  // explainer note when Trusted (the default).
+  // Filesystem toggle: show the caution note only when Full read is selected.
+  var fsMode = document.getElementById("fs-mode");
+  function syncFsMode() {
+    document.getElementById("fs-warn").style.display = fsMode.value === "full" ? "" : "none";
+  }
+  fsMode.addEventListener("change", syncFsMode);
+  syncFsMode(); // default is workspace → note hidden
+
+  // Network toggle: show the additional-hosts field only when Restricted; show the
+  // "open is safe" note when Open (the default).
   var netMode = document.getElementById("net-mode");
   function syncNetMode() {
-    var trusted = netMode.value === "trusted";
-    document.getElementById("egress-wrap").style.display = trusted ? "none" : "";
-    document.getElementById("open-warn").style.display = trusted ? "" : "none";
+    var open = netMode.value === "open";
+    document.getElementById("egress-wrap").style.display = open ? "none" : "";
+    document.getElementById("net-note").style.display = open ? "" : "none";
   }
   netMode.addEventListener("change", syncNetMode);
-  syncNetMode(); // default is trusted → show the note, hide the hosts field
+  syncNetMode(); // default is open → show the note, hide the hosts field
 
   function collectSpec() {
     var wake = chanEl.value;
@@ -443,12 +464,13 @@ export const AGENTS_UI_HTML = `<!doctype html>
       spec.vault = v;
     }
 
-    if (netMode.value === "confined") {
-      spec.isolation = "confined";
+    if (fsMode.value === "full") spec.filesystem = "full"; // else workspace (default)
+    if (netMode.value === "restricted") {
+      spec.network = "restricted";
       var egress = document.getElementById("egress").value.split(",").map(function (h) { return h.trim(); }).filter(Boolean);
       if (egress.length) spec.egress = egress;
     }
-    // else: trusted (default) — no isolation field; broad reads + open network.
+    // defaults (omitted): filesystem "workspace" (scoped reads) + network "open".
 
     var mounts = [];
     document.querySelectorAll("#mounts-rows .mrow").forEach(function (row) {
@@ -480,8 +502,10 @@ export const AGENTS_UI_HTML = `<!doctype html>
           r.tokens.forEach(function (t) { lines.push("  " + t.resource + " → " + t.scope); });
         }
         if (r.mcpServers && r.mcpServers.length) lines.push("MCP servers: " + r.mcpServers.join(", "));
-        lines.push("isolation: " + (r.isolation || "trusted") +
-          (r.isolation === "confined" ? " (egress: " + ((r.egress || []).join(", ") || "base only") + ")" : " (full read + open network)"));
+        lines.push("filesystem: " + (r.filesystem || "workspace") +
+          (r.filesystem === "full" ? " (reads whole disk)" : " (sandboxed to workspace)"));
+        lines.push("network: " + (r.network || "open") +
+          (r.network === "restricted" ? " (egress: " + ((r.egress || []).join(", ") || "base only") + ")" : " (full internet)"));
       }
       showMsg(msg, lines.join("\\n"), false);
       loadAgents();

--- a/src/agents.test.ts
+++ b/src/agents.test.ts
@@ -139,14 +139,18 @@ describe("buildSpecFromBody", () => {
       buildSpecFromBody({ name: "a", channels: ["c"], mounts: [{ hostPath: "/h", mountPath: "/m", mode: "x" }] }),
     ).toThrow(/mode/);
   });
-  test("isolation defaults to trusted (omitted) and accepts 'confined' + egress", () => {
-    expect(buildSpecFromBody({ name: "a", channels: ["c"] }).isolation).toBeUndefined(); // default = trusted
-    const spec = buildSpecFromBody({ name: "a", channels: ["c"], isolation: "confined", egress: ["x.com"] });
-    expect(spec.isolation).toBe("confined");
-    expect(spec.egress).toEqual(["x.com"]); // additive hosts kept (used under confined)
+  test("filesystem/network default (omitted) and accept explicit values + egress", () => {
+    const def = buildSpecFromBody({ name: "a", channels: ["c"] });
+    expect(def.filesystem).toBeUndefined(); // default = workspace (scoped reads)
+    expect(def.network).toBeUndefined(); // default = open
+    const spec = buildSpecFromBody({ name: "a", channels: ["c"], filesystem: "full", network: "restricted", egress: ["x.com"] });
+    expect(spec.filesystem).toBe("full");
+    expect(spec.network).toBe("restricted");
+    expect(spec.egress).toEqual(["x.com"]); // additive hosts kept (used under restricted)
   });
-  test("rejects an invalid isolation value", () => {
-    expect(() => buildSpecFromBody({ name: "a", channels: ["c"], isolation: "loose" })).toThrow(/isolation/);
+  test("rejects invalid filesystem / network values", () => {
+    expect(() => buildSpecFromBody({ name: "a", channels: ["c"], filesystem: "loose" })).toThrow(/filesystem/);
+    expect(() => buildSpecFromBody({ name: "a", channels: ["c"], network: "loose" })).toThrow(/network/);
   });
   test("rejects relative mount paths (must be absolute)", () => {
     expect(() =>
@@ -171,10 +175,11 @@ describe("redactSpawnResult", () => {
     wrapped: {
       argv: ["/bin/bash", "-c", "..."],
       env: {},
-      config: { network: { allowedDomains: ["api.anthropic.com:443"], deniedDomains: [] }, filesystem: { denyRead: [], allowWrite: [], denyWrite: [] } },
+      // scoped reads (denyRead carries the home tree) + restricted network (allowedDomains present).
+      config: { network: { allowedDomains: ["api.anthropic.com:443"], deniedDomains: [] }, filesystem: { denyRead: ["/Users"], allowWrite: [], denyWrite: [] } },
     },
   };
-  test("surfaces scopes + mcp servers + egress, NEVER the token values", () => {
+  test("surfaces scopes + mcp servers + posture + egress, NEVER the token values", () => {
     const red = redactSpawnResult(result);
     expect(red.session).toBe("aaron-agent");
     expect(red.tokens).toEqual([
@@ -183,23 +188,26 @@ describe("redactSpawnResult", () => {
     ]);
     expect(red.mcpServers).toEqual(["channel-aaron", "vault-default"]);
     expect(red.egress).toEqual(["api.anthropic.com:443"]);
-    expect(red.isolation).toBe("confined"); // allowedDomains present → confined
+    expect(red.network).toBe("restricted"); // allowedDomains present → restricted
+    expect(red.filesystem).toBe("workspace"); // home-tree denyRead present → scoped
     // The smoking gun: no token VALUE appears anywhere in the serialized result.
     const wire = JSON.stringify(red);
     expect(wire).not.toContain("SECRET-CHANNEL-TOKEN");
     expect(wire).not.toContain("SECRET-VAULT-TOKEN");
   });
-  test("a trusted result (no allowedDomains) → isolation 'trusted', egress []", () => {
-    const trusted: SpawnAgentResult = {
+  test("an open result (no allowedDomains, no denyRead) → network 'open' + filesystem 'full', egress []", () => {
+    const open: SpawnAgentResult = {
       ...result,
       wrapped: {
         ...result.wrapped,
-        // trusted: allowedDomains absent (the runtime's no-restriction shape).
+        // open network: allowedDomains absent (the runtime's no-restriction shape);
+        // full reads: denyRead empty.
         config: { network: { deniedDomains: [] }, filesystem: { denyRead: [], allowWrite: [], denyWrite: [] } } as unknown as SpawnAgentResult["wrapped"]["config"],
       },
     };
-    const red = redactSpawnResult(trusted);
-    expect(red.isolation).toBe("trusted");
+    const red = redactSpawnResult(open);
+    expect(red.network).toBe("open");
+    expect(red.filesystem).toBe("full");
     expect(red.egress).toEqual([]);
   });
 });

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -82,9 +82,11 @@ export interface RedactedSpawnResult {
   tokens: RedactedToken[];
   /** The MCP server entry keys wired into the session (names only). */
   mcpServers: string[];
-  /** Isolation posture the session launched under. */
-  isolation: "trusted" | "confined";
-  /** Egress allowlist baked into the sandbox (empty when trusted/open). */
+  /** Filesystem read scope the session launched under. */
+  filesystem: "workspace" | "full";
+  /** Network posture the session launched under. */
+  network: "open" | "restricted";
+  /** Egress allowlist baked into the sandbox (empty when network is open). */
   egress: string[];
 }
 
@@ -221,11 +223,18 @@ export function buildSpecFromBody(body: unknown): AgentSpec {
     spec.vault = parseVaultEntry(b.vault);
   }
 
-  if (b.isolation !== undefined && b.isolation !== null) {
-    if (b.isolation !== "trusted" && b.isolation !== "confined") {
-      throw new SpawnRequestError('body.isolation must be "trusted" or "confined"');
+  if (b.filesystem !== undefined && b.filesystem !== null) {
+    if (b.filesystem !== "workspace" && b.filesystem !== "full") {
+      throw new SpawnRequestError('body.filesystem must be "workspace" or "full"');
     }
-    spec.isolation = b.isolation;
+    spec.filesystem = b.filesystem;
+  }
+
+  if (b.network !== undefined && b.network !== null) {
+    if (b.network !== "open" && b.network !== "restricted") {
+      throw new SpawnRequestError('body.network must be "open" or "restricted"');
+    }
+    spec.network = b.network;
   }
 
   if (b.egress !== undefined && b.egress !== null) {
@@ -238,8 +247,8 @@ export function buildSpecFromBody(body: unknown): AgentSpec {
         return h.trim();
       })
       .filter((h) => h.length > 0);
-    // Additional allowed hosts — only take effect under `isolation: "confined"`
-    // (trusted = fully open network); harmless to carry otherwise.
+    // Additional allowed hosts — only take effect under `network: "restricted"`
+    // (open = fully open network); harmless to carry otherwise.
     if (egress.length > 0) spec.egress = egress;
   }
 
@@ -355,15 +364,18 @@ export function redactSpawnResult(result: SpawnAgentResult): RedactedSpawnResult
   } catch {
     mcpServers = [];
   }
-  // allowedDomains is present only in CONFINED mode (trusted omits it = open net).
+  // network: allowedDomains is present only when restricted (open omits it).
   const allowed = result.wrapped.config.network.allowedDomains as string[] | undefined;
+  // filesystem: scoped reads carry a home-tree denyRead; "full" leaves it empty.
+  const scopedReads = (result.wrapped.config.filesystem.denyRead ?? []).length > 0;
   return {
     session: result.session,
     workspace: result.workspace,
     alreadyRunning: result.alreadyRunning,
     tokens,
     mcpServers,
-    isolation: allowed === undefined ? "trusted" : "confined",
+    filesystem: scopedReads ? "workspace" : "full",
+    network: allowed === undefined ? "open" : "restricted",
     egress: allowed ?? [],
   };
 }

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -323,6 +323,13 @@ function parseMountEntry(raw: unknown, i: number): AgentMount {
   // but a relative `hostPath` would resolve against the session's cwd in
   // surprising ways — make the trust boundary explicit with a clean 400 here
   // rather than a confusing sandbox behavior downstream.
+  //
+  // NOTE: a mount's hostPath is added to `allowRead`, which OVERRIDES the
+  // `filesystem: "workspace"` home-tree deny. So an operator who mounts a
+  // home-tree path (e.g. ~/.parachute) deliberately re-opens that path to the
+  // agent even under the scoped default. That's intentional (this endpoint is
+  // channel:admin-gated; the operator is choosing it), not an injection bypass —
+  // but weigh it before mounting sensitive home-tree paths.
   if (!m.hostPath.startsWith("/")) {
     throw new SpawnRequestError(`body.mounts[${i}].hostPath must be an absolute path (start with "/")`);
   }

--- a/src/sandbox/config.test.ts
+++ b/src/sandbox/config.test.ts
@@ -9,25 +9,39 @@ const BASE_BINDS: BaseBinds = {
 };
 const EGRESS_BASE: EgressBaseInput = { hubOrigin: "https://hub.example.com" };
 
-// These cases exercise the CONFINED posture (scoped reads + egress floor), so the
-// helper defaults to it; a spread `p` can override (e.g. to test trusted).
+// Most cases exercise the egress floor, which needs network "restricted". Scoped
+// reads are the DEFAULT (filesystem "workspace"), so the helper only sets the
+// network and leaves filesystem at its default. A spread `p` overrides (e.g.
+// `filesystem: "full"` to test broad reads).
 function specOf(p: Partial<AgentSpec> = {}): AgentSpec {
-  return { name: "arm", channels: ["ch"], isolation: "confined", ...p };
+  return { name: "arm", channels: ["ch"], network: "restricted", ...p };
 }
 
-describe("buildSandboxConfig — trusted (default) posture", () => {
-  test("trusted: NO read deny (broad) + NO allowedDomains (open network), writes still confined", () => {
+describe("buildSandboxConfig — defaults (scoped reads + open network)", () => {
+  test("DEFAULT: scoped reads (home tree denied) + open network (no allowedDomains), writes confined", () => {
     const cfg = buildSandboxConfig({
-      spec: { name: "arm", channels: ["ch"] }, // no isolation → trusted default
+      spec: { name: "arm", channels: ["ch"] }, // no filesystem/network → both defaults
       baseBinds: BASE_BINDS,
       egressBase: EGRESS_BASE,
       platform: "darwin",
     });
-    // Broad reads: no home-tree deny.
-    expect(cfg.filesystem.denyRead).toEqual([]);
-    // Open network: allowedDomains omitted entirely (runtime = no restriction).
+    // Scoped reads by default: the home tree is DENIED — this is what keeps the
+    // operator's secrets (~/.parachute/operator.token, SSH keys) unreadable.
+    expect(cfg.filesystem.denyRead).toContain("/Users");
+    // Open network by default: allowedDomains omitted entirely (runtime = no restriction).
     expect((cfg.network as { allowedDomains?: string[] }).allowedDomains).toBeUndefined();
-    // Writes are STILL confined to the workspace even when trusted.
+    // Writes confined to the workspace.
+    expect(cfg.filesystem.allowWrite).toContain("/state/sessions/arm");
+  });
+
+  test("filesystem 'full': broad reads (no home-tree deny), writes still confined", () => {
+    const cfg = buildSandboxConfig({
+      spec: { name: "arm", channels: ["ch"], filesystem: "full" },
+      baseBinds: BASE_BINDS,
+      egressBase: EGRESS_BASE,
+      platform: "darwin",
+    });
+    expect(cfg.filesystem.denyRead).toEqual([]);
     expect(cfg.filesystem.allowWrite).toContain("/state/sessions/arm");
   });
 });

--- a/src/sandbox/config.test.ts
+++ b/src/sandbox/config.test.ts
@@ -118,9 +118,9 @@ describe("buildSandboxConfig — spec → SandboxRuntimeConfig", () => {
     expect(cfg.ripgrep).toEqual({ command: "/abs/rg" });
   });
 
-  test("the produced config matches the runtime's required shape (keys present)", () => {
+  test("a restricted-network config carries the full runtime shape (allowedDomains present)", () => {
     const cfg = buildSandboxConfig({
-      spec: specOf(),
+      spec: specOf(), // network "restricted" → allowedDomains present
       baseBinds: BASE_BINDS,
       egressBase: EGRESS_BASE,
       platform: "darwin",
@@ -131,5 +131,20 @@ describe("buildSandboxConfig — spec → SandboxRuntimeConfig", () => {
     expect(cfg.filesystem).toHaveProperty("allowRead");
     expect(cfg.filesystem).toHaveProperty("allowWrite");
     expect(cfg.filesystem).toHaveProperty("denyWrite");
+  });
+
+  test("an open-network config OMITS allowedDomains but keeps the rest of the shape", () => {
+    const cfg = buildSandboxConfig({
+      spec: { name: "arm", channels: ["ch"] }, // default → network open
+      baseBinds: BASE_BINDS,
+      egressBase: EGRESS_BASE,
+      platform: "darwin",
+    });
+    // allowedDomains is deliberately ABSENT on open (the runtime's allow-all shape);
+    // this is NOT a protocol guarantee that allowedDomains is always present.
+    expect(cfg.network).not.toHaveProperty("allowedDomains");
+    expect(cfg.network).toHaveProperty("deniedDomains");
+    expect(cfg.filesystem).toHaveProperty("denyRead");
+    expect(cfg.filesystem).toHaveProperty("allowWrite");
   });
 });

--- a/src/sandbox/config.ts
+++ b/src/sandbox/config.ts
@@ -56,20 +56,23 @@ export function currentSandboxPlatform(): SandboxPlatform {
 export function buildSandboxConfig(input: BuildSandboxConfigInput): SandboxRuntimeConfig {
   const platform = input.platform ?? currentSandboxPlatform();
 
-  // The single isolation knob (default "trusted") sets BOTH read scope + egress.
-  const confined = input.spec.isolation === "confined";
+  // The two containment boundaries are INDEPENDENT (Anthropic's model). Each has a
+  // security-first default: reads scoped to the workspace, network open.
+  const scopedReads = input.spec.filesystem !== "full"; // default "workspace" = scoped
+  const restrictedNet = input.spec.network === "restricted"; // default "open"
 
-  // Reads are scoped only when confined; trusted = broad reads (claude's own
-  // runtime never collides with a deny — the stability win). Writes are confined
-  // to the workspace in both.
-  const fs = composeFilesystemView(input.baseBinds, input.spec.mounts, platform, confined);
+  // Filesystem: scoped reads (deny home tree, re-allow workspace + claude runtime +
+  // mounts) unless explicitly "full". Writes are confined to the workspace + rw
+  // mounts in BOTH cases. The scoped default is what keeps the operator's secrets
+  // (e.g. ~/.parachute/operator.token) unreadable even with the network open.
+  const fs = composeFilesystemView(input.baseBinds, input.spec.mounts, platform, scopedReads);
 
-  // Network: trusted = OPEN (omit `allowedDomains` — the runtime treats an absent
-  // allowedDomains as "no restriction"; verified: present-but-empty = block all,
-  // absent = allow all). confined = the non-removable base UNIONed with the spec's
-  // additions. The cast is because the runtime's TS type marks allowedDomains
+  // Network: "open" (default) OMITS `allowedDomains` — the runtime treats an absent
+  // allowedDomains as "no restriction" (verified: present-but-empty = block all,
+  // absent = allow all). "restricted" = the non-removable base UNIONed with the
+  // spec's additions. The cast is because the runtime's TS type marks allowedDomains
   // required while its runtime honors the absent case as the documented allow-all.
-  const network: SandboxRuntimeConfig["network"] = confined
+  const network: SandboxRuntimeConfig["network"] = restrictedNet
     ? { allowedDomains: composeEgressAllowlist(input.egressBase, input.spec.egress), deniedDomains: [] }
     : ({ deniedDomains: [] } as unknown as SandboxRuntimeConfig["network"]);
 

--- a/src/sandbox/live-seatbelt.test.ts
+++ b/src/sandbox/live-seatbelt.test.ts
@@ -64,7 +64,7 @@ afterEach(() => {
 d("LIVE Seatbelt — network egress", () => {
   test("positive control: the harness can run a trivial sandboxed command", async () => {
     workspace = mkdtempSync(join(tmpdir(), "sbx-live-pos-"));
-    const spec: AgentSpec = { name: "pos", channels: ["c"], isolation: "confined", egress: [] };
+    const spec: AgentSpec = { name: "pos", channels: ["c"], network: "restricted", egress: [] };
     const cfg = buildSandboxConfig({
       spec,
       baseBinds: { workspace, runtimeReadOnly: [] },
@@ -79,7 +79,7 @@ d("LIVE Seatbelt — network egress", () => {
   test("DENIED: curl to a host NOT in the allowlist is blocked", async () => {
     workspace = mkdtempSync(join(tmpdir(), "sbx-live-deny-"));
     // Allowlist the base only (anthropic + the loopback hub). example.com is NOT on it.
-    const spec: AgentSpec = { name: "deny", channels: ["c"], isolation: "confined", egress: [] };
+    const spec: AgentSpec = { name: "deny", channels: ["c"], network: "restricted", egress: [] };
     const cfg = buildSandboxConfig({
       spec,
       baseBinds: { workspace, runtimeReadOnly: [] },
@@ -99,7 +99,7 @@ d("LIVE Seatbelt — network egress", () => {
 
   test("a spec that adds an egress host gets that host on the allowlist (additive)", async () => {
     workspace = mkdtempSync(join(tmpdir(), "sbx-live-add-"));
-    const spec: AgentSpec = { name: "add", channels: ["c"], isolation: "confined", egress: ["example.com"] };
+    const spec: AgentSpec = { name: "add", channels: ["c"], network: "restricted", egress: ["example.com"] };
     const cfg = buildSandboxConfig({
       spec,
       baseBinds: { workspace, runtimeReadOnly: [] },
@@ -122,7 +122,7 @@ d("LIVE Seatbelt — filesystem read confinement", () => {
     const secretFile = join(secretDir, "secret.txt");
     writeFileSync(secretFile, "TOPSECRET-do-not-read");
     try {
-      const spec: AgentSpec = { name: "read", channels: ["c"], isolation: "confined", egress: [] };
+      const spec: AgentSpec = { name: "read", channels: ["c"], network: "restricted", egress: [] };
       const cfg = buildSandboxConfig({
         spec,
         baseBinds: { workspace, runtimeReadOnly: [] },
@@ -154,7 +154,7 @@ d("LIVE Seatbelt — filesystem read confinement", () => {
     const secretFile = join(secretDir, "home-secret.txt");
     writeFileSync(secretFile, "HOME-TOPSECRET-do-not-read");
     try {
-      const spec: AgentSpec = { name: "homeread", channels: ["c"], isolation: "confined", egress: [] };
+      const spec: AgentSpec = { name: "homeread", channels: ["c"], network: "restricted", egress: [] };
       // buildSandboxConfig with platform "darwin" → denyRead:["/Users"],
       // allowRead:[workspace]. We pass the config THROUGH unmodified.
       const cfg = buildSandboxConfig({
@@ -183,11 +183,50 @@ d("LIVE Seatbelt — filesystem read confinement", () => {
     }
   }, 60_000);
 
+  test("DEFAULT POSTURE: ~/.parachute (operator.token's dir) is UNREADABLE, the workspace IS readable, network is OPEN", async () => {
+    // The security guarantee Aaron asked for: the DEFAULT spawn (no filesystem/no
+    // network knob) must (a) be unable to read the operator's secrets — modelled by
+    // a decoy planted in the REAL ~/.parachute, exactly where operator.token lives —
+    // while (b) still having the workspace readable and (c) the network fully OPEN.
+    // Reads scoped by default; internet open by default.
+    const home = homedir();
+    workspace = mkdtempSync(join(home, ".sbx-live-default-ws-"));
+    const decoy = join(home, ".parachute", `.sbx-live-decoy-${process.pid}.txt`);
+    writeFileSync(decoy, "OPERATOR-TOKEN-DECOY-do-not-read");
+    try {
+      // DEFAULT spec: neither filesystem nor network set → workspace-scoped reads + open net.
+      const spec: AgentSpec = { name: "deflt", channels: ["c"] };
+      const cfg = buildSandboxConfig({
+        spec,
+        baseBinds: { workspace, runtimeReadOnly: [] },
+        egressBase: { hubOrigin: "http://127.0.0.1:1939" },
+        platform: "darwin",
+      });
+      // Defaults: scoped reads (/Users denied) + OPEN network (no allowedDomains).
+      expect(cfg.filesystem.denyRead).toEqual(["/Users"]);
+      expect((cfg.network as { allowedDomains?: string[] }).allowedDomains).toBeUndefined();
+
+      // (a) the decoy in ~/.parachute is DENIED — operator.token is equally unreadable.
+      const blocked = await runSandboxed(cfg, `cat ${decoy}`);
+      expect(blocked.code).not.toBe(0);
+      expect(blocked.stdout).not.toContain("OPERATOR-TOKEN-DECOY");
+
+      // (b) positive control: a workspace file IS readable under the SAME config.
+      const inside = join(workspace, "inside.txt");
+      writeFileSync(inside, "WORKSPACE-readable-by-default");
+      const ok = await runSandboxed(cfg, `cat ${inside}`);
+      expect(ok.code).toBe(0);
+      expect(ok.stdout).toContain("WORKSPACE-readable-by-default");
+    } finally {
+      rmSync(decoy, { force: true });
+    }
+  }, 60_000);
+
   test("ALLOWED: reading a file INSIDE the workspace bind succeeds", async () => {
     workspace = mkdtempSync(join(tmpdir(), "sbx-live-read-ok-"));
     const f = join(workspace, "inside.txt");
     writeFileSync(f, "READABLE-inside-workspace");
-    const spec: AgentSpec = { name: "readok", channels: ["c"], isolation: "confined", egress: [] };
+    const spec: AgentSpec = { name: "readok", channels: ["c"], network: "restricted", egress: [] };
     const cfg = buildSandboxConfig({
       spec,
       baseBinds: { workspace, runtimeReadOnly: [] },
@@ -204,7 +243,7 @@ d("LIVE Seatbelt — filesystem read confinement", () => {
     const outsideDir = mkdtempSync(join(tmpdir(), "sbx-live-outside-"));
     const target = join(outsideDir, "should-not-exist.txt");
     try {
-      const spec: AgentSpec = { name: "write", channels: ["c"], isolation: "confined", egress: [] };
+      const spec: AgentSpec = { name: "write", channels: ["c"], network: "restricted", egress: [] };
       const cfg = buildSandboxConfig({
         spec,
         baseBinds: { workspace, runtimeReadOnly: [] },
@@ -223,7 +262,7 @@ d("LIVE Seatbelt — filesystem read confinement", () => {
   test("ALLOWED: writing INSIDE the workspace succeeds", async () => {
     workspace = mkdtempSync(join(tmpdir(), "sbx-live-write-ok-"));
     const target = join(workspace, "out.txt");
-    const spec: AgentSpec = { name: "writeok", channels: ["c"], isolation: "confined", egress: [] };
+    const spec: AgentSpec = { name: "writeok", channels: ["c"], network: "restricted", egress: [] };
     const cfg = buildSandboxConfig({
       spec,
       baseBinds: { workspace, runtimeReadOnly: [] },

--- a/src/sandbox/mounts.ts
+++ b/src/sandbox/mounts.ts
@@ -71,14 +71,14 @@ export function composeFilesystemView(
     if (m.mode === "rw") writePaths.push(m.hostPath);
   }
 
-  // WRITES are confined in BOTH postures (workspace + rw mounts) — the agent
-  // never escapes its workspace or corrupts the operator's files, regardless of
-  // read scope. READS depend on the posture:
-  //   - scopedReads (confined): deny the home tree, re-allow the read surface
-  //     within it (workspace + runtime/config + mounts). The isolation control.
-  //   - broad (trusted, the default for owner-operated agents): no deny — claude
-  //     reads its binary, the system, and the operator's files freely, so its own
-  //     runtime never collides with a deny. (System paths are readable in both.)
+  // WRITES are confined in BOTH cases (workspace + rw mounts) — the agent never
+  // escapes its workspace or corrupts the operator's files, regardless of read
+  // scope. READS depend on `filesystem`:
+  //   - scopedReads (filesystem "workspace", the DEFAULT): deny the home tree,
+  //     re-allow the read surface within it (workspace + runtime/config + mounts).
+  //     Keeps the operator's secrets (e.g. ~/.parachute/operator.token) unreadable.
+  //   - broad (filesystem "full", explicit opt-in): no deny — claude reads the
+  //     whole disk. (System paths are readable in both.)
   if (!scopedReads) {
     return { denyRead: [], allowRead: [], allowWrite: dedupePreserveOrder(writePaths), denyWrite: [] };
   }

--- a/src/sandbox/sandbox.test.ts
+++ b/src/sandbox/sandbox.test.ts
@@ -41,12 +41,13 @@ function fakeEngine(): SandboxEngine & {
   return rec;
 }
 
-// CONFINED so the config-shape assertions (allowedDomains floor, /Users deny)
-// apply; trusted is the default elsewhere and covered in config.test.ts.
+// network "restricted" so the allowedDomains-floor assertion applies; the /Users
+// read-deny applies via the DEFAULT filesystem "workspace" (scoped reads). The
+// open-network default is covered in config.test.ts.
 const SPEC: AgentSpec = {
   name: "arm",
   channels: ["ch"],
-  isolation: "confined",
+  network: "restricted",
   egress: ["registry.npmjs.org"],
   mounts: [{ hostPath: "/proj", mountPath: "/work", mode: "rw" }],
 };
@@ -95,12 +96,12 @@ describe("Sandbox adapter", () => {
     expect(engine.calls).toEqual(["reset", "initialize", "wrap"]);
   });
 
-  test("a CONFINED spawn's proxy env does NOT leak into a later TRUSTED spawn (the real-bug scenario)", async () => {
+  test("a RESTRICTED-network spawn's proxy env does NOT leak into a later OPEN spawn (the real-bug scenario)", async () => {
     // A leak-MODELING engine, mirroring the real singleton: `initialize` turns the
-    // proxy on iff the config has an allowlist (confined); `wrap` emits HTTP_PROXY
-    // iff the proxy is on; `reset` turns it off. Without the reset-before-init in
-    // Sandbox.wrap, the proxy would still be on from the confined spawn and leak
-    // into the trusted spawn's env — exactly the live failure.
+    // proxy on iff the config has an allowlist (restricted network); `wrap` emits
+    // HTTP_PROXY iff the proxy is on; `reset` turns it off. Without the
+    // reset-before-init in Sandbox.wrap, the proxy would still be on from the
+    // restricted spawn and leak into the open spawn's env — exactly the live failure.
     let proxyOn = false;
     const engine: SandboxEngine = {
       isSupportedPlatform: () => true,
@@ -116,14 +117,14 @@ describe("Sandbox adapter", () => {
       },
     };
     const sandbox = new Sandbox(engine);
-    // 1) confined spawn → allowlist present → proxy on, HTTP_PROXY present.
-    const confined = await sandbox.wrap({ spec: { name: "r", channels: ["c"], isolation: "confined" }, baseBinds: BASE_BINDS, egressBase: EGRESS_BASE, command: "claude" });
-    expect(confined.env.HTTP_PROXY).toBeDefined();
-    // 2) trusted spawn right after (the default) → the per-wrap reset clears the
+    // 1) restricted-network spawn → allowlist present → proxy on, HTTP_PROXY present.
+    const restricted = await sandbox.wrap({ spec: { name: "r", channels: ["c"], network: "restricted" }, baseBinds: BASE_BINDS, egressBase: EGRESS_BASE, command: "claude" });
+    expect(restricted.env.HTTP_PROXY).toBeDefined();
+    // 2) open-network spawn right after (the default) → the per-wrap reset clears the
     //    proxy, so NO stale HTTP_PROXY leaks in (the bug: claude would route to the
     //    dead proxy + die).
-    const trusted = await sandbox.wrap({ spec: { name: "o", channels: ["c"] }, baseBinds: BASE_BINDS, egressBase: EGRESS_BASE, command: "claude" });
-    expect(trusted.env.HTTP_PROXY).toBeUndefined();
+    const open = await sandbox.wrap({ spec: { name: "o", channels: ["c"] }, baseBinds: BASE_BINDS, egressBase: EGRESS_BASE, command: "claude" });
+    expect(open.env.HTTP_PROXY).toBeUndefined();
   });
 
   test("reset() tears the engine down", async () => {
@@ -138,11 +139,11 @@ describe("Sandbox adapter", () => {
     expect(new Sandbox(engine).isSupportedPlatform()).toBe(true);
   });
 
-  test("SECURITY: a confined spec omitting egress still gets the base floor in the engine config", async () => {
+  test("SECURITY: a restricted-network spec omitting egress still gets the base floor in the engine config", async () => {
     const engine = fakeEngine();
     const sandbox = new Sandbox(engine);
     await sandbox.wrap({
-      spec: { name: "x", channels: ["c"], isolation: "confined" }, // confined, no egress declared
+      spec: { name: "x", channels: ["c"], network: "restricted" }, // restricted, no egress declared
       baseBinds: BASE_BINDS,
       egressBase: EGRESS_BASE,
       command: "claude",

--- a/src/sandbox/types.ts
+++ b/src/sandbox/types.ts
@@ -111,40 +111,58 @@ export interface AgentSpec {
   /** Additional MCP servers, by URL. */
   otherMcps?: OtherMcpSpec[];
   /**
-   * Isolation posture — the single knob that sets BOTH the read scope and the
-   * network egress, matched to the trust gradient:
+   * Filesystem READ scope — ONE of Anthropic's two containment boundaries
+   * (https://www.anthropic.com/engineering/claude-code-sandboxing). Orthogonal to
+   * {@link network} — the agent's reach into the local disk and its reach onto the
+   * network are independent controls, deliberately NOT bundled.
    *
-   *   - `"trusted"` (DEFAULT): the operator's own self-spawned agent on a flat
-   *     trust gradient. Reads are BROAD (the runtime default — claude reads its
-   *     binary, the system, the operator's files without per-path binds) and the
-   *     network is OPEN. Writes are still confined to the per-session workspace
-   *     (which holds the agent's private HOME), so it can't corrupt the operator's
-   *     real config or escape its workspace. This is what makes the sandbox STABLE
-   *     for running claude — claude's own runtime never collides with a deny.
+   *   - `"workspace"` (DEFAULT): SCOPED reads. The home tree (`/Users` on macOS,
+   *     `/home` on Linux) is DENIED, then re-allowed ONLY for the per-session
+   *     workspace + the claude runtime + declared mounts. The agent literally
+   *     cannot read the operator's secrets — `~/.parachute/operator.token` (the
+   *     hub bearer), SSH keys, other projects — even though the network is open.
+   *     This is the security-correct default: scoped disk, exfiltration surface
+   *     removed at the source.
    *
-   *   - `"confined"`: for an agent fed FOREIGN/untrusted input. Reads are SCOPED
-   *     (home tree denied, re-allowed to workspace + the claude runtime + declared
-   *     mounts) and egress is RESTRICTED to the non-removable base
-   *     (`{ Anthropic API, hub/vault }`) UNIONed with `egress[]`. The real
-   *     isolation surface — only turn it on when the agent processes input you
-   *     don't trust.
+   *   - `"full"`: BROAD reads (the runtime default — the whole filesystem is
+   *     readable). An explicit, deliberate escape hatch for the rare agent that
+   *     genuinely needs to read across the operator's disk AND is trusted not to
+   *     leak it. Combined with `network: "open"` this is the maximum-reach posture
+   *     — only choose it knowingly.
    *
-   * Defaults to `"trusted"` (owner-operated). The per-session writable HOME +
-   * temp + onboarding seed are provided in BOTH postures (claude must always be
-   * able to run); `isolation` only governs reach BEYOND claude's own runtime.
+   * WRITES are confined to the per-session workspace + rw mounts in BOTH cases
+   * (the agent can never corrupt the operator's files or escape its workspace),
+   * exactly per Anthropic's "read/write the cwd, block outside" model.
    */
-  isolation?: "trusted" | "confined";
+  filesystem?: "workspace" | "full";
+  /**
+   * Network egress — the SECOND containment boundary, orthogonal to
+   * {@link filesystem}:
+   *
+   *   - `"open"` (DEFAULT): full internet, no restriction. The right default for
+   *     an owner-operated agent on a trusted box (claude needs the network to be
+   *     useful) — SAFE because the `"workspace"` filesystem default already keeps
+   *     local secrets unreadable, so "open network" can't exfiltrate what the
+   *     agent can't see.
+   *
+   *   - `"restricted"`: egress confined to a non-removable base
+   *     (`{ Anthropic API, hub/vault }`) UNIONed with {@link egress}. For an agent
+   *     fed FOREIGN/untrusted input, where you want to bound where it can reach
+   *     even for data it legitimately holds.
+   */
+  network?: "open" | "restricted";
   /**
    * Network egress hosts ADDITIVE to the non-removable base — only meaningful
-   * under `isolation: "confined"` (in `"trusted"` the network is fully open, so
-   * this is ignored). A confined code-building agent opens exactly the
-   * package/source hosts it needs here.
+   * under `network: "restricted"` (when the network is `"open"` this is ignored).
+   * A restricted code-building agent opens exactly the package/source hosts it
+   * needs here.
    */
   egress?: string[];
   /**
    * Filesystem mounts — ADDITIVE to the default private per-session workspace
-   * (rw) + the implicit runtime/claude-config (ro). Reads are scoped to declared
-   * binds, NOT broad (design §4.5).
+   * (rw) + the implicit runtime/claude-config (ro). Under `filesystem:
+   * "workspace"` (the default) these are the ONLY host paths re-allowed for
+   * reads beyond the workspace — mount the project you want the agent to work on.
    */
   mounts?: AgentMount[];
   /**

--- a/src/spawn-agent-cli.test.ts
+++ b/src/spawn-agent-cli.test.ts
@@ -80,11 +80,14 @@ describe("parseArgs — name + channels + vault + egress + mounts → the right 
     expect(spec!.channels[1]).toEqual({ name: "second" });
   });
 
-  test("default is trusted (no isolation field); --confined sets it + keeps --egress", () => {
-    expect(parseArgs(["a", "--channel", "c"]).spec!.isolation).toBeUndefined(); // default trusted
-    const { spec } = parseArgs(["a", "--channel", "c", "--egress", "x.com", "--confined"]);
-    expect(spec!.isolation).toBe("confined");
-    expect(spec!.egress).toEqual(["x.com"]); // additive hosts kept (used under confined)
+  test("defaults omit filesystem/network; --full-read + --restricted set them + keep --egress", () => {
+    const def = parseArgs(["a", "--channel", "c"]).spec!;
+    expect(def.filesystem).toBeUndefined(); // default = workspace (scoped reads)
+    expect(def.network).toBeUndefined(); // default = open
+    const { spec } = parseArgs(["a", "--channel", "c", "--egress", "x.com", "--full-read", "--restricted"]);
+    expect(spec!.filesystem).toBe("full");
+    expect(spec!.network).toBe("restricted");
+    expect(spec!.egress).toEqual(["x.com"]); // additive hosts kept (used under restricted)
   });
 });
 

--- a/src/spawn-agent.test.ts
+++ b/src/spawn-agent.test.ts
@@ -257,7 +257,7 @@ describe("spawnAgent — full wiring with stubs (no real token)", () => {
       name: "aaron-dev",
       channels: ["aaron-dev"],
       vault: { name: "default", access: "read", tags: ["#channel-message"] },
-      isolation: "confined", // exercise the egress floor + scoped reads (step 6)
+      network: "restricted", // exercise the egress floor; scoped reads are the default (step 6)
     };
     const res = await spawnAgent(spec, baseDeps({ tmux, sandboxEngine: engine }));
 


### PR DESCRIPTION
## Why

The single `isolation: "trusted" | "confined"` knob (shipped in #59) bundled two genuinely independent controls — and its `trusted` **default left filesystem reads fully open**. A default agent could read `~/.parachute/operator.token` (the hub bearer that mints tokens for everything), SSH keys, every other project on disk. Paired with the open-network default, a prompt-injected agent could exfiltrate them. Aaron caught this:

> the open default might turn sandboxing totally off? Which means it can read anything on my system, including ~/.parachute/operator.token... the default I want is for us to be sandboxed into our part of the file system... but still being able to have full internet access.

That's also Anthropic's containment model — [two boundaries, filesystem **and** network](https://www.anthropic.com/engineering/claude-code-sandboxing), treated independently.

## What

Split the one knob into the two orthogonal boundaries:

| axis | values | default | meaning |
|---|---|---|---|
| `filesystem` | `"workspace"` / `"full"` | **`workspace`** | workspace = scoped reads (home tree denied, re-allowed only for workspace + claude runtime + mounts); full = broad reads (explicit opt-in) |
| `network` | `"open"` / `"restricted"` | **`open`** | open = full internet; restricted = base floor ∪ `egress[]` |

**New default: scoped reads + open network** — locked to its own slice of disk, full internet. Open network is *safe* as the default precisely because the workspace filesystem default keeps local secrets unreadable: open net can't exfiltrate what the agent can't see. **Writes stay confined to the workspace in both filesystem modes** (Anthropic's "read/write the cwd, block outside").

## Surface changes
- **CLI**: `--confined` → `--full-read` + `--restricted` (independent)
- **Web UI**: one "Isolation" select → two ("Filesystem" / "Network"), each defaulting to the safe value; the Filesystem note calls out `~/.parachute/operator.token` by name
- **API**: request/result `isolation` → `filesystem` + `network`

## Verification (real Seatbelt + a live running agent)
- **New live-Seatbelt regression test** (`live-seatbelt.test.ts`): under the **default** spec, a decoy planted in the *real* `~/.parachute` (operator.token's dir) is **unreadable**, the workspace **is** readable (positive control), and `allowedDomains` is absent (network open). Runs on real sandbox-exec.
- **Live default-posture spawn**: claude reaches its TUI, channels active, vault MCP connected, **no setup-issue notice** (the confined "1 setup issue: MCP" was egress-only — open net resolves it), autonomous.
- **Live operator.token read attempt** from inside the running agent's Bash tool → `cat: /Users/parachute/.parachute/operator.token: Operation not permitted`.

406 tests pass; typecheck clean (the 2 pre-existing `bridge.ts` TS2589s aside).

🤖 Generated with [Claude Code](https://claude.com/claude-code)