### PR TITLE
feat(ui): lifecycle cross-actions + first-run CTAs + chat markdown/attachments/permissions

### DIFF
--- a/src/admin-ui.ts
+++ b/src/admin-ui.ts
@@ -354,6 +354,14 @@ const STYLES = `
   .btn-remove:hover { background: ${PALETTE.dangerSoft}; border-color: ${PALETTE.danger}; }
   .btn-remove:disabled { opacity: 0.5; cursor: progress; }
 
+  /* Cross-action links (Spawn agent / Chat) on each channel row. The kit's .btn
+     is button-styled; as <a> elements they need inline-flex + no underline to
+     match. They sit just before Remove (which keeps margin-left:auto pushing the
+     status block left). */
+  .row-actions { display: inline-flex; align-items: center; gap: 0.4rem; }
+  .channel-row .btn { display: inline-flex; align-items: center; text-decoration: none; line-height: 1; }
+  .channel-row .btn:hover { text-decoration: none; }
+
   .add-form { display: flex; flex-direction: column; gap: 1rem; }
   /* A focus ring on inputs/selects — a touch richer than the kit's plain focus. */
   select:focus, input:focus {
@@ -631,6 +639,25 @@ const PAGE_SCRIPT = String.raw`
         status.appendChild(clients);
       }
       li.appendChild(status);
+
+      // Lifecycle cross-actions: jump from a configured channel straight to
+      // spawning an agent on it, or to its chat. These land on the other
+      // surfaces with ?channel=<name> pre-filled (MOUNT-prefixed so they resolve
+      // under the hub proxy). Styled as the kit's small ghost buttons; Remove
+      // stays as-is.
+      var actions = document.createElement("span");
+      actions.className = "row-actions";
+      var spawn = document.createElement("a");
+      spawn.className = "btn btn-sm btn-ghost";
+      spawn.href = MOUNT + "/agents?channel=" + encodeURIComponent(c.name);
+      spawn.textContent = "Spawn agent";
+      actions.appendChild(spawn);
+      var chat = document.createElement("a");
+      chat.className = "btn btn-sm btn-ghost";
+      chat.href = MOUNT + "/ui?channel=" + encodeURIComponent(c.name);
+      chat.textContent = "Chat";
+      actions.appendChild(chat);
+      li.appendChild(actions);
 
       var rm = document.createElement("button");
       rm.type = "button";

--- a/src/agents-ui.ts
+++ b/src/agents-ui.ts
@@ -474,6 +474,12 @@ ${SHELL_JS}
   // The terminal attaches to an AGENT (its tmux session), so the link carries the
   // agent name as ?agent= (the terminal page also accepts the legacy ?channel=).
   function terminalUrl(agent) { return MOUNT + "/terminal?agent=" + encodeURIComponent(agent); }
+  // /api/agents returns { name, session, attached } — it does NOT carry the
+  // agent's wake channel(s). The default is one-agent-one-channel (the spawn form
+  // auto-names the agent after its wake channel), so the Chat link uses the agent
+  // name as the channel (?channel=<name>). When an agent was custom-named off its
+  // channel, the chat page still loads on its picker — no fabricated data.
+  function chatUrl(channel) { return MOUNT + "/ui?channel=" + encodeURIComponent(channel); }
   function loadAgents() {
     return apiJson("/api/agents").then(function (j) {
       var host = document.getElementById("agents-table");
@@ -489,6 +495,7 @@ ${SHELL_JS}
           "<td><code>" + esc(a.session) + "</code></td>" +
           "<td>" + att + "</td>" +
           "<td class='actions'>" +
+            "<a href='" + esc(chatUrl(a.name)) + "'>chat →</a>" +
             "<a href='" + esc(terminalUrl(a.name)) + "' target='_blank' rel='noopener'>terminal ↗</a>" +
             "<button class='ghost danger' data-kill='" + esc(a.name) + "' type='button'>kill</button>" +
           "</td></tr>";
@@ -514,13 +521,37 @@ ${SHELL_JS}
   document.getElementById("refresh").addEventListener("click", function () { loadAgents(); });
 
   // --- pickers: channels + vaults -----------------------------------------
+  // A ?channel=<name> query param (from a "Spawn agent" link on another surface)
+  // pre-selects that channel + auto-fills the agent name, so the form lands
+  // ready-to-go. Only honored when the channel actually exists in the list.
+  function requestedChannel() {
+    try { return new URL(window.location.href).searchParams.get("channel") || ""; }
+    catch (_e) { return ""; }
+  }
   function loadChannels() {
     return fetch(MOUNT + "/.parachute/config").then(function (r) { return r.json(); }).then(function (cfg) {
       knownChannels = (cfg.channels || []).map(function (c) { return c.name; });
-      chanEl.innerHTML = knownChannels.length
-        ? channelOptions(knownChannels[0])
-        : "<option value=''>(no channels — add one in Config)</option>";
-      if (knownChannels.length && !nameEdited) nameEl.value = knownChannels[0];
+      if (!knownChannels.length) {
+        // No channels configured: don't dead-end. Show a CTA to Config in the
+        // picker AND surface it on the spawn form (a channel is required first).
+        chanEl.innerHTML = "<option value=''>(no channels — add one in Config)</option>";
+        showMsg(document.getElementById("spawn-msg"),
+          "No channels configured yet — configure a channel first, then spawn an agent on it.", true);
+        var sm = document.getElementById("spawn-msg");
+        // Append a real link (showMsg uses textContent; add the link after it).
+        var a = document.createElement("a");
+        a.href = MOUNT + "/admin";
+        a.textContent = " Configure a channel first →";
+        a.style.display = "inline-block";
+        a.style.marginTop = "6px";
+        sm.appendChild(document.createElement("br"));
+        sm.appendChild(a);
+        return;
+      }
+      var want = requestedChannel();
+      var pre = (want && knownChannels.indexOf(want) >= 0) ? want : knownChannels[0];
+      chanEl.innerHTML = channelOptions(pre);
+      if (!nameEdited) nameEl.value = pre;
     }).catch(function () {
       chanEl.innerHTML = "<option value=''>(channel list failed)</option>";
     });

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -313,12 +313,27 @@ ${THEME_CSS}
   }
   /* Light-theme message bubbles. "you" = accent; "them" = soft surface; "sys" =
      muted/italic system line; "perm" = a warn style for permission prompts. */
-  .msg { max-width: 78%; padding: 8px 12px; border-radius: 12px; white-space: pre-wrap; word-wrap: break-word; }
+  /* Bodies render Markdown (renderMarkdown -> innerHTML): newlines become <br>
+     and code blocks become <pre>, so the bubble itself wraps normally rather than
+     preserving raw whitespace (which would double the line breaks). */
+  .msg { max-width: 78%; padding: 8px 12px; border-radius: 12px; white-space: normal; word-wrap: break-word; overflow-wrap: anywhere; }
   .msg.you { align-self: flex-end; background: var(--accent); color: #fff; border-bottom-right-radius: 4px; }
   .msg.them { align-self: flex-start; background: var(--bg-soft); color: var(--fg); border: 1px solid var(--border); border-bottom-left-radius: 4px; }
   .msg.sys { align-self: center; background: transparent; color: var(--fg-muted); font-size: 0.8rem; font-style: italic; max-width: 90%; }
   .msg.perm { align-self: flex-start; background: var(--warn-soft); border: 1px solid var(--warn); border-left: 3px solid var(--warn); color: var(--warn); max-width: 90%; }
+  /* Markdown bits inside a bubble: inline code + fenced blocks, links, emphasis. */
+  .msg code { font-family: var(--font-mono); font-size: 0.85em; background: rgba(0,0,0,0.06); padding: 0.05rem 0.3rem; border-radius: 4px; }
+  .msg.you code { background: rgba(255,255,255,0.22); }
+  .msg pre { margin: 6px 0; padding: 8px 10px; background: rgba(0,0,0,0.06); border-radius: 8px; overflow-x: auto; }
+  .msg pre code { background: transparent; padding: 0; font-size: 0.82em; }
+  .msg.you pre { background: rgba(255,255,255,0.18); }
+  .msg a { text-decoration: underline; }
+  .msg.you a { color: #fff; }
   .files { margin-top: 4px; font-size: 0.8rem; opacity: .85; }
+  .files .file-name { font-family: var(--font-mono); }
+  /* Permission bubble: Approve/Deny row + the follow-up note. */
+  .perm-actions { display: flex; gap: 8px; margin-top: 8px; }
+  .perm-note { margin-top: 8px; font-size: 0.78rem; color: var(--fg-muted); font-style: italic; }
   form {
     display: flex; gap: 8px; padding: 12px 16px;
     border-top: 1px solid var(--border); background: var(--card);
@@ -429,13 +444,83 @@ ${SHELL_JS}
   function add(kind, text, files) {
     var el = document.createElement("div");
     el.className = "msg " + kind;
-    el.textContent = text;
+    // Message bodies render through renderMarkdown (SHELL_JS) — a SMALL, XSS-safe
+    // Markdown subset (escapes first, then a bounded set of patterns). Trusted
+    // HTML out, so assign via innerHTML. Phase 4's vault-backed chat reuses it.
+    el.innerHTML = renderMarkdown(text);
     if (files && files.length) {
+      // ATTACHMENTS: a reply's files is a string[] of file PATHS on the daemon
+      // host (the bridge documents reply files as absolute paths, e.g.
+      // /abs/path.png). There is NO endpoint that serves a reply attachment
+      // as a downloadable blob: the daemon's POST /api/download goes the OTHER
+      // way (a Telegram file_id -> a server-local path) and requires
+      // channel:write, which the chat page's token (channel:read channel:send)
+      // does not hold. So we render the names clearly rather than fabricate a
+      // download link. Making these downloadable needs new backend work (a
+      // blob-serving route scoped to channel:read) — left for a follow-up.
       var f = document.createElement("div");
       f.className = "files";
-      f.textContent = "📎 " + files.join(", ");
+      var label = document.createElement("span");
+      label.textContent = "📎 ";
+      f.appendChild(label);
+      files.forEach(function (name, i) {
+        if (i) f.appendChild(document.createTextNode(", "));
+        var n = document.createElement("span");
+        n.className = "file-name";
+        // Show the basename (paths are host-local); title carries the full path.
+        var base = String(name).split("/").pop() || String(name);
+        n.textContent = base;
+        n.title = String(name);
+        f.appendChild(n);
+      });
       el.appendChild(f);
     }
+    transcript.appendChild(el);
+    transcript.scrollTop = transcript.scrollHeight;
+  }
+
+  // Render a permission prompt as an interactive bubble with Approve / Deny.
+  //
+  // SCOPE NOTE (flagged): submitting a verdict has NO daemon endpoint today, and
+  // the chat page's token is channel:read + channel:send only. The existing
+  // POST /api/permission is the OUTBOUND prompt (bridge -> channel,
+  // transport.sendPermission) gated channel:write — NOT a verdict sink; the
+  // verdict path (ctx.emitPermissionVerdict -> bridges/MCP sessions) has no HTTP
+  // route the browser can call. So the buttons are wired to a clear, honest
+  // "needs backend + channel:write" state rather than a call that would 401 or
+  // hit the wrong endpoint. When the verdict route + scope land (Phase 4), swap
+  // the handler body for the real POST. We deliberately do NOT weaken the gate.
+  function addPermission(d) {
+    var el = document.createElement("div");
+    el.className = "msg perm";
+    var head = document.createElement("div");
+    head.innerHTML = renderMarkdown("🔐 **permission:** " + (d.tool_name || "") +
+      "\\n" + (d.description || "") + "\\n" + (d.input_preview || ""));
+    el.appendChild(head);
+    var actions = document.createElement("div");
+    actions.className = "perm-actions";
+    var note = document.createElement("div");
+    note.className = "perm-note";
+    function disableWithNote(verdict) {
+      approve.disabled = true; deny.disabled = true;
+      note.textContent = "Recorded your choice (" + verdict + ") in the UI. Approving/denying " +
+        "from chat needs a verdict endpoint + a channel:write token — follow-up. " +
+        "For now respond in the session's terminal.";
+    }
+    var approve = document.createElement("button");
+    approve.type = "button";
+    approve.className = "btn btn-sm btn-primary";
+    approve.textContent = "Approve";
+    approve.addEventListener("click", function () { disableWithNote("approve"); });
+    var deny = document.createElement("button");
+    deny.type = "button";
+    deny.className = "btn btn-sm btn-danger";
+    deny.textContent = "Deny";
+    deny.addEventListener("click", function () { disableWithNote("deny"); });
+    actions.appendChild(approve);
+    actions.appendChild(deny);
+    el.appendChild(actions);
+    el.appendChild(note);
     transcript.appendChild(el);
     transcript.scrollTop = transcript.scrollHeight;
   }
@@ -468,7 +553,7 @@ ${SHELL_JS}
     es.addEventListener("permission", function (e) {
       try {
         var d = JSON.parse(e.data);
-        add("perm", "🔐 permission: " + d.tool_name + "\\n" + (d.description || "") + "\\n" + (d.input_preview || ""));
+        addPermission(d);
       } catch (_) {}
     });
     es.addEventListener("close", function () { setStatus("closed", ""); });
@@ -540,10 +625,37 @@ ${SHELL_JS}
     connect();
   });
 
+  // No http-ui channel to chat on: don't dead-end. Drop a forward CTA into the
+  // transcript pointing at Config (to add a channel) + Home, and disable the
+  // composer (nothing to send to).
+  function showNoChannelCta() {
+    setStatus("no channels", "");
+    sendBtn.disabled = true;
+    var el = document.createElement("div");
+    el.className = "msg sys";
+    var p = document.createElement("div");
+    p.textContent = "No http-ui channel to chat on yet.";
+    el.appendChild(p);
+    var links = document.createElement("div");
+    links.style.marginTop = "6px";
+    var add = document.createElement("a");
+    add.href = MOUNT + "/admin";
+    add.textContent = "Add a channel →";
+    var sep = document.createTextNode("   ");
+    var home = document.createElement("a");
+    home.href = MOUNT + "/home";
+    home.textContent = "Home";
+    links.appendChild(add);
+    links.appendChild(sep);
+    links.appendChild(home);
+    el.appendChild(links);
+    transcript.appendChild(el);
+  }
+
   function loadChannelsAndConnect() {
     return fetch(MOUNT + "/.parachute/config").then(function (r) { return r.json(); }).then(function (cfg) {
       var chans = (cfg.channels || []).filter(function (c) { return c.transport === "http-ui"; });
-      if (!chans.length) { setStatus("no http-ui channels configured", ""); return; }
+      if (!chans.length) { showNoChannelCta(); return; }
       var preselect = new URL(window.location.href).searchParams.get("channel");
       chans.forEach(function (c) {
         var opt = document.createElement("option");

--- a/src/home-ui.ts
+++ b/src/home-ui.ts
@@ -139,6 +139,7 @@ ${SHELL_JS}
   }
 
   function chatUrl(channel) { return MOUNT + "/ui?channel=" + encodeURIComponent(channel); }
+  function spawnUrl(channel) { return MOUNT + "/agents?channel=" + encodeURIComponent(channel); }
   function terminalUrl(agent) { return MOUNT + "/terminal?agent=" + encodeURIComponent(agent); }
 
   // --- channels (OPEN config + health, no token needed) -------------------
@@ -174,6 +175,7 @@ ${SHELL_JS}
             "<span class='spacer'></span>" +
             clients +
             "<span class='links'>" +
+              "<a href='" + esc(spawnUrl(c.name)) + "'>spawn →</a>" +
               "<a href='" + esc(chatUrl(c.name)) + "'>chat →</a>" +
             "</span>" +
           "</div>";

--- a/src/ui-kit.test.ts
+++ b/src/ui-kit.test.ts
@@ -138,6 +138,23 @@ describe("renderMarkdown (SHELL_JS, XSS-safe Markdown subset)", () => {
     expect(out).toContain("[click]");
   });
 
+  test("rejects data: URLs too — only http/https survive as anchors", () => {
+    const out = renderMarkdown("[x](data:text/html,<script>alert(1)</script>)");
+    expect(out).not.toContain("<a ");
+    expect(out).not.toContain("href=");
+    // any escaped markup inside is inert text, never executable.
+    expect(out).not.toContain("<script>");
+  });
+
+  test("escapes other canonical XSS vectors (img onerror, svg onload)", () => {
+    const out1 = renderMarkdown('<img src=x onerror=alert(1)>');
+    expect(out1).not.toContain("<img");
+    expect(out1).toContain("&lt;img");
+    const out2 = renderMarkdown('<svg onload=alert(1)>');
+    expect(out2).not.toContain("<svg");
+    expect(out2).toContain("&lt;svg");
+  });
+
   test("converts newlines to <br>", () => {
     expect(renderMarkdown("line1\nline2")).toContain("line1<br>line2");
   });

--- a/src/ui-kit.test.ts
+++ b/src/ui-kit.test.ts
@@ -75,4 +75,70 @@ describe("SHELL_JS", () => {
   test("is safe to interpolate — no naked backtick that could break a host literal", () => {
     expect(SHELL_JS.includes("`")).toBe(false);
   });
+  test("exports a renderMarkdown helper (reused by the chat transcript)", () => {
+    expect(SHELL_JS).toContain("function renderMarkdown");
+  });
+});
+
+// renderMarkdown lives inside SHELL_JS (vanilla JS, no DOM). Evaluate SHELL_JS in
+// a fresh function scope and hand back its renderMarkdown so we can exercise it
+// directly — the same code the chat page runs in the browser.
+function loadRenderMarkdown(): (text: string) => string {
+  // SHELL_JS defines `var MOUNT = window.location...` at the top; stub a minimal
+  // window so that line doesn't throw when evaluated outside a browser.
+  const factory = new Function(
+    "window",
+    SHELL_JS + "\nreturn renderMarkdown;",
+  ) as (w: unknown) => (text: string) => string;
+  return factory({ location: { pathname: "/ui" } });
+}
+
+describe("renderMarkdown (SHELL_JS, XSS-safe Markdown subset)", () => {
+  const renderMarkdown = loadRenderMarkdown();
+
+  test("escapes raw HTML first — a <script> tag never survives as markup", () => {
+    const out = renderMarkdown("<script>alert(1)</script>");
+    expect(out).not.toContain("<script>");
+    expect(out).toContain("&lt;script&gt;");
+  });
+
+  test("renders bold and italic", () => {
+    expect(renderMarkdown("**bold**")).toContain("<strong>bold</strong>");
+    expect(renderMarkdown("an *italic* word")).toContain("<em>italic</em>");
+  });
+
+  test("renders inline code and fenced code blocks", () => {
+    const bt = String.fromCharCode(96);
+    expect(renderMarkdown(bt + "inline" + bt)).toContain("<code>inline</code>");
+    const fenced = renderMarkdown(bt + bt + bt + "\nconst x = 1;\n" + bt + bt + bt);
+    expect(fenced).toContain("<pre><code>");
+    expect(fenced).toContain("const x = 1;");
+  });
+
+  test("does not apply inline rules inside code spans", () => {
+    const bt = String.fromCharCode(96);
+    const out = renderMarkdown(bt + "**not bold**" + bt);
+    expect(out).toContain("<code>**not bold**</code>");
+    expect(out).not.toContain("<strong>");
+  });
+
+  test("renders http/https links as anchors with the url preserved", () => {
+    const out = renderMarkdown("[site](https://example.com/x)");
+    expect(out).toContain('href="https://example.com/x"');
+    expect(out).toContain(">site</a>");
+    expect(out).toContain('rel="noopener noreferrer"');
+  });
+
+  test("rejects javascript: URLs — renders inert escaped text, no anchor", () => {
+    const out = renderMarkdown("[click](javascript:alert(1))");
+    // No anchor and no href is produced — the would-be URL never reaches markup.
+    expect(out).not.toContain("<a ");
+    expect(out).not.toContain("href=");
+    // The markdown is left as inert escaped text (safe — not an executable link).
+    expect(out).toContain("[click]");
+  });
+
+  test("converts newlines to <br>", () => {
+    expect(renderMarkdown("line1\nline2")).toContain("line1<br>line2");
+  });
 });

--- a/src/ui-kit.ts
+++ b/src/ui-kit.ts
@@ -277,6 +277,65 @@ export const SHELL_JS = `
   function escapeHtml(s) {
     return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#39;");
   }
+  // Render a SMALL, SAFE subset of Markdown to HTML. XSS-safe by construction:
+  // the input is escapeHtml'd FIRST (so no raw HTML can survive), THEN a limited
+  // set of patterns is applied to the already-escaped string. Supports fenced
+  // code blocks, inline code, bold, italic, links (http/https only), and line
+  // breaks. Anything else passes through as escaped text. Returns trusted HTML —
+  // assign it via innerHTML. Shared so Phase 4's vault-backed chat reuses it.
+  //
+  // No literal backtick appears in this source (SHELL_JS is asserted backtick-
+  // free so it is safe to interpolate into a host template literal); the fence +
+  // inline-code markers are built from char code 96 at runtime.
+  function renderMarkdown(text) {
+    var BT = String.fromCharCode(96); // the backtick character
+    var escaped = escapeHtml(String(text == null ? "" : text));
+    // 1. Fenced code blocks: a run of 3+ backticks, optional language token on
+    //    the open line, body until the closing fence. Pull these out FIRST and
+    //    park them as placeholders so inline rules never touch code contents.
+    // (These dynamic regexes are built via new RegExp from strings inside SHELL_JS,
+    //  which is itself a template literal then eval'd, so regex backslashes are
+    //  written four-deep in this source to survive both unescapes to a single
+    //  regex escape at runtime. The placeholder NUL sentinels are written the
+    //  same way so they reach the runtime as a real NUL.)
+    var blocks = [];
+    var fence = new RegExp(BT + "{3,}([^\\\\n]*)\\\\n([\\\\s\\\\S]*?)" + BT + "{3,}", "g");
+    escaped = escaped.replace(fence, function (_m, _lang, code) {
+      blocks.push(code.replace(/\\n$/, ""));
+      return "\\u0000B" + (blocks.length - 1) + "\\u0000";
+    });
+    // 2. Inline code: a single backtick run. Park it too so bold/italic/link
+    //    rules never fire inside code.
+    var inlines = [];
+    var inline = new RegExp(BT + "([^" + BT + "\\\\n]+)" + BT, "g");
+    escaped = escaped.replace(inline, function (_m, code) {
+      inlines.push(code);
+      return "\\u0000I" + (inlines.length - 1) + "\\u0000";
+    });
+    // 3. Links: [text](url) — only http/https URLs survive; anything else (e.g.
+    //    javascript:) renders as inert escaped text. The URL is already HTML-
+    //    escaped; we re-escape the double-quote for the attribute context.
+    escaped = escaped.replace(/\\[([^\\]]+)\\]\\(([^)\\s]+)\\)/g, function (m, label, url) {
+      if (!/^https?:\\/\\//i.test(url)) return m;
+      var safeUrl = url.replace(/"/g, "&quot;");
+      return '<a href="' + safeUrl + '" target="_blank" rel="noopener noreferrer">' + label + "</a>";
+    });
+    // 4. Bold (**x**) then italic (*x* / _x_). Bold first so ** is consumed
+    //    before the single-* italic rule sees it.
+    escaped = escaped.replace(/\\*\\*([^*\\n]+)\\*\\*/g, "<strong>$1</strong>");
+    escaped = escaped.replace(/(^|[^*])\\*([^*\\n]+)\\*/g, "$1<em>$2</em>");
+    escaped = escaped.replace(/(^|[^_])_([^_\\n]+)_/g, "$1<em>$2</em>");
+    // 5. Line breaks → <br>.
+    escaped = escaped.replace(/\\n/g, "<br>");
+    // 6. Restore the parked code spans (their contents stay escaped, never parsed).
+    escaped = escaped.replace(/\\u0000I(\\d+)\\u0000/g, function (_m, i) {
+      return "<code>" + inlines[+i] + "</code>";
+    });
+    escaped = escaped.replace(/\\u0000B(\\d+)\\u0000/g, function (_m, i) {
+      return "<pre><code>" + blocks[+i] + "</code></pre>";
+    });
+    return escaped;
+  }
   function setStatus(text, kind) {
     var el = document.getElementById("status");
     if (!el) return;


### PR DESCRIPTION
Phase 3 (final) of the channel-UI coherence pass. Wires the five surfaces to each other along the lifecycle (configure channel → spawn agent → watch/chat), removes first-run dead-ends, and polishes the chat transcript. Branch off current `main`; do not merge until reviewed.

## Part A — lifecycle cross-actions
- **Agents spawn form** (`agents-ui.ts`): reads `?channel=<name>` on load, pre-selects that channel in the wake-channel `<select>` and auto-fills the agent name — so "Spawn" links from other surfaces land ready-to-go.
- **Config channel rows** (`admin-ui.ts`): each row gains **Spawn agent** (→ `MOUNT + /agents?channel=<name>`) and **Chat** (→ `MOUNT + /ui?channel=<name>`) ghost link-buttons (`.btn .btn-sm .btn-ghost`); Remove unchanged.
- **Home channel rows** (`home-ui.ts`): each row gains **spawn →** (→ `/agents?channel=<name>`) beside the existing chat →.
- **Agents running-agents table** (`agents-ui.ts`): rows gain **chat →**. `GET /api/agents` returns `{ name, session, attached }` — it does **not** carry the agent's wake channel — so chat links to `?channel=<agent.name>` (the default one-agent-one-channel case, where the spawn form auto-names the agent after its channel). No fabricated data.

## Part B — first-run / empty-state CTAs
- **Chat** (`daemon.ts`): when no `http-ui` channel is configured, the transcript shows a forward CTA ("Add a channel →" to Config, plus Home) and disables the composer — no dead-end.
- **Agents** (`agents-ui.ts`): when no channels exist, the spawn area surfaces a "Configure a channel first →" CTA.
- Home + Terminal already had forward CTAs — left as-is.

## Part C — chat message polish
- **Markdown**: `renderMarkdown(text)` added to `SHELL_JS` (`ui-kit.ts`) — a SMALL, XSS-safe subset: `escapeHtml` **first**, then fenced + inline code, bold, italic, http/https links (validated; `javascript:` rejected to inert text), and line breaks. No raw HTML passthrough. Chat bodies render through it. Reusable by Phase 4. `SHELL_JS` stays backtick-free (fence/inline markers built from char code 96). **7 unit tests** added to `ui-kit.test.ts` (escapes `<script>`, bold/italic, inline+fenced code, code-spans untouched by inline rules, link rendering, `javascript:` rejection, newlines).
- **Attachments** ⚠️: a reply's `files[]` is a `string[]` of **daemon-host file paths** (the bridge documents reply files as absolute paths). There is **no endpoint that serves a reply attachment as a downloadable blob** — `POST /api/download` goes the *other* direction (Telegram `file_id` → server-local path) and requires `channel:write`, which the chat token (`channel:read channel:send`) lacks. So names render clearly (basename shown, full path in `title`) with a code comment; downloadability is left for a backend follow-up rather than inventing a route.
- **Permission approve/deny** ⚠️: permission bubbles gain Approve / Deny buttons. **There is no verdict endpoint today** — the existing `/api/permission` is the *outbound* prompt (bridge → channel, `transport.sendPermission`, `channel:write`), not a verdict sink; the verdict path (`ctx.emitPermissionVerdict` → bridges/MCP sessions) has no HTTP route the browser can call. And the chat token is `channel:read channel:send` only. So the buttons record the choice in-UI and explain that submitting needs a verdict route + a `channel:write` token — **flagged, not faked. The auth gate is not weakened.**

## Flagged for follow-up
1. **Permission verdicts from chat** need (a) a daemon verdict endpoint that calls `ctx.emitPermissionVerdict`, and (b) a token scope that authorizes it. The chat's `channel:send` token can't drive `channel:write`.
2. **Attachment downloads** need a `channel:read`-scoped blob-serving route for reply file paths; the current `/api/download` is the wrong direction + scope.

## Verification
- `bun run typecheck` → only the 2 pre-existing `src/bridge.ts` TS2589 errors.
- `bun test` → **426 pass / 0 fail** (telegram/vault 401/ECONNREFUSED/500 = documented fixture noise).
- Page-integrity probe → all five pages start `<!doctype`, end `</html>`, include `app-nav`, length > 5000. `SHELL_JS` backtick-free; `renderMarkdown` present.
- Terminal CONTENT pane untouched (still `--term-bg` / `#000000`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
