### PR TITLE
feat(ui): Home overview as the landing + vocabulary cleanup

### DIFF
--- a/.parachute/module.json
+++ b/.parachute/module.json
@@ -7,7 +7,7 @@
   "paths": ["/channel"],
   "health": "/health",
   "stripPrefix": true,
-  "uiUrl": "/channel/ui",
+  "uiUrl": "/channel/home",
   "configUiUrl": "/channel/admin",
   "websocket": true,
   "focus": "experimental",

--- a/src/admin-ui.test.ts
+++ b/src/admin-ui.test.ts
@@ -485,7 +485,7 @@ describe("module.json — modular-UI (P4) declaration", () => {
     const m = JSON.parse(await Bun.file(manifestPath).text()) as Record<string, unknown>;
     expect(m.name).toBe("channel");
     expect(m.port).toBe(1941);
-    expect(m.uiUrl).toBe("/channel/ui");
+    expect(m.uiUrl).toBe("/channel/home");
     const scopes = m.scopes as { defines?: string[] } | undefined;
     expect(scopes?.defines).toContain("channel:admin");
   });

--- a/src/agents-ui.ts
+++ b/src/agents-ui.ts
@@ -471,7 +471,9 @@ ${SHELL_JS}
   });
 
   // --- running agents list ------------------------------------------------
-  function terminalUrl(channel) { return MOUNT + "/terminal?channel=" + encodeURIComponent(channel); }
+  // The terminal attaches to an AGENT (its tmux session), so the link carries the
+  // agent name as ?agent= (the terminal page also accepts the legacy ?channel=).
+  function terminalUrl(agent) { return MOUNT + "/terminal?agent=" + encodeURIComponent(agent); }
   function loadAgents() {
     return apiJson("/api/agents").then(function (j) {
       var host = document.getElementById("agents-table");

--- a/src/daemon.test.ts
+++ b/src/daemon.test.ts
@@ -174,6 +174,14 @@ describe("UI-facing + discovery endpoints stay open (no token, 200)", () => {
     expect(res.headers.get("content-type")).toContain("text/html");
   });
 
+  test("GET /home → 200 (html) — the overview landing (uiUrl points here)", async () => {
+    const res = await fetch(`${base}/home`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    const body = await res.text();
+    expect(body).toContain("app-nav");
+  });
+
   test("GET /admin → 200 (html) — the page loads open; its API calls are gated", async () => {
     const res = await fetch(`${base}/admin`);
     expect(res.status).toBe(200);

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -76,6 +76,7 @@ import {
 import { TERMINAL_UI_HTML } from "./terminal-ui.ts";
 import { serveTerminalAsset } from "./terminal-assets.ts";
 import { AGENTS_UI_HTML } from "./agents-ui.ts";
+import { HOME_UI_HTML } from "./home-ui.ts";
 import {
   createRealAgentOps,
   buildSpecFromBody,
@@ -802,6 +803,17 @@ export function createFetchHandler(
     // every channel via the spawn form + the running-agents list).
     if (req.method === "GET" && url.pathname === "/agents") {
       return new Response(AGENTS_UI_HTML, {
+        headers: { "content-type": "text/html; charset=utf-8" },
+      });
+    }
+
+    // Home / overview landing (Phase 2) — `/home`, the DEFAULT page the hub
+    // portal lands on (`uiUrl: "/channel/home"`). Loads OPEN (like /ui, /admin,
+    // /terminal, /agents): the channels card reads the public config, the agents
+    // card mints a hub-minted channel:admin token client-side and tolerates a
+    // failed mint. Served by the daemon (spans every channel + agent).
+    if (req.method === "GET" && url.pathname === "/home") {
+      return new Response(HOME_UI_HTML, {
         headers: { "content-type": "text/html; charset=utf-8" },
       });
     }
@@ -1612,7 +1624,7 @@ function main(): void {
       // `parachute restart channel` 404s and we don't survive reboot (channel#34).
       startCmd: START_CMD,
       stripPrefix: true,
-      uiUrl: "/channel/ui", // portal "Open UI" link (also in module.json; written here in case hub reads it from services.json)
+      uiUrl: "/channel/home", // portal "Open UI" link → the Home overview landing (also in module.json; written here in case hub reads it from services.json)
       configUiUrl: "/channel/admin", // module-owned config surface (modular-UI P4); hub frames/links it. Also in module.json.
       // WebSocket support — tells the hub's Bun-native upgrade bridge to forward
       // `Upgrade: websocket` requests on `/channel/*` to this daemon (the

--- a/src/home-ui.ts
+++ b/src/home-ui.ts
@@ -1,0 +1,232 @@
+/**
+ * Static HTML for `/channel/home` — the overview landing (Phase 2 of the
+ * channel-UI coherence pass). This is the new DEFAULT page the hub portal lands
+ * on (`uiUrl: "/channel/home"`); it orients the operator before they dive into a
+ * specific surface.
+ *
+ * Self-contained document (HTML + inline CSS + inline JS, no build step — the
+ * same shape as `daemon.ts`'s chat UI, `agents-ui.ts`, and `terminal-ui.ts`). It
+ * adopts the shared UI kit (`THEME_CSS` + `appShell` + `SHELL_JS`) so it reads as
+ * a peer of the Agents/Config pages, and shows two at-a-glance cards:
+ *
+ *   - Channels       — fetched from `<mount>/.parachute/config` (OPEN, no auth):
+ *                      each channel's name + transport + a live dot, linking to
+ *                      its Chat. Footer: "Configure channels →" (the Config page).
+ *   - Running agents — fetched from `<mount>/api/agents` (channel:admin Bearer via
+ *                      authedFetch): each agent's name + state, linking to its
+ *                      Terminal + Chat. Auto-refreshes every 5s. Footer: "Spawn an
+ *                      agent →" (the Agents page).
+ *
+ * Auth: the page loads OPEN (like the other surfaces); the channels card needs no
+ * token, the agents card mints a hub `channel:admin` Bearer (fetchToken) and
+ * tolerates failure with a "sign in via the portal" note — an unauthenticated
+ * load still shows channels + the quick actions.
+ *
+ * Vocabulary (settled this phase): a CHANNEL is the messaging pipe; an AGENT is
+ * the sandboxed Claude Code session bound to a channel.
+ */
+
+import { THEME_CSS, appShell, SHELL_JS } from "./ui-kit.ts";
+
+export const HOME_UI_HTML = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="referrer" content="no-referrer" />
+<title>parachute-channel · home</title>
+<style>
+${THEME_CSS}
+  /* ---- Home page layout (page-specific, layered after the shared kit) ------ */
+  .app-header { position: sticky; top: 0; z-index: 5; }
+  .page-head { margin: 0 0 1.5rem; }
+  .overview-grid {
+    display: grid; grid-template-columns: 1fr 1fr; gap: 1.25rem; align-items: start;
+  }
+  /* Stack the two cards on narrow viewports. */
+  @media (max-width: 720px) { .overview-grid { grid-template-columns: 1fr; } }
+  .card-surface .card-head {
+    display: flex; align-items: baseline; gap: 0.6rem; margin: 0 0 0.9rem;
+  }
+  .card-surface .card-head .count { color: var(--fg-dim); font-size: 0.85rem; }
+  .ov-list { display: flex; flex-direction: column; gap: 0.4rem; margin: 0 0 1rem; }
+  .ov-row {
+    display: flex; align-items: center; gap: 0.6rem;
+    padding: 0.6rem 0.7rem; border: 1px solid var(--border); border-radius: 8px;
+    background: var(--bg); transition: border-color 0.12s ease, background 0.12s ease;
+  }
+  .ov-row:hover { border-color: var(--fg-dim); background: var(--card); }
+  .ov-row .name { font-weight: 600; color: var(--fg); }
+  .ov-row .spacer { flex: 1 1 auto; }
+  .ov-row .links { display: inline-flex; gap: 0.5rem; font-size: 0.85rem; flex: 0 0 auto; }
+  .ov-empty { color: var(--fg-muted); font-size: 0.9rem; padding: 0.7rem 0.2rem; }
+  .ov-empty a { font-weight: 500; }
+  .card-foot {
+    margin: 0; padding-top: 0.6rem; border-top: 1px solid var(--border-light);
+    font-size: 0.85rem;
+  }
+  .quick-actions {
+    display: flex; flex-wrap: wrap; gap: 0.6rem; align-items: center;
+    margin: 1.5rem 0 0;
+  }
+  .quick-actions .spacer { flex: 1 1 auto; }
+</style>
+</head>
+<body>
+  ${appShell({ active: "home", tag: "home", status: "loading…" })}
+
+  <main class="page">
+    <div class="page-head">
+      <h1>Home</h1>
+      <p class="subtitle">Your channels and the agents running on them.</p>
+    </div>
+
+    <div class="overview-grid">
+      <!-- Channels (the messaging pipes) -->
+      <section class="card-surface">
+        <div class="card-head">
+          <h2>Channels</h2>
+          <span id="channels-count" class="count"></span>
+        </div>
+        <div id="channels-list" class="ov-list">
+          <div class="ov-empty">Loading channels…</div>
+        </div>
+        <p class="card-foot"><a id="channels-config" href="#">Configure channels →</a></p>
+      </section>
+
+      <!-- Running agents (the sandboxed sessions) -->
+      <section class="card-surface">
+        <div class="card-head">
+          <h2>Running agents</h2>
+          <span id="agents-count" class="count"></span>
+        </div>
+        <div id="agents-list" class="ov-list">
+          <div class="ov-empty">Loading agents…</div>
+        </div>
+        <p class="card-foot"><a id="agents-spawn" href="#">Spawn an agent →</a></p>
+      </section>
+    </div>
+
+    <div class="quick-actions">
+      <a id="qa-spawn" class="btn btn-primary" href="#">Spawn agent</a>
+      <a id="qa-chat" class="btn" href="#">Open chat</a>
+      <a id="qa-config" class="btn" href="#">Configure</a>
+      <span class="spacer"></span>
+      <button id="refresh" class="btn btn-sm" type="button">Refresh</button>
+    </div>
+  </main>
+
+<script>
+${SHELL_JS}
+(function () {
+  // MOUNT, setStatus, escapeHtml, fetchToken (caches on window.__token),
+  // authedFetch all come from SHELL_JS. Wire the shared nav for the home view.
+  wireShell("home");
+  var esc = escapeHtml;
+
+  var channelsList = document.getElementById("channels-list");
+  var channelsCount = document.getElementById("channels-count");
+  var agentsList = document.getElementById("agents-list");
+  var agentsCount = document.getElementById("agents-count");
+
+  // Static cross-surface links (resolved under the runtime mount prefix).
+  function wireLinks() {
+    document.getElementById("channels-config").href = MOUNT + "/admin";
+    document.getElementById("agents-spawn").href = MOUNT + "/agents";
+    document.getElementById("qa-spawn").href = MOUNT + "/agents";
+    document.getElementById("qa-chat").href = MOUNT + "/ui";
+    document.getElementById("qa-config").href = MOUNT + "/admin";
+  }
+
+  function chatUrl(channel) { return MOUNT + "/ui?channel=" + encodeURIComponent(channel); }
+  function terminalUrl(agent) { return MOUNT + "/terminal?agent=" + encodeURIComponent(agent); }
+
+  // --- channels (OPEN config, no token needed) ----------------------------
+  // The config listing is non-sensitive and served PUBLIC, so the channels card
+  // renders even on an unauthenticated load.
+  function loadChannels() {
+    return fetch(MOUNT + "/.parachute/config")
+      .then(function (r) { if (!r.ok) throw new Error("config " + r.status); return r.json(); })
+      .then(function (cfg) {
+        var chans = cfg.channels || [];
+        channelsCount.textContent = chans.length ? String(chans.length) : "";
+        if (!chans.length) {
+          channelsList.innerHTML = "<div class='ov-empty'>No channels yet. " +
+            "<a href='" + MOUNT + "/admin'>Add one in Config →</a></div>";
+          return;
+        }
+        channelsList.innerHTML = chans.map(function (c) {
+          return "<div class='ov-row'>" +
+            "<span class='dot live'></span>" +
+            "<span class='name'>" + esc(c.name) + "</span>" +
+            "<span class='pill'>" + esc(c.transport || "channel") + "</span>" +
+            "<span class='spacer'></span>" +
+            "<span class='links'>" +
+              "<a href='" + esc(chatUrl(c.name)) + "'>chat →</a>" +
+            "</span>" +
+          "</div>";
+        }).join("");
+      })
+      .catch(function (err) {
+        channelsCount.textContent = "";
+        channelsList.innerHTML = "<div class='ov-empty'>Could not load channels (" + esc(err.message) + ").</div>";
+      });
+  }
+
+  // --- running agents (channel:admin Bearer via authedFetch) --------------
+  function loadAgents() {
+    return authedFetch(MOUNT + "/api/agents")
+      .then(function (r) { if (!r.ok) { var e = new Error("agents " + r.status); e.status = r.status; throw e; } return r.json(); })
+      .then(function (j) {
+        var agents = j.agents || [];
+        agentsCount.textContent = agents.length ? String(agents.length) : "";
+        if (!agents.length) {
+          agentsList.innerHTML = "<div class='ov-empty'>No agents running — " +
+            "<a href='" + MOUNT + "/agents'>Spawn one →</a></div>";
+          return;
+        }
+        agentsList.innerHTML = agents.map(function (a) {
+          var state = a.attached
+            ? "<span class='pill attached'>attached</span>"
+            : "<span class='pill'>running</span>";
+          return "<div class='ov-row'>" +
+            "<span class='name'>" + esc(a.name) + "</span>" +
+            state +
+            "<span class='spacer'></span>" +
+            "<span class='links'>" +
+              "<a href='" + esc(terminalUrl(a.name)) + "'>terminal →</a>" +
+              "<a href='" + esc(chatUrl(a.name)) + "'>chat →</a>" +
+            "</span>" +
+          "</div>";
+        }).join("");
+      })
+      .catch(function (err) {
+        agentsCount.textContent = "";
+        if (err.status === 401) {
+          agentsList.innerHTML = "<div class='ov-empty'>Sign in via the portal to see running agents.</div>";
+        } else {
+          agentsList.innerHTML = "<div class='ov-empty'>Could not load agents (" + esc(err.message) + ").</div>";
+        }
+      });
+  }
+
+  function refreshAll() {
+    return Promise.all([loadChannels(), loadAgents()]);
+  }
+
+  document.getElementById("refresh").addEventListener("click", function () { refreshAll(); });
+
+  // --- boot ---------------------------------------------------------------
+  // Mint the channel:admin Bearer first so the agents card is authed; tolerate a
+  // failed mint (unauthenticated load) — channels still render, agents shows the
+  // sign-in note. Then auto-refresh agents every 5s (like the Agents page).
+  wireLinks();
+  fetchToken()
+    .then(function () { setStatus("● ready", "live"); })
+    .catch(function () { setStatus("sign in via the portal", "err"); })
+    .then(refreshAll)
+    .then(function () { setInterval(loadAgents, 5000); });
+})();
+</script>
+</body>
+</html>`;

--- a/src/home-ui.ts
+++ b/src/home-ui.ts
@@ -141,13 +141,21 @@ ${SHELL_JS}
   function chatUrl(channel) { return MOUNT + "/ui?channel=" + encodeURIComponent(channel); }
   function terminalUrl(agent) { return MOUNT + "/terminal?agent=" + encodeURIComponent(agent); }
 
-  // --- channels (OPEN config, no token needed) ----------------------------
-  // The config listing is non-sensitive and served PUBLIC, so the channels card
-  // renders even on an unauthenticated load.
+  // --- channels (OPEN config + health, no token needed) -------------------
+  // The config listing + /health are non-sensitive and served PUBLIC, so the
+  // channels card renders even on an unauthenticated load. Config gives the
+  // channel list + transport; /health gives real liveness (which channels the
+  // daemon has actually loaded) + client counts — so the dot reflects truth
+  // rather than always showing green.
   function loadChannels() {
-    return fetch(MOUNT + "/.parachute/config")
-      .then(function (r) { if (!r.ok) throw new Error("config " + r.status); return r.json(); })
-      .then(function (cfg) {
+    return Promise.all([
+      fetch(MOUNT + "/.parachute/config").then(function (r) { if (!r.ok) throw new Error("config " + r.status); return r.json(); }),
+      fetch(MOUNT + "/health").then(function (r) { return r.ok ? r.json() : { channels: [] }; }).catch(function () { return { channels: [] }; }),
+    ])
+      .then(function (res) {
+        var cfg = res[0], health = res[1] || {};
+        var live = {};
+        (health.channels || []).forEach(function (c) { live[c.name] = c; });
         var chans = cfg.channels || [];
         channelsCount.textContent = chans.length ? String(chans.length) : "";
         if (!chans.length) {
@@ -156,11 +164,15 @@ ${SHELL_JS}
           return;
         }
         channelsList.innerHTML = chans.map(function (c) {
+          var h = live[c.name];
+          var dot = h ? "<span class='dot live' title='loaded'></span>" : "<span class='dot' title='configured, not loaded'></span>";
+          var clients = h && h.clients ? "<span class='count'>" + h.clients + (h.clients === 1 ? " client" : " clients") + "</span>" : "";
           return "<div class='ov-row'>" +
-            "<span class='dot live'></span>" +
+            dot +
             "<span class='name'>" + esc(c.name) + "</span>" +
             "<span class='pill'>" + esc(c.transport || "channel") + "</span>" +
             "<span class='spacer'></span>" +
+            clients +
             "<span class='links'>" +
               "<a href='" + esc(chatUrl(c.name)) + "'>chat →</a>" +
             "</span>" +

--- a/src/terminal-ui.ts
+++ b/src/terminal-ui.ts
@@ -58,8 +58,8 @@ ${THEME_CSS}
     tag: "terminal",
     status: "loading…",
     controls:
-      '<select id="channel" class="btn-sm" title="agent session" style="width:auto;"></select>' +
-      '<button id="reconnect" type="button" class="btn btn-sm" title="Re-attach to the tmux session">Reconnect</button>',
+      '<select id="agent" class="btn-sm" title="agent session" style="width:auto;"></select>' +
+      '<button id="reconnect" type="button" class="btn btn-sm" title="Re-attach to the agent session">Reconnect</button>',
   })}
   <div id="notice" class="notice" hidden></div>
   <div id="term-wrap"><div id="term"></div></div>
@@ -67,7 +67,9 @@ ${THEME_CSS}
 <script>
 ${SHELL_JS}
 (function () {
-  var sel = document.getElementById("channel");
+  // The picker lists running AGENTS (an agent's tmux session is what the terminal
+  // attaches to), so its id is "agent" — not "channel". See loadAgentsAndConnect.
+  var sel = document.getElementById("agent");
   var noticeEl = document.getElementById("notice");
   var reconnectBtn = document.getElementById("reconnect");
   var termHost = document.getElementById("term");
@@ -142,7 +144,7 @@ ${SHELL_JS}
   var reconnectTimer = null;
   var enc = new TextEncoder();
 
-  function currentChannel() { return sel.value; }
+  function currentAgent() { return sel.value; }
 
   function doFit() {
     if (!fit) return;
@@ -163,28 +165,30 @@ ${SHELL_JS}
   }
 
   // --- WebSocket relay ----------------------------------------------------
-  function wsUrl(ch) {
+  // The path segment is the AGENT name — the daemon attaches to that agent's tmux
+  // session (<name>-agent). NOT a channel.
+  function wsUrl(agent) {
     var proto = location.protocol === "https:" ? "wss:" : "ws:";
     var dims = "cols=" + term.cols + "&rows=" + term.rows;
-    var u = proto + "//" + location.host + MOUNT + "/terminal/" + encodeURIComponent(ch) + "?" + dims;
+    var u = proto + "//" + location.host + MOUNT + "/terminal/" + encodeURIComponent(agent) + "?" + dims;
     if (window.__token) u += "&token=" + encodeURIComponent(window.__token);
     return u;
   }
 
   function connect() {
-    var ch = currentChannel();
-    if (!ch) { setStatus("no channel"); return; }
+    var agent = currentAgent();
+    if (!agent) { setStatus("no agent"); return; }
     if (ws) { manualClose = true; try { ws.close(); } catch (_e) {} ws = null; }
     manualClose = false;
     clearNotice();
     setStatus("connecting…");
     doFit();
-    var socket = new WebSocket(wsUrl(ch));
+    var socket = new WebSocket(wsUrl(agent));
     socket.binaryType = "arraybuffer";
     ws = socket;
 
     socket.onopen = function () {
-      setStatus("● attached · " + ch, "live");
+      setStatus("● attached · " + agent, "live");
       sendResize();
       term.focus();
     };
@@ -202,7 +206,7 @@ ${SHELL_JS}
           "re-attach to the live session (scrollback intact via tmux).", true);
       } else if (ev.code === 1000) {
         setStatus("session ended");
-        showNotice("The tmux session ended (or detached). Spawn a session from the " +
+        showNotice("The agent's tmux session ended (or detached). Spawn an agent from the " +
           "<a href='" + MOUNT + "/agents'>Agents</a> page, then Reconnect.", false);
         return;
       } else {

--- a/src/terminal-ui.ts
+++ b/src/terminal-ui.ts
@@ -105,7 +105,7 @@ ${SHELL_JS}
     s.onerror = function () {
       setStatus("xterm unavailable", "err");
       showNotice("Failed to load the terminal renderer from <code>" + src + "</code>. " +
-        "You can always attach on the host: <code>tmux attach -t &lt;channel&gt;-agent</code>.", true);
+        "You can always attach on the host: <code>tmux attach -t &lt;agent-name&gt;-agent</code>.", true);
     };
     document.head.appendChild(s);
   }
@@ -117,7 +117,7 @@ ${SHELL_JS}
     if (typeof window.Terminal !== "function") {
       setStatus("xterm unavailable", "err");
       showNotice("The terminal renderer didn't initialize. " +
-        "You can always attach on the host: <code>tmux attach -t &lt;channel&gt;-agent</code>.", true);
+        "You can always attach on the host: <code>tmux attach -t &lt;agent-name&gt;-agent</code>.", true);
       return;
     }
     setStatus("connecting…");

--- a/src/ui-kit.test.ts
+++ b/src/ui-kit.test.ts
@@ -7,13 +7,20 @@ import { describe, test, expect } from "bun:test";
 import { THEME_CSS, SHELL_JS, appShell, NAV_VIEWS, BRAND } from "./ui-kit.ts";
 
 describe("appShell", () => {
-  test("renders the brand + all four nav tabs, marking only the active one", () => {
+  test("renders the brand + all nav tabs, marking only the active one", () => {
     const h = appShell({ active: "agents" });
     expect(h).toContain("app-header");
     expect(h).toContain('class="brand-mark"');
     for (const v of NAV_VIEWS) expect(h).toContain(`data-view="${v.view}"`);
     // active tab gets class="active"; others don't.
     expect(h).toContain('data-view="agents" href="#" class="active"');
+    expect(h).toContain('data-view="chat" href="#"');
+    expect(h).not.toContain('data-view="chat" href="#" class="active"');
+  });
+
+  test("marks Home active when it is the current view", () => {
+    const h = appShell({ active: "home" });
+    expect(h).toContain('data-view="home" href="#" class="active"');
     expect(h).toContain('data-view="chat" href="#"');
     expect(h).not.toContain('data-view="chat" href="#" class="active"');
   });
@@ -32,8 +39,8 @@ describe("appShell", () => {
     expect(appShell({ active: "terminal" })).not.toContain("app-controls");
   });
 
-  test("nav covers exactly chat/agents/terminal/config (no Home yet)", () => {
-    expect(NAV_VIEWS.map((v) => v.view)).toEqual(["chat", "agents", "terminal", "config"]);
+  test("nav covers exactly home/chat/agents/terminal/config, Home first", () => {
+    expect(NAV_VIEWS.map((v) => v.view)).toEqual(["home", "chat", "agents", "terminal", "config"]);
   });
 });
 

--- a/src/ui-kit.ts
+++ b/src/ui-kit.ts
@@ -54,8 +54,9 @@ export const BRAND = {
   fontMono: `ui-monospace, "SF Mono", Menlo, Monaco, "Cascadia Mono", monospace`,
 } as const;
 
-/** The four navigable views, in nav order. Home arrives in Phase 2. */
+/** The navigable views, in nav order. Home is the default landing (Phase 2). */
 export const NAV_VIEWS = [
+  { view: "home", label: "Home", path: "/home" },
   { view: "chat", label: "Chat", path: "/ui" },
   { view: "agents", label: "Agents", path: "/agents" },
   { view: "terminal", label: "Terminal", path: "/terminal" },
@@ -262,8 +263,8 @@ export function appShell(opts: { active: ShellView; controls?: string; status?: 
  */
 export const SHELL_JS = `
   // Public mount prefix: "" on loopback, "/channel" behind the hub proxy.
-  var MOUNT = window.location.pathname.replace(/\\/(ui|admin|agents|terminal)(\\/[^?]*)?\\/?$/, "");
-  var NAV_MAP = { chat: "/ui", agents: "/agents", terminal: "/terminal", config: "/admin" };
+  var MOUNT = window.location.pathname.replace(/\\/(home|ui|admin|agents|terminal)(\\/[^?]*)?\\/?$/, "");
+  var NAV_MAP = { home: "/home", chat: "/ui", agents: "/agents", terminal: "/terminal", config: "/admin" };
   function wireShell(active) {
     var links = document.querySelectorAll(".app-nav a[data-view]");
     for (var i = 0; i < links.length; i++) {


### PR DESCRIPTION
Phase 2 of the channel-UI coherence pass. Builds on the Phase 1 shared UI kit (#61) — adds a Home/overview landing as the new default page and settles Channel-vs-Agent vocabulary across the surfaces. Presentation + nav + the new route only; no auth, API-shape, sandbox, or SSE/WS protocol changes.

## Task A — new Home/overview page (`src/home-ui.ts`)
`HOME_UI_HTML`, same self-contained template-literal shape as the other pages, adopting `THEME_CSS` + `appShell({active:"home"})` + `SHELL_JS`/`wireShell("home")`.
- Serif **Home** h1 + muted subtitle.
- **Channels** card — `GET /.parachute/config` (OPEN, no auth): each channel = name + transport `.pill` + live `.dot`, row links to its Chat (`/ui?channel=`). Empty state + "Configure channels →" footer (`/admin`).
- **Running agents** card — `authedFetch /api/agents` (mints the `channel:admin` Bearer first; tolerates a failed mint with a "sign in via the portal" note): each agent = name + state `.pill`, row links to its Terminal (`/terminal?agent=`) + Chat. Empty state "No agents running — Spawn one →" + "Spawn an agent →" footer (`/agents`).
- Responsive 2-col grid (stacks under 720px), a quick-actions row (Spawn / Open chat / Configure), a Refresh button, and a 5s auto-refresh on the agents list.

## Task B — Home is the landing + in the nav
- `ui-kit.ts`: `{view:"home",...}` prepended to `NAV_VIEWS` (first entry) → `ShellView` gains `"home"` automatically; `home:"/home"` added to `NAV_MAP`; `home` added to the MOUNT-suffix-strip regex so MOUNT derives correctly on `/home`.
- `daemon.ts`: `GET /home` serves `HOME_UI_HTML` (mirrors `GET /agents`); the services.json `uiUrl` → `/channel/home`.
- `.parachute/module.json`: `uiUrl` → `/channel/home` (so the hub portal lands on Home); `configUiUrl` unchanged (`/channel/admin`).
- Tests updated: `ui-kit.test.ts` nav set now `["home","chat","agents","terminal","config"]` + a new home-active case; `admin-ui.test.ts` manifest `uiUrl` assertion → `/channel/home`.

## Task C — vocabulary (Channel = the messaging pipe; Agent = the sandboxed Claude Code session)
- `terminal-ui.ts`: the agent picker `<select id="channel">` → `id="agent"` (+ JS `getElementById`, `currentChannel()`→`currentAgent()`, the local `ch`→`agent`, label/title, and "no channel"→"no agent" / "Spawn a session"→"Spawn an agent" copy). Attach logic preserved — it keys off the `?agent=` query param + the selected value → `<name>-agent` tmux session (legacy `?channel=` fallback intact).
- `agents-ui.ts`: `terminalUrl` now emits `?agent=` (it is called with the agent name).
- Swept the chat/admin "session" copy: those describe an external **Claude Code session** connecting to a channel via MCP (a legitimately different thing from the spawned sandboxed agent), so they were left accurate rather than force-renamed.

No internal code identifiers / API shapes (`result.session`, `/api/agents`) were renamed — UI copy + the misleading select id only.

## Verification
- `bun run typecheck` → only the 2 pre-existing `src/bridge.ts` TS2589 errors.
- `bun test` → **417 pass, 0 fail** (1144 expect() calls; telegram/vault 401/ECONNREFUSED lines are fixture noise).
- Page-integrity probe — all 5 pages start `<!doctype`, end `</html>`, include `app-header` + `app-nav`, length > 5000:
  - home 17930 · chat 21764 · agents 35247 · terminal 20058 · config(admin) 55921
- Nav renders 5 tabs in order **home, chat, agents, terminal, config** (Home first); Home page marks Home active; `module.json` + services.json `uiUrl` = `/channel/home`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)