### PR TITLE
feat(ui): shared app shell — unify the channel pages on the Parachute brand

### DIFF
--- a/src/admin-ui.ts
+++ b/src/admin-ui.ts
@@ -65,6 +65,8 @@
  * one add-form, switched by the transport select.
  */
 
+import { THEME_CSS, appShell, SHELL_JS } from "./ui-kit.ts";
+
 const PALETTE = {
   bg: "#faf8f4",
   bgSoft: "#f3f0ea",
@@ -83,8 +85,8 @@ const PALETTE = {
   successSoft: "rgba(61, 104, 73, 0.08)",
 } as const;
 
-const FONT_SERIF = `Georgia, "Times New Roman", serif`;
-const FONT_SANS = `-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif`;
+// Mono is the only font const still referenced by the page-specific STYLES;
+// the shared THEME_CSS owns the sans/serif tokens now.
 const FONT_MONO = `ui-monospace, "SF Mono", Menlo, Monaco, "Cascadia Mono", monospace`;
 
 /**
@@ -133,24 +135,15 @@ export function renderAdminPage(mount = ""): string {
   <title>Channel — Configuration</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="referrer" content="no-referrer" />
-  <style>${STYLES}</style>
+  <style>${THEME_CSS}${STYLES}</style>
 </head>
 <body>
+  ${appShell({ active: "config", tag: "configuration", status: "" })}
   <main>
     <div class="card">
       <header class="card-header">
-        <div class="brand">
-          <span class="brand-mark">C</span>
-          <span class="brand-name">Channel</span>
-          <span class="brand-tag">configuration</span>
-        </div>
         <h1>Manage channels</h1>
         <p class="subtitle">Add and remove the channels your Claude Code sessions talk over. Each channel is bound to one transport.</p>
-        <p class="subtitle" style="margin-top:6px;">
-          <a id="nav-agents" href="#">Agents →</a> spawn &amp; watch sandboxed sessions ·
-          <a id="nav-chat" href="#">Chat</a> ·
-          <a id="nav-terminal" href="#">Terminal</a>
-        </p>
       </header>
 
       <div id="status-banner" class="banner" hidden></div>
@@ -265,23 +258,21 @@ export function renderAdminPage(mount = ""): string {
       }
     })();
   </script>
-  <script>${PAGE_SCRIPT}</script>
+  <script>${SHELL_JS}${PAGE_SCRIPT}</script>
 </body>
 </html>`;
 }
 
+/**
+ * Page-specific styles, layered AFTER ${THEME_CSS} (the shared kit). The kit
+ * owns the tokens, base elements, header/nav shell, banners, buttons, inputs,
+ * fields, dot, h1/subtitle/section-title. These rules are the bits unique to the
+ * config page: the centered card layout, the section dividers, the channel-row
+ * list, the link-result panel, and the footer. The page is LIGHT-only now (the
+ * old prefers-color-scheme dark block was dropped — every channel page is the
+ * one brand-light look; only the terminal CONTENT pane stays black).
+ */
 const STYLES = `
-  *, *::before, *::after { box-sizing: border-box; }
-  html, body { margin: 0; padding: 0; }
-  body {
-    font-family: ${FONT_SANS};
-    background: ${PALETTE.bg};
-    color: ${PALETTE.fg};
-    line-height: 1.55;
-    min-height: 100vh;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-  }
   main { display: flex; justify-content: center; padding: 2.5rem 1.5rem; }
   .card {
     width: 100%;
@@ -293,65 +284,8 @@ const STYLES = `
     box-shadow: 0 1px 2px rgba(44, 42, 38, 0.04), 0 8px 24px rgba(44, 42, 38, 0.06);
   }
   .card-header { margin-bottom: 1.5rem; }
-  .brand {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    color: ${PALETTE.accent};
-    font-weight: 500;
-    font-size: 0.95rem;
-    margin-bottom: 1.25rem;
-  }
-  .brand-mark {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 1.5rem;
-    height: 1.5rem;
-    border-radius: 50%;
-    background: ${PALETTE.accent};
-    color: ${PALETTE.cardBg};
-    font-weight: 600;
-    font-size: 0.85rem;
-    line-height: 1;
-  }
-  .brand-name { letter-spacing: 0.01em; font-weight: 600; }
-  .brand-tag {
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    font-size: 0.7rem;
-    color: ${PALETTE.fgDim};
-    border-left: 1px solid ${PALETTE.border};
-    padding-left: 0.55rem;
-    margin-left: 0.15rem;
-  }
-  h1 {
-    font-family: ${FONT_SERIF};
-    font-weight: 400;
-    font-size: 1.75rem;
-    line-height: 1.2;
-    margin: 0 0 0.4rem;
-    color: ${PALETTE.fg};
-  }
-  .subtitle { margin: 0; color: ${PALETTE.fgMuted}; font-size: 0.95rem; }
-
-  .banner {
-    margin: 0 0 1.25rem;
-    padding: 0.75rem 0.9rem;
-    border-radius: 6px;
-    font-size: 0.9rem;
-    border: 1px solid transparent;
-  }
-  .banner-error { background: ${PALETTE.dangerSoft}; border-color: ${PALETTE.danger}; color: ${PALETTE.danger}; }
-  .banner-success { background: ${PALETTE.successSoft}; border-color: ${PALETTE.success}; color: ${PALETTE.success}; }
-  .banner-warn { background: ${PALETTE.bgSoft}; border-color: ${PALETTE.border}; color: ${PALETTE.fgMuted}; }
-  .banner code {
-    font-family: ${FONT_MONO};
-    font-size: 0.85em;
-    background: rgba(255,255,255,0.5);
-    padding: 0.05rem 0.3rem;
-    border-radius: 3px;
-  }
+  /* The card's h1 is a touch larger than the kit's default page h1. */
+  .card-header h1 { font-size: 1.75rem; }
 
   .section {
     display: flex;
@@ -363,13 +297,6 @@ const STYLES = `
   }
   #list-section { border-top: none; padding-top: 0; margin-top: 0; }
   .section-head { display: flex; align-items: center; justify-content: space-between; gap: 0.5rem; }
-  .section-title {
-    font-family: ${FONT_SERIF};
-    font-weight: 400;
-    font-size: 1.2rem;
-    margin: 0;
-    color: ${PALETTE.fg};
-  }
   .section-desc { margin: 0; font-size: 0.85rem; color: ${PALETTE.fgMuted}; }
   .section-desc code, .field-hint code {
     font-family: ${FONT_MONO};
@@ -411,8 +338,6 @@ const STYLES = `
   }
   .channel-vault { font-size: 0.78rem; color: ${PALETTE.fgDim}; }
   .channel-status { margin-left: auto; display: inline-flex; align-items: center; gap: 0.35rem; font-size: 0.8rem; }
-  .dot { width: 0.55rem; height: 0.55rem; border-radius: 50%; display: inline-block; background: ${PALETTE.fgDim}; }
-  .dot.live { background: ${PALETTE.accent}; }
   .channel-status .clients { color: ${PALETTE.fgDim}; }
   .btn-remove {
     font: inherit;
@@ -430,49 +355,13 @@ const STYLES = `
   .btn-remove:disabled { opacity: 0.5; cursor: progress; }
 
   .add-form { display: flex; flex-direction: column; gap: 1rem; }
-  .field { display: flex; flex-direction: column; gap: 0.3rem; }
-  /* The author \`display:flex\` above outranks the UA \`[hidden]{display:none}\`
-     rule, so a per-transport field with the \`hidden\` attribute would still
-     render. Re-assert the hide at matching specificity so applyTransportUI's
-     \`field.hidden = …\` toggling actually shows/hides the field. */
-  .field[hidden] { display: none; }
-  .field-label { font-size: 0.85rem; font-weight: 500; color: ${PALETTE.fgMuted}; letter-spacing: 0.01em; }
-  .field-hint { font-size: 0.8rem; color: ${PALETTE.fgDim}; }
-  .field-error { font-size: 0.8rem; color: ${PALETTE.danger}; font-weight: 500; }
-
-  select, input[type=text], input[type=password] {
-    font: inherit;
-    width: 100%;
-    padding: 0.55rem 0.7rem;
-    border: 1px solid ${PALETTE.border};
-    border-radius: 6px;
-    background: ${PALETTE.bg};
-    color: ${PALETTE.fg};
-    transition: border-color 0.15s ease, background 0.15s ease;
-  }
+  /* A focus ring on inputs/selects — a touch richer than the kit's plain focus. */
   select:focus, input:focus {
-    outline: none;
-    border-color: ${PALETTE.accent};
     background: ${PALETTE.cardBg};
     box-shadow: 0 0 0 3px ${PALETTE.accentSoft};
   }
   .field-invalid select, .field-invalid input { border-color: ${PALETTE.danger}; }
-
-  .btn {
-    font: inherit;
-    font-weight: 500;
-    padding: 0.6rem 1.1rem;
-    border-radius: 6px;
-    border: 1px solid transparent;
-    cursor: pointer;
-    transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
-  }
-  .btn-sm { padding: 0.3rem 0.7rem; font-size: 0.82rem; }
-  .btn-primary { background: ${PALETTE.accent}; color: ${PALETTE.cardBg}; }
-  .btn-primary:hover { background: ${PALETTE.accentHover}; }
-  .btn-primary:disabled { background: ${PALETTE.fgDim}; cursor: progress; }
-  .btn-secondary { background: ${PALETTE.cardBg}; color: ${PALETTE.fgMuted}; border-color: ${PALETTE.border}; }
-  .btn-secondary:hover { color: ${PALETTE.fg}; border-color: ${PALETTE.fgDim}; }
+  .btn-primary:disabled { background: ${PALETTE.fgDim}; border-color: ${PALETTE.fgDim}; cursor: progress; }
   .button-row { display: flex; gap: 0.6rem; margin-top: 0.25rem; }
 
   #link-result {
@@ -528,26 +417,10 @@ const STYLES = `
   .footer-hint a { color: ${PALETTE.accent}; }
   .footer-hint a:hover { color: ${PALETTE.accentHover}; }
 
-  @media (prefers-color-scheme: dark) {
-    body { background: #1a1815; color: #e8e4dc; }
-    .card { background: #25221d; border-color: #3a362f; box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3); }
-    h1, .section-title { color: #f0ece4; }
-    .subtitle, .section-desc, .field-label, .field-hint { color: #a8a29a; }
-    .channel-row { background: #1f1c18; border-color: #3a362f; }
-    .channel-transport { background: #2a2620; }
-    select, input[type=text], input[type=password] { background: #1f1c18; border-color: #3a362f; color: #e8e4dc; }
-    select:focus, input:focus { background: #25221d; }
-    .btn-secondary { background: #25221d; border-color: #3a362f; color: #a8a29a; }
-    .btn-secondary:hover { color: #e8e4dc; border-color: #6b6860; }
-    .card-footer, .section { border-color: #3a362f; }
-    .loading { background: #1f1c18; }
-    .section-desc code, .field-hint code, .footer-hint code { background: #2a2620; }
-  }
-
   @media (max-width: 600px) {
     main { padding: 1rem; }
     .card { padding: 1.5rem 1.25rem; border-radius: 10px; }
-    h1 { font-size: 1.45rem; }
+    .card-header h1 { font-size: 1.45rem; }
     .button-row .btn { width: 100%; }
     .channel-row { flex-wrap: wrap; }
     .channel-status { margin-left: 0; }
@@ -569,38 +442,21 @@ const PAGE_SCRIPT = String.raw`
   var MOUNT = window.__CHANNEL_MOUNT__ || "";
   var API_URL = window.__CHANNEL_API_URL__ || "/api/channels";
 
-  // Wire the header nav links to the sibling surfaces under the same mount.
-  (function wireNav() {
-    var map = { "nav-agents": "/agents", "nav-chat": "/ui", "nav-terminal": "/terminal" };
-    Object.keys(map).forEach(function (id) {
-      var a = document.getElementById(id);
-      if (a) a.href = MOUNT + map[id];
-    });
-  })();
+  // Wire the shared app-shell nav (hrefs from MOUNT + the active tab) for the
+  // config view. wireShell + MOUNT come from SHELL_JS; the admin page sets its
+  // own MOUNT from window.__CHANNEL_MOUNT__ (the runtime-detected prefix) just
+  // above, which wireShell then reads.
+  wireShell("config");
 
   // --- Auth: a channel:admin Bearer minted by the hub --------------------
   // The channel config API (/api/channels) requires a hub JWT with
-  // channel:admin. The hub mints one for the logged-in portal operator at
-  // <origin>/admin/channel-token (cookie-gated) -- the same endpoint the chat
-  // UI uses. We fetch it from the page origin (which IS the hub origin when
-  // served through the expose) and attach it as a Bearer on every API call.
-  // A direct-to-daemon / not-logged-in load leaves the token null and surfaces
-  // a notice -- the daemon's requireScope then 401s the API calls.
-  window.__token = null;
-  function fetchToken() {
-    return fetch(window.location.origin + "/admin/channel-token", { credentials: "include" })
-      .then(function (r) {
-        if (!r.ok) throw new Error("token " + r.status);
-        return r.json();
-      })
-      .then(function (j) {
-        window.__token = j && j.token ? j.token : null;
-        return window.__token;
-      })
-      .catch(function (_err) {
-        window.__token = null;
-        return null;
-      });
+  // channel:admin. fetchToken (SHELL_JS) mints one for the logged-in portal
+  // operator at <origin>/admin/channel-token (cookie-gated) and caches it on
+  // window.__token; it REJECTS on failure. ensureToken wraps it to resolve to
+  // null instead, so boot still proceeds to loadChannels -- which surfaces the
+  // no-auth banner on the resulting 401 (one clear notice, not two).
+  function ensureToken() {
+    return fetchToken().catch(function (_err) { return null; });
   }
 
   function authHeaders(extra) {
@@ -708,14 +564,8 @@ const PAGE_SCRIPT = String.raw`
     }
   }
 
-  function escapeHtml(s) {
-    return String(s)
-      .replace(/&/g, "&amp;")
-      .replace(/</g, "&lt;")
-      .replace(/>/g, "&gt;")
-      .replace(/"/g, "&quot;")
-      .replace(/'/g, "&#39;");
-  }
+  // escapeHtml comes from SHELL_JS (identical 5-char escape) — the page's many
+  // setBanner(...) interpolations reuse it, one escaping discipline page-wide.
 
   // --- List + render ------------------------------------------------------
   // Two reads: /api/channels (channel:admin, the authoritative config list:
@@ -1346,7 +1196,7 @@ const PAGE_SCRIPT = String.raw`
     // list. A token failure still proceeds to loadChannels -- which surfaces the
     // no-auth banner on the resulting 401, so the operator sees one clear notice.
     // The vault dropdown loads in parallel (public discovery doc, no token).
-    fetchToken().then(loadChannels);
+    ensureToken().then(loadChannels);
     loadVaults();
   });
 `;

--- a/src/agents-ui.ts
+++ b/src/agents-ui.ts
@@ -311,7 +311,7 @@ ${SHELL_JS}
     var note = document.getElementById("spawn-note");
     if (!defaultSet && (!overrides || !overrides.length)) {
       note.textContent = "⚠ no Claude credential set — set one above before spawning.";
-      note.style.color = "var(--danger)";
+      note.style.color = "var(--warn)";
     } else { note.textContent = ""; }
   }
 

--- a/src/agents-ui.ts
+++ b/src/agents-ui.ts
@@ -27,6 +27,8 @@
  * read back; the spawn result shows scopes but never minted token values.
  */
 
+import { THEME_CSS, appShell, SHELL_JS } from "./ui-kit.ts";
+
 export const AGENTS_UI_HTML = `<!doctype html>
 <html lang="en">
 <head>
@@ -35,70 +37,45 @@ export const AGENTS_UI_HTML = `<!doctype html>
 <meta name="referrer" content="no-referrer" />
 <title>parachute-channel · agents</title>
 <style>
-  :root {
-    --bg: #0f1115; --panel: #171a21; --line: #262b36; --fg: #e6e9ef;
-    --muted: #8b93a3; --accent: #4cc2a0; --danger: #e0796b; --warn: #d9b25f;
-  }
-  * { box-sizing: border-box; }
-  html, body { margin: 0; }
-  body {
-    background: var(--bg); color: var(--fg);
-    font: 14px/1.5 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-    padding-bottom: 48px;
-  }
-  header {
-    display: flex; align-items: center; gap: 14px;
-    padding: 12px 20px; border-bottom: 1px solid var(--line); background: var(--panel);
-    position: sticky; top: 0; z-index: 5;
-  }
-  header .brand { font-weight: 600; }
-  header .brand small { color: var(--muted); font-weight: 400; }
-  header nav { display: flex; gap: 12px; }
-  header nav a { color: var(--muted); text-decoration: none; font-size: 13px; }
-  header nav a:hover { color: var(--fg); text-decoration: underline; }
-  header .spacer { margin-left: auto; }
-  #status { font-size: 12px; color: var(--muted); }
-  #status.live { color: var(--accent); }
-  #status.err { color: var(--danger); }
+${THEME_CSS}
+  /* ---- Agents page layout (page-specific, layered after the shared kit) ---- */
+  .app-header { position: sticky; top: 0; z-index: 5; }
+  body { padding-bottom: 48px; }
   main { max-width: 940px; margin: 0 auto; padding: 20px; display: grid; gap: 20px; }
   section {
-    background: var(--panel); border: 1px solid var(--line); border-radius: 10px; padding: 16px 18px;
+    background: var(--card); border: 1px solid var(--border); border-radius: 12px; padding: 16px 18px;
+    box-shadow: 0 1px 2px rgba(44,42,38,0.04), 0 8px 24px rgba(44,42,38,0.06);
   }
-  section h2 { margin: 0 0 4px; font-size: 15px; }
-  section p.hint { margin: 0 0 14px; color: var(--muted); font-size: 13px; }
-  label { display: block; font-size: 12px; color: var(--muted); margin: 0 0 4px; }
-  input[type=text], input[type=password], select, textarea {
-    width: 100%; background: var(--bg); color: var(--fg);
-    border: 1px solid var(--line); border-radius: 6px; padding: 8px 10px; font: inherit;
-  }
+  section h2 { margin: 0 0 4px; font-size: 1.2rem; }
+  section p.hint { margin: 0 0 14px; color: var(--fg-muted); font-size: 0.85rem; }
+  label { display: block; font-size: 0.78rem; color: var(--fg-muted); margin: 0 0 4px; }
   .row { display: flex; gap: 10px; align-items: flex-end; flex-wrap: wrap; }
   .row > .grow { flex: 1 1 160px; }
   .grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
   .grid3 { display: grid; grid-template-columns: 1.4fr 1fr 1.2fr; gap: 12px; }
+  /* The agents page predates the kit's .btn classes; keep its bare <button>
+     selectors working by mapping them onto the brand tokens. .primary/.danger/
+     .ghost are page-local button modifiers (distinct from the kit's .btn-*). */
   button {
-    background: var(--bg); color: var(--fg); border: 1px solid var(--line);
+    background: var(--card); color: var(--fg); border: 1px solid var(--border);
     border-radius: 6px; padding: 8px 14px; font: inherit; cursor: pointer;
   }
-  button:hover { border-color: var(--muted); }
+  button:hover { border-color: var(--fg-dim); }
   button:disabled { opacity: .4; cursor: default; }
   button.primary { background: var(--accent); color: #06140f; border-color: var(--accent); font-weight: 600; }
-  button.danger { color: var(--danger); border-color: #3a2a2a; }
-  button.danger:hover { border-color: var(--danger); }
-  button.ghost { padding: 4px 9px; font-size: 12px; }
-  .pill { display: inline-block; padding: 2px 8px; border-radius: 999px; font-size: 11px; border: 1px solid var(--line); }
-  .pill.on { color: var(--accent); border-color: #244; }
-  .pill.off { color: var(--warn); border-color: #443; }
-  .pill.attached { color: var(--accent); border-color: #244; }
-  .pill.detached { color: var(--muted); }
-  table { width: 100%; border-collapse: collapse; font-size: 13px; }
-  th, td { text-align: left; padding: 8px 10px; border-bottom: 1px solid var(--line); vertical-align: middle; }
-  th { color: var(--muted); font-weight: 500; font-size: 12px; }
+  button.primary:hover { background: var(--accent-hover); border-color: var(--accent-hover); }
+  button.danger { color: var(--danger); border-color: var(--border); background: transparent; }
+  button.danger:hover { border-color: var(--danger); background: var(--danger-soft); }
+  button.ghost { padding: 4px 9px; font-size: 12px; background: transparent; border-color: transparent; color: var(--fg-muted); }
+  button.ghost:hover { background: var(--bg-soft); color: var(--fg); }
+  .pill.detached { color: var(--fg-dim); }
+  table { width: 100%; border-collapse: collapse; font-size: 0.85rem; }
+  th, td { text-align: left; padding: 8px 10px; border-bottom: 1px solid var(--border); vertical-align: middle; }
+  th { color: var(--fg-muted); font-weight: 500; font-size: 0.78rem; }
   td.actions { text-align: right; white-space: nowrap; }
   td.actions a, td.actions button { margin-left: 6px; }
-  a { color: var(--accent); text-decoration: none; }
-  a:hover { text-decoration: underline; }
-  details { margin-top: 14px; border-top: 1px solid var(--line); padding-top: 12px; }
-  details summary { cursor: pointer; color: var(--muted); font-size: 13px; user-select: none; }
+  details { margin-top: 14px; border-top: 1px solid var(--border); padding-top: 12px; }
+  details summary { cursor: pointer; color: var(--fg-muted); font-size: 0.85rem; user-select: none; }
   details[open] summary { color: var(--fg); margin-bottom: 12px; }
   .sub { display: grid; gap: 12px; }
   .extra-channels { display: grid; gap: 8px; }
@@ -108,26 +85,16 @@ export const AGENTS_UI_HTML = `<!doctype html>
   .mounts-rows { display: grid; gap: 8px; }
   .mounts-rows .mrow input { flex: 1 1 auto; }
   .mounts-rows .mrow select { flex: 0 0 90px; }
-  .msg { margin-top: 12px; padding: 10px 12px; border-radius: 8px; font-size: 13px; display: none; white-space: pre-wrap; }
-  .msg.ok { display: block; background: #11241d; color: var(--accent); border: 1px solid #244; }
-  .msg.err { display: block; background: #241313; color: var(--danger); border: 1px solid #3a2a2a; }
-  code { color: var(--fg); background: #0b0d11; padding: 1px 5px; border-radius: 4px; font-size: 12px; }
-  .scopes { margin: 8px 0 0; font-size: 12px; color: var(--muted); }
-  .muted { color: var(--muted); }
-  .empty { color: var(--muted); font-size: 13px; padding: 8px 2px; }
+  .msg { margin-top: 12px; padding: 10px 12px; border-radius: 8px; font-size: 0.85rem; display: none; white-space: pre-wrap; border: 1px solid transparent; }
+  .msg.ok { display: block; background: var(--success-soft); color: var(--success); border-color: var(--success); }
+  .msg.err { display: block; background: var(--danger-soft); color: var(--danger); border-color: var(--danger); }
+  code { font-family: var(--font-mono); color: var(--fg); background: var(--bg-soft); padding: 1px 5px; border-radius: 4px; font-size: 0.8rem; }
+  .scopes { margin: 8px 0 0; font-size: 0.78rem; color: var(--fg-muted); }
+  .empty { color: var(--fg-muted); font-size: 0.85rem; padding: 8px 2px; }
 </style>
 </head>
 <body>
-  <header>
-    <div class="brand">parachute-channel <small>· agents</small></div>
-    <nav>
-      <a id="nav-chat" href="#">Chat</a>
-      <a id="nav-terminal" href="#">Terminal</a>
-      <a id="nav-config" href="#">Config</a>
-    </nav>
-    <span class="spacer"></span>
-    <span id="status">connecting…</span>
-  </header>
+  ${appShell({ active: "agents", tag: "agents" })}
 
   <main>
     <!-- Claude credential -->
@@ -273,25 +240,16 @@ export const AGENTS_UI_HTML = `<!doctype html>
   </main>
 
 <script>
+${SHELL_JS}
 (function () {
-  // Served through the hub the page is /channel/agents; locally /agents. Derive
-  // the mount prefix so API + token + nav URLs resolve under the same prefix.
-  var MOUNT = location.pathname.replace(/\\/agents\\/?$/, "");
-  var statusEl = document.getElementById("status");
-  var TOKEN = null;
+  // MOUNT, setStatus, escapeHtml, fetchToken (caches on window.__token),
+  // authedFetch all come from SHELL_JS. Wire the shared nav for the agents view.
+  wireShell("agents");
   var knownChannels = [];
 
-  // Wire nav links under the same mount.
-  document.getElementById("nav-chat").href = MOUNT + "/ui";
-  document.getElementById("nav-terminal").href = MOUNT + "/terminal";
-  document.getElementById("nav-config").href = MOUNT + "/admin";
+  // esc is the page-local name for the shared escapeHtml (used widely below).
+  var esc = escapeHtml;
 
-  function setStatus(text, cls) { statusEl.textContent = text; statusEl.className = cls || ""; }
-  function esc(s) {
-    return String(s == null ? "" : s).replace(/[&<>"]/g, function (c) {
-      return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c];
-    });
-  }
   function showMsg(el, text, isErr) {
     // textContent (NOT innerHTML) — server/result strings flow through here, so
     // this deliberately avoids needing esc(): the browser never parses them as HTML.
@@ -300,18 +258,14 @@ export const AGENTS_UI_HTML = `<!doctype html>
   }
   function clearMsg(el) { el.textContent = ""; el.className = "msg"; }
 
-  // --- token (operator channel:admin, minted by the hub) ------------------
-  function fetchToken() {
-    return fetch(location.origin + "/admin/channel-token", { credentials: "include" })
-      .then(function (r) { if (!r.ok) throw new Error("token " + r.status); return r.json(); })
-      .then(function (j) { TOKEN = (j && j.token) ? j.token : null; return TOKEN; })
-      .catch(function (err) { TOKEN = null; setStatus("not authenticated", "err"); throw err; });
-  }
-
+  // --- token + API --------------------------------------------------------
+  // fetchToken (SHELL_JS) mints + caches the channel:admin Bearer on
+  // window.__token. api() is the agents-page JSON wrapper: it prefixes MOUNT,
+  // attaches the Bearer + a JSON content-type, and retries once on 401.
   function api(path, opts, _retried) {
     opts = opts || {};
     var headers = Object.assign({}, opts.headers || {});
-    if (TOKEN) headers["authorization"] = "Bearer " + TOKEN;
+    if (window.__token) headers["authorization"] = "Bearer " + window.__token;
     if (opts.body && !headers["content-type"]) headers["content-type"] = "application/json";
     return fetch(MOUNT + path, Object.assign({}, opts, { headers: headers })).then(function (r) {
       if (r.status === 401 && !_retried) {
@@ -357,7 +311,7 @@ export const AGENTS_UI_HTML = `<!doctype html>
     var note = document.getElementById("spawn-note");
     if (!defaultSet && (!overrides || !overrides.length)) {
       note.textContent = "⚠ no Claude credential set — set one above before spawning.";
-      note.style.color = "var(--warn)";
+      note.style.color = "var(--danger)";
     } else { note.textContent = ""; }
   }
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -316,7 +316,7 @@ ${THEME_CSS}
   .msg.you { align-self: flex-end; background: var(--accent); color: #fff; border-bottom-right-radius: 4px; }
   .msg.them { align-self: flex-start; background: var(--bg-soft); color: var(--fg); border: 1px solid var(--border); border-bottom-left-radius: 4px; }
   .msg.sys { align-self: center; background: transparent; color: var(--fg-muted); font-size: 0.8rem; font-style: italic; max-width: 90%; }
-  .msg.perm { align-self: flex-start; background: var(--bg-soft); border: 1px solid var(--border); color: var(--fg-muted); max-width: 90%; }
+  .msg.perm { align-self: flex-start; background: var(--warn-soft); border: 1px solid var(--warn); border-left: 3px solid var(--warn); color: var(--warn); max-width: 90%; }
   .files { margin-top: 4px; font-size: 0.8rem; opacity: .85; }
   form {
     display: flex; gap: 8px; padding: 12px 16px;

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -100,6 +100,7 @@ import {
   mcpSessionCount,
 } from "./mcp-http.ts";
 import { renderAdminPage } from "./admin-ui.ts";
+import { THEME_CSS, appShell, SHELL_JS } from "./ui-kit.ts";
 
 // Re-export the shared auth surface so existing importers of the daemon module
 // keep working; the canonical home is now `auth.ts` (shared with http-ui.ts).
@@ -293,82 +294,62 @@ async function removeChannelLive(
  * POSTs sends to /api/channels/<sel>/send. This is the surface for verifying
  * messaging works end to end with no Telegram and no vault.
  */
-const CHAT_UI_HTML = `<!doctype html>
+export const CHAT_UI_HTML = `<!doctype html>
 <html lang="en">
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>parachute-channel · chat</title>
 <style>
-  :root {
-    --bg: #0f1115; --panel: #171a21; --line: #262b36; --fg: #e6e9ef;
-    --muted: #8b93a3; --you: #2b5cff; --them: #232936; --accent: #4cc2a0;
-  }
-  * { box-sizing: border-box; }
-  html, body { height: 100%; margin: 0; }
-  body {
-    background: var(--bg); color: var(--fg);
-    font: 15px/1.5 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-    display: flex; flex-direction: column; height: 100vh;
-  }
-  header {
-    display: flex; align-items: center; gap: 12px;
-    padding: 10px 16px; border-bottom: 1px solid var(--line); background: var(--panel);
-  }
-  header .brand { font-weight: 600; }
-  header .brand small { color: var(--muted); font-weight: 400; }
-  header select {
-    margin-left: auto; background: var(--bg); color: var(--fg);
-    border: 1px solid var(--line); border-radius: 6px; padding: 6px 10px; font: inherit;
-  }
-  #status { font-size: 12px; color: var(--muted); }
-  #status.live { color: var(--accent); }
+${THEME_CSS}
+  /* ---- Chat page layout + transcript (page-specific, after the shared kit) -- */
+  html, body { height: 100%; }
+  body { display: flex; flex-direction: column; height: 100vh; }
+  .app-header { flex: 0 0 auto; }
   #transcript {
     flex: 1; overflow-y: auto; padding: 16px;
     display: flex; flex-direction: column; gap: 8px;
   }
+  /* Light-theme message bubbles. "you" = accent; "them" = soft surface; "sys" =
+     muted/italic system line; "perm" = a warn style for permission prompts. */
   .msg { max-width: 78%; padding: 8px 12px; border-radius: 12px; white-space: pre-wrap; word-wrap: break-word; }
-  .msg.you { align-self: flex-end; background: var(--you); color: #fff; border-bottom-right-radius: 4px; }
-  .msg.them { align-self: flex-start; background: var(--them); border-bottom-left-radius: 4px; }
-  .msg.sys { align-self: center; background: transparent; color: var(--muted); font-size: 12px; font-style: italic; max-width: 90%; }
-  .msg.perm { align-self: flex-start; background: #3a2f1a; border: 1px solid #6b5320; color: #ffd98a; max-width: 90%; }
-  .files { margin-top: 4px; font-size: 12px; opacity: .85; }
+  .msg.you { align-self: flex-end; background: var(--accent); color: #fff; border-bottom-right-radius: 4px; }
+  .msg.them { align-self: flex-start; background: var(--bg-soft); color: var(--fg); border: 1px solid var(--border); border-bottom-left-radius: 4px; }
+  .msg.sys { align-self: center; background: transparent; color: var(--fg-muted); font-size: 0.8rem; font-style: italic; max-width: 90%; }
+  .msg.perm { align-self: flex-start; background: var(--bg-soft); border: 1px solid var(--border); color: var(--fg-muted); max-width: 90%; }
+  .files { margin-top: 4px; font-size: 0.8rem; opacity: .85; }
   form {
     display: flex; gap: 8px; padding: 12px 16px;
-    border-top: 1px solid var(--line); background: var(--panel);
+    border-top: 1px solid var(--border); background: var(--card);
   }
   #input {
-    flex: 1; resize: none; background: var(--bg); color: var(--fg);
-    border: 1px solid var(--line); border-radius: 8px; padding: 10px 12px; font: inherit; max-height: 120px;
+    flex: 1; resize: none;
+    border-radius: 8px; padding: 10px 12px; max-height: 120px;
   }
-  button {
-    background: var(--you); color: #fff; border: 0; border-radius: 8px;
-    padding: 0 18px; font: inherit; font-weight: 600; cursor: pointer;
-  }
-  button:disabled { opacity: .4; cursor: default; }
-  details.setup { border-bottom: 1px solid var(--line); background: var(--panel); }
+  #send { flex: 0 0 auto; }
+  details.setup { border-bottom: 1px solid var(--border); background: var(--card); }
   details.setup > summary {
-    cursor: pointer; padding: 8px 16px; color: var(--accent); font-size: 13px; user-select: none;
+    cursor: pointer; padding: 8px 16px; color: var(--accent-hover); font-size: 0.85rem; user-select: none;
   }
-  details.setup .body { padding: 4px 16px 14px; font-size: 13px; color: var(--muted); }
+  details.setup .body { padding: 4px 16px 14px; font-size: 0.85rem; color: var(--fg-muted); }
   details.setup .body p { margin: 8px 0 4px; }
   details.setup pre {
-    margin: 4px 0; padding: 10px 12px; background: var(--bg); border: 1px solid var(--line);
-    border-radius: 8px; overflow-x: auto; color: var(--fg); font-size: 12px; line-height: 1.45;
+    margin: 4px 0; padding: 10px 12px; background: var(--bg-soft); border: 1px solid var(--border);
+    border-radius: 8px; overflow-x: auto; color: var(--fg); font-size: 0.8rem; line-height: 1.45;
   }
-  details.setup code { color: var(--fg); }
+  details.setup code { font-family: var(--font-mono); color: var(--fg); }
   details.setup .copy {
-    float: right; padding: 1px 8px; font-size: 11px; font-weight: 500; background: var(--them);
-    border: 1px solid var(--line); border-radius: 6px;
+    float: right; padding: 1px 8px; font-size: 0.7rem; font-weight: 500; background: var(--bg-soft);
+    color: var(--fg-muted); border: 1px solid var(--border); border-radius: 6px; cursor: pointer;
   }
 </style>
 </head>
 <body>
-  <header>
-    <div class="brand">parachute-channel <small>· chat</small></div>
-    <span id="status">connecting…</span>
-    <select id="channel" title="channel"></select>
-  </header>
+  ${appShell({
+    active: "chat",
+    tag: "chat",
+    controls: '<select id="channel" class="btn-sm" title="channel" style="width:auto;"></select>',
+  })}
   <details class="setup">
     <summary>Connect a Claude Code session ▾</summary>
     <div class="body">
@@ -383,46 +364,35 @@ const CHAT_UI_HTML = `<!doctype html>
   <div id="transcript"></div>
   <form id="composer">
     <textarea id="input" rows="1" placeholder="Type a message… (Enter to send, Shift+Enter for newline)" autocomplete="off"></textarea>
-    <button id="send" type="submit" disabled>Send</button>
+    <button id="send" type="submit" class="btn btn-primary" disabled>Send</button>
   </form>
 <script>
+${SHELL_JS}
 (function () {
   var transcript = document.getElementById("transcript");
   var sel = document.getElementById("channel");
   var input = document.getElementById("input");
   var sendBtn = document.getElementById("send");
-  var statusEl = document.getElementById("status");
   var form = document.getElementById("composer");
   var es = null;
-  // Served through hub the page is /channel/ui; locally it's /ui. Derive the
-  // mount prefix so every API/SSE call resolves under the same prefix.
-  var MOUNT = location.pathname.replace(/\\/ui\\/?$/, "");
+  // MOUNT, escapeHtml, fetchToken (caches on window.__token), authedFetch come
+  // from SHELL_JS. Wire the shared nav for the chat view.
+  wireShell("chat");
 
   // ----- Layer 2 auth -----------------------------------------------------
   // The daemon's send + SSE endpoints require a hub-issued channel JWT
-  // (aud:channel, scopes channel:read channel:send). The hub mints one for the
-  // logged-in portal operator at <hub-origin>/admin/channel-token (cookie-gated,
-  // ~10min TTL). We fetch it from the page origin (same origin as the hub when
-  // served through the expose) and attach it: Bearer header on POST, ?token= on
-  // the EventSource (which can't set headers). A direct-to-daemon / not-logged-in
-  // load just leaves the token unset and surfaces a notice — an unguarded dev
-  // daemon may still accept the calls, so we don't hard-crash.
-  window.__token = null;
-  function fetchToken() {
-    return fetch(window.location.origin + "/admin/channel-token", { credentials: "include" })
-      .then(function (r) {
-        if (!r.ok) throw new Error("token " + r.status);
-        return r.json();
-      })
-      .then(function (j) {
-        window.__token = j && j.token ? j.token : null;
-        return window.__token;
-      })
-      .catch(function (err) {
-        window.__token = null;
-        add("sys", "Not authenticated — open this UI through the hub portal (" + err + ")");
-        return null;
-      });
+  // (aud:channel, scopes channel:read channel:send). The shared fetchToken
+  // (SHELL_JS) mints one for the logged-in portal operator at
+  // <hub-origin>/admin/channel-token (cookie-gated, ~10min TTL) and caches it on
+  // window.__token; it REJECTS on failure. ensureToken wraps it with the chat's
+  // own notice (a "sys" transcript line) so a not-authenticated load explains
+  // itself, then resolves to null — an unguarded dev daemon may still accept the
+  // calls, so we don't hard-crash.
+  function ensureToken() {
+    return fetchToken().catch(function (err) {
+      add("sys", "Not authenticated — open this UI through the hub portal (" + err + ")");
+      return null;
+    });
   }
 
   function updateSetup(ch) {
@@ -469,11 +439,8 @@ const CHAT_UI_HTML = `<!doctype html>
     transcript.scrollTop = transcript.scrollHeight;
   }
 
-  function setStatus(text, live) {
-    statusEl.textContent = text;
-    statusEl.className = live ? "live" : "";
-  }
-
+  // setStatus(text, kind) comes from SHELL_JS — it updates the shared #status
+  // element the appShell header renders. Kinds: "live" | "err" | "" (default).
   function currentChannel() { return sel.value; }
 
   // Guard so an SSE error triggers at most one token-refresh+reconnect per
@@ -483,13 +450,13 @@ const CHAT_UI_HTML = `<!doctype html>
   function connect() {
     if (es) { es.close(); es = null; }
     var ch = currentChannel();
-    if (!ch) { setStatus("no channel", false); sendBtn.disabled = true; return; }
+    if (!ch) { setStatus("no channel", ""); sendBtn.disabled = true; return; }
     updateSetup(ch);
-    setStatus("connecting…", false);
+    setStatus("connecting…", "");
     var url = MOUNT + "/ui/events?channel=" + encodeURIComponent(ch);
     if (window.__token) url += "&token=" + encodeURIComponent(window.__token);
     es = new EventSource(url);
-    es.onopen = function () { sseRetried = false; setStatus("● live · " + ch, true); sendBtn.disabled = false; };
+    es.onopen = function () { sseRetried = false; setStatus("● live · " + ch, "live"); sendBtn.disabled = false; };
     es.addEventListener("reply", function (e) {
       try { var d = JSON.parse(e.data); add("them", d.text || "", d.files); }
       catch (_) { add("them", e.data); }
@@ -503,18 +470,18 @@ const CHAT_UI_HTML = `<!doctype html>
         add("perm", "🔐 permission: " + d.tool_name + "\\n" + (d.description || "") + "\\n" + (d.input_preview || ""));
       } catch (_) {}
     });
-    es.addEventListener("close", function () { setStatus("closed", false); });
+    es.addEventListener("close", function () { setStatus("closed", ""); });
     es.onerror = function () {
       // A stale/short-lived token 401s the stream. Refresh the token once and
       // reconnect; otherwise let EventSource auto-reconnect (transient network).
       if (!sseRetried && window.__token) {
         sseRetried = true;
-        setStatus("re-authenticating…", false);
+        setStatus("re-authenticating…", "");
         if (es) { es.close(); es = null; }
-        fetchToken().then(function () { connect(); });
+        ensureToken().then(function () { connect(); });
         return;
       }
-      setStatus("reconnecting…", false);
+      setStatus("reconnecting…", "");
     };
   }
 
@@ -539,7 +506,7 @@ const CHAT_UI_HTML = `<!doctype html>
       if (r.ok) return;
       // The token is short-lived; on a 401 refresh it once and retry the send.
       if (r.status === 401) {
-        return fetchToken().then(function (tok) {
+        return ensureToken().then(function (tok) {
           if (!tok) { add("sys", "send failed: not authenticated"); return; }
           return postSend(ch, text).then(function (r2) {
             if (!r2.ok) return r2.json().catch(function(){return {};}).then(function (j) {
@@ -575,7 +542,7 @@ const CHAT_UI_HTML = `<!doctype html>
   function loadChannelsAndConnect() {
     return fetch(MOUNT + "/.parachute/config").then(function (r) { return r.json(); }).then(function (cfg) {
       var chans = (cfg.channels || []).filter(function (c) { return c.transport === "http-ui"; });
-      if (!chans.length) { setStatus("no http-ui channels configured", false); return; }
+      if (!chans.length) { setStatus("no http-ui channels configured", ""); return; }
       var preselect = new URL(window.location.href).searchParams.get("channel");
       chans.forEach(function (c) {
         var opt = document.createElement("option");
@@ -584,13 +551,13 @@ const CHAT_UI_HTML = `<!doctype html>
         sel.appendChild(opt);
       });
       connect();
-    }).catch(function (err) { setStatus("config load failed: " + err, false); });
+    }).catch(function (err) { setStatus("config load failed: " + err, "err"); });
   }
 
   // Fetch a hub token first (so SSE + send go out authenticated), then list the
   // channels and connect. A token failure still proceeds — an unguarded dev
   // daemon may accept the calls, and the failure already surfaced a notice.
-  fetchToken().then(loadChannelsAndConnect);
+  ensureToken().then(loadChannelsAndConnect);
 })();
 </script>
 </body>

--- a/src/terminal-ui.ts
+++ b/src/terminal-ui.ts
@@ -23,6 +23,8 @@
  *      the live session with scrollback intact.
  */
 
+import { THEME_CSS, appShell, SHELL_JS } from "./ui-kit.ts";
+
 export const TERMINAL_UI_HTML = `<!doctype html>
 <html lang="en">
 <head>
@@ -31,81 +33,49 @@ export const TERMINAL_UI_HTML = `<!doctype html>
 <meta name="referrer" content="no-referrer" />
 <title>parachute-channel · terminal</title>
 <style>
-  :root {
-    --bg: #0f1115; --panel: #171a21; --line: #262b36; --fg: #e6e9ef;
-    --muted: #8b93a3; --accent: #4cc2a0; --danger: #e0796b;
-  }
-  * { box-sizing: border-box; }
-  html, body { height: 100%; margin: 0; }
-  body {
-    background: var(--bg); color: var(--fg);
-    font: 14px/1.5 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-    display: flex; flex-direction: column; height: 100vh;
-  }
-  header {
-    display: flex; align-items: center; gap: 12px;
-    padding: 10px 16px; border-bottom: 1px solid var(--line); background: var(--panel);
-    flex: 0 0 auto;
-  }
-  header .brand { font-weight: 600; }
-  header .brand small { color: var(--muted); font-weight: 400; }
-  header nav a { color: var(--muted); text-decoration: none; font-size: 13px; margin-right: 4px; }
-  header nav a:hover { color: var(--fg); text-decoration: underline; }
-  header select {
-    background: var(--bg); color: var(--fg);
-    border: 1px solid var(--line); border-radius: 6px; padding: 6px 10px; font: inherit;
-  }
-  header .spacer { margin-left: auto; }
-  #status { font-size: 12px; color: var(--muted); }
-  #status.live { color: var(--accent); }
-  #status.err { color: var(--danger); }
-  button {
-    background: var(--bg); color: var(--fg); border: 1px solid var(--line);
-    border-radius: 6px; padding: 6px 12px; font: inherit; cursor: pointer;
-  }
-  button:hover { border-color: var(--muted); }
-  button:disabled { opacity: .4; cursor: default; }
+${THEME_CSS}
+  /* ---- Terminal-pane layout (page-specific, layered after the shared kit) -- */
+  html, body { height: 100%; }
+  body { display: flex; flex-direction: column; height: 100vh; }
+  .app-header { flex: 0 0 auto; }
+  /* The terminal CONTENT pane stays dark — a terminal is black everywhere. Only
+     the chrome (header/nav) above is the brand-light kit. */
   #term-wrap {
-    flex: 1 1 auto; min-height: 0; padding: 8px; background: #000;
+    flex: 1 1 auto; min-height: 0; padding: 8px; background: var(--term-bg);
   }
   #term { width: 100%; height: 100%; }
   .notice {
-    padding: 8px 16px; font-size: 13px; color: var(--muted);
-    border-bottom: 1px solid var(--line); background: var(--panel);
+    padding: 0.6rem 1.1rem; font-size: 0.9rem; color: var(--fg-muted);
+    border-bottom: 1px solid var(--border); background: var(--card);
   }
   .notice.err { color: var(--danger); }
-  .notice code { color: var(--fg); }
+  .notice code { font-family: var(--font-mono); color: var(--fg); }
 </style>
 </head>
 <body>
-  <header>
-    <div class="brand">parachute-channel <small>· terminal</small></div>
-    <nav><a id="nav-agents" href="#">← Agents</a></nav>
-    <select id="channel" title="agent session"></select>
-    <button id="reconnect" type="button" title="Re-attach to the tmux session">Reconnect</button>
-    <span class="spacer"></span>
-    <span id="status">loading…</span>
-  </header>
+  ${appShell({
+    active: "terminal",
+    tag: "terminal",
+    status: "loading…",
+    controls:
+      '<select id="channel" class="btn-sm" title="agent session" style="width:auto;"></select>' +
+      '<button id="reconnect" type="button" class="btn btn-sm" title="Re-attach to the tmux session">Reconnect</button>',
+  })}
   <div id="notice" class="notice" hidden></div>
   <div id="term-wrap"><div id="term"></div></div>
 
 <script>
+${SHELL_JS}
 (function () {
   var sel = document.getElementById("channel");
-  var statusEl = document.getElementById("status");
   var noticeEl = document.getElementById("notice");
   var reconnectBtn = document.getElementById("reconnect");
   var termHost = document.getElementById("term");
 
-  // Served through the hub the page is /channel/terminal; locally it's
-  // /terminal. Derive the mount prefix so the WS + token + asset URLs resolve
-  // under the same prefix (same shape as the chat UI's MOUNT).
-  var MOUNT = location.pathname.replace(/\\/terminal(\\/[^/]*)?\\/?$/, "");
+  // MOUNT, setStatus, escapeHtml, fetchToken, authedFetch come from SHELL_JS.
+  // Wire the shared nav (hrefs + active tab) for the terminal view.
+  wireShell("terminal");
 
-  // Wire the nav link to the agents page under the same mount.
-  document.getElementById("nav-agents").href = MOUNT + "/agents";
-
-  function setStatus(text, cls) { statusEl.textContent = text; statusEl.className = cls || ""; }
   function showNotice(html, isErr) {
     noticeEl.innerHTML = html;
     noticeEl.className = "notice" + (isErr ? " err" : "");
@@ -180,17 +150,16 @@ export const TERMINAL_UI_HTML = `<!doctype html>
   }
 
   // --- token (operator channel:admin, minted by the hub) ------------------
-  window.__token = null;
-  function fetchToken() {
-    return fetch(window.location.origin + "/admin/channel-token", { credentials: "include" })
-      .then(function (r) { if (!r.ok) throw new Error("token " + r.status); return r.json(); })
-      .then(function (j) { window.__token = (j && j.token) ? j.token : null; return window.__token; })
-      .catch(function (err) {
-        window.__token = null;
-        showNotice("Not authenticated — open this page through the hub portal, signed in " +
-          "as the operator. The terminal needs a <code>channel:admin</code> token (" + err + ").", true);
-        return null;
-      });
+  // The shared fetchToken (SHELL_JS) does the mint + caches it on window.__token,
+  // and REJECTS on failure. ensureToken wraps it with the terminal's own notice
+  // affordance so a not-authenticated load explains itself, then resolves to null
+  // (never rejects) — the WS attach validates the token anyway.
+  function ensureToken() {
+    return fetchToken().catch(function (err) {
+      showNotice("Not authenticated — open this page through the hub portal, signed in " +
+        "as the operator. The terminal needs a <code>channel:admin</code> token (" + err + ").", true);
+      return null;
+    });
   }
 
   // --- WebSocket relay ----------------------------------------------------
@@ -248,7 +217,7 @@ export const TERMINAL_UI_HTML = `<!doctype html>
     if (reconnectTimer) return;
     reconnectTimer = setTimeout(function () {
       reconnectTimer = null;
-      fetchToken().then(function () { connect(); });
+      ensureToken().then(function () { connect(); });
     }, 1500);
   }
 
@@ -270,7 +239,7 @@ export const TERMINAL_UI_HTML = `<!doctype html>
 
   reconnectBtn.addEventListener("click", function () {
     if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
-    fetchToken().then(function () { connect(); });
+    ensureToken().then(function () { connect(); });
   });
 
   sel.addEventListener("change", function () {
@@ -285,12 +254,8 @@ export const TERMINAL_UI_HTML = `<!doctype html>
   // --- boot: list running AGENTS, then connect ----------------------------
   // The terminal attaches to an AGENT's tmux session (name-agent), so the picker
   // lists running agents (operator-gated /api/agents), NOT channels — an agent has
-  // its own name, which isn't necessarily a configured channel.
-  function authedFetch(path) {
-    var headers = {};
-    if (window.__token) headers["authorization"] = "Bearer " + window.__token;
-    return fetch(MOUNT + path, { headers: headers });
-  }
+  // its own name, which isn't necessarily a configured channel. authedFetch (from
+  // SHELL_JS) attaches the Bearer + retries once on 401.
   function requestedAgent() {
     var u = new URL(window.location.href);
     var p = u.searchParams.get("agent") || u.searchParams.get("channel") || "";
@@ -299,7 +264,7 @@ export const TERMINAL_UI_HTML = `<!doctype html>
     return p;
   }
   function loadAgentsAndConnect() {
-    return authedFetch("/api/agents")
+    return authedFetch(MOUNT + "/api/agents")
       .then(function (r) { if (!r.ok) throw new Error("agents " + r.status); return r.json(); })
       .then(function (j) {
         var names = (j.agents || []).map(function (a) { return a.name; });
@@ -328,7 +293,7 @@ export const TERMINAL_UI_HTML = `<!doctype html>
       });
   }
 
-  fetchToken().then(loadAgentsAndConnect);
+  ensureToken().then(loadAgentsAndConnect);
   } // end boot()
 })();
 </script>

--- a/src/ui-kit.test.ts
+++ b/src/ui-kit.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Unit tests for the shared UI kit (src/ui-kit.ts) — the foundation every
+ * channel page adopts. Guards the shell contract (active-tab marking, controls
+ * slot, nav set) + the token/CSS invariants the pages depend on.
+ */
+import { describe, test, expect } from "bun:test";
+import { THEME_CSS, SHELL_JS, appShell, NAV_VIEWS, BRAND } from "./ui-kit.ts";
+
+describe("appShell", () => {
+  test("renders the brand + all four nav tabs, marking only the active one", () => {
+    const h = appShell({ active: "agents" });
+    expect(h).toContain("app-header");
+    expect(h).toContain('class="brand-mark"');
+    for (const v of NAV_VIEWS) expect(h).toContain(`data-view="${v.view}"`);
+    // active tab gets class="active"; others don't.
+    expect(h).toContain('data-view="agents" href="#" class="active"');
+    expect(h).toContain('data-view="chat" href="#"');
+    expect(h).not.toContain('data-view="chat" href="#" class="active"');
+  });
+
+  test("status defaults, and a custom status + tag suffix render", () => {
+    expect(appShell({ active: "chat" })).toContain('id="status"');
+    const h = appShell({ active: "chat", status: "● ready", tag: "chat" });
+    expect(h).toContain("● ready");
+    expect(h).toContain("· chat");
+  });
+
+  test("controls slot is injected before the status when provided, omitted otherwise", () => {
+    const withCtl = appShell({ active: "terminal", controls: "<button id='reconnect'>Reconnect</button>" });
+    expect(withCtl).toContain("app-controls");
+    expect(withCtl).toContain("id='reconnect'");
+    expect(appShell({ active: "terminal" })).not.toContain("app-controls");
+  });
+
+  test("nav covers exactly chat/agents/terminal/config (no Home yet)", () => {
+    expect(NAV_VIEWS.map((v) => v.view)).toEqual(["chat", "agents", "terminal", "config"]);
+  });
+});
+
+describe("THEME_CSS", () => {
+  test("declares the brand tokens incl. the warm-light bg, accent, warn, and dark term pane", () => {
+    expect(THEME_CSS).toContain(":root");
+    expect(THEME_CSS).toContain(`--bg: ${BRAND.bg}`); // #faf8f4, the warm light brand
+    expect(THEME_CSS).toContain(`--accent: ${BRAND.accent}`);
+    expect(THEME_CSS).toContain(`--warn: ${BRAND.warn}`);
+    expect(THEME_CSS).toContain(`--term-bg: ${BRAND.termBg}`); // #000 — the only intended black
+  });
+  test("ships the shared component layer (shell + buttons + banners + pills)", () => {
+    for (const sel of [".app-nav", ".app-nav a.active", ".btn-primary", ".banner-warn", ".pill.warn"]) {
+      expect(THEME_CSS).toContain(sel);
+    }
+  });
+  test("carries NO leftover dark-console tokens (the pages unified on the brand)", () => {
+    expect(THEME_CSS).not.toContain("#0f1115");
+    expect(THEME_CSS).not.toContain("--panel");
+  });
+});
+
+describe("SHELL_JS", () => {
+  test("provides MOUNT derivation, nav wiring, token fetch, and helpers", () => {
+    for (const sym of ["var MOUNT", "function wireShell", "function escapeHtml", "function setStatus", "function fetchToken", "function authedFetch"]) {
+      expect(SHELL_JS).toContain(sym);
+    }
+    // It hits the hub channel-token endpoint with the operator cookie.
+    expect(SHELL_JS).toContain("/admin/channel-token");
+    expect(SHELL_JS).toContain('credentials: "include"');
+  });
+  test("is safe to interpolate — no naked backtick that could break a host literal", () => {
+    expect(SHELL_JS.includes("`")).toBe(false);
+  });
+});

--- a/src/ui-kit.ts
+++ b/src/ui-kit.ts
@@ -41,6 +41,11 @@ export const BRAND = {
   dangerSoft: "rgba(163, 57, 43, 0.08)",
   success: "#3d6849",
   successSoft: "rgba(61, 104, 73, 0.08)",
+  // A warm amber for warnings (distinct from danger-red and accent-teal) — fits
+  // the warm-light palette. Used for "needs attention" states (e.g. no credential
+  // set yet, a permission prompt) that aren't errors.
+  warn: "#8a6d1b",
+  warnSoft: "rgba(184, 134, 11, 0.12)",
   // The terminal content pane stays dark — a terminal is black everywhere.
   termBg: "#000000",
   termFg: "#e6e9ef",
@@ -82,6 +87,8 @@ export const THEME_CSS = `
     --danger-soft: ${BRAND.dangerSoft};
     --success: ${BRAND.success};
     --success-soft: ${BRAND.successSoft};
+    --warn: ${BRAND.warn};
+    --warn-soft: ${BRAND.warnSoft};
     --term-bg: ${BRAND.termBg};
     --term-fg: ${BRAND.termFg};
     --font-sans: ${BRAND.fontSans};
@@ -185,7 +192,7 @@ export const THEME_CSS = `
   }
   .banner-error, .banner-err { background: var(--danger-soft); border-color: var(--danger); color: var(--danger); }
   .banner-success, .banner-ok { background: var(--success-soft); border-color: var(--success); color: var(--success); }
-  .banner-warn { background: var(--bg-soft); border-color: var(--border); color: var(--fg-muted); }
+  .banner-warn { background: var(--warn-soft); border-color: var(--warn); color: var(--warn); }
   .banner code { font-family: var(--font-mono); font-size: 0.85em; background: rgba(255,255,255,0.5); padding: 0.05rem 0.3rem; border-radius: 3px; }
 
   /* ---- Inputs / fields --------------------------------------------------- */
@@ -209,6 +216,7 @@ export const THEME_CSS = `
   .pill { display: inline-flex; align-items: center; gap: 0.35rem; font-size: 0.78rem; padding: 0.1rem 0.5rem; border-radius: 999px; border: 1px solid var(--border); color: var(--fg-muted); background: var(--bg-soft); }
   .pill.on, .pill.attached { color: var(--accent-hover); border-color: var(--accent); background: var(--accent-soft); }
   .pill.off { color: var(--fg-dim); }
+  .pill.warn { color: var(--warn); border-color: var(--warn); background: var(--warn-soft); }
   .dot { width: 0.55rem; height: 0.55rem; border-radius: 50%; display: inline-block; background: var(--fg-dim); }
   .dot.live { background: var(--accent); }
 

--- a/src/ui-kit.ts
+++ b/src/ui-kit.ts
@@ -1,0 +1,299 @@
+/**
+ * Shared UI kit for the channel module's web pages (chat, agents, terminal,
+ * config). ONE source of truth for the look + the app shell, so the four pages
+ * read as one app instead of four hand-rolled surfaces.
+ *
+ * Why this exists: every page used to re-implement its own theme, header, nav,
+ * buttons, MOUNT derivation, and token fetch. That guaranteed drift (a light
+ * admin page vs three dark ones; a nav on some pages, a dead-end on others).
+ * This module is the fix at the root — adopt it on every page and the surfaces
+ * can't diverge.
+ *
+ * The look is the canonical Parachute brand (warm/light, teal accent, serif
+ * headlines) — consistent with the hub portal, brain, and surfaces. The ONE
+ * exception is the terminal CONTENT pane, which stays black like any terminal
+ * (`--term-bg`); only the chrome around it is brand-light.
+ *
+ * Three exports:
+ *   - THEME_CSS  — the full stylesheet (tokens + base + shell + components).
+ *   - appShell() — the shared <header> markup (brand + nav tabs + status slot).
+ *   - SHELL_JS   — shared client JS (MOUNT, nav wiring, token fetch, helpers).
+ *
+ * Pages drop `<style>${THEME_CSS}</style>` + `${appShell({active})}` +
+ * `<script>${SHELL_JS} ...page JS...</script>` and add only their page-specific
+ * styles/markup/logic on top.
+ */
+
+/** The Parachute brand palette + fonts, promoted from the original admin page. */
+export const BRAND = {
+  bg: "#faf8f4",
+  bgSoft: "#f3f0ea",
+  fg: "#2c2a26",
+  fgMuted: "#6b6860",
+  fgDim: "#9a9690",
+  accent: "#4cc2a0",
+  accentHover: "#3da689",
+  accentSoft: "rgba(76, 194, 160, 0.10)",
+  border: "#e4e0d8",
+  borderLight: "#ece9e2",
+  card: "#ffffff",
+  danger: "#a3392b",
+  dangerSoft: "rgba(163, 57, 43, 0.08)",
+  success: "#3d6849",
+  successSoft: "rgba(61, 104, 73, 0.08)",
+  // The terminal content pane stays dark — a terminal is black everywhere.
+  termBg: "#000000",
+  termFg: "#e6e9ef",
+  fontSans: `-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif`,
+  fontSerif: `Georgia, "Times New Roman", serif`,
+  fontMono: `ui-monospace, "SF Mono", Menlo, Monaco, "Cascadia Mono", monospace`,
+} as const;
+
+/** The four navigable views, in nav order. Home arrives in Phase 2. */
+export const NAV_VIEWS = [
+  { view: "chat", label: "Chat", path: "/ui" },
+  { view: "agents", label: "Agents", path: "/agents" },
+  { view: "terminal", label: "Terminal", path: "/terminal" },
+  { view: "config", label: "Config", path: "/admin" },
+] as const;
+
+export type ShellView = (typeof NAV_VIEWS)[number]["view"];
+
+/**
+ * The shared stylesheet: CSS custom properties (the brand tokens) + base
+ * element styles + the app-shell header/nav + the component layer (buttons,
+ * cards, banners, inputs, fields, pills, sections). Every page includes this
+ * verbatim and layers only page-specific rules on top.
+ */
+export const THEME_CSS = `
+  :root {
+    --bg: ${BRAND.bg};
+    --bg-soft: ${BRAND.bgSoft};
+    --fg: ${BRAND.fg};
+    --fg-muted: ${BRAND.fgMuted};
+    --fg-dim: ${BRAND.fgDim};
+    --accent: ${BRAND.accent};
+    --accent-hover: ${BRAND.accentHover};
+    --accent-soft: ${BRAND.accentSoft};
+    --border: ${BRAND.border};
+    --border-light: ${BRAND.borderLight};
+    --card: ${BRAND.card};
+    --danger: ${BRAND.danger};
+    --danger-soft: ${BRAND.dangerSoft};
+    --success: ${BRAND.success};
+    --success-soft: ${BRAND.successSoft};
+    --term-bg: ${BRAND.termBg};
+    --term-fg: ${BRAND.termFg};
+    --font-sans: ${BRAND.fontSans};
+    --font-serif: ${BRAND.fontSerif};
+    --font-mono: ${BRAND.fontMono};
+  }
+  *, *::before, *::after { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    font-family: var(--font-sans);
+    background: var(--bg);
+    color: var(--fg);
+    line-height: 1.55;
+    min-height: 100vh;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { color: var(--accent-hover); text-decoration: underline; }
+  code, pre { font-family: var(--font-mono); }
+
+  /* ---- App shell: the shared top bar on every page ------------------------ */
+  .app-header {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.6rem 1.1rem;
+    background: var(--card);
+    border-bottom: 1px solid var(--border);
+    flex-wrap: wrap;
+  }
+  .app-brand { display: inline-flex; align-items: center; gap: 0.5rem; flex: 0 0 auto; }
+  .brand-mark {
+    display: inline-flex; align-items: center; justify-content: center;
+    width: 1.5rem; height: 1.5rem; border-radius: 50%;
+    background: var(--accent); color: var(--card);
+    font-weight: 600; font-size: 0.85rem; line-height: 1;
+  }
+  .brand-name { font-weight: 600; letter-spacing: 0.01em; color: var(--fg); }
+  .brand-name small { color: var(--fg-dim); font-weight: 400; }
+  .app-nav { display: flex; align-items: center; gap: 0.15rem; flex-wrap: wrap; }
+  .app-nav a {
+    color: var(--fg-muted);
+    text-decoration: none;
+    font-size: 0.9rem;
+    padding: 0.3rem 0.6rem;
+    border-radius: 6px;
+    transition: background 0.12s ease, color 0.12s ease;
+  }
+  .app-nav a:hover { background: var(--bg-soft); color: var(--fg); text-decoration: none; }
+  .app-nav a.active { background: var(--accent-soft); color: var(--accent-hover); font-weight: 600; }
+  .app-controls { display: inline-flex; align-items: center; gap: 0.5rem; flex: 0 0 auto; }
+  .app-status { font-size: 0.8rem; color: var(--fg-dim); flex: 0 0 auto; }
+  .app-status.live { color: var(--accent-hover); }
+  .app-status.err { color: var(--danger); }
+  .spacer { flex: 1 1 auto; }
+
+  /* ---- Buttons ----------------------------------------------------------- */
+  .btn {
+    font: inherit;
+    font-weight: 500;
+    padding: 0.5rem 0.9rem;
+    border-radius: 6px;
+    border: 1px solid var(--border);
+    background: var(--card);
+    color: var(--fg);
+    cursor: pointer;
+    transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease;
+  }
+  .btn:hover { border-color: var(--fg-dim); }
+  .btn:disabled { opacity: 0.5; cursor: default; }
+  .btn-primary { background: var(--accent); border-color: var(--accent); color: #06140f; font-weight: 600; }
+  .btn-primary:hover { background: var(--accent-hover); border-color: var(--accent-hover); }
+  .btn-secondary { background: var(--bg-soft); }
+  .btn-danger { color: var(--danger); border-color: var(--border); background: transparent; }
+  .btn-danger:hover { background: var(--danger-soft); border-color: var(--danger); }
+  .btn-ghost { background: transparent; border-color: transparent; color: var(--fg-muted); }
+  .btn-ghost:hover { background: var(--bg-soft); color: var(--fg); }
+  .btn-sm { font-size: 0.8rem; padding: 0.3rem 0.7rem; }
+
+  /* ---- Cards / sections -------------------------------------------------- */
+  .card-surface {
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 1.5rem 1.5rem;
+    box-shadow: 0 1px 2px rgba(44,42,38,0.04), 0 8px 24px rgba(44,42,38,0.06);
+  }
+  h1 { font-family: var(--font-serif); font-weight: 400; font-size: 1.6rem; line-height: 1.2; margin: 0 0 0.4rem; color: var(--fg); }
+  h2, .section-title { font-family: var(--font-serif); font-weight: 400; font-size: 1.2rem; margin: 0; color: var(--fg); }
+  .subtitle, .muted { margin: 0; color: var(--fg-muted); font-size: 0.95rem; }
+  .dim { color: var(--fg-dim); }
+
+  /* ---- Banners / notices ------------------------------------------------- */
+  .banner {
+    margin: 0 0 1rem;
+    padding: 0.75rem 0.9rem;
+    border-radius: 6px;
+    font-size: 0.9rem;
+    border: 1px solid transparent;
+  }
+  .banner-error, .banner-err { background: var(--danger-soft); border-color: var(--danger); color: var(--danger); }
+  .banner-success, .banner-ok { background: var(--success-soft); border-color: var(--success); color: var(--success); }
+  .banner-warn { background: var(--bg-soft); border-color: var(--border); color: var(--fg-muted); }
+  .banner code { font-family: var(--font-mono); font-size: 0.85em; background: rgba(255,255,255,0.5); padding: 0.05rem 0.3rem; border-radius: 3px; }
+
+  /* ---- Inputs / fields --------------------------------------------------- */
+  select, input[type=text], input[type=password], textarea {
+    font: inherit;
+    width: 100%;
+    padding: 0.5rem 0.7rem;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--card);
+    color: var(--fg);
+  }
+  select:focus, input:focus, textarea:focus { outline: none; border-color: var(--accent); }
+  .field { display: flex; flex-direction: column; gap: 0.3rem; }
+  .field[hidden] { display: none; }
+  .field-label { font-size: 0.85rem; font-weight: 500; color: var(--fg-muted); letter-spacing: 0.01em; }
+  .field-hint { font-size: 0.8rem; color: var(--fg-dim); }
+  .field-error { font-size: 0.8rem; color: var(--danger); font-weight: 500; }
+
+  /* ---- Pills (status badges) -------------------------------------------- */
+  .pill { display: inline-flex; align-items: center; gap: 0.35rem; font-size: 0.78rem; padding: 0.1rem 0.5rem; border-radius: 999px; border: 1px solid var(--border); color: var(--fg-muted); background: var(--bg-soft); }
+  .pill.on, .pill.attached { color: var(--accent-hover); border-color: var(--accent); background: var(--accent-soft); }
+  .pill.off { color: var(--fg-dim); }
+  .dot { width: 0.55rem; height: 0.55rem; border-radius: 50%; display: inline-block; background: var(--fg-dim); }
+  .dot.live { background: var(--accent); }
+
+  /* ---- Generic page main ------------------------------------------------- */
+  .page { max-width: 60rem; margin: 0 auto; padding: 1.5rem 1.25rem; }
+`;
+
+/**
+ * Render the shared app-shell header. `active` highlights the current view;
+ * `controls` is an optional HTML slot for page-specific header controls (the
+ * terminal's agent picker + Reconnect, the chat/terminal channel select) placed
+ * before the status. `status` seeds the status text (default "connecting…").
+ * Nav hrefs are placeholders wired client-side by SHELL_JS (so they resolve
+ * under the hub proxy mount). `tag` is an optional brand suffix (e.g. "agents").
+ */
+export function appShell(opts: { active: ShellView; controls?: string; status?: string; tag?: string }): string {
+  const links = NAV_VIEWS.map((v) => {
+    const cls = v.view === opts.active ? ' class="active"' : "";
+    return `<a data-view="${v.view}" href="#"${cls}>${v.label}</a>`;
+  }).join("");
+  const tag = opts.tag ? ` <small>· ${opts.tag}</small>` : "";
+  const controls = opts.controls ? `<span class="app-controls">${opts.controls}</span>` : "";
+  const status = opts.status ?? "connecting…";
+  return `<header class="app-header">
+    <span class="app-brand"><span class="brand-mark">C</span><span class="brand-name">Channel${tag}</span></span>
+    <nav class="app-nav">${links}</nav>
+    <span class="spacer"></span>
+    ${controls}
+    <span id="status" class="app-status">${status}</span>
+  </header>`;
+}
+
+/**
+ * Shared client JS, injected into each page's <script> (interpolated as
+ * `${SHELL_JS}` — its content, including any backticks, is inserted at runtime,
+ * so it never collides with the host page's own template literal). Provides:
+ *   - MOUNT      — the public path prefix (handles loopback + hub /channel proxy)
+ *   - wireShell  — set nav hrefs from MOUNT + mark the active tab
+ *   - escapeHtml — text/attribute-safe escape (mirrors the server-side one)
+ *   - setStatus  — update the shared #status element
+ *   - fetchToken / authedFetch — hub channel-token fetch with one 401 retry
+ * Pages keep their own stream logic (SSE/WS) but reuse fetchToken for the token.
+ */
+export const SHELL_JS = `
+  // Public mount prefix: "" on loopback, "/channel" behind the hub proxy.
+  var MOUNT = window.location.pathname.replace(/\\/(ui|admin|agents|terminal)(\\/[^?]*)?\\/?$/, "");
+  var NAV_MAP = { chat: "/ui", agents: "/agents", terminal: "/terminal", config: "/admin" };
+  function wireShell(active) {
+    var links = document.querySelectorAll(".app-nav a[data-view]");
+    for (var i = 0; i < links.length; i++) {
+      var v = links[i].getAttribute("data-view");
+      if (NAV_MAP[v] != null) links[i].setAttribute("href", MOUNT + NAV_MAP[v]);
+      if (v === active) links[i].classList.add("active");
+      else links[i].classList.remove("active");
+    }
+  }
+  function escapeHtml(s) {
+    return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+  }
+  function setStatus(text, kind) {
+    var el = document.getElementById("status");
+    if (!el) return;
+    el.textContent = text;
+    el.className = "app-status" + (kind ? " " + kind : "");
+  }
+  // Hub-minted channel token (cookie-gated to the logged-in operator). Cached on
+  // window.__token; pages attach it as a Bearer header and/or ?token= param.
+  function fetchToken() {
+    return fetch(window.location.origin + "/admin/channel-token", { credentials: "include" })
+      .then(function (r) { if (!r.ok) throw new Error("token " + r.status); return r.json(); })
+      .then(function (j) { window.__token = j && j.token ? j.token : null; return window.__token; })
+      .catch(function (err) { window.__token = null; throw err; });
+  }
+  // fetch() with the channel Bearer + a single token-refresh retry on 401.
+  function authedFetch(url, opts) {
+    opts = opts || {};
+    var headers = Object.assign({}, opts.headers || {});
+    if (window.__token) headers["authorization"] = "Bearer " + window.__token;
+    return fetch(url, Object.assign({}, opts, { headers: headers })).then(function (r) {
+      if (r.status !== 401) return r;
+      return fetchToken().then(function (tok) {
+        if (!tok) return r;
+        var h2 = Object.assign({}, opts.headers || {}, { authorization: "Bearer " + tok });
+        return fetch(url, Object.assign({}, opts, { headers: h2 }));
+      });
+    });
+  }
+`;


### PR DESCRIPTION
## What

The channel daemon serves four web pages (Chat, Agents, Terminal, Config) that read as four separate apps: three were dark, one (admin) light; nav was asymmetric (chat was a dead-end); and each page hand-rolled its own theme tokens, header, nav, MOUNT derivation, and token/fetch logic — guaranteed drift.

This adopts the new **`src/ui-kit.ts`** on all four pages so they share one look and one shell.

### The ui-kit (one source of truth)
- **`THEME_CSS`** — brand tokens (CSS vars), base element styles, the `.app-header`/`.app-nav` shell, and the component layer (buttons/cards/banners/inputs/fields/pills/dot/headings).
- **`appShell({ active, controls?, status?, tag? })`** — the shared `<header>`: brand-mark "C" + "Channel", the `Chat·Agents·Terminal·Config` tabs (active highlighted), a spacer, an optional page-controls slot, and the `#status` element.
- **`SHELL_JS`** — shared client JS: `MOUNT`, `wireShell(active)`, `escapeHtml`, `setStatus(text, kind)`, `fetchToken()`, `authedFetch(url, opts)` (Bearer + one 401 retry).

### The 4-page adoption
- **Terminal** (`src/terminal-ui.ts`), **Agents** (`src/agents-ui.ts`), **Chat** (`src/daemon.ts` `CHAT_UI_HTML`), **Config** (`src/admin-ui.ts`) each now drop `${THEME_CSS}` + `${appShell({active})}` + `${SHELL_JS}`, keep only their page-specific styles (terminal pane, chat transcript/bubbles, agents table, admin channel-row list) and their own stream logic (SSE/WS), and remove the now-duplicate local theme/header/nav/escapeHtml/token definitions.
- Terminal & Chat pass their header controls (agent select + Reconnect / channel select) via the `controls` slot.
- Admin's old text-link nav (inside a `<p class="subtitle">`) is replaced by the shared header; its `prefers-color-scheme: dark` block is dropped so it matches the others.

### Light brand chrome, dark terminal pane
Chrome is the light Parachute brand on every page. The terminal **content** pane stays dark: `#term-wrap` background = `var(--term-bg)` (#000) and the xterm theme is unchanged (`{ background: "#000000", foreground: "#e6e9ef" }`). Chat bubbles move to the light palette (you = accent, them = soft surface, sys = muted/italic, perm = warn).

### Nav on every page
Chat is no longer a dead-end — every page carries the full `Chat·Agents·Terminal·Config` tab set. Agents + Terminal were already advertised to the hub portal via the daemon's `services.json` `uis` registration (`audience: "surface"`), so nothing to add there.

**No route / API / auth / sandbox / behavior changes — presentation + nav only.**

## Verification
- `bun run typecheck` → only the 2 pre-existing `src/bridge.ts` TS2589 errors (unchanged baseline).
- `bun test` → **407 pass / 0 fail** (the vault/telegram 401 + ECONNREFUSED log lines are expected fixture noise from failure-path tests). `admin-ui.test.ts`'s 39 pinned-string tests pass **unchanged** — `SHELL_JS` supplies the same `fetchToken`/`credentials: "include"`/`Bearer`/`escapeHtml` shapes the tests assert.
- **Page-integrity probe** — all four pages render starting with `<!doctype`, healthy length, and include `app-header` + `app-nav` (no template-literal truncation).
- **Stale-token grep** — no `0f1115`/`171a21`/`262b36`/`--panel`/`--line`/`--you`/`--them` remains anywhere in `src/`; the terminal's `var(--term-bg)` #000 pane is the only intended black.

> Branch note: opened from `ag-channel-ui-shell` (off `main`) rather than `ag-unforced-dev` — the shared dev branch carried two unrelated leftover commits from a prior session, so this isolates the change cleanly on top of current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)