### PR TITLE
fix(channel): no silent message loss — delivery high-water-mark + backlog replay on (re)connect

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,6 +240,17 @@ Bearer `vault:<name>:write`).
 - `.env` — optional generic env vars (e.g. `PARACHUTE_HUB_ORIGIN`). The daemon no longer consumes `TELEGRAM_BOT_TOKEN` here.
 - `access.json` — allowlist (compatible with the official plugin's format)
 - `inbox/` — downloaded attachments
+- `delivery-state.json` — per-channel last-delivered high-water-mark (`{ "<channel>": "<iso-ts>" }`), the spine of the no-silent-loss guarantee (below). Cheap, monotonic, write-through; losing it only costs a bounded re-replay.
+
+## No silent message loss (delivery high-water-mark + backlog replay)
+
+A connected vault-backed session used to go silently deaf after a daemon restart: MCP sessions drop on restart and only reconnect on the next interaction, and an inbound that lands with **zero** live subscribers reaches no one — yet the vault trigger acks success and stamps `..._rendered_at`, so it never re-fires. The message stays durable in the vault but is lost from the live wake.
+
+The fix (`src/delivery-state.ts`):
+- **Per-channel high-water-mark** — the ISO `ts` of the last inbound we actually delivered to ≥1 live subscriber. `contextFor.emit` advances it ONLY on a real delivery (SSE client count + MCP session count > 0); a 0-subscriber emit deliberately leaves the mark behind so the message replays later. Monotonic (never rewinds), persisted to `delivery-state.json`. A channel with no persisted mark defaults to the **daemon boot time** — so a first connect never replays ancient history, only the genuine deaf-window gap.
+- **Backlog replay on (re)connect** (`replayBacklog`, VAULT channels only) — when an MCP session registers or an SSE bridge reopens `/events`, the daemon loads the channel transcript (reusing the index-free `loadTranscript`), replays the inbound messages newer than the mark — oldest-first, capped at the newest 50 — to **that one new subscriber only** (a per-session MCP push / a write to that one SSE stream, so existing subscribers aren't re-woken), then advances the mark.
+
+`markSeen` (the webhook idempotency dedup that prevents the N-trigger fan-out from double-waking) is unchanged and orthogonal — the backlog path is gated by the mark, not by `markSeen`.
 
 ## Access control (`access.json`)
 

--- a/src/backlog-replay.test.ts
+++ b/src/backlog-replay.test.ts
@@ -353,6 +353,31 @@ describe("MCP connect replays the backlog to the new session only", () => {
     // Mark advanced past the replayed message → a third connect replays nothing.
     expect(ds.getLastDelivered("eng")).toBe("2026-06-16T10:05:00.000Z");
   });
+
+  test("a STREAMLESS session does not replay or advance the mark (it waits for its GET stream)", async () => {
+    // A session that registered but never opened its GET push stream is not
+    // deliverable; replay must NOT fire for it (firing would push into the void and
+    // advance the mark past a message nobody received — the silent-loss bug). The
+    // backlog stays pending until the session opens its stream.
+    const ds = new DeliveryState({ stateDir, defaultMark: "2026-01-01T00:00:00.000Z" });
+    ds.advance("eng", "2026-06-16T10:00:00.000Z");
+    const t = stubVault("eng", [
+      { id: "in-pending", text: "still here?", direction: "inbound", sender: "a", ts: "2026-06-16T10:05:00.000Z" },
+    ]);
+    const channels = vaultChannels("eng", t);
+    const registry = new ClientRegistry();
+    createFetchHandler(channels, registry, { deliveryState: ds });
+
+    const streamless = capture();
+    _registerSessionForTest("eng", "sid-streamless", streamless.server as never, ["channel:read"], {
+      streamless: true,
+    });
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(mcpSessionCount("eng")).toBe(1); // registered…
+    expect(streamless.wakes()).toHaveLength(0); // …but got no replay
+    expect(ds.getLastDelivered("eng")).toBe("2026-06-16T10:00:00.000Z"); // mark held — message still pending
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/backlog-replay.test.ts
+++ b/src/backlog-replay.test.ts
@@ -1,0 +1,471 @@
+/**
+ * No-silent-loss tests — the delivery high-water-mark + backlog replay that fix
+ * a connected channel session silently going deaf after a daemon restart
+ * (messages that arrive while nobody is subscribed are lost from the live wake,
+ * though they stay durable in the vault).
+ *
+ * Layers exercised here (delivery-state unit coverage lives in delivery-state.test.ts):
+ *  - replayBacklog: inbound-since-mark delivered ASCENDING + capped at REPLAY_CAP;
+ *    outbound excluded; mark advances to the newest replayed ts; a SECOND call
+ *    returns empty; a non-vault channel is skipped (0); a load failure → 0 (the
+ *    connect never fails); a missing-ts message is skipped.
+ *  - emit (via the live daemon /api/vault/inbound webhook): 0 subscribers → mark
+ *    NOT advanced (so it replays later); ≥1 subscriber → mark advanced to the note ts.
+ *  - MCP connect → backlog replayed to THAT session only (the _registerSessionForTest
+ *    seam fires the connect hook installed by createFetchHandler).
+ *  - SSE /events connect → backlog replayed onto the new stream.
+ *  - END-TO-END deaf window: an inbound arrives with no subscriber (mark stays) →
+ *    a session connects → the missed message is delivered exactly once.
+ *
+ * Auth: the same sentinel-token hub-jwt mock the other daemon tests use — a
+ * `Bearer test-rw-token` validates with channel:read + write + send WITHOUT a live
+ * hub/JWKS. The vault I/O is a REAL VaultTransport whose loadTranscript is
+ * monkeypatched on the instance (the daemon branches on `instanceof VaultTransport`),
+ * so NO real vault is touched.
+ */
+import { describe, test, expect, mock, beforeEach, afterEach } from "bun:test";
+
+const RW_TOKEN = "test-rw-token"; // channel:read + write + send
+import { HubJwtError, looksLikeJwt } from "@openparachute/scope-guard";
+mock.module("./hub-jwt.ts", () => ({
+  CHANNEL_AUDIENCE: "channel",
+  async validateHubJwt(token: string) {
+    const base = { sub: "test", aud: "channel", jti: undefined, clientId: undefined, vaultScope: undefined };
+    if (token === RW_TOKEN) {
+      // All scopes — the config-API hot-add (used to start a channel through the
+      // daemon's OWN contextFor, so emit advances the mark) needs channel:admin.
+      return { ...base, scopes: ["channel:read", "channel:write", "channel:send", "channel:admin"] };
+    }
+    throw new HubJwtError("issuer", "invalid token");
+  },
+  HubJwtError,
+  looksLikeJwt,
+  resetJwksCache() {},
+  resetRevocationCache() {},
+}));
+
+import { createFetchHandler, replayBacklog, REPLAY_CAP, type ReplayMessage } from "./daemon.ts";
+import { ClientRegistry } from "./routing.ts";
+import { DeliveryState } from "./delivery-state.ts";
+import { VaultTransport, type ChannelMessage } from "./transports/vault.ts";
+import { HttpUiTransport } from "./transports/http-ui.ts";
+import type { Channel } from "./registry.ts";
+import {
+  _resetSessionsForTest,
+  _registerSessionForTest,
+  mcpSessionCount,
+} from "./mcp-http.ts";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const auth = { authorization: `Bearer ${RW_TOKEN}` };
+
+/** A VaultTransport whose loadTranscript is stubbed on the instance (instanceof holds). */
+function stubVault(channel: string, transcript: ChannelMessage[], loadThrows?: Error): VaultTransport {
+  const t = new VaultTransport({ vault: "default", vaultUrl: "http://127.0.0.1:59999", token: "x" });
+  (t as unknown as { ctx: { channel: string } }).ctx = { channel };
+  t.loadTranscript = async () => {
+    if (loadThrows) throw loadThrows;
+    return transcript;
+  };
+  return t;
+}
+
+function vaultChannels(channel: string, transport: VaultTransport): Map<string, Channel> {
+  return new Map([[channel, { name: channel, transport, entry: { name: channel, transport: "vault" } }]]);
+}
+
+let stateDir: string;
+let prevStateDirEnv: string | undefined;
+beforeEach(() => {
+  stateDir = mkdtempSync(join(tmpdir(), "channel-backlog-"));
+  // Point the config-API hot-add's channels.json write (defaultStateDir reads the
+  // env at request time) at the temp dir, so tests NEVER touch the real
+  // ~/.parachute/channel/. The DeliveryState instances are also constructed with
+  // this stateDir explicitly.
+  prevStateDirEnv = process.env.PARACHUTE_CHANNEL_STATE_DIR;
+  process.env.PARACHUTE_CHANNEL_STATE_DIR = stateDir;
+  _resetSessionsForTest();
+});
+afterEach(() => {
+  _resetSessionsForTest();
+  if (prevStateDirEnv === undefined) delete process.env.PARACHUTE_CHANNEL_STATE_DIR;
+  else process.env.PARACHUTE_CHANNEL_STATE_DIR = prevStateDirEnv;
+  rmSync(stateDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// replayBacklog — the pure recovery primitive.
+// ---------------------------------------------------------------------------
+
+describe("replayBacklog", () => {
+  const MARK = "2026-06-16T10:00:00.000Z";
+
+  function dsAt(mark: string): DeliveryState {
+    // A boot default OLDER than the messages so nothing is filtered by the default;
+    // the per-channel mark we set drives the cut.
+    const ds = new DeliveryState({ stateDir, defaultMark: "2026-01-01T00:00:00.000Z" });
+    ds.advance("eng", mark);
+    return ds;
+  }
+
+  test("delivers inbound-since-mark ascending; excludes outbound + at-or-before-mark; advances the mark", async () => {
+    const transcript: ChannelMessage[] = [
+      { id: "old", text: "before the mark", direction: "inbound", sender: "a", ts: "2026-06-16T09:59:00.000Z" },
+      { id: "at", text: "exactly at the mark", direction: "inbound", sender: "a", ts: MARK },
+      { id: "in1", text: "missed 1", direction: "inbound", sender: "a", ts: "2026-06-16T10:01:00.000Z" },
+      { id: "out", text: "a reply", direction: "outbound", sender: "session", ts: "2026-06-16T10:02:00.000Z" },
+      { id: "in2", text: "missed 2", direction: "inbound", sender: "a", ts: "2026-06-16T10:03:00.000Z" },
+    ];
+    const t = stubVault("eng", transcript);
+    const channels = vaultChannels("eng", t);
+    const ds = dsAt(MARK);
+
+    const got: ReplayMessage[] = [];
+    const n = await replayBacklog(channels, ds, "eng", (m) => got.push(m));
+
+    expect(n).toBe(2);
+    // Ascending, inbound-only, strictly after the mark.
+    expect(got.map((m) => m.content)).toEqual(["missed 1", "missed 2"]);
+    // Replay carries the original ts + a replay marker + inbound direction.
+    expect(got[0]!.meta.ts).toBe("2026-06-16T10:01:00.000Z");
+    expect(got[0]!.meta.direction).toBe("inbound");
+    expect(got[0]!.meta.replay).toBe("true");
+    expect(got[0]!.meta.note_id).toBe("in1");
+    // The mark advanced to the newest replayed ts.
+    expect(ds.getLastDelivered("eng")).toBe("2026-06-16T10:03:00.000Z");
+  });
+
+  test("a SECOND replay (mark now caught up) returns empty", async () => {
+    const transcript: ChannelMessage[] = [
+      { id: "in1", text: "missed", direction: "inbound", sender: "a", ts: "2026-06-16T10:01:00.000Z" },
+    ];
+    const t = stubVault("eng", transcript);
+    const channels = vaultChannels("eng", t);
+    const ds = dsAt(MARK);
+
+    const first: ReplayMessage[] = [];
+    expect(await replayBacklog(channels, ds, "eng", (m) => first.push(m))).toBe(1);
+    const second: ReplayMessage[] = [];
+    expect(await replayBacklog(channels, ds, "eng", (m) => second.push(m))).toBe(0);
+    expect(second).toHaveLength(0);
+  });
+
+  test("caps at REPLAY_CAP, keeping the NEWEST", async () => {
+    const transcript: ChannelMessage[] = [];
+    const total = REPLAY_CAP + 10;
+    for (let i = 0; i < total; i++) {
+      // ts strictly increasing + all after the mark.
+      const ts = `2026-06-16T11:00:${String(i).padStart(2, "0")}.000Z`;
+      transcript.push({ id: `n${i}`, text: `m${i}`, direction: "inbound", sender: "a", ts });
+    }
+    const t = stubVault("eng", transcript);
+    const channels = vaultChannels("eng", t);
+    const ds = dsAt(MARK);
+
+    const got: ReplayMessage[] = [];
+    const n = await replayBacklog(channels, ds, "eng", (m) => got.push(m));
+    expect(n).toBe(REPLAY_CAP);
+    // The NEWEST REPLAY_CAP were kept (the first 10 dropped).
+    expect(got[0]!.content).toBe("m10");
+    expect(got[got.length - 1]!.content).toBe(`m${total - 1}`);
+    // The mark advanced to the very newest, so the dropped older ones never replay.
+    expect(ds.getLastDelivered("eng")).toBe(`2026-06-16T11:00:${String(total - 1).padStart(2, "0")}.000Z`);
+  });
+
+  test("a non-vault channel is skipped (0, no throw)", async () => {
+    const httpUi = new HttpUiTransport({ channel: "ui1" });
+    const channels = new Map<string, Channel>([
+      ["ui1", { name: "ui1", transport: httpUi, entry: { name: "ui1", transport: "http-ui" } }],
+    ]);
+    const ds = new DeliveryState({ stateDir, defaultMark: "2026-01-01T00:00:00.000Z" });
+    let delivered = 0;
+    expect(await replayBacklog(channels, ds, "ui1", () => { delivered++; })).toBe(0);
+    expect(delivered).toBe(0);
+  });
+
+  test("a missing channel is skipped (0)", async () => {
+    const ds = new DeliveryState({ stateDir, defaultMark: "2026-01-01T00:00:00.000Z" });
+    expect(await replayBacklog(new Map(), ds, "nope", () => {})).toBe(0);
+  });
+
+  test("a transcript load failure → 0 (the connect never fails); the mark is untouched", async () => {
+    const t = stubVault("eng", [], new Error("vault unreachable"));
+    const channels = vaultChannels("eng", t);
+    const ds = dsAt(MARK);
+    expect(await replayBacklog(channels, ds, "eng", () => {})).toBe(0);
+    expect(ds.getLastDelivered("eng")).toBe(MARK); // unchanged — retried next connect
+  });
+
+  test("a missing-ts inbound message is skipped (can't be tracked by the mark)", async () => {
+    const transcript: ChannelMessage[] = [
+      { id: "no-ts", text: "no timestamp", direction: "inbound", sender: "a", ts: "" },
+      { id: "in1", text: "good", direction: "inbound", sender: "a", ts: "2026-06-16T10:01:00.000Z" },
+    ];
+    const t = stubVault("eng", transcript);
+    const channels = vaultChannels("eng", t);
+    const ds = dsAt(MARK);
+    const got: ReplayMessage[] = [];
+    expect(await replayBacklog(channels, ds, "eng", (m) => got.push(m))).toBe(1);
+    expect(got.map((m) => m.content)).toEqual(["good"]);
+  });
+
+  test("if deliverOne throws mid-loop, the mark stops at the last DELIVERED ts (no false-mark)", async () => {
+    // The advance-after-deliverOne ordering: a throw on the 2nd message must leave
+    // the mark at the 1st message's ts, so the 2nd + 3rd replay on the next connect.
+    const transcript: ChannelMessage[] = [
+      { id: "in1", text: "first", direction: "inbound", sender: "a", ts: "2026-06-16T10:01:00.000Z" },
+      { id: "in2", text: "second", direction: "inbound", sender: "a", ts: "2026-06-16T10:02:00.000Z" },
+      { id: "in3", text: "third", direction: "inbound", sender: "a", ts: "2026-06-16T10:03:00.000Z" },
+    ];
+    const t = stubVault("eng", transcript);
+    const channels = vaultChannels("eng", t);
+    const ds = dsAt(MARK);
+    let count = 0;
+    await expect(
+      replayBacklog(channels, ds, "eng", () => {
+        count++;
+        if (count === 2) throw new Error("dead subscriber");
+      }),
+    ).rejects.toThrow("dead subscriber");
+    // The 1st was delivered + marked; the throw on the 2nd aborted before its advance.
+    expect(ds.getLastDelivered("eng")).toBe("2026-06-16T10:01:00.000Z");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// emit — the mark advances ONLY on a real delivery (via the live webhook).
+// ---------------------------------------------------------------------------
+
+describe("emit advances the mark only on real delivery (via /api/vault/inbound)", () => {
+  test("≥1 SSE subscriber → mark advances to the note ts; 0 subscribers → mark stays", async () => {
+    // We exercise the real emit by standing up the daemon, opening (or not) an SSE
+    // subscriber, and POSTing the inbound webhook. The transport is started by the
+    // daemon's hot-add so its ctx is the daemon's contextFor (the one that advances
+    // the mark). loadTranscript is stubbed AFTER the hot-add.
+    const ds = new DeliveryState({ stateDir, defaultMark: "2026-01-01T00:00:00.000Z" });
+    const channels = new Map<string, Channel>();
+    const registry = new ClientRegistry();
+    const handler = createFetchHandler(channels, registry, { deliveryState: ds });
+    const srv = Bun.serve({ port: 0, hostname: "127.0.0.1", idleTimeout: 0, fetch: handler });
+    const base = `http://127.0.0.1:${srv.port}`;
+    try {
+      // Hot-add a vault channel through the config API so the daemon starts its
+      // transport with ITS contextFor (the emit that advances the mark). We then
+      // stub loadTranscript on the live instance + neutralize the network write.
+      const addRes = await fetch(`${base}/api/channels`, {
+        method: "POST",
+        headers: { ...auth, "content-type": "application/json" },
+        body: JSON.stringify({
+          name: "eng",
+          transport: "vault",
+          config: { vault: "default", vaultUrl: "http://127.0.0.1:59999", token: "x" },
+        }),
+      });
+      expect([200, 201]).toContain(addRes.status);
+      const live = channels.get("eng")!.transport as VaultTransport;
+      live.loadTranscript = async () => [];
+
+      // --- 0 subscribers: post the inbound webhook; the mark must NOT advance. ---
+      const ts0 = "2026-06-16T10:00:00.000Z";
+      const r0 = await fetch(`${base}/api/vault/inbound`, {
+        method: "POST",
+        headers: { ...auth, "content-type": "application/json" },
+        body: JSON.stringify({
+          note: { id: "note-0", content: "deaf", tags: ["#channel-message/inbound"], metadata: { channel: "eng", ts: ts0, direction: "inbound" } },
+        }),
+      });
+      expect(r0.status).toBe(200);
+      // No subscriber → emit delivered to 0 → mark stayed at the boot default.
+      expect(ds.getLastDelivered("eng")).toBe("2026-01-01T00:00:00.000Z");
+
+      // --- ≥1 subscriber: open an SSE stream, then post a newer inbound. ---
+      const evRes = await fetch(`${base}/events?channel=eng&token=${RW_TOKEN}`, { headers: auth });
+      expect(evRes.status).toBe(200);
+      const reader = evRes.body!.getReader();
+      // Drain the ": connected" preamble so the registry add has happened.
+      await reader.read();
+
+      const ts1 = "2026-06-16T10:05:00.000Z";
+      const r1 = await fetch(`${base}/api/vault/inbound`, {
+        method: "POST",
+        headers: { ...auth, "content-type": "application/json" },
+        body: JSON.stringify({
+          note: { id: "note-1", content: "heard", tags: ["#channel-message/inbound"], metadata: { channel: "eng", ts: ts1, direction: "inbound" } },
+        }),
+      });
+      expect(r1.status).toBe(200);
+      // Delivered to ≥1 subscriber → mark advanced to the note ts.
+      expect(ds.getLastDelivered("eng")).toBe(ts1);
+
+      await reader.cancel();
+    } finally {
+      srv.stop(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MCP connect hook → replay to THAT session only.
+// ---------------------------------------------------------------------------
+
+describe("MCP connect replays the backlog to the new session only", () => {
+  function capture() {
+    const notes: Array<{ method: string; params: unknown }> = [];
+    const server = { notification: (n: unknown) => notes.push(n as { method: string; params: unknown }) };
+    const wakes = () => notes.filter((n) => n.method === "notifications/claude/channel");
+    return { server, notes, wakes };
+  }
+
+  test("a newly-registered MCP session is pushed its missed backlog; an EXISTING session is not re-woken", async () => {
+    const ds = new DeliveryState({ stateDir, defaultMark: "2026-01-01T00:00:00.000Z" });
+    ds.advance("eng", "2026-06-16T10:00:00.000Z");
+    const t = stubVault("eng", []);
+    const channels = vaultChannels("eng", t);
+    const registry = new ClientRegistry();
+    // Building the handler installs setOnSessionConnect → replayBacklog (fire-and-forget).
+    createFetchHandler(channels, registry, { deliveryState: ds });
+
+    // Phase 1: an existing session connects with NO pending backlog (transcript
+    // empty) — its connect-replay delivers nothing and leaves the mark at 10:00.
+    const existing = capture();
+    _registerSessionForTest("eng", "sid-existing", existing.server as never, ["channel:read"]);
+    await new Promise((r) => setTimeout(r, 20));
+    expect(existing.wakes()).toHaveLength(0); // nothing pending at its connect
+
+    // Phase 2: a NEW inbound is now pending in the vault (mark still 10:00).
+    t.loadTranscript = async () => [
+      { id: "in-new", text: "newly missed", direction: "inbound", sender: "a", ts: "2026-06-16T10:05:00.000Z" },
+    ];
+
+    // A FRESH session connects → its connect-replay pushes the pending message to IT.
+    const fresh = capture();
+    _registerSessionForTest("eng", "sid-fresh", fresh.server as never, ["channel:read"]);
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(mcpSessionCount("eng")).toBe(2);
+    // The fresh session received exactly the pending message.
+    expect(fresh.wakes()).toHaveLength(1);
+    expect((fresh.wakes()[0]!.params as { content: string }).content).toBe("newly missed");
+    // The existing session was NOT re-woken — replay targets the connector only.
+    expect(existing.wakes()).toHaveLength(0);
+    // Mark advanced past the replayed message → a third connect replays nothing.
+    expect(ds.getLastDelivered("eng")).toBe("2026-06-16T10:05:00.000Z");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SSE connect hook → replay onto the new stream.
+// ---------------------------------------------------------------------------
+
+describe("SSE /events connect replays the backlog onto the new stream", () => {
+  test("a reconnecting bridge gets its missed inbound as message frames", async () => {
+    const ds = new DeliveryState({ stateDir, defaultMark: "2026-01-01T00:00:00.000Z" });
+    ds.advance("eng", "2026-06-16T10:00:00.000Z");
+    const transcript: ChannelMessage[] = [
+      { id: "in1", text: "missed A", direction: "inbound", sender: "a", ts: "2026-06-16T10:01:00.000Z" },
+      { id: "in2", text: "missed B", direction: "inbound", sender: "a", ts: "2026-06-16T10:02:00.000Z" },
+    ];
+    const t = stubVault("eng", transcript);
+    const channels = vaultChannels("eng", t);
+    const registry = new ClientRegistry();
+    const handler = createFetchHandler(channels, registry, { deliveryState: ds });
+    const srv = Bun.serve({ port: 0, hostname: "127.0.0.1", idleTimeout: 0, fetch: handler });
+    const base = `http://127.0.0.1:${srv.port}`;
+    try {
+      const res = await fetch(`${base}/events?channel=eng&token=${RW_TOKEN}`, { headers: auth });
+      expect(res.status).toBe(200);
+      const reader = res.body!.getReader();
+      const decoder = new TextDecoder();
+      let buf = "";
+      // Read until we've seen both replayed frames (or a couple of chunks).
+      for (let i = 0; i < 5 && !(buf.includes("missed A") && buf.includes("missed B")); i++) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buf += decoder.decode(value, { stream: true });
+      }
+      expect(buf).toContain("event: message");
+      expect(buf).toContain("missed A");
+      expect(buf).toContain("missed B");
+      // The mark advanced to the newest replayed ts.
+      expect(ds.getLastDelivered("eng")).toBe("2026-06-16T10:02:00.000Z");
+      await reader.cancel();
+    } finally {
+      srv.stop(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// END-TO-END deaf window — the headline scenario.
+// ---------------------------------------------------------------------------
+
+describe("end-to-end deaf window", () => {
+  test("inbound with no subscriber (mark stays) → session connects → the missed message is delivered once", async () => {
+    const ds = new DeliveryState({ stateDir, defaultMark: "2026-06-16T09:00:00.000Z" });
+    const channels = new Map<string, Channel>();
+    const registry = new ClientRegistry();
+    const handler = createFetchHandler(channels, registry, { deliveryState: ds });
+    const srv = Bun.serve({ port: 0, hostname: "127.0.0.1", idleTimeout: 0, fetch: handler });
+    const base = `http://127.0.0.1:${srv.port}`;
+    try {
+      // Bring up a vault channel through the daemon's own hot-add (so emit uses the
+      // daemon's contextFor). The vault's transcript is what a later connect replays.
+      const addRes = await fetch(`${base}/api/channels`, {
+        method: "POST",
+        headers: { ...auth, "content-type": "application/json" },
+        body: JSON.stringify({
+          name: "eng",
+          transport: "vault",
+          config: { vault: "default", vaultUrl: "http://127.0.0.1:59999", token: "x" },
+        }),
+      });
+      expect([200, 201]).toContain(addRes.status);
+      const live = channels.get("eng")!.transport as VaultTransport;
+
+      // The missed message — durable in the "vault" (our stubbed transcript), and
+      // arriving via the webhook with NO subscriber present.
+      const missedTs = "2026-06-16T10:00:00.000Z";
+      live.loadTranscript = async () => [
+        { id: "note-deaf", text: "are you there?", direction: "inbound", sender: "aaron", ts: missedTs },
+      ];
+
+      // Inbound arrives while nobody is subscribed → emit delivers to 0 → mark stays.
+      const wh = await fetch(`${base}/api/vault/inbound`, {
+        method: "POST",
+        headers: { ...auth, "content-type": "application/json" },
+        body: JSON.stringify({
+          note: { id: "note-deaf", content: "are you there?", tags: ["#channel-message/inbound"], metadata: { channel: "eng", ts: missedTs, sender: "aaron", direction: "inbound" } },
+        }),
+      });
+      expect(wh.status).toBe(200);
+      expect(ds.getLastDelivered("eng")).toBe("2026-06-16T09:00:00.000Z"); // mark held — message is pending
+
+      // Now a session connects (SSE) → it replays the missed message.
+      const res = await fetch(`${base}/events?channel=eng&token=${RW_TOKEN}`, { headers: auth });
+      expect(res.status).toBe(200);
+      const reader = res.body!.getReader();
+      const decoder = new TextDecoder();
+      let buf = "";
+      for (let i = 0; i < 5 && !buf.includes("are you there?"); i++) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buf += decoder.decode(value, { stream: true });
+      }
+      expect(buf).toContain("are you there?");
+      // Mark caught up → a SECOND connect replays nothing (delivered exactly once).
+      expect(ds.getLastDelivered("eng")).toBe(missedTs);
+      await reader.cancel();
+
+      const res2 = await fetch(`${base}/events?channel=eng&token=${RW_TOKEN}`, { headers: auth });
+      const reader2 = res2.body!.getReader();
+      const first = await reader2.read(); // just the ": connected" preamble
+      const text = decoder.decode(first.value);
+      expect(text).not.toContain("are you there?");
+      await reader2.cancel();
+    } finally {
+      srv.stop(true);
+    }
+  });
+});

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -101,6 +101,7 @@ import {
   pushPermissionVerdict as mcpPushPermissionVerdict,
   mcpSessionCount,
   setOnSessionConnect,
+  assertMcpSdkStreamContract,
 } from "./mcp-http.ts";
 import { renderAdminPage } from "./admin-ui.ts";
 import { THEME_CSS, appShell, SHELL_JS } from "./ui-kit.ts";
@@ -2045,6 +2046,11 @@ function toReplyArgs(body: {
 function main(): void {
   mkdirSync(STATE_DIR, { recursive: true });
   mkdirSync(INBOX_DIR, { recursive: true });
+
+  // Verify the one MCP SDK internal our HTTP-MCP delivery accounting reads
+  // (`_streamMapping['_GET_stream']`, see assertMcpSdkStreamContract). A screaming
+  // boot error on SDK drift beats discovering it as silent message loss later.
+  assertMcpSdkStreamContract();
 
   let channels: Map<string, Channel>;
   try {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -58,7 +58,8 @@ import {
   removeChannelClaudeCredential,
   describeClaudeCredentials,
 } from "./credentials.ts";
-import { ClientRegistry } from "./routing.ts";
+import { ClientRegistry, sseFrame } from "./routing.ts";
+import { DeliveryState } from "./delivery-state.ts";
 import {
   requireScope,
   extractToken,
@@ -99,6 +100,7 @@ import {
   pushToChannel as mcpPushToChannel,
   pushPermissionVerdict as mcpPushPermissionVerdict,
   mcpSessionCount,
+  setOnSessionConnect,
 } from "./mcp-http.ts";
 import { renderAdminPage } from "./admin-ui.ts";
 import { THEME_CSS, appShell, SHELL_JS } from "./ui-kit.ts";
@@ -203,7 +205,11 @@ const START_CMD: string[] = resolveStartCmd(INSTALL_DIR);
 // ---------------------------------------------------------------------------
 
 /** Build the per-channel context a transport routes through. */
-function contextFor(registry: ClientRegistry, channel: string): TransportContext {
+function contextFor(
+  registry: ClientRegistry,
+  channel: string,
+  deliveryState: DeliveryState,
+): TransportContext {
   return {
     channel,
     emit(msg: InboundMessage): void {
@@ -211,7 +217,7 @@ function contextFor(registry: ClientRegistry, channel: string): TransportContext
       // channel is authoritative. This makes it impossible for a transport to
       // emit onto another channel (closing a silent cross-channel-leak footgun)
       // even if a future transport sets msg.channel incorrectly.
-      registry.routeToChannel(channel, "message", {
+      const sseDelivered = registry.routeToChannel(channel, "message", {
         content: msg.content,
         meta: msg.meta,
         source: msg.source,
@@ -220,13 +226,146 @@ function contextFor(registry: ClientRegistry, channel: string): TransportContext
       // over /mcp/<channel> (vs. the stdio bridge over /events) receives the
       // same inbound as a server-pushed notifications/claude/channel. Additive:
       // the SSE path above is untouched.
-      mcpPushToChannel(channel, msg.content, msg.meta);
+      const mcpDelivered = mcpPushToChannel(channel, msg.content, msg.meta);
+
+      // Advance the per-channel delivery high-water-mark ONLY on a real delivery
+      // (≥1 live subscriber across SSE bridges + MCP sessions). If nobody was
+      // listening (delivered === 0) we deliberately leave the mark BEHIND so this
+      // message replays the next time a session (re)connects — the spine of the
+      // no-silent-loss fix. The note's ts rides in `meta.ts` (ingestInbound
+      // flattens the note metadata, which carries the vault-written `ts`).
+      const delivered = sseDelivered + mcpDelivered;
+      const ts = msg.meta?.ts;
+      if (delivered > 0 && typeof ts === "string" && ts) {
+        deliveryState.advance(channel, ts);
+      }
     },
     emitPermissionVerdict(v): void {
       registry.routeToChannel(channel, "permission_verdict", v);
       mcpPushPermissionVerdict(channel, v);
     },
   };
+}
+
+/** The replayed-message shape handed to a per-session / per-stream `deliverOne`.
+ *  Mirrors what `contextFor.emit` fans out so a replayed wake is indistinguishable
+ *  from a live one to the receiving session. */
+export interface ReplayMessage {
+  content: string;
+  meta: Record<string, string>;
+  source: string;
+}
+
+/** Hard cap on how many backlog messages a single (re)connect replays — newest N.
+ *  A long deaf window shouldn't dump hundreds of messages onto a freshly-attached
+ *  session; the older ones stay durable in the vault and visible in the transcript. */
+export const REPLAY_CAP = 50;
+
+/**
+ * Replay the inbound backlog a channel missed onto a SINGLE newly-(re)connected
+ * subscriber — the recovery half of the no-silent-loss fix.
+ *
+ * On (re)connect (an MCP session attaching, or an SSE bridge reopening `/events`)
+ * we load the channel's durable transcript, keep the INBOUND messages with `ts`
+ * strictly newer than the delivery high-water-mark (the ones emitted while nobody
+ * was listening, or that arrived during the daemon's restart deaf window), and
+ * hand each — oldest-first — to `deliverOne`, which targets ONLY this one new
+ * subscriber (a per-session MCP push / a write to this one SSE stream). Targeting
+ * a single subscriber is deliberate: a broadcast would re-wake sessions that
+ * already saw these messages.
+ *
+ * VAULT-ONLY. Replay needs a durable transcript to read; only `VaultTransport`
+ * has one. http-ui / telegram channels are skipped (a non-vault transport, or a
+ * channel with no transport, returns 0 — nothing to replay).
+ *
+ * CAPPED. At most `REPLAY_CAP` (the NEWEST) messages are replayed; a longer
+ * backlog is truncated with a log note. The older messages remain durable in the
+ * vault and render in the transcript — they're just not pushed as fresh wakes.
+ *
+ * MARK ADVANCE. After a successful replay the mark advances to the newest replayed
+ * `ts` (monotonic), so a second connect on the same channel replays nothing. A
+ * `deliverOne` that throws aborts before advancing that message's ts, so a failed
+ * push doesn't silently mark the message delivered.
+ *
+ * Returns the number of messages delivered (0 for a non-vault / missing channel,
+ * or an empty backlog). Best-effort on the load: a transcript read failure is
+ * logged and treated as an empty backlog — a (re)connect must never fail because
+ * the vault was briefly unreachable.
+ */
+export async function replayBacklog(
+  channels: Map<string, Channel>,
+  deliveryState: DeliveryState,
+  channel: string,
+  deliverOne: (msg: ReplayMessage) => void,
+): Promise<number> {
+  const ch = channels.get(channel);
+  const transport = ch?.transport;
+  // VAULT-ONLY: a durable transcript is the prerequisite for replay.
+  if (!(transport instanceof VaultTransport)) return 0;
+
+  const mark = deliveryState.getLastDelivered(channel);
+
+  let transcript;
+  try {
+    // Reuse the index-free, tag-only transcript read (no metadata-operator query —
+    // `channel` isn't indexed). It returns BOTH directions sorted ascending by ts.
+    transcript = await transport.loadTranscript();
+  } catch (err) {
+    // The vault was unreachable / errored — don't fail the connect. Nothing to
+    // replay this time; the mark stays put so a later connect retries the backlog.
+    console.warn(
+      `parachute-channel: replayBacklog for "${channel}" — transcript load failed (${(err as Error).message}); ` +
+        `skipping replay (backlog stays durable in the vault).`,
+    );
+    return 0;
+  }
+
+  // Keep only INBOUND messages newer than the mark, with a usable ts (we advance
+  // the mark by ts, so a blank-ts message can't be tracked → skip it). Ascending
+  // by ts already (loadTranscript sorts), but filter preserves order.
+  let pending = transcript.filter(
+    (m) => m.direction === "inbound" && typeof m.ts === "string" && m.ts > mark,
+  );
+  if (pending.length === 0) return 0;
+
+  // Cap at the NEWEST REPLAY_CAP — drop the oldest overflow (they stay in the vault).
+  if (pending.length > REPLAY_CAP) {
+    const dropped = pending.length - REPLAY_CAP;
+    console.log(
+      `parachute-channel: replayBacklog for "${channel}" — backlog of ${pending.length} exceeds cap ${REPLAY_CAP}; ` +
+        `replaying the newest ${REPLAY_CAP}, ${dropped} older message(s) left in the vault transcript.`,
+    );
+    pending = pending.slice(pending.length - REPLAY_CAP);
+  }
+
+  let delivered = 0;
+  for (const m of pending) {
+    // Shape the replayed wake to match a live `ingestInbound` emit: content +
+    // flattened meta (carrying the ORIGINAL ts so the receiving session sees the
+    // real arrival time) + provenance fields the session keys off.
+    const meta: Record<string, string> = {
+      ts: m.ts,
+      sender: m.sender,
+      source: "vault",
+      note_id: m.id,
+      direction: "inbound",
+      replay: "true", // marks this as a backlog replay (vs. a live wake) for any consumer that cares
+    };
+    if (m.inReplyTo) meta.in_reply_to = m.inReplyTo;
+    // deliverOne targets ONLY this one new subscriber (the SSE caller writes to
+    // its own stream; the MCP caller pushes to its own session). Both current
+    // callers swallow a dead-stream/dead-session error internally, so the loop
+    // runs to completion in practice. The `advance` BELOW (after deliverOne) is
+    // the load-bearing safety property: were deliverOne ever to throw, we abort
+    // before advancing THIS message's ts, so it's never silently marked delivered.
+    deliverOne({ content: m.text, meta, source: "vault" });
+    // Advance per-message (monotonic). Ordering matters: advancing only after a
+    // successful deliverOne means a (hypothetical) mid-loop throw leaves the mark
+    // at the last delivered ts, so the next connect resumes from there.
+    deliveryState.advance(channel, m.ts);
+    delivered++;
+  }
+  return delivered;
 }
 
 /**
@@ -245,6 +384,7 @@ async function addChannelLive(
   channels: Map<string, Channel>,
   registry: ClientRegistry,
   entry: ChannelEntry,
+  deliveryState: DeliveryState,
 ): Promise<Channel> {
   const existing = channels.get(entry.name);
   if (existing) {
@@ -260,7 +400,7 @@ async function addChannelLive(
   const transport = instantiateTransport(entry);
   const channel: Channel = { name: entry.name, transport, entry };
   channels.set(entry.name, channel);
-  await transport.start(contextFor(registry, entry.name));
+  await transport.start(contextFor(registry, entry.name, deliveryState));
   return channel;
 }
 
@@ -904,12 +1044,28 @@ function clampQueryDim(raw: string | null, fallback: number): number {
 export function createFetchHandler(
   channels: Map<string, Channel>,
   registry: ClientRegistry,
-  opts?: { agentOps?: AgentOps },
+  opts?: { agentOps?: AgentOps; deliveryState?: DeliveryState },
 ): (req: Request, server?: { upgrade: (req: Request, opts: { data: TerminalWsData }) => boolean }) => Promise<Response> {
   // Spawn/list/kill operations behind the web agents surface. Lazily defaulted to
   // the real ops (resolve-deps + real tmux); tests inject a stub so the routes are
   // exercised without a hub, a sandbox, or a tmux server. Built once per handler.
   const agentOps: AgentOps = opts?.agentOps ?? createRealAgentOps();
+
+  // Per-channel delivery high-water-mark store (the no-silent-loss spine). The
+  // daemon's `main` passes the boot-time instance; tests that don't care get a
+  // throwaway instance whose default mark is "now" — so a test channel never
+  // surprise-replays its whole transcript on connect. The MCP connect hook +
+  // the SSE `/events` replay below both run `replayBacklog` against it.
+  const deliveryState: DeliveryState = opts?.deliveryState ?? new DeliveryState();
+
+  // Install the MCP connect hook: when a NEW MCP session registers (in
+  // mcp-http's onsessioninitialized), replay its missed backlog to THAT session
+  // only. Last-handler-wins is fine — there's one live daemon; tests reset it.
+  setOnSessionConnect((channel, pushToThisSession) => {
+    void replayBacklog(channels, deliveryState, channel, (msg) =>
+      pushToThisSession(msg.content, msg.meta),
+    );
+  });
   /** Resolve the transport for a channel name, or null on miss. */
   function transportFor(channel: string | undefined): Transport | null {
     if (!channel) return null;
@@ -1174,7 +1330,7 @@ export function createFetchHandler(
         return json({ error: `failed to write channels.json: ${(err as Error).message}` }, 500);
       }
       try {
-        await addChannelLive(channels, registry, entry);
+        await addChannelLive(channels, registry, entry, deliveryState);
       } catch (err) {
         return json(
           {
@@ -1414,6 +1570,21 @@ export function createFetchHandler(
             enqueue: (payload) => controller.enqueue(payload),
           });
           controller.enqueue(": connected\n\n");
+          // Replay any backlog this (re)connecting stdio bridge missed while it
+          // was detached — written to THIS stream only (a per-stream `message`
+          // frame, the same event the live route emits), so a reconnect after a
+          // daemon restart / a deaf window picks up the messages that arrived in
+          // the gap. Fire-and-forget: a vault read failure inside replayBacklog is
+          // logged + treated as an empty backlog, never failing the connect.
+          void replayBacklog(channels, deliveryState, subscribedChannel, (msg) => {
+            try {
+              controller.enqueue(
+                sseFrame("message", { content: msg.content, meta: msg.meta, source: msg.source }),
+              );
+            } catch {
+              // Stream already closed — drop; the next connect retries the backlog.
+            }
+          });
         },
         cancel() {
           registry.remove(clientId);
@@ -1887,13 +2058,24 @@ function main(): void {
 
   const registry = new ClientRegistry();
 
+  // Per-channel delivery high-water-mark store, constructed ONCE at boot with the
+  // daemon's boot time as the default mark — so a channel with no persisted mark
+  // replays only messages that arrive AFTER this start (the deaf-window case),
+  // never its whole vault history. Persisted marks (from a prior run) survive the
+  // restart and replay exactly the gap. Shared by `contextFor.emit` (advance) and
+  // both connect-hook replays (MCP session + SSE bridge).
+  const deliveryState = new DeliveryState({
+    stateDir: STATE_DIR,
+    defaultMark: new Date().toISOString(),
+  });
+
   // The terminal WS handler set (pty↔socket relay + backpressure flow control,
   // src/terminal.ts). One handler object serves every terminal connection;
   // per-connection state lives on `ws.data`. The fetch handler routes accepted
   // upgrades into these via `server.upgrade(req, { data })`.
   const terminalWs = createTerminalWsHandlers();
 
-  const fetchHandler = createFetchHandler(channels, registry);
+  const fetchHandler = createFetchHandler(channels, registry, { deliveryState });
   const server = Bun.serve<TerminalWsData, never>({
     port: PORT,
     hostname: "127.0.0.1",
@@ -1977,7 +2159,7 @@ function main(): void {
   // Per-channel failures are logged and don't abort the others; the daemon must
   // still serve the channels that did come up.
   for (const channel of [...channels.values()]) {
-    addChannelLive(channels, registry, channel.entry).catch((err) => {
+    addChannelLive(channels, registry, channel.entry, deliveryState).catch((err) => {
       console.error(`parachute-channel: transport "${channel.name}" start failed:`, err);
     });
   }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -340,6 +340,12 @@ export async function replayBacklog(
 
   let delivered = 0;
   for (const m of pending) {
+    // Re-read the LIVE mark each iteration. `mark` above was snapshotted BEFORE the
+    // `await loadTranscript()`, so a concurrent emit (a live delivery) or a racing
+    // second (re)connect on the same channel may have advanced the mark past this
+    // message in the meantime. Skip anything already delivered so two near-
+    // simultaneous connects can't double-deliver the same backlog. (Reviewer nit, PR #67.)
+    if (m.ts <= deliveryState.getLastDelivered(channel)) continue;
     // Shape the replayed wake to match a live `ingestInbound` emit: content +
     // flattened meta (carrying the ORIGINAL ts so the receiving session sees the
     // real arrival time) + provenance fields the session keys off.
@@ -1058,9 +1064,10 @@ export function createFetchHandler(
   // the SSE `/events` replay below both run `replayBacklog` against it.
   const deliveryState: DeliveryState = opts?.deliveryState ?? new DeliveryState();
 
-  // Install the MCP connect hook: when a NEW MCP session registers (in
-  // mcp-http's onsessioninitialized), replay its missed backlog to THAT session
-  // only. Last-handler-wins is fine — there's one live daemon; tests reset it.
+  // Install the MCP connect hook: when an MCP session's GET push stream goes live
+  // (mcp-http's handleMcp GET branch → fireConnectReplay — NOT at registration,
+  // which precedes the stream and would drop the pushes), replay its missed backlog
+  // to THAT session only. Last-handler-wins is fine — one live daemon; tests reset it.
   setOnSessionConnect((channel, pushToThisSession) => {
     void replayBacklog(channels, deliveryState, channel, (msg) =>
       pushToThisSession(msg.content, msg.meta),

--- a/src/delivery-state.test.ts
+++ b/src/delivery-state.test.ts
@@ -1,0 +1,110 @@
+/**
+ * DeliveryState tests — the per-channel high-water-mark that gates backlog replay.
+ *
+ * Covered:
+ *  - monotonic advance (never rewinds; reports whether it moved);
+ *  - default-to-bootTime for an unknown channel (so a first connect never replays
+ *    ancient history);
+ *  - persist + reload across a simulated restart (a new instance reads the file);
+ *  - blank-ts advance is a no-op (we never mark to an empty ts).
+ *
+ * Each test points the store at a throwaway temp dir, so there's no shared global
+ * state and no touch of the real `~/.parachute/channel/`.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { DeliveryState } from "./delivery-state.ts";
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "channel-delivery-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("getLastDelivered default", () => {
+  test("an unknown channel returns the boot-time default mark, not epoch", () => {
+    const boot = "2026-06-16T12:00:00.000Z";
+    const ds = new DeliveryState({ stateDir: dir, defaultMark: boot });
+    expect(ds.getLastDelivered("never-seen")).toBe(boot);
+  });
+
+  test("defaultMark defaults to ~now when omitted", () => {
+    const before = Date.now();
+    const ds = new DeliveryState({ stateDir: dir });
+    const mark = Date.parse(ds.getLastDelivered("x"));
+    const after = Date.now();
+    expect(mark).toBeGreaterThanOrEqual(before);
+    expect(mark).toBeLessThanOrEqual(after + 1000);
+  });
+});
+
+describe("advance is monotonic", () => {
+  test("moves forward + reports true; a stale/equal ts is a no-op reporting false", () => {
+    const ds = new DeliveryState({ stateDir: dir, defaultMark: "2026-01-01T00:00:00.000Z" });
+    expect(ds.advance("c", "2026-06-16T10:00:00.000Z")).toBe(true);
+    expect(ds.getLastDelivered("c")).toBe("2026-06-16T10:00:00.000Z");
+
+    // An OLDER ts must not rewind the mark.
+    expect(ds.advance("c", "2026-06-16T09:00:00.000Z")).toBe(false);
+    expect(ds.getLastDelivered("c")).toBe("2026-06-16T10:00:00.000Z");
+
+    // The SAME ts is also a no-op (strictly-greater advance).
+    expect(ds.advance("c", "2026-06-16T10:00:00.000Z")).toBe(false);
+    expect(ds.getLastDelivered("c")).toBe("2026-06-16T10:00:00.000Z");
+
+    // A NEWER ts advances again.
+    expect(ds.advance("c", "2026-06-16T11:00:00.000Z")).toBe(true);
+    expect(ds.getLastDelivered("c")).toBe("2026-06-16T11:00:00.000Z");
+  });
+
+  test("a blank ts never advances the mark", () => {
+    const ds = new DeliveryState({ stateDir: dir, defaultMark: "2026-01-01T00:00:00.000Z" });
+    expect(ds.advance("c", "")).toBe(false);
+    expect(ds.getLastDelivered("c")).toBe("2026-01-01T00:00:00.000Z");
+  });
+
+  test("per-channel marks are independent", () => {
+    const ds = new DeliveryState({ stateDir: dir, defaultMark: "2026-01-01T00:00:00.000Z" });
+    ds.advance("a", "2026-06-16T10:00:00.000Z");
+    expect(ds.getLastDelivered("a")).toBe("2026-06-16T10:00:00.000Z");
+    // b is untouched — still the default.
+    expect(ds.getLastDelivered("b")).toBe("2026-01-01T00:00:00.000Z");
+  });
+});
+
+describe("persist + reload (simulated restart)", () => {
+  test("a fresh instance reads the persisted marks (the restart case)", () => {
+    const ds1 = new DeliveryState({ stateDir: dir, defaultMark: "2026-01-01T00:00:00.000Z" });
+    ds1.advance("eng", "2026-06-16T10:00:00.000Z");
+    ds1.advance("ops", "2026-06-16T11:00:00.000Z");
+    expect(existsSync(join(dir, "delivery-state.json"))).toBe(true);
+
+    // Simulate a daemon restart: a brand-new instance with a LATER boot default.
+    // The persisted per-channel marks must win over the new default — that's what
+    // makes the replay-the-gap behavior work across a bounce.
+    const ds2 = new DeliveryState({ stateDir: dir, defaultMark: "2026-06-16T12:00:00.000Z" });
+    expect(ds2.getLastDelivered("eng")).toBe("2026-06-16T10:00:00.000Z");
+    expect(ds2.getLastDelivered("ops")).toBe("2026-06-16T11:00:00.000Z");
+    // A channel with no persisted mark still falls back to the new boot default.
+    expect(ds2.getLastDelivered("brand-new")).toBe("2026-06-16T12:00:00.000Z");
+  });
+
+  test("the persisted file is valid JSON of channel→ts", () => {
+    const ds = new DeliveryState({ stateDir: dir, defaultMark: "2026-01-01T00:00:00.000Z" });
+    ds.advance("eng", "2026-06-16T10:00:00.000Z");
+    const onDisk = JSON.parse(readFileSync(join(dir, "delivery-state.json"), "utf8"));
+    expect(onDisk).toEqual({ eng: "2026-06-16T10:00:00.000Z" });
+  });
+
+  test("a corrupt file is tolerated — starts empty, the default covers unknowns", () => {
+    writeFileSync(join(dir, "delivery-state.json"), "{ not json");
+    const ds = new DeliveryState({ stateDir: dir, defaultMark: "2026-06-16T12:00:00.000Z" });
+    expect(ds.getLastDelivered("eng")).toBe("2026-06-16T12:00:00.000Z");
+    // Still usable: advance + persist overwrites the corrupt file.
+    expect(ds.advance("eng", "2026-06-16T13:00:00.000Z")).toBe(true);
+  });
+});

--- a/src/delivery-state.ts
+++ b/src/delivery-state.ts
@@ -1,0 +1,148 @@
+/**
+ * Per-channel delivery high-water-mark — the spine of the no-silent-loss fix.
+ *
+ * THE PROBLEM. The vault-backed inbound pipeline wakes a session by `ctx.emit`
+ * fanning a new `#channel-message/inbound` note to whatever SSE bridges + HTTP
+ * MCP sessions are live on the channel. But:
+ *  - the daemon acks the vault trigger `{ok:true}` regardless of how many
+ *    subscribers actually received it, and the vault stamps `..._rendered_at` on
+ *    the note so the trigger never re-fires — so a note delivered to ZERO live
+ *    subscribers is lost from the live path (it stays durable in the vault, but
+ *    no session is ever woken on it); and
+ *  - MCP sessions drop on every daemon restart and only reconnect on the next
+ *    interaction, so any inbound that lands during that deaf window reaches no
+ *    one.
+ *
+ * THE FIX. Track, per channel, the timestamp of the last inbound message we
+ * actually DELIVERED to at least one live subscriber (the high-water-mark). On
+ * (re)connect, a session replays the backlog of inbound notes with `ts` newer
+ * than that mark — so messages that arrived while nobody was listening get
+ * delivered the moment a session attaches. `emit` advances the mark only on a
+ * real delivery (≥1 subscriber); a 0-subscriber emit leaves the mark behind so
+ * the message replays later.
+ *
+ * THE MARK IS MONOTONIC. `advance` only ever moves the mark FORWARD. Out-of-order
+ * or duplicate deliveries can never rewind it (which would re-replay already-seen
+ * messages). ISO-8601 timestamps compare correctly as strings (lexicographic ==
+ * chronological for the `Z`-suffixed UTC form the vault writes), so the compare is
+ * a plain string `>`.
+ *
+ * DEFAULT = BOOT TIME. A channel with no persisted mark defaults to the daemon's
+ * boot time — NOT epoch. This is deliberate: on a FIRST connect we must not
+ * replay the channel's entire (possibly ancient) vault history as if it were all
+ * unread. The only messages a fresh mark replays are ones that arrived AFTER the
+ * daemon started (the genuine deaf-window case). Persisted marks survive restarts,
+ * so a channel that has been delivering keeps its real high-water-mark across a
+ * bounce and replays exactly the restart gap.
+ *
+ * PERSISTENCE. The marks live in a single small JSON file under the channel state
+ * dir (`<PARACHUTE_CHANNEL_STATE_DIR>/delivery-state.json`, default
+ * `~/.parachute/channel/delivery-state.json`). Writes are write-through but
+ * resilient: a failed write is logged and swallowed — losing a mark only costs a
+ * bounded re-replay, never a crash. Load-on-construct reads the file once.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync } from "fs";
+import { join, dirname } from "path";
+import { defaultStateDir } from "./registry.ts";
+
+/** The on-disk shape: `{ "<channel>": "<iso-ts>", ... }`. */
+type DeliveryStateFile = Record<string, string>;
+
+export interface DeliveryStateOptions {
+  /** State dir for the persisted file. Defaults to the channel state dir. */
+  stateDir?: string;
+  /**
+   * The default mark for a channel with no persisted entry — an ISO timestamp.
+   * The daemon passes its boot time so a first connect never replays ancient
+   * history. Defaults to "now" at construction if omitted.
+   */
+  defaultMark?: string;
+}
+
+/**
+ * Per-channel last-delivered high-water-mark store. One instance per daemon;
+ * constructed at boot with the boot time as the default mark, then read/advanced
+ * on every emit + every (re)connect. Each instance owns its own file + in-memory
+ * map, so tests construct throwaway instances pointed at a temp dir with no
+ * global state to reset.
+ */
+export class DeliveryState {
+  private readonly file: string;
+  private readonly defaultMark: string;
+  private readonly marks: Map<string, string> = new Map();
+
+  constructor(opts: DeliveryStateOptions = {}) {
+    const stateDir = opts.stateDir ?? defaultStateDir();
+    this.file = join(stateDir, "delivery-state.json");
+    this.defaultMark = opts.defaultMark ?? new Date().toISOString();
+    this.load();
+  }
+
+  /** Read the persisted marks once at construction. Missing/corrupt file → empty. */
+  private load(): void {
+    let raw: string;
+    try {
+      raw = readFileSync(this.file, "utf8");
+    } catch {
+      // No file yet (first boot) — start empty; the default mark covers unknowns.
+      return;
+    }
+    try {
+      const parsed = JSON.parse(raw) as unknown;
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        for (const [k, v] of Object.entries(parsed as DeliveryStateFile)) {
+          if (typeof v === "string" && v) this.marks.set(k, v);
+        }
+      }
+    } catch (err) {
+      // Corrupt file — log and start empty rather than crash. The marks rebuild
+      // from boot-time defaults; the cost is a bounded re-replay, not a loss.
+      console.warn(
+        `parachute-channel: delivery-state file ${this.file} is unreadable (${(err as Error).message}); ` +
+          `starting with empty marks.`,
+      );
+    }
+  }
+
+  /** Write the current marks through to disk. Best-effort: a failure is logged, never thrown. */
+  private persist(): void {
+    try {
+      mkdirSync(dirname(this.file), { recursive: true });
+      const obj: DeliveryStateFile = {};
+      for (const [k, v] of this.marks) obj[k] = v;
+      writeFileSync(this.file, JSON.stringify(obj, null, 2));
+    } catch (err) {
+      console.warn(
+        `parachute-channel: failed to persist delivery-state to ${this.file} ` +
+          `(${(err as Error).message}); the mark is held in memory only.`,
+      );
+    }
+  }
+
+  /**
+   * The last-delivered mark for a channel: the persisted value, or the daemon's
+   * boot-time default when this channel has never delivered. Always an ISO string,
+   * so callers can compare note timestamps against it with a plain string `>`.
+   */
+  getLastDelivered(channel: string): string {
+    return this.marks.get(channel) ?? this.defaultMark;
+  }
+
+  /**
+   * Move a channel's mark forward to `ts` IF it's newer than the current mark
+   * (monotonic — never rewinds). Returns true if the mark advanced (and was
+   * persisted), false if `ts` was not newer (no write). An empty/missing `ts` is
+   * a no-op (we never advance to a blank mark — that would replay everything).
+   */
+  advance(channel: string, ts: string): boolean {
+    if (!ts) return false;
+    const current = this.getLastDelivered(channel);
+    if (ts > current) {
+      this.marks.set(channel, ts);
+      this.persist();
+      return true;
+    }
+    return false;
+  }
+}

--- a/src/mcp-http.test.ts
+++ b/src/mcp-http.test.ts
@@ -99,6 +99,35 @@ describe("per-channel MCP session registry + wake push", () => {
     expect(pushPermissionVerdict("nope", { request_id: "r", behavior: "deny" })).toBe(0);
   });
 
+  test("a streamless session (registered, no live GET stream) is NOT counted as delivered", () => {
+    // The bug this guards: a session that POSTed `initialize` but hasn't opened (or
+    // has dropped) its standalone GET stream is registered, but the SDK silently
+    // drops any notification to it. If pushToChannel counted it, the daemon would
+    // advance the channel's delivery mark and the message would be lost.
+    const a = fakeSession();
+    _registerSessionForTest("A", "sid-streamless", a.server as never, ["channel:read"], {
+      streamless: true,
+    });
+    expect(mcpSessionCount("A")).toBe(1); // it IS registered…
+    expect(pushToChannel("A", "into the void", {})).toBe(0); // …but NOT deliverable
+    expect(a.captured.notes).toHaveLength(0); // not even attempted
+    // Permission verdicts honor the same gate.
+    expect(pushPermissionVerdict("A", { request_id: "r", behavior: "allow" })).toBe(0);
+  });
+
+  test("pushToChannel counts only the live-stream sessions in a mixed set", () => {
+    const live = fakeSession();
+    const dead = fakeSession();
+    _registerSessionForTest("A", "sid-live", live.server as never, ["channel:read"]);
+    _registerSessionForTest("A", "sid-streamless", dead.server as never, ["channel:read"], {
+      streamless: true,
+    });
+    expect(mcpSessionCount("A")).toBe(2); // both registered
+    expect(pushToChannel("A", "hi", {})).toBe(1); // only the one with a live stream
+    expect(live.captured.notes).toHaveLength(1);
+    expect(dead.captured.notes).toHaveLength(0);
+  });
+
   test("mcpSessionCount tracks registration + reset", () => {
     expect(mcpSessionCount("A")).toBe(0);
     const a = fakeSession();

--- a/src/mcp-http.test.ts
+++ b/src/mcp-http.test.ts
@@ -11,6 +11,7 @@ import {
   pushToChannel,
   pushPermissionVerdict,
   mcpSessionCount,
+  assertMcpSdkStreamContract,
   _resetSessionsForTest,
 } from "./mcp-http.ts";
 import { createFetchHandler } from "./daemon.ts";
@@ -126,6 +127,12 @@ describe("per-channel MCP session registry + wake push", () => {
     expect(pushToChannel("A", "hi", {})).toBe(1); // only the one with a live stream
     expect(live.captured.notes).toHaveLength(1);
     expect(dead.captured.notes).toHaveLength(0);
+  });
+
+  test("the installed MCP SDK still keys the standalone GET stream as we expect (contract guard)", () => {
+    // If this fails, the SDK renamed the internal sessionHasLivePushStream reads —
+    // HTTP-MCP delivery would silently break. Catch it here, not in production.
+    expect(assertMcpSdkStreamContract()).toBe(true);
   });
 
   test("mcpSessionCount tracks registration + reset", () => {

--- a/src/mcp-http.ts
+++ b/src/mcp-http.ts
@@ -113,11 +113,43 @@ function registerSession(channel: string, id: string, session: McpSession): void
   }
   set.add(session);
   sessionsById.set(id, session);
-  // Fire the daemon-installed connect hook so this freshly-registered session
-  // replays any backlog it missed — targeted at THIS session only.
-  if (onSessionConnect) {
-    onSessionConnect(channel, (content, meta) => pushToSession(session, content, meta));
-  }
+  // NOTE: backlog replay is deliberately NOT fired here. Registration happens at
+  // `onsessioninitialized` — DURING the POST initialize, BEFORE the client opens
+  // its standalone GET SSE stream. The SDK silently drops server-initiated
+  // notifications when that stream isn't open yet (webStandardStreamableHttp
+  // send(): "Stream is disconnected ... nothing more to do" — no event store, so
+  // nothing is buffered). Replaying here would push the backlog into the void
+  // while the channel's delivery mark advanced past it — silent loss. Replay is
+  // fired from `fireConnectReplay` once the GET stream is provably live (see
+  // handleMcp's GET branch).
+}
+
+/**
+ * Whether a session has a LIVE standalone GET SSE push stream — the stream the
+ * SDK writes `notifications/claude/channel` onto. A session that has only POSTed
+ * `initialize` (registered) but not yet opened — or has since dropped — its GET
+ * stream is NOT deliverable: `transport.send()` silently no-ops for it (no event
+ * store is configured, so the message is dropped, not buffered). We read the SAME
+ * internal map the SDK's send() consults (`_streamMapping['_GET_stream']`), so our
+ * notion of "deliverable" can never disagree with whether the SDK actually writes.
+ */
+function sessionHasLivePushStream(session: McpSession): boolean {
+  const t = session.transport as unknown as
+    | { _streamMapping?: Map<string, unknown> }
+    | undefined;
+  return !!t && t._streamMapping?.get("_GET_stream") !== undefined;
+}
+
+/**
+ * Fire the daemon-installed backlog-replay hook for ONE session whose GET stream
+ * is now live — replays the messages it missed, targeted at this session only.
+ * No-ops when no hook is installed or the session has no live push stream (so a
+ * streamless session waits to be replayed until it actually opens its stream).
+ */
+function fireConnectReplay(channel: string, session: McpSession): void {
+  if (!onSessionConnect) return;
+  if (!sessionHasLivePushStream(session)) return;
+  onSessionConnect(channel, (content, meta) => pushToSession(session, content, meta));
 }
 
 function unregisterSession(channel: string, id: string): void {
@@ -154,8 +186,22 @@ export function _registerSessionForTest(
   id: string,
   server: Server,
   scopes: string[],
+  opts?: { streamless?: boolean },
 ): void {
-  registerSession(channel, id, { server, transport: undefined as never, scopes });
+  // Model the real transport's deliverability: a connected session whose GET
+  // stream is open carries `_streamMapping['_GET_stream']` — the same key
+  // sessionHasLivePushStream + the SDK's send() consult. `streamless: true` models
+  // a session that registered (POSTed initialize) but never opened — or has since
+  // dropped — its GET stream: registered but NOT deliverable.
+  const transport = opts?.streamless
+    ? (undefined as never)
+    : ({ _streamMapping: new Map<string, unknown>([["_GET_stream", {}]]) } as never);
+  const session: McpSession = { server, transport, scopes };
+  registerSession(channel, id, session);
+  // Production fires replay from handleMcp's GET branch once the stream is live;
+  // mirror that here so the connect-replay tests exercise the real trigger path.
+  // No-ops for a streamless session (it has no live stream to receive a push).
+  fireConnectReplay(channel, session);
 }
 
 /** Test-only: remove a registered session — exercises the empty-set cleanup path. */
@@ -182,6 +228,12 @@ export function pushToChannel(
   if (!set) return 0;
   let delivered = 0;
   for (const session of set) {
+    // Only sessions with a LIVE GET push stream are deliverable. The SDK silently
+    // drops a notification to a streamless session (no throw, nothing buffered), so
+    // counting one here would falsely advance the channel's delivery mark and lose
+    // the message. A skipped session receives the message via backlog replay when
+    // it (re)opens its GET stream (handleMcp's GET branch → fireConnectReplay).
+    if (!sessionHasLivePushStream(session)) continue;
     try {
       void session.server.notification({
         method: "notifications/claude/channel",
@@ -209,6 +261,9 @@ export function pushPermissionVerdict(
   if (!set) return 0;
   let delivered = 0;
   for (const session of set) {
+    // Same deliverability gate as pushToChannel: a streamless session can't
+    // receive the verdict (the SDK would drop it), so don't claim it did.
+    if (!sessionHasLivePushStream(session)) continue;
     try {
       void session.server.notification({
         method: "notifications/claude/channel/permission",
@@ -514,7 +569,15 @@ export async function handleMcp(
     // a re-auth with a narrower/wider token takes effect (the daemon re-validates
     // channel:read on every call before reaching here).
     existing.scopes = scopes;
-    return existing.transport.handleRequest(req);
+    const res = await existing.transport.handleRequest(req);
+    // A GET opens (or reopens, after a drop) the standalone SSE push stream. The
+    // SDK registers it synchronously inside handleRequest, so it's provably live
+    // now — replay the backlog this session missed. Firing at registration would
+    // push into a not-yet-open stream and the SDK would silently drop it. This is
+    // idempotent: replayBacklog only delivers messages newer than the channel's
+    // delivery mark, so a reconnect (or a redundant GET) replays nothing already seen.
+    if (req.method === "GET") fireConnectReplay(channel, existing);
+    return res;
   }
 
   if (req.method === "DELETE") {

--- a/src/mcp-http.ts
+++ b/src/mcp-http.ts
@@ -70,6 +70,41 @@ const sessionsByChannel = new Map<string, Set<McpSession>>();
 /** mcp-session-id → session, so a follow-up POST/GET/DELETE finds its transport. */
 const sessionsById = new Map<string, McpSession>();
 
+/**
+ * Connect-hook the daemon installs (via `setOnSessionConnect`) so a NEWLY
+ * connected MCP session can replay the backlog it missed while the daemon had no
+ * subscriber on the channel (the deaf-on-restart / 0-subscriber case). It's
+ * invoked right after `onsessioninitialized` registers the session, with a
+ * `pushToThisSession` bound to ONLY the new session — so the daemon's
+ * `replayBacklog` wakes this one connection without re-waking the others.
+ *
+ * Optional: unset in unit tests that don't exercise replay; the registration path
+ * no-ops when absent.
+ */
+type OnSessionConnect = (
+  channel: string,
+  pushToThisSession: (content: string, meta: Record<string, string>) => void,
+) => void;
+let onSessionConnect: OnSessionConnect | undefined;
+
+/** The daemon calls this once at boot to install the backlog-replay connect hook. */
+export function setOnSessionConnect(hook: OnSessionConnect | undefined): void {
+  onSessionConnect = hook;
+}
+
+/** Push a `notifications/claude/channel` wake to ONE session (used by backlog replay,
+ *  so a reconnecting session gets its missed messages without re-waking the others). */
+function pushToSession(session: McpSession, content: string, meta: Record<string, string>): void {
+  try {
+    void session.server.notification({
+      method: "notifications/claude/channel",
+      params: { content, meta: { source: "parachute-channel", ...meta } },
+    });
+  } catch {
+    // Dead session — its onclose handler removes it from the set; nothing to do.
+  }
+}
+
 function registerSession(channel: string, id: string, session: McpSession): void {
   let set = sessionsByChannel.get(channel);
   if (!set) {
@@ -78,6 +113,11 @@ function registerSession(channel: string, id: string, session: McpSession): void
   }
   set.add(session);
   sessionsById.set(id, session);
+  // Fire the daemon-installed connect hook so this freshly-registered session
+  // replays any backlog it missed — targeted at THIS session only.
+  if (onSessionConnect) {
+    onSessionConnect(channel, (content, meta) => pushToSession(session, content, meta));
+  }
 }
 
 function unregisterSession(channel: string, id: string): void {
@@ -95,10 +135,13 @@ export function mcpSessionCount(channel: string): number {
   return sessionsByChannel.get(channel)?.size ?? 0;
 }
 
-/** Test/teardown helper — drop every registered session without touching transports. */
+/** Test/teardown helper — drop every registered session without touching transports.
+ *  Also clears the connect hook so a hook installed by one test's createFetchHandler
+ *  can't leak into the next test's `_registerSessionForTest`. */
 export function _resetSessionsForTest(): void {
   sessionsByChannel.clear();
   sessionsById.clear();
+  onSessionConnect = undefined;
 }
 
 /**

--- a/src/mcp-http.ts
+++ b/src/mcp-http.ts
@@ -167,6 +167,45 @@ export function mcpSessionCount(channel: string): number {
   return sessionsByChannel.get(channel)?.size ?? 0;
 }
 
+/**
+ * Boot-time guard for the ONE SDK internal `sessionHasLivePushStream` depends on:
+ * the standalone GET stream is keyed by `_standaloneSseStreamId === "_GET_stream"`
+ * inside the transport's `_streamMapping`. We read that private field (the SDK
+ * exposes no public "is the push stream open?" API), so an SDK upgrade that renamed
+ * it would make `sessionHasLivePushStream` return false forever — silently breaking
+ * ALL HTTP-MCP delivery (both the live wake AND backlog replay), since both now gate
+ * on it. The caret pin (`^1.x`) lets a `bun update` pull such a version, so we verify
+ * the contract LOUDLY at boot rather than discover it as silent message loss in
+ * production. Verified against @modelcontextprotocol/sdk 1.29.x. Returns true when
+ * the contract holds; logs a screaming error and returns false otherwise.
+ */
+export function assertMcpSdkStreamContract(): boolean {
+  try {
+    const probe = new WebStandardStreamableHTTPServerTransport({
+      sessionIdGenerator: () => "contract-probe",
+      enableJsonResponse: false,
+    });
+    const id = (probe as unknown as { _standaloneSseStreamId?: unknown })._standaloneSseStreamId;
+    const hasMap =
+      (probe as unknown as { _streamMapping?: unknown })._streamMapping instanceof Map;
+    if (id === "_GET_stream" && hasMap) return true;
+    console.error(
+      "parachute-channel: FATAL CONTRACT DRIFT — the MCP SDK's standalone-GET-stream " +
+        `internals changed (expected _standaloneSseStreamId="_GET_stream" + a _streamMapping Map; ` +
+        `got id=${JSON.stringify(id)}, map=${hasMap}). sessionHasLivePushStream() can no longer ` +
+        "detect a live push stream, so HTTP-MCP channel delivery (live wake AND backlog replay) is " +
+        "BROKEN. Pin @modelcontextprotocol/sdk back, or update mcp-http.ts to the new internals.",
+    );
+    return false;
+  } catch (err) {
+    console.error(
+      `parachute-channel: could not verify MCP SDK stream contract (${(err as Error).message}); ` +
+        "HTTP-MCP delivery may be unreliable.",
+    );
+    return false;
+  }
+}
+
 /** Test/teardown helper — drop every registered session without touching transports.
  *  Also clears the connect hook so a hook installed by one test's createFetchHandler
  *  can't leak into the next test's `_registerSessionForTest`. */


### PR DESCRIPTION
## Problem

A connected vault-backed channel session **silently stops receiving inbound messages after any daemon restart**, and messages sent during the gap are lost from the live wake (still durable in the vault). Two compounding bugs:

- **Silent loss (0-subscriber):** `contextFor.emit` fanned an inbound to whatever SSE bridges + MCP sessions were live, but the daemon acked the vault trigger `{ok:true}` regardless of subscriber count and the vault stamped `_rendered_at`, so the trigger never re-fired. An inbound delivered to **zero** live subscribers reached no one.
- **Deaf-on-restart:** MCP sessions drop on daemon restart and only reconnect on the next interaction. Combined with the above, anything that arrived in that deaf window was lost.

Confirmed live on uni-dev: `mcp_sessions:0` after restarts; "Hello?"/"Test?" landed in the vault marked `conn_..._rendered_at` but were never delivered.

## Fix — per-channel delivery high-water-mark + backlog replay

**`src/delivery-state.ts` (new)** — per-channel last-delivered ISO `ts`, monotonic `advance` (never rewinds), write-through to `delivery-state.json`, load-on-boot. An unknown channel defaults to the **daemon boot time** — so a first connect never replays ancient vault history, only the genuine deaf-window gap. Persisted marks survive a restart and replay exactly the gap.

**`emit` advances the mark only on real delivery** — `delivered = SSE client count + MCP session count`. `> 0` → advance to the note ts (read from `msg.meta.ts`, which `ingestInbound` flattens from the note metadata). `=== 0` → leave the mark behind so the message replays later.

**`replayBacklog` (new, exported)** — on (re)connect (MCP session register / SSE `/events` reopen), load the channel transcript (reusing the index-free `loadTranscript`), replay the inbound messages newer than the mark — oldest-first, capped at the newest 50 — to **that one new subscriber only** (a per-session MCP push / a write to that one SSE stream, so existing subscribers aren't re-woken), then advance the mark. **VaultTransport channels only**; http-ui/telegram skipped. A transcript-load failure → 0 (the connect never fails).

**Connect hooks** — `mcp-http` gains a per-session push (`pushToSession`) + an `onSessionConnect` hook fired from `registerSession`; the daemon installs it to run `replayBacklog` against the freshly-connected session. The SSE `/events` handler replays onto the new stream after the client is registered.

`markSeen` (the webhook idempotency dedup that stops the N-trigger fan-out from double-waking) is **unchanged and orthogonal** — the backlog path is gated by the mark, not by `markSeen`.

## Out of scope — filed as #66

Bug 3 (N-trigger fan-out: every connection-trigger fires on every `#channel-message/inbound` note → N webhooks + N `_rendered_at` markers per inbound; `markSeen` dedups the actual wake, so wasteful not incorrect). Scoping each connection's trigger to its own channel is a hub/connection-model change → **#66**.

## Per-file changes

- `src/delivery-state.ts` (new, +156): `DeliveryState` class — `getLastDelivered` / `advance` (monotonic, persist) / load-on-construct / boot-time default.
- `src/daemon.ts`: `contextFor.emit` advances the mark on real delivery; `replayBacklog` + `REPLAY_CAP` exported; `addChannelLive` threads `deliveryState`; `createFetchHandler` owns the instance + installs the MCP connect hook; `/events` replays onto the new stream; `main` constructs the boot-time instance.
- `src/mcp-http.ts`: `setOnSessionConnect` / `onSessionConnect` hook + `pushToSession` (per-session wake); `registerSession` fires the hook; `_resetSessionsForTest` clears it.
- `src/delivery-state.test.ts` (new): monotonic advance, persist+reload across a simulated restart, default-to-bootTime, corrupt-file tolerance, per-channel isolation.
- `src/backlog-replay.test.ts` (new): `replayBacklog` (ascending + capped-keeps-newest + outbound-excluded + second-call-empty + non-vault-skip + load-failure + missing-ts-skip + throw-aborts-before-advance); `emit` 0-vs-≥1 subscriber via the live webhook; MCP connect replays to that session only; SSE connect replays onto the new stream; **end-to-end deaf window** (inbound → 0 subscribers → mark stays → connect → delivered exactly once).
- `CLAUDE.md`: documents the no-loss mechanism + the new state file.

## Verification

- `bun test src/` → **465 pass, 0 fail** (+20 new).
- `bun run typecheck` clean except two pre-existing `bridge.ts` TS2589 errors (present on `origin/main`, unrelated).
- Reviewer subagent: LGTM, no blocking issues.

DO NOT MERGE — reviewer-gated + a live restart→deaf→reconnect verification before the human merges. Channel is delegated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)