### PR TITLE
feat(channel): per-channel env/credential injection + per-session restart

### DIFF
--- a/src/agents-ui.ts
+++ b/src/agents-ui.ts
@@ -11,11 +11,16 @@
  *   - GET    /api/credentials/claude   → credential status (default set? overrides?)
  *   - POST   /api/credentials/claude[/:channel]  → set default / per-channel token
  *   - DELETE /api/credentials/claude/:channel    → remove an override
+ *   - GET    /api/credentials/env      → per-channel env-var NAMES (values redacted)
+ *   - POST   /api/credentials/env      → set an env var ({ channel?, name, value })
+ *   - DELETE /api/credentials/env      → remove an env var ({ channel?, name })
  *   - GET    /api/agents               → list running agent sessions
  *   - POST   /api/agents               → spawn a sandboxed agent from a spec
+ *   - POST   /api/agents/:name/restart → per-session restart (re-source env + reconnect)
  *   - DELETE /api/agents/:name         → kill a session
  *   - GET    /api/vaults               → installed vault instances (the picker)
  *   - GET    /.parachute/config        → channel list (the picker)
+ *   - GET    /health                   → live per-channel connection status (mcp_sessions)
  *
  * UX: the DEFAULT flow is one-agent-one-channel — pick a channel, the agent name
  * auto-fills from it, click Spawn. Everything else (extra channels, vault binding,
@@ -91,6 +96,15 @@ ${THEME_CSS}
   code { font-family: var(--font-mono); color: var(--fg); background: var(--bg-soft); padding: 1px 5px; border-radius: 4px; font-size: 0.8rem; }
   .scopes { margin: 8px 0 0; font-size: 0.78rem; color: var(--fg-muted); }
   .empty { color: var(--fg-muted); font-size: 0.85rem; padding: 8px 2px; }
+  /* Env-var chips: name + inline remove, grouped per scope. */
+  .env-block { margin: 6px 0; display: flex; flex-wrap: wrap; align-items: center; gap: 6px; }
+  .env-scope { font-size: 0.78rem; color: var(--fg-muted); font-weight: 500; }
+  .env-chip { display: inline-flex; align-items: center; gap: 2px; background: var(--bg-soft); border: 1px solid var(--border); border-radius: 6px; padding: 2px 4px 2px 8px; }
+  .env-chip code { background: transparent; padding: 0; font-size: 0.8rem; }
+  .env-chip button { padding: 0 6px; font-size: 14px; line-height: 1; }
+  /* Connection-status pill on the running-agents list (mcp_sessions from /health). */
+  .pill.connected { color: var(--success); }
+  .pill.idle-conn { color: var(--fg-dim); }
 </style>
 </head>
 <body>
@@ -127,6 +141,42 @@ ${THEME_CSS}
         </div>
       </details>
       <div id="cred-msg" class="msg"></div>
+    </section>
+
+    <!-- Per-channel env / credentials (GH_TOKEN, CLOUDFLARE_API_TOKEN, …) -->
+    <section id="env-section">
+      <h2>Channel env / credentials</h2>
+      <p class="hint">Scope a channel's spawned agent extra secrets &mdash; a
+        <code>GH_TOKEN</code>, <code>CLOUDFLARE_API_TOKEN</code>, etc. These are injected
+        into the session's shell (its <code>gh</code>/<code>git</code>/build tooling) &mdash;
+        Claude's own login is never touched. Set a default for every channel, or override per
+        channel. After setting one, hit <strong>Restart / reconnect</strong> on a running session
+        to apply it.</p>
+      <div id="env-list" class="scopes"></div>
+      <details open>
+        <summary>Set an env var</summary>
+        <div class="sub">
+          <div class="grid3">
+            <div>
+              <label for="env-channel">Channel (blank = default/all)</label>
+              <input type="text" id="env-channel" placeholder="channel name, or blank for default" autocomplete="off" />
+            </div>
+            <div>
+              <label for="env-name">Name</label>
+              <input type="text" id="env-name" placeholder="GH_TOKEN" autocomplete="off" />
+            </div>
+            <div>
+              <label for="env-value">Value</label>
+              <input type="password" id="env-value" placeholder="ghp_…" autocomplete="off" />
+            </div>
+          </div>
+          <div class="row">
+            <button id="env-save" class="primary" type="button">Save env var</button>
+            <span class="muted" style="font-size:12px;">Stored 0600, never shown again. <code>ANTHROPIC_API_KEY</code> &amp; the Claude-auth vars are reserved.</span>
+          </div>
+        </div>
+      </details>
+      <div id="env-msg" class="msg"></div>
     </section>
 
     <!-- Spawn -->
@@ -338,6 +388,75 @@ ${SHELL_JS}
     }).catch(function (err) { showMsg(msg, "Failed: " + err.message, true); });
   }
 
+  // --- per-channel env vars (GH_TOKEN, CLOUDFLARE_API_TOKEN, …) ------------
+  // GET /api/credentials/env returns { default:[names], channels:{ch:[names]} } —
+  // NAMES only, values are never returned. Render each as a removable chip; the
+  // scope ("default" or a channel) rides on the delete button.
+  function envChip(scope, name) {
+    // scope is "" for the default layer, else the channel name. Data-attrs are
+    // server-enforced shapes (env name regex; channel slug) but esc() anyway.
+    return "<span class='env-chip'><code>" + esc(name) + "</code>" +
+      "<button class='ghost danger' data-env-scope='" + esc(scope) + "' data-env-name='" + esc(name) +
+      "' type='button' title='remove'>&times;</button></span>";
+  }
+  function loadEnv() {
+    return apiJson("/api/credentials/env").then(function (j) {
+      var host = document.getElementById("env-list");
+      var blocks = [];
+      var dflt = (j && j.default) || [];
+      if (dflt.length) {
+        blocks.push("<div class='env-block'><span class='env-scope'>default (all channels):</span> " +
+          dflt.map(function (n) { return envChip("", n); }).join(" ") + "</div>");
+      }
+      var chans = (j && j.channels) || {};
+      Object.keys(chans).sort().forEach(function (ch) {
+        var names = chans[ch] || [];
+        if (!names.length) return;
+        blocks.push("<div class='env-block'><span class='env-scope'>" + esc(ch) + ":</span> " +
+          names.map(function (n) { return envChip(ch, n); }).join(" ") + "</div>");
+      });
+      host.innerHTML = blocks.length ? blocks.join("") :
+        "<div class='muted' style='font-size:13px;'>No env vars set. Add one below to scope a channel's agent a token.</div>";
+      host.querySelectorAll("[data-env-name]").forEach(function (btn) {
+        btn.addEventListener("click", function () {
+          removeEnv(btn.getAttribute("data-env-scope") || "", btn.getAttribute("data-env-name"));
+        });
+      });
+      return j;
+    }).catch(function (err) {
+      document.getElementById("env-list").innerHTML =
+        "<div class='muted' style='font-size:13px;'>Could not load env vars: " + esc(err.message) + "</div>";
+    });
+  }
+  document.getElementById("env-save").addEventListener("click", function () {
+    var msg = document.getElementById("env-msg");
+    clearMsg(msg);
+    var channel = document.getElementById("env-channel").value.trim();
+    var name = document.getElementById("env-name").value.trim();
+    var value = document.getElementById("env-value").value;
+    if (!name) { showMsg(msg, "Enter a variable name (e.g. GH_TOKEN).", true); return; }
+    if (!value) { showMsg(msg, "Enter a value.", true); return; }
+    var body = { name: name, value: value };
+    if (channel) body.channel = channel;
+    apiJson("/api/credentials/env", { method: "POST", body: JSON.stringify(body) }).then(function () {
+      document.getElementById("env-name").value = "";
+      document.getElementById("env-value").value = "";
+      showMsg(msg, "Saved " + name + (channel ? (" for channel " + channel) : " (default)") +
+        ". Restart a session to apply it.", false);
+      loadEnv();
+    }).catch(function (err) { showMsg(msg, "Failed: " + err.message, true); });
+  });
+  function removeEnv(scope, name) {
+    var msg = document.getElementById("env-msg");
+    clearMsg(msg);
+    var body = { name: name };
+    if (scope) body.channel = scope;
+    apiJson("/api/credentials/env", { method: "DELETE", body: JSON.stringify(body) }).then(function () {
+      showMsg(msg, "Removed " + name + (scope ? (" for " + scope) : " (default)") + ".", false);
+      loadEnv();
+    }).catch(function (err) { showMsg(msg, "Failed: " + err.message, true); });
+  }
+
   // --- spawn form ---------------------------------------------------------
   function channelOptions(selected) {
     return knownChannels.map(function (c) {
@@ -480,8 +599,32 @@ ${SHELL_JS}
   // name as the channel (?channel=<name>). When an agent was custom-named off its
   // channel, the chat page still loads on its picker — no fabricated data.
   function chatUrl(channel) { return MOUNT + "/ui?channel=" + encodeURIComponent(channel); }
+  // /health is OPEN (no token) and carries per-channel { mcp_sessions, clients }.
+  // The default is one-agent-one-channel (the agent name IS its wake channel), so we
+  // key live connection status by the agent name. An agent custom-named off its
+  // channel shows "—" (no fabricated data), which is honest.
+  function fetchHealth() {
+    return fetch(MOUNT + "/health").then(function (r) { return r.ok ? r.json() : null; }).catch(function () { return null; });
+  }
+  function connectionCell(h) {
+    // h is the channel's /health row ({ mcp_sessions, clients }) or undefined.
+    if (!h) return "<span class='pill idle-conn' title='no matching channel in /health'>—</span>";
+    var sessions = (typeof h.mcp_sessions === "number") ? h.mcp_sessions : 0;
+    var clients = (typeof h.clients === "number") ? h.clients : 0;
+    if (sessions + clients > 0) {
+      return "<span class='pill connected'>● connected</span> " +
+        "<span class='muted' style='font-size:11px;'>(" + sessions + " mcp, " + clients + " sse)</span>";
+    }
+    return "<span class='pill idle-conn'>○ not connected</span>";
+  }
   function loadAgents() {
-    return apiJson("/api/agents").then(function (j) {
+    return Promise.all([apiJson("/api/agents"), fetchHealth()]).then(function (res) {
+      var j = res[0];
+      var health = res[1];
+      var liveByChannel = {};
+      if (health && Array.isArray(health.channels)) {
+        health.channels.forEach(function (c) { liveByChannel[c.name] = c; });
+      }
       var host = document.getElementById("agents-table");
       var agents = j.agents || [];
       if (!agents.length) {
@@ -494,16 +637,21 @@ ${SHELL_JS}
           "<td><strong>" + esc(a.name) + "</strong></td>" +
           "<td><code>" + esc(a.session) + "</code></td>" +
           "<td>" + att + "</td>" +
+          "<td>" + connectionCell(liveByChannel[a.name]) + "</td>" +
           "<td class='actions'>" +
             "<a href='" + esc(chatUrl(a.name)) + "'>chat →</a>" +
             "<a href='" + esc(terminalUrl(a.name)) + "' target='_blank' rel='noopener'>terminal ↗</a>" +
+            "<button class='ghost' data-restart='" + esc(a.name) + "' type='button' title='Re-source env + reconnect this session'>restart / reconnect</button>" +
             "<button class='ghost danger' data-kill='" + esc(a.name) + "' type='button'>kill</button>" +
           "</td></tr>";
       }).join("");
-      host.innerHTML = "<table><thead><tr><th>Agent</th><th>tmux session</th><th>State</th><th></th></tr></thead><tbody>" +
+      host.innerHTML = "<table><thead><tr><th>Agent</th><th>tmux session</th><th>State</th><th>Connection</th><th></th></tr></thead><tbody>" +
         rows + "</tbody></table>";
       host.querySelectorAll("[data-kill]").forEach(function (btn) {
         btn.addEventListener("click", function () { killAgent(btn.getAttribute("data-kill")); });
+      });
+      host.querySelectorAll("[data-restart]").forEach(function (btn) {
+        btn.addEventListener("click", function () { restartAgent(btn.getAttribute("data-restart"), btn); });
       });
     }).catch(function (err) {
       document.getElementById("agents-table").innerHTML = "<div class='empty'>Could not load agents: " + esc(err.message) + "</div>";
@@ -517,6 +665,27 @@ ${SHELL_JS}
     apiJson("/api/agents/" + encodeURIComponent(name), { method: "DELETE" }).then(function () {
       loadAgents();
     }).catch(function (err) { alert("Kill failed: " + err.message); });
+  }
+
+  // Restart = kill + re-spawn from the persisted spec, re-resolving env + the Claude
+  // credential — so setting a token then applying it is one click. A fresh spawn
+  // (NOT claude -c): the prior conversation context is not resumed (the channel MCP
+  // reconnects either way). The server returns 400 if there's no persisted spec (an
+  // older session) — surfaced as a clear message.
+  function restartAgent(name, btn) {
+    if (!confirm("Restart agent " + name + "? It re-sources env (picks up newly-set credentials) and reconnects. The current conversation context is not resumed.")) return;
+    var orig = btn ? btn.textContent : "";
+    if (btn) { btn.disabled = true; btn.textContent = "restarting…"; }
+    apiJson("/api/agents/" + encodeURIComponent(name) + "/restart", { method: "POST" }).then(function (r) {
+      var msg = document.getElementById("spawn-msg");
+      clearMsg(msg);
+      showMsg(msg, "Restarted " + (r.session || (name + "-agent")) + " — env re-sourced, session reconnected.", false);
+      loadAgents();
+    }).catch(function (err) {
+      alert("Restart failed: " + err.message);
+    }).then(function () {
+      if (btn) { btn.disabled = false; btn.textContent = orig; }
+    });
   }
   document.getElementById("refresh").addEventListener("click", function () { loadAgents(); });
 
@@ -569,7 +738,7 @@ ${SHELL_JS}
   setStatus("authenticating…");
   fetchToken().then(function () {
     setStatus("● ready", "live");
-    return Promise.all([loadChannels(), loadVaults(), loadCreds(), loadAgents()]);
+    return Promise.all([loadChannels(), loadVaults(), loadCreds(), loadEnv(), loadAgents()]);
   }).then(function () {
     setInterval(loadAgents, 5000);
   }).catch(function (err) {

--- a/src/agents.test.ts
+++ b/src/agents.test.ts
@@ -35,6 +35,9 @@ mock.module("./hub-jwt.ts", () => ({
   resetRevocationCache() {},
 }));
 
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   parseTmuxSessions,
   agentInfoFromSessions,
@@ -52,7 +55,15 @@ import { CredentialNotConfiguredError } from "./credentials.ts";
 import { SpawnDepsError } from "./spawn-deps.ts";
 import { MintError } from "./mint-token.ts";
 import type { Channel } from "./registry.ts";
-import type { SpawnAgentResult } from "./spawn-agent.ts";
+import {
+  persistSpec,
+  sessionWorkspace,
+  type SpawnAgentResult,
+  type SpawnAgentDeps,
+  type TmuxLauncher,
+} from "./spawn-agent.ts";
+import type { SandboxEngine } from "./sandbox/index.ts";
+import type { AgentSpec } from "./sandbox/types.ts";
 
 const adminAuth = { authorization: "Bearer " + ADMIN_TOKEN } as const;
 const readAuth = { authorization: "Bearer " + READ_TOKEN } as const;
@@ -254,6 +265,132 @@ describe("createRealAgentOps — list + kill", () => {
 });
 
 // ===========================================================================
+// 2b. createRealAgentOps.restart — kill + re-spawn from the persisted spec
+// ===========================================================================
+describe("createRealAgentOps — restart (param recovery via persisted spec)", () => {
+  // A recording spawn-launcher (the tmux launcher spawnAgent uses) + a fake sandbox
+  // engine, so restart drives the REAL spawnAgent through a persisted spec without a
+  // hub/sandbox/tmux server.
+  function spawnDeps(sessionsDirPath: string): {
+    deps: SpawnAgentDeps;
+    launched: Array<{ name: string }>;
+  } {
+    const launched: Array<{ name: string }> = [];
+    const launcher: TmuxLauncher = {
+      async hasSession() {
+        return false;
+      },
+      async newSession(opts) {
+        launched.push({ name: opts.name });
+      },
+    };
+    const engine: SandboxEngine = {
+      isSupportedPlatform: () => true,
+      isSandboxingEnabled: () => true,
+      async initialize() {},
+      async wrapWithSandboxArgv(command: string) {
+        return { argv: ["/bin/bash", "-c", command], env: {} };
+      },
+      async reset() {},
+    };
+    const fetchFn = (async (_u: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { scope: string };
+      return new Response(
+        JSON.stringify({ jti: "j", token: "TOK", expires_at: "2026-09-01T00:00:00Z", scope: body.scope }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+    const deps: SpawnAgentDeps = {
+      hubOrigin: "https://hub.example.com",
+      managerBearer: "MANAGER",
+      channelUrl: "http://127.0.0.1:1941",
+      vaultUrl: "http://127.0.0.1:1940",
+      sessionsDir: sessionsDirPath,
+      runtimeReadOnly: [],
+      resolveClaudeToken: () => "OAUTH-PLACEHOLDER",
+      resolveChannelEnv: () => ({ GH_TOKEN: "ghp_FROM-STORE" }),
+      sandboxEngine: engine,
+      tmux: launcher,
+      fetchFn,
+      parentEnv: { PATH: "/usr/bin" },
+      claudeBin: "claude",
+    };
+    return { deps, launched };
+  }
+
+  test("recovers the persisted spec, kills the old session, re-spawns it", async () => {
+    const sessionsDirPath = mkdtempSync(join(tmpdir(), "restart-ops-"));
+    try {
+      const spec: AgentSpec = { name: "aaron", channels: ["aaron"], network: "open" };
+      // Seed a persisted spec where a prior spawn would have written it.
+      persistSpec(sessionWorkspace(sessionsDirPath, "aaron"), spec);
+
+      const killed: string[] = [];
+      const tmux: TmuxAdmin = {
+        async listSessions() {
+          return [{ name: "aaron-agent", attached: false }];
+        },
+        async killSession(name) {
+          killed.push(name);
+          return true;
+        },
+      };
+      const { deps, launched } = spawnDeps(sessionsDirPath);
+      const ops = createRealAgentOps({ tmux, sessionsDirPath, depsFactory: () => deps });
+
+      const result = await ops.restart("aaron");
+      // It killed the old `<name>-agent` first…
+      expect(killed).toEqual(["aaron-agent"]);
+      // …then re-spawned from the recovered spec (the spawn launcher fired).
+      expect(launched).toEqual([{ name: "aaron-agent" }]);
+      expect(result.killed).toBe(true);
+      expect(result.session).toBe("aaron-agent");
+      // The result is redacted (scopes surfaced, no token values).
+      expect(JSON.stringify(result)).not.toContain("TOK");
+    } finally {
+      rmSync(sessionsDirPath, { recursive: true, force: true });
+    }
+  });
+
+  test("a missing persisted spec → SpawnRequestError (kill not attempted)", async () => {
+    const sessionsDirPath = mkdtempSync(join(tmpdir(), "restart-nospec-"));
+    try {
+      const killed: string[] = [];
+      const tmux: TmuxAdmin = {
+        async listSessions() {
+          return [];
+        },
+        async killSession(name) {
+          killed.push(name);
+          return true;
+        },
+      };
+      const { deps } = spawnDeps(sessionsDirPath);
+      const ops = createRealAgentOps({ tmux, sessionsDirPath, depsFactory: () => deps });
+      await expect(ops.restart("ghost")).rejects.toThrow(SpawnRequestError);
+      await expect(ops.restart("ghost")).rejects.toThrow(/no persisted spec/);
+      expect(killed).toEqual([]); // bailed before touching tmux
+    } finally {
+      rmSync(sessionsDirPath, { recursive: true, force: true });
+    }
+  });
+
+  test("restart rejects a non-slug name before touching anything", async () => {
+    const tmux: TmuxAdmin = {
+      async listSessions() {
+        return [];
+      },
+      async killSession() {
+        return false;
+      },
+    };
+    const { deps } = spawnDeps("/tmp/s");
+    const ops = createRealAgentOps({ tmux, sessionsDirPath: "/tmp/s", depsFactory: () => deps });
+    await expect(ops.restart("../escape")).rejects.toThrow(SpawnRequestError);
+  });
+});
+
+// ===========================================================================
 // 3. The daemon routes (real handler, mocked JWT, stub AgentOps)
 // ===========================================================================
 function buildServer(agentOps?: Partial<AgentOps>) {
@@ -272,6 +409,9 @@ function buildServer(agentOps?: Partial<AgentOps>) {
     },
     async kill() {
       return { killed: false };
+    },
+    async restart() {
+      throw new Error("restart not stubbed");
     },
     ...agentOps,
   };
@@ -558,6 +698,131 @@ describe("DELETE /api/agents/:name", () => {
     try {
       const res = await fetch(`${base}/api/agents/whatever`, { method: "DELETE", headers: adminAuth });
       expect(res.status).toBe(400);
+    } finally {
+      srv.stop(true);
+    }
+  });
+});
+
+describe("POST /api/agents/:name/restart — per-session restart (channel:admin)", () => {
+  function restartResult(name: string, killed: boolean) {
+    return {
+      session: name + "-agent",
+      workspace: "/s/" + name,
+      alreadyRunning: false,
+      killed,
+      tokens: [{ resource: name, scope: "channel:read channel:write", expiresAt: "2026-07-01T00:00:00Z" }],
+      mcpServers: ["channel-" + name],
+      filesystem: "workspace" as const,
+      network: "open" as const,
+      egress: [],
+    };
+  }
+
+  test("no token → 401 (restart never called)", async () => {
+    let restarted = false;
+    const { srv, base } = buildServer({
+      async restart() {
+        restarted = true;
+        return restartResult("aaron", true);
+      },
+    });
+    try {
+      const res = await fetch(`${base}/api/agents/aaron/restart`, { method: "POST" });
+      expect(res.status).toBe(401);
+      expect(restarted).toBe(false);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("channel:read (insufficient) → 403 (restart never called)", async () => {
+    let restarted = false;
+    const { srv, base } = buildServer({
+      async restart() {
+        restarted = true;
+        return restartResult("aaron", true);
+      },
+    });
+    try {
+      const res = await fetch(`${base}/api/agents/aaron/restart`, { method: "POST", headers: readAuth });
+      expect(res.status).toBe(403);
+      expect(restarted).toBe(false);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("admin token → 200 redacted restart result (killed + new session, no token values)", async () => {
+    const { srv, base } = buildServer({
+      async restart(name) {
+        expect(name).toBe("aaron");
+        return restartResult("aaron", true);
+      },
+    });
+    try {
+      const res = await fetch(`${base}/api/agents/aaron/restart`, { method: "POST", headers: adminAuth });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { session: string; killed: boolean; mcpServers: string[] };
+      expect(body.session).toBe("aaron-agent");
+      expect(body.killed).toBe(true);
+      expect(body.mcpServers).toEqual(["channel-aaron"]);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("a missing persisted spec (SpawnRequestError) → 400 with the fix", async () => {
+    const { srv, base } = buildServer({
+      async restart() {
+        throw new SpawnRequestError("no persisted spec at .../spec.json");
+      },
+    });
+    try {
+      const res = await fetch(`${base}/api/agents/aaron/restart`, { method: "POST", headers: adminAuth });
+      expect(res.status).toBe(400);
+      expect(((await res.json()) as { error: string }).error).toContain("no persisted spec");
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("a missing operator token (SpawnDepsError) → 503; a missing credential → 400", async () => {
+    const deps = buildServer({
+      async restart() {
+        throw new SpawnDepsError("no operator token");
+      },
+    });
+    try {
+      const res = await fetch(`${deps.base}/api/agents/aaron/restart`, { method: "POST", headers: adminAuth });
+      expect(res.status).toBe(503);
+    } finally {
+      deps.srv.stop(true);
+    }
+    const creds = buildServer({
+      async restart() {
+        throw new CredentialNotConfiguredError("aaron");
+      },
+    });
+    try {
+      const res = await fetch(`${creds.base}/api/agents/aaron/restart`, { method: "POST", headers: adminAuth });
+      expect(res.status).toBe(400);
+      expect(((await res.json()) as { error: string }).error).toContain("no Claude credential");
+    } finally {
+      creds.srv.stop(true);
+    }
+  });
+
+  test("a refused mint (MintError) → forwards the hub status", async () => {
+    const { srv, base } = buildServer({
+      async restart() {
+        throw new MintError("over-broad scope", 403, "forbidden");
+      },
+    });
+    try {
+      const res = await fetch(`${base}/api/agents/aaron/restart`, { method: "POST", headers: adminAuth });
+      expect(res.status).toBe(403);
+      expect(((await res.json()) as { error: string }).error).toContain("mint failed");
     } finally {
       srv.stop(true);
     }

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -30,6 +30,7 @@ import {
   spawnAgent,
   sessionName,
   sessionWorkspace,
+  readPersistedSpec,
   type SpawnAgentResult,
   type SpawnAgentDeps,
 } from "./spawn-agent.ts";
@@ -90,7 +91,13 @@ export interface RedactedSpawnResult {
   egress: string[];
 }
 
-/** The spawn/list/kill operations the daemon routes call. Injectable for tests. */
+/** The redacted result a per-session restart returns. */
+export interface RedactedRestartResult extends RedactedSpawnResult {
+  /** Whether a previous live session was killed (false = it wasn't running). */
+  killed: boolean;
+}
+
+/** The spawn/list/kill/restart operations the daemon routes call. Injectable for tests. */
 export interface AgentOps {
   /** Launch a sandboxed agent session from a validated spec. */
   spawn(spec: AgentSpec): Promise<SpawnAgentResult>;
@@ -98,6 +105,12 @@ export interface AgentOps {
   list(): Promise<AgentInfo[]>;
   /** Kill an agent session by name (returns whether one existed). */
   kill(name: string): Promise<{ killed: boolean }>;
+  /**
+   * PER-SESSION restart: kill `<name>-agent`, then re-spawn from the persisted spec
+   * (re-resolving env + the Claude credential), so a newly-set credential applies.
+   * Returns the redacted spawn result + whether a prior session was killed.
+   */
+  restart(name: string): Promise<RedactedRestartResult>;
 }
 
 /** A tmux admin seam — real impl shells out to tmux; tests inject a recorder. */
@@ -420,6 +433,38 @@ export function createRealAgentOps(opts?: {
       }
       const killed = await tmux.killSession(sessionName(name));
       return { killed };
+    },
+    async restart(name) {
+      if (!AGENT_NAME_SLUG.test(name)) {
+        throw new SpawnRequestError(
+          `agent name "${name}" must be a slug (alphanumeric, dash, underscore only)`,
+        );
+      }
+      // Recover the original launch params from the persisted spec (the live tmux
+      // session carries none of them; the workspace's .mcp.json inlines minted
+      // tokens, not a clean spec). No spec → can't faithfully reproduce → a clear
+      // error (the operator kills + re-spawns from the form instead).
+      const workspace = sessionWorkspace(dir, name);
+      const spec = readPersistedSpec(workspace);
+      if (!spec) {
+        throw new SpawnRequestError(
+          `cannot restart agent "${name}": no persisted spec at ${workspace}/spec.json ` +
+            `(it predates spawn-spec persistence, or was never spawned through this daemon). ` +
+            `Kill it and spawn a fresh session from the Agents page.`,
+        );
+      }
+      // Kill the existing session FIRST — spawnAgent is idempotent (a live session is
+      // a no-op), so without the kill a restart wouldn't re-source env. killSession is
+      // a no-op for a missing session (the restart still re-spawns), so a restart also
+      // doubles as "bring back a crashed/stopped session from its spec."
+      const killed = await tmux.killSession(sessionName(name));
+      // Re-spawn with FRESHLY-resolved deps — the env store + Claude credential are
+      // re-read here, so a credential set just before this restart is now applied. A
+      // fresh spawn (NOT `claude -c`) is deliberate: see the daemon route's note on
+      // the context-loss tradeoff. The MCP/channel reconnect is inherent — the new
+      // session re-establishes its channel MCP entries from the regenerated config.
+      const result = await spawnAgent(spec, depsFactory());
+      return { ...redactSpawnResult(result), killed };
     },
   };
 }

--- a/src/credentials.test.ts
+++ b/src/credentials.test.ts
@@ -19,6 +19,12 @@ import {
   readCredentialsFile,
   credentialsFilePath,
   CredentialNotConfiguredError,
+  setChannelEnvVar,
+  removeChannelEnvVar,
+  resolveChannelEnv,
+  describeChannelEnv,
+  DenylistedEnvError,
+  DENYLISTED_ENV,
 } from "./credentials.ts";
 
 const DEFAULT_TOKEN = "oat_DEFAULT-OPERATOR-TOKEN-SECRET";
@@ -132,5 +138,137 @@ describe("default-vs-override resolution", () => {
     expect(resolveClaudeCredential("c", dir)).toBe(DEFAULT_TOKEN);
     setDefaultClaudeCredential("oat_ROTATED", dir);
     expect(resolveClaudeCredential("c", dir)).toBe("oat_ROTATED");
+  });
+});
+
+// ===========================================================================
+// Generic per-channel env store (GH_TOKEN / CLOUDFLARE_API_TOKEN / …)
+// ===========================================================================
+const GH = "ghp_GITHUB-TOKEN-SECRET";
+const CF = "cf_CLOUDFLARE-TOKEN-SECRET";
+
+describe("env store — set / resolve / channel-over-default merge", () => {
+  test("default var: set with null channel, resolves for any channel", () => {
+    setChannelEnvVar(null, "GH_TOKEN", GH, dir);
+    expect(resolveChannelEnv("anything", dir)).toEqual({ GH_TOKEN: GH });
+    // An empty-string channel also targets the default layer.
+    setChannelEnvVar("", "CF_TOKEN", CF, dir);
+    expect(resolveChannelEnv("anything", dir)).toEqual({ GH_TOKEN: GH, CF_TOKEN: CF });
+  });
+
+  test("per-channel override WINS over the default for that channel; others see only the default", () => {
+    setChannelEnvVar(null, "GH_TOKEN", "ghp_DEFAULT", dir);
+    setChannelEnvVar("aaron-dev", "GH_TOKEN", "ghp_AARON", dir);
+    setChannelEnvVar("aaron-dev", "CLOUDFLARE_API_TOKEN", CF, dir);
+    // channel layer wins on GH_TOKEN, plus its own CF token, plus inherits nothing extra.
+    expect(resolveChannelEnv("aaron-dev", dir)).toEqual({ GH_TOKEN: "ghp_AARON", CLOUDFLARE_API_TOKEN: CF });
+    // a different channel falls back to the default only.
+    expect(resolveChannelEnv("other", dir)).toEqual({ GH_TOKEN: "ghp_DEFAULT" });
+  });
+
+  test("resolves to {} when nothing is configured (env injection is optional)", () => {
+    expect(resolveChannelEnv("ghost", dir)).toEqual({});
+  });
+
+  test("setting an env var preserves the Claude slice (independent namespaces)", () => {
+    setDefaultClaudeCredential(DEFAULT_TOKEN, dir);
+    setChannelEnvVar(null, "GH_TOKEN", GH, dir);
+    const file = readCredentialsFile(dir);
+    expect(file.claude!.default).toBe(DEFAULT_TOKEN); // untouched
+    expect(file.env!.default!.GH_TOKEN).toBe(GH);
+  });
+
+  test("read dynamically — a value change takes effect on the next resolve", () => {
+    setChannelEnvVar("c", "GH_TOKEN", "ghp_OLD", dir);
+    expect(resolveChannelEnv("c", dir).GH_TOKEN).toBe("ghp_OLD");
+    setChannelEnvVar("c", "GH_TOKEN", "ghp_NEW", dir);
+    expect(resolveChannelEnv("c", dir).GH_TOKEN).toBe("ghp_NEW");
+  });
+
+  test("the env store file is written 0600 (holds secrets)", () => {
+    setChannelEnvVar(null, "GH_TOKEN", GH, dir);
+    expect(statSync(credentialsFilePath(dir)).mode & 0o777).toBe(0o600);
+  });
+});
+
+describe("env store — remove", () => {
+  test("remove a default var; remove a missing one is a no-op (false)", () => {
+    setChannelEnvVar(null, "GH_TOKEN", GH, dir);
+    setChannelEnvVar(null, "CF_TOKEN", CF, dir);
+    expect(removeChannelEnvVar(null, "GH_TOKEN", dir)).toBe(true);
+    expect(resolveChannelEnv("any", dir)).toEqual({ CF_TOKEN: CF });
+    expect(removeChannelEnvVar(null, "GH_TOKEN", dir)).toBe(false); // already gone
+  });
+
+  test("remove a channel override; the default for that name re-emerges", () => {
+    setChannelEnvVar(null, "GH_TOKEN", "ghp_DEFAULT", dir);
+    setChannelEnvVar("aaron-dev", "GH_TOKEN", "ghp_AARON", dir);
+    expect(removeChannelEnvVar("aaron-dev", "GH_TOKEN", dir)).toBe(true);
+    expect(resolveChannelEnv("aaron-dev", dir)).toEqual({ GH_TOKEN: "ghp_DEFAULT" }); // back to default
+  });
+
+  test("removing the last var of a channel prunes the empty channel map", () => {
+    setChannelEnvVar("c", "GH_TOKEN", GH, dir);
+    removeChannelEnvVar("c", "GH_TOKEN", dir);
+    const file = readCredentialsFile(dir);
+    // The channel (and the now-empty channels map) is pruned, not left as {}.
+    expect(file.env?.channels).toBeUndefined();
+  });
+});
+
+describe("env store — redaction (describeChannelEnv returns NAMES only)", () => {
+  test("describe reports names per layer, never the values", () => {
+    setChannelEnvVar(null, "GH_TOKEN", GH, dir);
+    setChannelEnvVar("aaron-dev", "CLOUDFLARE_API_TOKEN", CF, dir);
+    setChannelEnvVar("aaron-dev", "GH_TOKEN", "ghp_AARON", dir);
+    const desc = describeChannelEnv(dir);
+    expect(desc.default).toEqual(["GH_TOKEN"]);
+    expect(desc.channels["aaron-dev"]).toEqual(["CLOUDFLARE_API_TOKEN", "GH_TOKEN"]); // sorted
+    const serialized = JSON.stringify(desc);
+    expect(serialized).not.toContain(GH);
+    expect(serialized).not.toContain(CF);
+    expect(serialized).not.toContain("ghp_AARON");
+  });
+
+  test("describe on an empty store: no default, no channels", () => {
+    expect(describeChannelEnv(dir)).toEqual({ default: [], channels: {} });
+  });
+});
+
+describe("env store — denylist (the Claude-auth trio is never settable)", () => {
+  test("the denylist is exactly the Claude-auth vars", () => {
+    expect([...DENYLISTED_ENV].sort()).toEqual(
+      ["ANTHROPIC_API_KEY", "CLAUDE_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"].sort(),
+    );
+  });
+
+  test("setter REJECTS each denylisted name (default + channel), nothing persisted", () => {
+    for (const name of DENYLISTED_ENV) {
+      expect(() => setChannelEnvVar(null, name, "x", dir)).toThrow(DenylistedEnvError);
+      expect(() => setChannelEnvVar("c", name, "x", dir)).toThrow(DenylistedEnvError);
+    }
+    expect(existsSync(credentialsFilePath(dir))).toBe(false);
+  });
+
+  test("setter rejects a malformed name + an empty value", () => {
+    expect(() => setChannelEnvVar(null, "9BAD", "x", dir)).toThrow(/invalid/);
+    expect(() => setChannelEnvVar(null, "has space", "x", dir)).toThrow(/invalid/);
+    expect(() => setChannelEnvVar(null, "GH_TOKEN", "", dir)).toThrow(/non-empty/);
+    expect(existsSync(credentialsFilePath(dir))).toBe(false);
+  });
+
+  test("resolve defensively STRIPS a denylisted key planted by a hand-edited file", () => {
+    // Plant a denylisted key directly on disk (bypassing the setter), then prove
+    // resolveChannelEnv never returns it — the injection defense's first line.
+    setChannelEnvVar(null, "GH_TOKEN", GH, dir);
+    const fs = require("fs") as typeof import("fs");
+    const file = JSON.parse(fs.readFileSync(credentialsFilePath(dir), "utf8")) as {
+      env: { default: Record<string, string> };
+    };
+    file.env.default.ANTHROPIC_API_KEY = "sk-ant-SMUGGLED";
+    fs.writeFileSync(credentialsFilePath(dir), JSON.stringify(file));
+    const resolved = resolveChannelEnv("any", dir);
+    expect(resolved.GH_TOKEN).toBe(GH);
+    expect(resolved.ANTHROPIC_API_KEY).toBeUndefined();
   });
 });

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -43,9 +43,74 @@ export interface ClaudeCredentialStore {
   channels?: Record<string, string>;
 }
 
+/**
+ * The generic per-channel ENVIRONMENT-VARIABLE slice (`env`). Same two-principal
+ * shape as the Claude slice (an operator-level default layer + per-channel
+ * overrides), but each layer is a NAME→VALUE map rather than a single token: an
+ * operator scopes a channel's spawned agent a `GH_TOKEN`, `CLOUDFLARE_API_TOKEN`,
+ * etc. {@link resolveChannelEnv} flattens the two layers into one map (channel
+ * wins) at spawn time, and {@link buildAgentChildEnv} (spawn-agent.ts) merges that
+ * into the sandboxed child's env so the agent's `gh`/`git`/build tooling sees the
+ * tokens — while Claude's own auth (`CLAUDE_CODE_OAUTH_TOKEN`) stays untouched.
+ */
+export interface ChannelEnvStore {
+  /** Operator-level default env vars, used by every channel (lowest precedence). */
+  default?: Record<string, string>;
+  /** Per-channel env overrides, keyed by channel name (wins over the default). */
+  channels?: Record<string, Record<string, string>>;
+}
+
 /** The on-disk `credentials.json` shape (namespaced by credential type). */
 export interface CredentialsFile {
   claude?: ClaudeCredentialStore;
+  /** Generic per-channel env-var injection (the GH_TOKEN/CLOUDFLARE_* slice). */
+  env?: ChannelEnvStore;
+}
+
+/**
+ * Env-var names that MUST NEVER be settable through the env store — they'd break
+ * the module's two load-bearing guarantees:
+ *
+ *   - `ANTHROPIC_API_KEY` / `CLAUDE_API_KEY` would route the spawned session onto
+ *     METERED API billing instead of the interactive subscription (the exact thing
+ *     `buildAgentChildEnv` deliberately scrubs — see spawn-agent.ts §6).
+ *   - `CLAUDE_CODE_OAUTH_TOKEN` is the session's MANAGED auth, resolved per-channel
+ *     from the Claude slice; letting the generic env store override it would let an
+ *     operator (or a future less-trusted caller) silently swap the session's
+ *     identity out from under the credential resolver.
+ *
+ * The setters REJECT these (throw {@link DenylistedEnvError}); the injection step
+ * (`buildAgentChildEnv`) ALSO drops them defensively, so even a hand-edited
+ * credentials.json can't smuggle one through.
+ *
+ * `PATH`/`HOME` are deliberately NOT denylisted: `buildAgentChildEnv` layers the
+ * resolved channel env UNDER its own structural passthrough + the seeded-HOME
+ * overrides, so a channel-set PATH/HOME can't clobber the sandbox's own (the
+ * passthrough copies the real PATH/HOME after, and seedAgentHome's CLAUDE_CONFIG_DIR
+ * /XDG/TMP win last). Rejecting them would only deny a harmless no-op; allowing
+ * them keeps the denylist focused on the keys that actually matter (the Claude-auth
+ * trio). See the layering comment in `buildAgentChildEnv`.
+ */
+export const DENYLISTED_ENV: ReadonlySet<string> = new Set([
+  "ANTHROPIC_API_KEY",
+  "CLAUDE_API_KEY",
+  "CLAUDE_CODE_OAUTH_TOKEN",
+]);
+
+/** A basic POSIX-ish env-var name guard (letters/digits/underscore, no leading digit). */
+const ENV_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/** Thrown when a setter is asked to set/override a denylisted env-var name. */
+export class DenylistedEnvError extends Error {
+  constructor(name: string) {
+    super(
+      `env var "${name}" is not settable here: it controls Claude auth / billing ` +
+        `(ANTHROPIC_API_KEY, CLAUDE_API_KEY, CLAUDE_CODE_OAUTH_TOKEN are reserved by ` +
+        `the managed subscription-billing path). Set the Claude credential via ` +
+        `POST /api/credentials/claude instead.`,
+    );
+    this.name = "DenylistedEnvError";
+  }
 }
 
 /** The default credential reference an unspecified spec resolves against. */
@@ -185,5 +250,131 @@ export function describeClaudeCredentials(
   return {
     defaultSet: Boolean(claude?.default),
     channels: Object.keys(claude?.channels ?? {}).sort(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Generic per-channel env-var store (the GH_TOKEN / CLOUDFLARE_API_TOKEN slice).
+//
+// Mirrors the Claude helpers exactly: read-modify-write JSON, 0600 + unconditional
+// chmod, sibling-preserving, dynamic-read-at-resolve. A `null`/`undefined` channel
+// targets the operator-level DEFAULT layer; a channel name targets that channel's
+// override layer. Every setter enforces DENYLISTED_ENV (the Claude-auth trio) so
+// the subscription-billing guarantee can't be subverted via this surface.
+// ---------------------------------------------------------------------------
+
+/** Validate an env-var NAME for the setters: non-denylisted + a sane shape. */
+function assertSettableEnvName(name: string): void {
+  if (typeof name !== "string" || name.length === 0) {
+    throw new Error("credentials: an env var name is required");
+  }
+  if (DENYLISTED_ENV.has(name)) throw new DenylistedEnvError(name);
+  if (!ENV_NAME_RE.test(name)) {
+    throw new Error(
+      `credentials: env var name "${name}" is invalid (letters, digits, underscore; no leading digit)`,
+    );
+  }
+}
+
+/**
+ * Set ONE env var on the operator-level default layer (`channel` is null/undefined)
+ * or on a specific channel's override layer. Read-modify-write so the Claude slice,
+ * the other layer, and other vars are preserved. Rejects denylisted names
+ * ({@link DenylistedEnvError}) and an empty value.
+ */
+export function setChannelEnvVar(
+  channel: string | null | undefined,
+  name: string,
+  value: string,
+  stateDir?: string,
+): void {
+  assertSettableEnvName(name);
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error("credentials: a non-empty env var value is required");
+  }
+  const file = readCredentialsFile(stateDir);
+  const env = file.env ?? {};
+  if (channel === null || channel === undefined || channel === "") {
+    const def = env.default ?? {};
+    def[name] = value;
+    env.default = def;
+  } else {
+    const channels = env.channels ?? {};
+    const forChannel = channels[channel] ?? {};
+    forChannel[name] = value;
+    channels[channel] = forChannel;
+    env.channels = channels;
+  }
+  file.env = env;
+  writeCredentialsFile(file, stateDir);
+}
+
+/**
+ * Remove ONE env var from the operator-level default layer (`channel` null/undefined)
+ * or a channel's override layer. Returns true if it existed, false if there was
+ * nothing to remove. Prunes an emptied channel map so a removed-everything channel
+ * doesn't linger as `{}`. Read-modify-write; the Claude slice + other vars untouched.
+ */
+export function removeChannelEnvVar(
+  channel: string | null | undefined,
+  name: string,
+  stateDir?: string,
+): boolean {
+  const file = readCredentialsFile(stateDir);
+  const env = file.env;
+  if (!env) return false;
+  if (channel === null || channel === undefined || channel === "") {
+    if (!env.default || !(name in env.default)) return false;
+    delete env.default[name];
+    if (Object.keys(env.default).length === 0) delete env.default;
+  } else {
+    const forChannel = env.channels?.[channel];
+    if (!forChannel || !(name in forChannel)) return false;
+    delete forChannel[name];
+    if (Object.keys(forChannel).length === 0) delete env.channels![channel];
+    if (env.channels && Object.keys(env.channels).length === 0) delete env.channels;
+  }
+  writeCredentialsFile(file, stateDir);
+  return true;
+}
+
+/**
+ * Resolve the FLATTENED env a session on `channel` should run with:
+ *
+ *   { ...env.default, ...env.channels[channel] }   (the channel layer wins)
+ *
+ * Read at resolve time (not cached), like the Claude resolver — so a var set via the
+ * config API takes effect on the next spawn (or per-session restart) without a daemon
+ * restart. Defensively SKIPS any denylisted key that somehow landed on disk (a
+ * hand-edited file): the setter blocks them, but the resolver never returns one
+ * either, so `buildAgentChildEnv`'s own denylist drop is a belt to this suspenders.
+ * Returns an empty map when nothing is configured (a channel with no env is fine).
+ */
+export function resolveChannelEnv(channel: string, stateDir?: string): Record<string, string> {
+  const env = readCredentialsFile(stateDir).env;
+  const merged: Record<string, string> = { ...(env?.default ?? {}), ...(env?.channels?.[channel] ?? {}) };
+  for (const k of Object.keys(merged)) {
+    if (DENYLISTED_ENV.has(k)) delete merged[k];
+  }
+  return merged;
+}
+
+/**
+ * Describe the env store for an operator-facing read WITHOUT leaking values: the
+ * NAMES set on the default layer, and the names set per channel. The raw values are
+ * NEVER returned (`GET /api/credentials/env`) — same redaction posture as
+ * `describeClaudeCredentials`.
+ */
+export function describeChannelEnv(
+  stateDir?: string,
+): { default: string[]; channels: Record<string, string[]> } {
+  const env = readCredentialsFile(stateDir).env;
+  const channels: Record<string, string[]> = {};
+  for (const [ch, vars] of Object.entries(env?.channels ?? {})) {
+    channels[ch] = Object.keys(vars).sort();
+  }
+  return {
+    default: Object.keys(env?.default ?? {}).sort(),
+    channels,
   };
 }

--- a/src/daemon-config-api.test.ts
+++ b/src/daemon-config-api.test.ts
@@ -49,7 +49,12 @@ import { ClientRegistry } from "./routing.ts";
 import { VaultTransport, CHANNEL_VAULT_TRIGGER_TEMPLATE } from "./transports/vault.ts";
 import { channelsFilePath } from "./registry.ts";
 import type { Channel } from "./registry.ts";
-import { credentialsFilePath, resolveClaudeCredential } from "./credentials.ts";
+import {
+  credentialsFilePath,
+  resolveClaudeCredential,
+  resolveChannelEnv,
+  describeChannelEnv,
+} from "./credentials.ts";
 import type { TransportContext, InboundMessage } from "./transport.ts";
 
 const sendAuth = { authorization: "Bearer " + SEND_TOKEN } as const;
@@ -725,6 +730,188 @@ describe("D — Claude credential store API (channel:admin)", () => {
         (await fetch(`${base}/api/credentials/claude/c`, { method: "DELETE", headers: { ...readAuth } })).status,
       ).toBe(403);
       // Nothing was persisted by any unauthorized call.
+      expect(existsSync(credentialsFilePath(stateDir))).toBe(false);
+    } finally {
+      srv.stop(true);
+    }
+  });
+});
+
+// ===========================================================================
+// E. Generic per-channel ENV-VAR store API (channel:admin)
+// ===========================================================================
+describe("E — per-channel env-var store API (channel:admin)", () => {
+  test("POST /api/credentials/env sets a default var; 0600; resolves for any channel", async () => {
+    const { srv, base } = buildServer([]);
+    try {
+      const res = await fetch(`${base}/api/credentials/env`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ name: "GH_TOKEN", value: "ghp_DEFAULT-SECRET" }),
+      });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toMatchObject({ ok: true, scope: "default", name: "GH_TOKEN" });
+
+      const file = credentialsFilePath(stateDir);
+      expect(existsSync(file)).toBe(true);
+      expect(statSync(file).mode & 0o777).toBe(0o600);
+      expect(resolveChannelEnv("any-channel", stateDir)).toEqual({ GH_TOKEN: "ghp_DEFAULT-SECRET" });
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("POST with a channel sets an override that WINS over the default", async () => {
+    const { srv, base } = buildServer([]);
+    try {
+      await fetch(`${base}/api/credentials/env`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ name: "GH_TOKEN", value: "ghp_DEFAULT" }),
+      });
+      const res = await fetch(`${base}/api/credentials/env`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ channel: "aaron-dev", name: "GH_TOKEN", value: "ghp_AARON" }),
+      });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toMatchObject({ ok: true, scope: "channel", channel: "aaron-dev", name: "GH_TOKEN" });
+
+      expect(resolveChannelEnv("aaron-dev", stateDir)).toEqual({ GH_TOKEN: "ghp_AARON" }); // override wins
+      expect(resolveChannelEnv("other", stateDir)).toEqual({ GH_TOKEN: "ghp_DEFAULT" }); // other → default
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("POST a DENYLISTED name → 400, nothing persisted (subscription-billing guarantee)", async () => {
+    const { srv, base } = buildServer([]);
+    try {
+      for (const name of ["ANTHROPIC_API_KEY", "CLAUDE_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"]) {
+        const res = await fetch(`${base}/api/credentials/env`, {
+          method: "POST",
+          headers: { "content-type": "application/json", ...adminAuth },
+          body: JSON.stringify({ name, value: "x" }),
+        });
+        expect(res.status).toBe(400);
+        expect(((await res.json()) as { error: string }).error).toMatch(/Claude auth|reserved|not settable/);
+      }
+      expect(existsSync(credentialsFilePath(stateDir))).toBe(false);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("GET reports names per layer — NEVER the values", async () => {
+    const { srv, base } = buildServer([]);
+    try {
+      await fetch(`${base}/api/credentials/env`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ name: "GH_TOKEN", value: "ghp_SECRET-DEFAULT" }),
+      });
+      await fetch(`${base}/api/credentials/env`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ channel: "aaron-dev", name: "CLOUDFLARE_API_TOKEN", value: "cf_SECRET" }),
+      });
+      const res = await fetch(`${base}/api/credentials/env`, { headers: { ...adminAuth } });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { default: string[]; channels: Record<string, string[]> };
+      expect(body.default).toEqual(["GH_TOKEN"]);
+      expect(body.channels["aaron-dev"]).toEqual(["CLOUDFLARE_API_TOKEN"]);
+      const serialized = JSON.stringify(body);
+      expect(serialized).not.toContain("ghp_SECRET-DEFAULT");
+      expect(serialized).not.toContain("cf_SECRET");
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("DELETE removes a var (default + channel); the default re-emerges after a channel delete", async () => {
+    const { srv, base } = buildServer([]);
+    try {
+      await fetch(`${base}/api/credentials/env`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ name: "GH_TOKEN", value: "ghp_DEFAULT" }),
+      });
+      await fetch(`${base}/api/credentials/env`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ channel: "aaron-dev", name: "GH_TOKEN", value: "ghp_AARON" }),
+      });
+      // Delete the channel override (via body).
+      const del = await fetch(`${base}/api/credentials/env`, {
+        method: "DELETE",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ channel: "aaron-dev", name: "GH_TOKEN" }),
+      });
+      expect(del.status).toBe(200);
+      expect(await del.json()).toMatchObject({ ok: true, scope: "channel", channel: "aaron-dev", name: "GH_TOKEN", removed: true });
+      expect(resolveChannelEnv("aaron-dev", stateDir)).toEqual({ GH_TOKEN: "ghp_DEFAULT" }); // back to default
+
+      // Delete the default too.
+      const delDef = await fetch(`${base}/api/credentials/env`, {
+        method: "DELETE",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ name: "GH_TOKEN" }),
+      });
+      expect(delDef.status).toBe(200);
+      expect(await delDef.json()).toMatchObject({ ok: true, scope: "default", name: "GH_TOKEN", removed: true });
+      expect(describeChannelEnv(stateDir)).toEqual({ default: [], channels: {} });
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("POST with an empty/missing name or value → 400, nothing persisted", async () => {
+    const { srv, base } = buildServer([]);
+    try {
+      const noName = await fetch(`${base}/api/credentials/env`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ value: "x" }),
+      });
+      expect(noName.status).toBe(400);
+      const noVal = await fetch(`${base}/api/credentials/env`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ name: "GH_TOKEN" }),
+      });
+      expect(noVal.status).toBe(400);
+      expect(existsSync(credentialsFilePath(stateDir))).toBe(false);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("env API without channel:admin → 401 (none) / 403 (wrong scope), on every verb", async () => {
+    const { srv, base } = buildServer([]);
+    try {
+      expect((await fetch(`${base}/api/credentials/env`)).status).toBe(401);
+      expect((await fetch(`${base}/api/credentials/env`, { headers: { ...readAuth } })).status).toBe(403);
+      expect(
+        (await fetch(`${base}/api/credentials/env`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ name: "GH_TOKEN", value: "x" }),
+        })).status,
+      ).toBe(401);
+      expect(
+        (await fetch(`${base}/api/credentials/env`, {
+          method: "POST",
+          headers: { "content-type": "application/json", ...sendAuth },
+          body: JSON.stringify({ name: "GH_TOKEN", value: "x" }),
+        })).status,
+      ).toBe(403);
+      expect(
+        (await fetch(`${base}/api/credentials/env`, {
+          method: "DELETE",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ name: "GH_TOKEN" }),
+        })).status,
+      ).toBe(401);
       expect(existsSync(credentialsFilePath(stateDir))).toBe(false);
     } finally {
       srv.stop(true);

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -57,6 +57,10 @@ import {
   setChannelClaudeCredential,
   removeChannelClaudeCredential,
   describeClaudeCredentials,
+  setChannelEnvVar,
+  removeChannelEnvVar,
+  describeChannelEnv,
+  DenylistedEnvError,
 } from "./credentials.ts";
 import { ClientRegistry, sseFrame } from "./routing.ts";
 import { DeliveryState } from "./delivery-state.ts";
@@ -1452,6 +1456,76 @@ export function createFetchHandler(
     }
 
     // ---------------------------------------------------------------------
+    // Generic per-channel ENV-VAR store (GH_TOKEN / CLOUDFLARE_API_TOKEN / …) —
+    // the secrets a launched agent's `gh`/`git`/build tooling needs. Same
+    // `channel:admin` gate + 0600 file-store + redaction-on-read posture as the
+    // Claude credential API above. A blank/omitted `channel` targets the
+    // operator-level DEFAULT layer; a channel name targets that channel's override.
+    // Denylisted names (the Claude-auth trio) are REJECTED with a 400 — they'd break
+    // the managed subscription-billing guarantee.
+    //
+    //   GET    /api/credentials/env          → { default:[names], channels:{ch:[names]} } (NO values)
+    //   POST   /api/credentials/env  { channel?, name, value } → set
+    //   DELETE /api/credentials/env  { channel?, name } (or ?channel=&name=) → remove
+    //
+    // Externally hub strips `/channel`, so these are `<hub>/channel/api/credentials/env`.
+    // ---------------------------------------------------------------------
+    if (
+      url.pathname === "/api/credentials/env" &&
+      (req.method === "GET" || req.method === "POST" || req.method === "DELETE")
+    ) {
+      const denied = await requireScope(req, url, SCOPE_ADMIN);
+      if (denied) return denied;
+
+      if (req.method === "GET") {
+        // Inspect WITHOUT leaking values: names per channel + the default layer.
+        return json(describeChannelEnv(defaultStateDir()));
+      }
+
+      let envBody: { channel?: unknown; name?: unknown; value?: unknown };
+      try {
+        envBody = (await req.json()) as typeof envBody;
+      } catch {
+        return json({ error: "invalid JSON body" }, 400);
+      }
+      // `channel` is optional — blank/absent/empty means the operator-level default.
+      const channelRaw = typeof envBody.channel === "string" ? envBody.channel : "";
+      const channel = channelRaw.length > 0 ? channelRaw : null;
+      if (typeof envBody.name !== "string" || envBody.name.length === 0) {
+        return json({ error: "body.name (non-empty string) is required" }, 400);
+      }
+      const name = envBody.name;
+
+      if (req.method === "DELETE") {
+        let removed: boolean;
+        try {
+          removed = removeChannelEnvVar(channel, name, defaultStateDir());
+        } catch (err) {
+          return json({ error: `failed to update credentials.json: ${(err as Error).message}` }, 500);
+        }
+        return json({ ok: true, scope: channel ? "channel" : "default", ...(channel ? { channel } : {}), name, removed });
+      }
+
+      // POST — set the var.
+      if (typeof envBody.value !== "string" || envBody.value.length === 0) {
+        return json({ error: "body.value (non-empty string) is required" }, 400);
+      }
+      try {
+        setChannelEnvVar(channel, name, envBody.value, defaultStateDir());
+      } catch (err) {
+        // A denylisted name (ANTHROPIC_API_KEY/CLAUDE_API_KEY/CLAUDE_CODE_OAUTH_TOKEN)
+        // or a malformed name is the operator's mistake → 400 with the clear reason.
+        if (err instanceof DenylistedEnvError) return json({ error: err.message }, 400);
+        if ((err as Error).message?.startsWith("credentials:")) {
+          return json({ error: (err as Error).message }, 400);
+        }
+        return json({ error: `failed to write credentials.json: ${(err as Error).message}` }, 500);
+      }
+      // Echo back only the fact of the write — never the value.
+      return json({ ok: true, scope: channel ? "channel" : "default", ...(channel ? { channel } : {}), name });
+    }
+
+    // ---------------------------------------------------------------------
     // Agent management API (the web spawn/list/kill surface, design §4/§5) —
     // the SAME least-privilege launch path as the operator CLI
     // (`scripts/spawn-agent.ts`), driven from the browser. Operator-gated on
@@ -1508,6 +1582,33 @@ export function createFetchHandler(
           return json({ error: `token mint failed: ${err.message}` }, err.status >= 400 && err.status < 600 ? err.status : 502);
         }
         // A bad slug (spawnAgent's guard) or any other launch fault.
+        return json({ error: (err as Error).message }, 400);
+      }
+    }
+
+    // PER-SESSION restart — POST /api/agents/:name/restart (channel:admin). Kills
+    // `<name>-agent`, then re-spawns from the persisted spec, re-resolving the env
+    // store + Claude credential, so a newly-set credential applies in ONE click.
+    // PER-SESSION ONLY — no blanket "restart all" (the operator controls each
+    // session; restarting one never disrupts another). Must match BEFORE the
+    // single-segment DELETE below (this is a 2-segment subpath). Same error→status
+    // mapping as the spawn route (a missing spec / bad slug → 400; no operator token
+    // → 503; a refused mint → the hub status; a missing credential → 400 with the fix).
+    const restartMatch = url.pathname.match(/^\/api\/agents\/([^/]+)\/restart$/);
+    if (restartMatch && req.method === "POST") {
+      const denied = await requireScope(req, url, SCOPE_ADMIN);
+      if (denied) return denied;
+      const name = decodeURIComponent(restartMatch[1]!);
+      try {
+        const result = await agentOps.restart(name);
+        return json(result);
+      } catch (err) {
+        if (err instanceof SpawnRequestError) return json({ error: err.message }, 400);
+        if (err instanceof SpawnDepsError) return json({ error: err.message }, 503);
+        if (err instanceof CredentialNotConfiguredError) return json({ error: err.message }, 400);
+        if (err instanceof MintError) {
+          return json({ error: `token mint failed: ${err.message}` }, err.status >= 400 && err.status < 600 ? err.status : 502);
+        }
         return json({ error: (err as Error).message }, 400);
       }
     }

--- a/src/spawn-agent.test.ts
+++ b/src/spawn-agent.test.ts
@@ -785,6 +785,9 @@ describe("persistSpec / readPersistedSpec — spawn-spec recovery for restart", 
       const spec: AgentSpec = { name: "a", channels: ["c"], filesystem: "full" };
       persistSpec(ws, spec);
       expect(readPersistedSpec(ws)).toEqual(spec);
+      // Written 0600 (matches the secret-bearing .mcp.json discipline; the workspace
+      // dir is only umask-tight, so the file perm is the real guard).
+      expect(statSync(specFilePath(ws)).mode & 0o777).toBe(0o600);
       // Corrupt it -> null (the restart path treats this as "no spec").
       writeFileSync(specFilePath(ws), "{not json");
       expect(readPersistedSpec(ws)).toBeNull();

--- a/src/spawn-agent.test.ts
+++ b/src/spawn-agent.test.ts
@@ -11,6 +11,9 @@ import {
   seedAgentHome,
   sessionName,
   shellJoin,
+  persistSpec,
+  readPersistedSpec,
+  specFilePath,
   type SpawnAgentDeps,
   type TmuxLauncher,
 } from "./spawn-agent.ts";
@@ -145,6 +148,63 @@ describe("buildAgentChildEnv — scrub, inject OAuth, NEVER ANTHROPIC_API_KEY", 
   test("provides a default PATH if the parent had none", () => {
     const env = buildAgentChildEnv({}, "tok");
     expect(env.PATH).toBe("/usr/local/bin:/usr/bin:/bin");
+  });
+
+  test("INJECTION: the per-channel env reaches the child (gh/git see the token)", () => {
+    const env = buildAgentChildEnv(
+      { PATH: "/usr/bin", HOME: "/h" },
+      "tok",
+      { GH_TOKEN: "ghp_X", CLOUDFLARE_API_TOKEN: "cf_Y" },
+    );
+    expect(env.GH_TOKEN).toBe("ghp_X");
+    expect(env.CLOUDFLARE_API_TOKEN).toBe("cf_Y");
+  });
+
+  test("INJECTION: a channel-set var can NOT clobber CLAUDE_CODE_OAUTH_TOKEN (auth wins)", () => {
+    // Even if the store somehow carried CLAUDE_CODE_OAUTH_TOKEN, the managed token
+    // set last must win — and the denylist drop means it never even lands.
+    const env = buildAgentChildEnv(
+      { PATH: "/usr/bin" },
+      "THE-REAL-OAUTH",
+      { CLAUDE_CODE_OAUTH_TOKEN: "ATTACKER-SWAP", GH_TOKEN: "ghp_X" },
+    );
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe("THE-REAL-OAUTH");
+    expect(env.GH_TOKEN).toBe("ghp_X");
+  });
+
+  test("INJECTION: a channel-set var can NOT clobber a structural passthrough (PATH/HOME)", () => {
+    const env = buildAgentChildEnv(
+      { PATH: "/real/path", HOME: "/real/home" },
+      "tok",
+      { PATH: "/evil", HOME: "/evil" },
+    );
+    expect(env.PATH).toBe("/real/path");
+    expect(env.HOME).toBe("/real/home");
+  });
+
+  test("INJECTION: denylisted keys (API keys) are dropped defensively with a warning", () => {
+    const warnings: string[] = [];
+    const orig = console.warn;
+    console.warn = (...a: unknown[]) => warnings.push(a.map(String).join(" "));
+    try {
+      const env = buildAgentChildEnv(
+        { PATH: "/usr/bin" },
+        "tok",
+        { ANTHROPIC_API_KEY: "sk-ant-SMUGGLED", CLAUDE_API_KEY: "y", GH_TOKEN: "ghp_X" },
+      );
+      expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+      expect(env.CLAUDE_API_KEY).toBeUndefined();
+      expect(env.GH_TOKEN).toBe("ghp_X"); // the legit var still passes
+      expect(warnings.some((w) => w.includes("ANTHROPIC_API_KEY") && w.includes("denylisted"))).toBe(true);
+    } finally {
+      console.warn = orig;
+    }
+  });
+
+  test("INJECTION: an empty channel env is a no-op (back-compat default arg)", () => {
+    const env = buildAgentChildEnv({ PATH: "/usr/bin" }, "tok");
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe("tok");
+    expect(env.PATH).toBe("/usr/bin");
   });
 });
 
@@ -406,6 +466,56 @@ describe("spawnAgent — full wiring with stubs (no real token)", () => {
     expect(res.session).toBe("aaron_dev-2-agent");
   });
 
+  test("ENV INJECTION: the resolved per-channel env reaches the tmux launch env (Claude auth intact)", async () => {
+    sessionsDir = mkdtempSync(join(tmpdir(), "spawn-agent-env-"));
+    const tmux = recordingTmux();
+    const deps = baseDeps({
+      tmux,
+      // The wake channel is the first channel ("aaron-dev") — env resolves on it.
+      resolveChannelEnv: (ch): Record<string, string> =>
+        ch === "aaron-dev" ? { GH_TOKEN: "ghp_INJECTED", CLOUDFLARE_API_TOKEN: "cf_INJECTED" } : {},
+    });
+    await spawnAgent({ name: "aaron-dev", channels: ["aaron-dev"] }, deps);
+    expect(tmux.launched).toHaveLength(1);
+    const env = tmux.launched[0]!.env;
+    // The injected vars reach the child…
+    expect(env.GH_TOKEN).toBe("ghp_INJECTED");
+    expect(env.CLOUDFLARE_API_TOKEN).toBe("cf_INJECTED");
+    // …Claude auth is the stub placeholder (not clobbered), and no API key leaked.
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe("OAUTH-CRED-PLACEHOLDER");
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+  });
+
+  test("ENV INJECTION: a denylisted key planted in the resolver is dropped at launch", async () => {
+    sessionsDir = mkdtempSync(join(tmpdir(), "spawn-agent-env-deny-"));
+    const tmux = recordingTmux();
+    const deps = baseDeps({
+      tmux,
+      resolveChannelEnv: () => ({ ANTHROPIC_API_KEY: "sk-ant-SMUGGLED", GH_TOKEN: "ghp_OK" }),
+    });
+    await spawnAgent({ name: "x", channels: ["c"] }, deps);
+    const env = tmux.launched[0]!.env;
+    expect(env.GH_TOKEN).toBe("ghp_OK");
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined(); // dropped defensively in buildAgentChildEnv
+  });
+
+  test("SPEC PERSISTENCE: spawn writes spec.json so a restart can reproduce the launch", async () => {
+    sessionsDir = mkdtempSync(join(tmpdir(), "spawn-agent-spec-"));
+    const spec: AgentSpec = {
+      name: "weaver",
+      channels: [{ name: "weave", access: "read" }],
+      vault: { name: "default", access: "read", tags: ["#channel-message"] },
+      network: "restricted",
+      egress: ["registry.npmjs.org"],
+    };
+    const res = await spawnAgent(spec, baseDeps());
+    // The persisted spec round-trips to the exact spec the launch used.
+    const recovered = readPersistedSpec(res.workspace);
+    expect(recovered).toEqual(spec);
+    // And it's at the conventional path.
+    expect(specFilePath(res.workspace)).toBe(join(res.workspace, "spec.json"));
+  });
+
   test("read-only channel mints channel:read ONLY (not read+write)", async () => {
     sessionsDir = mkdtempSync(join(tmpdir(), "spawn-agent-roch-"));
     const scopes: string[] = [];
@@ -663,6 +773,23 @@ describe("realTmuxLauncher — launch-script indirection (tmux can't take the ~8
       expect(body).not.toContain("OAUTH-SECRET");
     } finally {
       rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("persistSpec / readPersistedSpec — spawn-spec recovery for restart", () => {
+  test("round-trips a spec; readPersistedSpec returns null for a missing/garbage file", () => {
+    const ws = mkdtempSync(join(tmpdir(), "spec-rt-"));
+    try {
+      expect(readPersistedSpec(ws)).toBeNull(); // nothing written yet
+      const spec: AgentSpec = { name: "a", channels: ["c"], filesystem: "full" };
+      persistSpec(ws, spec);
+      expect(readPersistedSpec(ws)).toEqual(spec);
+      // Corrupt it -> null (the restart path treats this as "no spec").
+      writeFileSync(specFilePath(ws), "{not json");
+      expect(readPersistedSpec(ws)).toBeNull();
+    } finally {
+      rmSync(ws, { recursive: true, force: true });
     }
   });
 });

--- a/src/spawn-agent.ts
+++ b/src/spawn-agent.ts
@@ -188,13 +188,18 @@ export function specFilePath(workspace: string): string {
  *
  * The spec is NON-SECRET (channel names, access verbs, vault name, host paths) —
  * the actual credentials live in credentials.json (Claude) / the env store and are
- * re-resolved at each (re)spawn — so 0644 is fine; we still write under the 0700-ish
- * per-session workspace. Returns the path written.
+ * re-resolved at each (re)spawn. We still write it 0600 (matching the workspace's
+ * secret-bearing `.mcp.json`): the per-session workspace dir is umask-inherited (no
+ * tighter than 0755), so 0600 on the file is the real guard — defense-in-depth that
+ * also keeps the perms honest if a future field ever does carry something sensitive.
+ * `chmod`-ed unconditionally since writeFileSync's `mode` only applies on create.
+ * Returns the path written.
  */
 export function persistSpec(workspace: string, spec: AgentSpec): string {
   mkdirSync(workspace, { recursive: true });
   const path = specFilePath(workspace);
-  writeFileSync(path, JSON.stringify(spec, null, 2) + "\n");
+  writeFileSync(path, JSON.stringify(spec, null, 2) + "\n", { mode: 0o600 });
+  chmodSync(path, 0o600);
   return path;
 }
 

--- a/src/spawn-agent.ts
+++ b/src/spawn-agent.ts
@@ -45,7 +45,7 @@ import {
   type MintTokenDeps,
   type MintResult,
 } from "./mint-token.ts";
-import { resolveClaudeCredential } from "./credentials.ts";
+import { resolveClaudeCredential, resolveChannelEnv, DENYLISTED_ENV } from "./credentials.ts";
 
 /**
  * Slug guard for `spec.name`. The name is used UNESCAPED as a tmux session
@@ -121,6 +121,16 @@ export interface SpawnAgentDeps {
    * runs without auth).
    */
   resolveClaudeToken?: (channel: string) => string;
+  /**
+   * Resolve the per-channel ENV vars (the GH_TOKEN/CLOUDFLARE_* slice) to inject
+   * into the sandboxed child, given the spec's wake channel. Defaults to the real
+   * env store (`credentials.ts` — `{ ...default, ...channels[ch] }`, denylisted
+   * keys stripped). Tests inject a stub so they never read a real store. Read at
+   * spawn time so a var set via the config API applies on the next spawn / restart
+   * without a daemon restart. A missing/empty store resolves to `{}` (a channel
+   * with no scoped env is fine — unlike the Claude token, env injection is optional).
+   */
+  resolveChannelEnv?: (channel: string) => Record<string, string>;
   /** Sandbox engine override (tests inject a fake). */
   sandboxEngine?: SandboxEngine;
   /** tmux launcher (tests inject a recorder). */
@@ -163,6 +173,42 @@ export function sessionWorkspace(sessionsDir: string, specName: string): string 
   return join(sessionsDir, specName);
 }
 
+/** Path to the persisted spawn-spec for a session (recovered by restart). */
+export function specFilePath(workspace: string): string {
+  return join(workspace, "spec.json");
+}
+
+/**
+ * Persist the spawn {@link AgentSpec} alongside the session workspace so a
+ * per-session restart can faithfully reproduce the original launch (same channels,
+ * vault, network, mounts) WITHOUT re-asking the operator. The live tmux session
+ * carries none of this — `GET /api/agents` only knows name + attached — and the
+ * workspace's `.mcp.json` inlines minted tokens (not a clean spec), so the spec
+ * itself is the recoverable source of truth.
+ *
+ * The spec is NON-SECRET (channel names, access verbs, vault name, host paths) —
+ * the actual credentials live in credentials.json (Claude) / the env store and are
+ * re-resolved at each (re)spawn — so 0644 is fine; we still write under the 0700-ish
+ * per-session workspace. Returns the path written.
+ */
+export function persistSpec(workspace: string, spec: AgentSpec): string {
+  mkdirSync(workspace, { recursive: true });
+  const path = specFilePath(workspace);
+  writeFileSync(path, JSON.stringify(spec, null, 2) + "\n");
+  return path;
+}
+
+/** Read a persisted spawn-spec, or null if absent/unreadable. */
+export function readPersistedSpec(workspace: string): AgentSpec | null {
+  const path = specFilePath(workspace);
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf-8")) as AgentSpec;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Build the scrubbed child env for the sandboxed claude. Mirrors runner's
  * passthrough allowlist MINUS `ANTHROPIC_API_KEY` (and the `ANTHROPIC_*`/`CLAUDE_*`
@@ -172,12 +218,50 @@ export function sessionWorkspace(sessionsDir: string, specName: string): string 
  *
  * The sandbox engine's own env (proxy vars, sandbox markers) is layered on TOP of
  * this by the wrap step; this is the base the wrapper extends.
+ *
+ * SECURITY POSTURE — the per-channel env injection (`channelEnv`):
+ *
+ *   The operator scopes a channel's spawned agent extra credentials/vars
+ *   (`GH_TOKEN`, `CLOUDFLARE_API_TOKEN`, …) via the env store (credentials.ts).
+ *   They are resolved at SPAWN time (issuance-time scoping: the sandbox only ever
+ *   sees the minimal set the operator configured for THAT channel, never the
+ *   daemon's own ambient process env), then merged here. The layering is precise
+ *   so the injection can only ADD capability, never subvert the two guarantees:
+ *
+ *     1. `channelEnv` is applied FIRST (as the base), THEN the structural
+ *        passthrough (PATH/HOME/locale) and FINALLY `CLAUDE_CODE_OAUTH_TOKEN` —
+ *        so a channel-set var can never clobber the Claude auth token or a
+ *        structural fundamental. (seedAgentHome's CLAUDE_CONFIG_DIR/XDG/TMP layer
+ *        even later, in spawnAgent, so those win too.)
+ *     2. Denylisted keys (ANTHROPIC_API_KEY / CLAUDE_API_KEY / CLAUDE_CODE_OAUTH_TOKEN)
+ *        are dropped defensively with a warning — the setter already blocks them
+ *        and `resolveChannelEnv` already strips them, so this is belt-and-suspenders
+ *        for a hand-edited credentials.json: the subscription-billing + managed-auth
+ *        guarantee holds even if the store is tampered with.
  */
 export function buildAgentChildEnv(
   parentEnv: Record<string, string | undefined>,
   claudeOauthToken: string,
+  channelEnv: Record<string, string> = {},
 ): Record<string, string> {
   const out: Record<string, string> = {};
+
+  // 1. The operator-scoped per-channel env goes in FIRST (lowest precedence) so the
+  //    structural passthrough + the Claude auth token below always win. Drop any
+  //    denylisted key defensively (the store already blocks them; this guards a
+  //    hand-edited file from smuggling an API key / a swapped OAuth token in).
+  for (const [k, v] of Object.entries(channelEnv)) {
+    if (typeof v !== "string" || v.length === 0) continue;
+    if (DENYLISTED_ENV.has(k)) {
+      console.warn(
+        `parachute-channel: refusing to inject denylisted env var "${k}" from the channel env store ` +
+          `(it controls Claude auth/billing) — skipping. Remove it from credentials.json.`,
+      );
+      continue;
+    }
+    out[k] = v;
+  }
+
   // Fundamentals + locale, like runner — but NOT ANTHROPIC_API_KEY / CLAUDE_API_KEY.
   const passthrough = [
     "PATH",
@@ -208,7 +292,8 @@ export function buildAgentChildEnv(
   if (!out.PATH) out.PATH = "/usr/local/bin:/usr/bin:/bin";
 
   // The interactive subscription credential (design §6). Explicitly the ONLY
-  // Claude auth var set; ANTHROPIC_API_KEY is intentionally absent.
+  // Claude auth var set; ANTHROPIC_API_KEY is intentionally absent. Set LAST so no
+  // channel-injected var can ever override the session's managed auth.
   out.CLAUDE_CODE_OAUTH_TOKEN = claudeOauthToken;
   return out;
 }
@@ -403,6 +488,13 @@ export async function spawnAgent(
   const resolveToken = deps.resolveClaudeToken ?? ((ch: string) => resolveClaudeCredential(ch));
   const claudeOauthToken = resolveToken(wakeChannel);
 
+  // Resolve the per-channel env injection (GH_TOKEN/CLOUDFLARE_*/…). Keyed on the
+  // wake channel, like the Claude credential, and read at spawn time so a var set
+  // (or a per-session restart's re-source) takes effect without a daemon restart.
+  // Empty when nothing is configured — env injection is optional.
+  const resolveEnv = deps.resolveChannelEnv ?? ((ch: string) => resolveChannelEnv(ch));
+  const channelEnv = resolveEnv(wakeChannel);
+
   const mintDeps: MintTokenDeps = {
     hubOrigin: deps.hubOrigin,
     managerBearer: deps.managerBearer,
@@ -466,6 +558,10 @@ export async function spawnAgent(
     ...(otherEntries.length > 0 ? { otherMcps: otherEntries } : {}),
   });
   mkdirSync(workspace, { recursive: true });
+  // Persist the spec so a per-session restart can reproduce this exact launch
+  // (channels/vault/network/mounts) without re-asking the operator. Non-secret —
+  // credentials are re-resolved at each (re)spawn from the stores.
+  persistSpec(workspace, spec);
   const mcpConfigPath = join(workspace, ".mcp.json");
   // `mode: 0o600` on the write is sufficient here — the file is always newly
   // created per-launch under the per-session workspace, so there's no pre-existing
@@ -521,7 +617,7 @@ export async function spawnAgent(
   // LAST so they override even the engine's own (e.g. its non-writable TMPDIR) —
   // pointing claude at its private writable home is what stops the EPERM /
   // "could not start" deaths.
-  const childEnv = buildAgentChildEnv(deps.parentEnv ?? process.env, claudeOauthToken);
+  const childEnv = buildAgentChildEnv(deps.parentEnv ?? process.env, claudeOauthToken, channelEnv);
   const launchEnv: Record<string, string | undefined> = {
     ...childEnv,
     ...wrapped.env,

--- a/src/spawn-deps.ts
+++ b/src/spawn-deps.ts
@@ -22,7 +22,7 @@ import {
   realTmuxLauncher,
   type SpawnAgentDeps,
 } from "./spawn-agent.ts";
-import { resolveClaudeCredential } from "./credentials.ts";
+import { resolveClaudeCredential, resolveChannelEnv } from "./credentials.ts";
 import { defaultStateDir } from "./registry.ts";
 import { getHubOrigin } from "./hub-jwt.ts";
 
@@ -155,6 +155,8 @@ export function resolveSpawnDeps(): SpawnAgentDeps {
     runtimeReadOnly,
     // The real per-channel Claude OAuth resolver (channel override ?? default ?? throw).
     resolveClaudeToken: (channel: string) => resolveClaudeCredential(channel, stateDir),
+    // The real per-channel env resolver (GH_TOKEN/CLOUDFLARE_*/… — { default, channel } merged).
+    resolveChannelEnv: (channel: string) => resolveChannelEnv(channel, stateDir),
     // The real tmux launcher (writes the per-session launch script, runs tmux).
     tmux: realTmuxLauncher(),
     // Absolute claude path so the sandbox doesn't depend on PATH resolution at run


### PR DESCRIPTION
Two related capabilities, one coherent PR — operating sandboxed agent sessions through the web UI.

## (A) Per-channel environment-variable / credential injection
Scope a channel's spawned agent extra secrets — `GH_TOKEN`, `CLOUDFLARE_API_TOKEN`, etc. — easy to set from the Agents page.

- **`credentials.ts`** — new generic `env` slice on `CredentialsFile` (`{ default?, channels? }`, each a NAME→VALUE map). Helpers mirror the Claude slice exactly: `setChannelEnvVar(channel|null, name, value)`, `removeChannelEnvVar(...)→bool`, `resolveChannelEnv(channel) = { ...default, ...channels[ch] }` (channel wins, dynamic read), `describeChannelEnv()` (NAMES only, values redacted). Read-modify-write, 0600 + unconditional chmod, sibling-preserving.
- **`DENYLISTED_ENV`** = `{ ANTHROPIC_API_KEY, CLAUDE_API_KEY, CLAUDE_CODE_OAUTH_TOKEN }`. The setter rejects them (`DenylistedEnvError` → 400); `resolveChannelEnv` strips them; and `buildAgentChildEnv` drops them defensively at injection with a warning — so the subscription-billing / managed-auth guarantee holds even against a hand-edited `credentials.json`.
- **`spawn-agent.ts`** — `buildAgentChildEnv` now takes the resolved channel env and layers it UNDER the structural passthrough (PATH/HOME/locale) and FINALLY under the managed `CLAUDE_CODE_OAUTH_TOKEN`, so a channel-set var can only ADD capability, never clobber Claude auth or a fundamental. `spawnAgent` resolves the env (keyed on the wake channel) at spawn time via an injectable `deps.resolveChannelEnv`.
- **`daemon.ts`** — `channel:admin`-gated API mirroring the Claude creds routes: `GET /api/credentials/env` (redacted), `POST /api/credentials/env {channel?,name,value}`, `DELETE /api/credentials/env {channel?,name}`.

## (B) Per-session restart
`POST /api/agents/:name/restart` (`channel:admin`) — kills `<name>-agent`, then re-spawns it re-resolving env + the Claude credential, so **setting a credential then applying it is one click**. PER-SESSION ONLY (no blanket restart-all).

## Design decisions
- **Credential model**: generic `env` slice alongside the existing `claude` slice in the same `credentials.json` (namespaced by type — exactly what the file header anticipated). Two principals: operator default + per-channel override.
- **Restart param recovery**: `GET /api/agents` and the live tmux session carry NO spawn params, and the workspace `.mcp.json` inlines minted tokens (not a clean spec). **New seam**: `spawnAgent` now persists the `AgentSpec` to `spec.json` in the session workspace at spawn time; restart reads it back (`readPersistedSpec`) to faithfully reproduce channels/vault/network/mounts. A missing spec (old session) → 400 with a clear "kill + re-spawn from the form" message.
- **`claude -c` resume — NO**: restart does a fresh spawn, not `claude --continue`. The autonomous spawn path (seeded private HOME, `--dangerously-skip-permissions`, regenerated tokenized `.mcp.json`) makes a clean resume unreliable; correctness + a guaranteed MCP/channel reconnect win over preserving context. Documented in the route + surfaced in the UI confirm ("conversation context is not resumed"). The channel MCP reconnects either way (the new session re-establishes its entries from the regenerated config).
- **Denylist scope**: the Claude-auth trio only. `PATH`/`HOME` are deliberately NOT denylisted — the layering already makes a channel-set PATH/HOME a harmless no-op (the real passthrough + seeded-HOME overrides win), so rejecting them would only deny a no-op.

## UI (Agents page)
- New **Channel env / credentials** section: NAME + VALUE + optional channel field, a redacted per-scope chip list with inline delete.
- Running-agents list gains a **Connection** column (live `mcp_sessions`/`clients` from the open `/health`) and a **restart / reconnect** button per session.

## Files changed
`src/credentials.ts`, `src/spawn-agent.ts`, `src/spawn-deps.ts`, `src/agents.ts`, `src/daemon.ts`, `src/agents-ui.ts` + tests (`credentials.test.ts`, `spawn-agent.test.ts`, `daemon-config-api.test.ts`, `agents.test.ts`).

## New seam
Persisting the spawn spec (`spec.json` in the session workspace) — needed because restart param recovery had no other source of truth.

## Quality gates
- `bun test ./src`: **509 pass / 0 fail** (was 469; +40 new).
- `bun run typecheck`: only the **2 pre-existing `TS2589`** errors in `src/bridge.ts` (zero new).
- `bunx biome check`: clean.
- Version: left at `0.1.0` — channel is an experimental preview and recent feature PRs (#62–#67) did not bump; no rc cadence here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)