### PR TITLE
fix(channel): auto-confirm the dev-channels consent gate on spawn (#70)

### DIFF
--- a/src/agents.test.ts
+++ b/src/agents.test.ts
@@ -283,6 +283,9 @@ describe("createRealAgentOps — restart (param recovery via persisted spec)", (
       async newSession(opts) {
         launched.push({ name: opts.name });
       },
+      async confirmDevChannelsPrompt() {
+        return "already-running";
+      },
     };
     const engine: SandboxEngine = {
       isSupportedPlatform: () => true,

--- a/src/spawn-agent.test.ts
+++ b/src/spawn-agent.test.ts
@@ -7,6 +7,9 @@ import {
   buildAgentChildEnv,
   buildAgentClaudeArgs,
   buildLaunchScript,
+  confirmDevChannelsPrompt,
+  DEV_CHANNELS_PROMPT_MARKER,
+  DEV_CHANNELS_READY_MARKER,
   realTmuxLauncher,
   seedAgentHome,
   sessionName,
@@ -36,6 +39,7 @@ afterEach(() => {
 /** A recording tmux launcher. */
 function recordingTmux(existing = new Set<string>()): TmuxLauncher & {
   launched: Array<{ name: string; argv: string[]; env: Record<string, string | undefined>; cwd: string }>;
+  confirmed: string[];
 } {
   const launched: Array<{
     name: string;
@@ -43,13 +47,19 @@ function recordingTmux(existing = new Set<string>()): TmuxLauncher & {
     env: Record<string, string | undefined>;
     cwd: string;
   }> = [];
+  const confirmed: string[] = [];
   return {
     launched,
+    confirmed,
     async hasSession(name) {
       return existing.has(name);
     },
     async newSession(opts) {
       launched.push(opts);
+    },
+    async confirmDevChannelsPrompt(session) {
+      confirmed.push(session);
+      return "confirmed";
     },
   };
 }
@@ -328,6 +338,11 @@ describe("spawnAgent — full wiring with stubs (no real token)", () => {
     const launch = tmux.launched[0]!;
     expect(launch.name).toBe("aaron-dev-agent");
 
+    // 1b. The dev-channels consent gate is auto-answered for THIS session after the
+    // launch (channel#70) — otherwise the headless spawn hangs at the prompt forever.
+    expect(tmux.confirmed).toEqual(["aaron-dev-agent"]);
+    expect(res.devChannelsPrompt).toBe("confirmed");
+
     // 2. The launched argv is the sandbox wrapper carrying the claude command.
     expect(launch.argv[0]).toBe("/bin/bash");
     expect(launch.argv[2]).toContain("SBX claude");
@@ -419,6 +434,10 @@ describe("spawnAgent — full wiring with stubs (no real token)", () => {
     const res = await spawnAgent({ name: "arm", channels: ["c"] }, baseDeps({ tmux }));
     expect(res.alreadyRunning).toBe(true);
     expect(tmux.launched).toHaveLength(0);
+    // No launch → the dev-channels gate is NOT touched (guards against someone
+    // moving the confirm call above the early-return — channel#70).
+    expect(tmux.confirmed).toHaveLength(0);
+    expect(res.devChannelsPrompt).toBeUndefined();
   });
 
   test("a spec with no channels is rejected", async () => {
@@ -774,6 +793,108 @@ describe("realTmuxLauncher — launch-script indirection (tmux can't take the ~8
     } finally {
       rmSync(workspace, { recursive: true, force: true });
     }
+  });
+});
+
+describe("confirmDevChannelsPrompt — auto-answer the dev-channels consent gate (channel#70)", () => {
+  /**
+   * A recording spawnFn whose `tmux capture-pane` returns configurable pane text and
+   * whose `tmux send-keys` is recorded. Mirrors the `recordingSpawn` shape above but
+   * with a per-argv stdout (capture must return the pane content).
+   */
+  function recordingSpawn(paneText: string): {
+    fn: typeof Bun.spawn;
+    calls: string[][];
+  } {
+    const calls: string[][] = [];
+    const fn = ((argv: string[]) => {
+      calls.push(argv);
+      const isCapture = argv.includes("capture-pane");
+      return {
+        exited: Promise.resolve(0),
+        stdout: new Response(isCapture ? paneText : "").body,
+        stderr: new Response("").body,
+      };
+    }) as unknown as typeof Bun.spawn;
+    return { fn, calls };
+  }
+
+  const noSleep = async () => {};
+
+  test("prompt marker present → returns 'confirmed' AND sends Enter to the pane", async () => {
+    const pane = `WARNING: Loading development channels\n❯ 1. ${DEV_CHANNELS_PROMPT_MARKER}\n  2. Exit`;
+    const { fn, calls } = recordingSpawn(pane);
+    const result = await confirmDevChannelsPrompt("aaron-agent", {
+      spawnFn: fn,
+      timeoutMs: 5_000,
+      intervalMs: 10,
+      sleepFn: noSleep,
+    });
+    expect(result).toBe("confirmed");
+    // A `tmux send-keys -t aaron-agent Enter` call was recorded.
+    const sendKeys = calls.find((c) => c.includes("send-keys"));
+    expect(sendKeys).toBeDefined();
+    expect(sendKeys).toEqual(["tmux", "send-keys", "-t", "aaron-agent", "Enter"]);
+  });
+
+  test("ready marker present (no prompt) → returns 'already-running', NO send-keys", async () => {
+    const pane = `Welcome to Claude Code\n  ${DEV_CHANNELS_READY_MARKER} · /help for help`;
+    const { fn, calls } = recordingSpawn(pane);
+    const result = await confirmDevChannelsPrompt("aaron-agent", {
+      spawnFn: fn,
+      timeoutMs: 5_000,
+      intervalMs: 10,
+      sleepFn: noSleep,
+    });
+    expect(result).toBe("already-running");
+    expect(calls.some((c) => c.includes("send-keys"))).toBe(false);
+  });
+
+  test("neither marker, tiny timeout + no-op sleep → returns 'timeout', NO throw, NO send-keys", async () => {
+    const { fn, calls } = recordingSpawn("just some unrelated pane output\n$ ");
+    const result = await confirmDevChannelsPrompt("aaron-agent", {
+      spawnFn: fn,
+      timeoutMs: 1,
+      intervalMs: 1,
+      sleepFn: noSleep,
+    });
+    expect(result).toBe("timeout");
+    expect(calls.some((c) => c.includes("send-keys"))).toBe(false);
+    // It DID poll at least once (the do-while guarantees a capture even at timeoutMs<=interval).
+    expect(calls.some((c) => c.includes("capture-pane"))).toBe(true);
+  });
+
+  test("a capture subprocess that throws degrades to timeout, never throws", async () => {
+    const fn = (() => {
+      throw new Error("tmux not found");
+    }) as unknown as typeof Bun.spawn;
+    const result = await confirmDevChannelsPrompt("aaron-agent", {
+      spawnFn: fn,
+      timeoutMs: 1,
+      intervalMs: 1,
+      sleepFn: noSleep,
+    });
+    expect(result).toBe("timeout");
+  });
+
+  test("prompt seen but send-keys throws → degrades to timeout (does NOT lie 'confirmed'), never throws", async () => {
+    const pane = `❯ 1. ${DEV_CHANNELS_PROMPT_MARKER}\n  2. Exit`;
+    // capture-pane succeeds (returns the prompt); send-keys throws.
+    const fn = ((argv: string[]) => {
+      if (argv.includes("send-keys")) throw new Error("send-keys failed");
+      return {
+        exited: Promise.resolve(0),
+        stdout: new Response(pane).body,
+        stderr: new Response("").body,
+      };
+    }) as unknown as typeof Bun.spawn;
+    const result = await confirmDevChannelsPrompt("aaron-agent", {
+      spawnFn: fn,
+      timeoutMs: 1,
+      intervalMs: 1,
+      sleepFn: noSleep,
+    });
+    expect(result).toBe("timeout");
   });
 });
 

--- a/src/spawn-agent.ts
+++ b/src/spawn-agent.ts
@@ -94,6 +94,15 @@ export interface TmuxLauncher {
   }): Promise<void>;
   /** Whether a session by this name already exists (idempotency). */
   hasSession(name: string): Promise<boolean>;
+  /**
+   * Auto-answer claude's `--dangerously-load-development-channels` consent gate
+   * once it appears in the session's pane (channel#70). A headless tmux spawn has
+   * nobody at the keyboard, so the interactive "I am using this for local
+   * development" prompt would hang the session forever and the MCP never connects.
+   * We answer it by sending Enter to the pane. Returns the outcome; NEVER throws
+   * (a spawn must not fail because the prompt didn't show / capture failed).
+   */
+  confirmDevChannelsPrompt(session: string): Promise<"confirmed" | "already-running" | "timeout">;
 }
 
 export interface SpawnAgentDeps {
@@ -161,6 +170,13 @@ export interface SpawnAgentResult {
   wrapped: WrappedCommand;
   /** Already-running? (idempotent no-op). */
   alreadyRunning: boolean;
+  /**
+   * Outcome of auto-answering the dev-channels consent gate (channel#70):
+   * `"confirmed"` (we sent Enter), `"already-running"` (claude was past the prompt),
+   * or `"timeout"` (the prompt never appeared in the window — non-fatal). Absent on
+   * the already-running idempotent no-op path (no launch happened).
+   */
+  devChannelsPrompt?: "confirmed" | "already-running" | "timeout";
 }
 
 /** tmux session name for a spec — matches launch-session.sh's `<name>-agent`. */
@@ -418,12 +434,19 @@ export function seedAgentHome(
  * (the wake transport). `--strict-mcp-config` closes the MCP surface to the spec.
  *
  * `--dangerously-skip-permissions`: a spawned agent runs AUTONOMOUSLY — there is no
- * human at the terminal to answer claude's in-app permission / dev-channels
- * confirmation prompts, and the OS sandbox (+ scoped reads / egress when confined)
- * is the real containment, so claude's own prompts are redundant friction. Skipping
- * them is what lets the agent reach a usable state hands-off. (The meta "are you
- * sure" for this flag is pre-suppressed via the seeded settings.json — see
- * seedAgentHome.)
+ * human at the terminal to answer claude's in-app permission prompts, and the OS
+ * sandbox (+ scoped reads / egress when confined) is the real containment, so
+ * claude's own permission prompts are redundant friction. Skipping them is what lets
+ * the agent reach a usable state hands-off. (The meta "are you sure" for THIS flag is
+ * pre-suppressed via the seeded settings.json `skipDangerousModePermissionPrompt` —
+ * see seedAgentHome.)
+ *
+ * NOTE: `skipDangerousModePermissionPrompt` (and every other settings.json key / env
+ * var) suppresses ONLY the skip-permissions meta-prompt — it does NOT cover the
+ * SEPARATE `--dangerously-load-development-channels` consent gate ("I am using this
+ * for local development"), which has no skip flag and which `--channels` (the
+ * allowlist path) doesn't satisfy for custom `server:` channels. That gate is
+ * auto-answered post-launch by `confirmDevChannelsPrompt` (channel#70), not here.
  */
 export function buildAgentClaudeArgs(opts: {
   mcpConfigPath: string;
@@ -636,6 +659,13 @@ export async function spawnAgent(
     cwd: workspace,
   });
 
+  // Auto-answer claude's `--dangerously-load-development-channels` consent gate
+  // (channel#70). Without this, the headless tmux session hangs at the interactive
+  // "I am using this for local development" prompt forever and the MCP never
+  // connects. A non-"confirmed" result (already-running / timeout) is NON-FATAL —
+  // confirmDevChannelsPrompt never throws — so the spawn always returns.
+  const devChannelsPrompt = await deps.tmux.confirmDevChannelsPrompt(session);
+
   return {
     session,
     workspace,
@@ -643,6 +673,7 @@ export async function spawnAgent(
     mcpConfigJson,
     wrapped,
     alreadyRunning: false,
+    devChannelsPrompt,
   };
 }
 
@@ -700,6 +731,112 @@ export function buildLaunchScript(argv: string[]): string {
 /** Per-session launch-script path under the session workspace (`cwd`). */
 function launchScriptPath(cwd: string): string {
   return join(cwd, ".launch.sh");
+}
+
+/** The prompt marker for the dev-channels consent gate (channel#70). */
+export const DEV_CHANNELS_PROMPT_MARKER = "I am using this for local development";
+/**
+ * The ready marker shown once claude is running interactively. Our sessions always
+ * launch with `--dangerously-skip-permissions`, so the footer reads "bypass
+ * permissions on". Seeing it means the prompt is already past (or a future claude
+ * build dropped it) — short-circuit so we don't burn the full timeout.
+ *
+ * Coupling note: this is a claude-code UI-footer string (stable as of the claude-code
+ * we run today). If a future claude renames the footer, the worst case is we wait the
+ * full timeout before returning "timeout" — never a wrong keystroke — so the failure
+ * mode is benign. Update this string if the footer changes.
+ */
+export const DEV_CHANNELS_READY_MARKER = "bypass permissions on";
+
+/**
+ * Auto-confirm claude's `--dangerously-load-development-channels` consent gate in a
+ * detached tmux session (channel#70). The gate is INTERACTIVE — claude shows
+ *
+ *   WARNING: Loading development channels
+ *   ❯ 1. I am using this for local development
+ *     2. Exit
+ *
+ * on EVERY launch, and no settings.json key / env var / `--channels` flag suppresses
+ * it for custom `server:` channels. In a headless spawn nobody answers it, so claude
+ * hangs at the prompt forever and its MCP never connects (`/health` → `mcp_sessions:
+ * 0`). Because our sessions are interactive tmux panes (the operator attaches via the
+ * web terminal), we answer it the way a human would: send Enter to the pane.
+ *
+ * A BOUNDED poll loop — `capture-pane` every `intervalMs`, up to `timeoutMs`:
+ *  - prompt marker present → `send-keys Enter` → "confirmed".
+ *  - ready marker present (claude already running, prompt past / absent) →
+ *    "already-running" (no keystroke) — so a future claude that drops the prompt
+ *    doesn't make us wait the whole timeout.
+ *  - timeout → warn + "timeout". NEVER throws: the prompt not showing must not fail
+ *    a spawn (it may already have been past, or claude may render it differently),
+ *    and a capture/send subprocess failure degrades to best-effort.
+ *
+ * `spawnFn` / `timeoutMs` / `intervalMs` / `sleepFn` are injectable so tests run
+ * fast and hermetically (tiny timeout + no-op sleep). `Date.now()` is fine here —
+ * this is daemon code, not a workflow script.
+ */
+export async function confirmDevChannelsPrompt(
+  session: string,
+  opts: {
+    spawnFn?: typeof Bun.spawn;
+    timeoutMs?: number;
+    intervalMs?: number;
+    sleepFn?: (ms: number) => Promise<void>;
+  } = {},
+): Promise<"confirmed" | "already-running" | "timeout"> {
+  const spawnFn = opts.spawnFn ?? Bun.spawn;
+  const timeoutMs = opts.timeoutMs ?? 15_000;
+  const intervalMs = opts.intervalMs ?? 400;
+  const sleep = opts.sleepFn ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+
+  // Capture the pane text; any subprocess failure degrades to "" (best-effort).
+  async function capture(): Promise<string> {
+    try {
+      const proc = spawnFn(["tmux", "capture-pane", "-t", session, "-p"], {
+        stdout: "pipe",
+        stderr: "ignore",
+      });
+      const text = await new Response(proc.stdout as ReadableStream<Uint8Array>).text();
+      await proc.exited;
+      return text;
+    } catch {
+      return "";
+    }
+  }
+
+  const deadline = Date.now() + timeoutMs;
+  // Poll at least once even if timeoutMs <= 0 (do-while), so a present prompt is
+  // caught immediately without waiting an interval.
+  do {
+    const pane = await capture();
+    if (pane.includes(DEV_CHANNELS_PROMPT_MARKER)) {
+      try {
+        const proc = spawnFn(["tmux", "send-keys", "-t", session, "Enter"], {
+          stdout: "ignore",
+          stderr: "ignore",
+        });
+        await proc.exited;
+        return "confirmed";
+      } catch {
+        // The send subprocess failed — we saw the prompt but couldn't answer it.
+        // Don't claim "confirmed" (that would be a diagnostic lie); fall through to
+        // the warn + "timeout" so the operator is told to press Enter themselves.
+        break;
+      }
+    }
+    if (pane.includes(DEV_CHANNELS_READY_MARKER)) {
+      return "already-running";
+    }
+    if (Date.now() >= deadline) break;
+    await sleep(intervalMs);
+  } while (Date.now() < deadline);
+
+  console.warn(
+    `parachute-channel: dev-channels consent prompt for tmux session "${session}" did not ` +
+      `appear within ${timeoutMs}ms (channel#70). If \`mcp_sessions\` stays 0, attach to the ` +
+      `session and press Enter in its terminal to clear the gate.`,
+  );
+  return "timeout";
 }
 
 /**
@@ -774,6 +911,11 @@ export function realTmuxLauncher(spawnFn: typeof Bun.spawn = Bun.spawn): TmuxLau
         const err = await new Response(proc.stderr as ReadableStream<Uint8Array>).text();
         throw new Error(`tmux new-session failed (exit ${code}): ${err.trim()}`);
       }
+    },
+    async confirmDevChannelsPrompt(session) {
+      // Delegate to the standalone helper, threading this launcher's spawnFn so the
+      // real tmux subprocesses are used (tests inject a recorder via the helper).
+      return confirmDevChannelsPrompt(session, { spawnFn });
     },
   };
 }


### PR DESCRIPTION
Fixes #70.

## The bug
A spawned agent launches Claude Code with `--dangerously-load-development-channels=server:channel-<name>`, which pops an **interactive** consent gate on **every** launch:

```
WARNING: Loading development channels
❯ 1. I am using this for local development
  2. Exit
Enter to confirm · Esc to cancel
```

In a headless tmux spawn nobody answers it, so CC sits at the prompt forever and **never connects** — `/health` shows `mcp_sessions: 0` indefinitely. This partially defeats the #68 per-session restart (restart = kill + re-spawn → lands back at the prompt). A manual `tmux send-keys -t <name>-agent Enter` unblocks it immediately.

## Why no settings/env suppresses it
- **No settings.json key or env var** suppresses this gate (verified). The seeded `settings.json` `skipDangerousModePermissionPrompt: true` covers only the **separate** `--dangerously-skip-permissions` meta-prompt — the comment in `buildAgentClaudeArgs`/`seedAgentHome` wrongly assumed it covered this one too; that comment is now corrected.
- **`--channels`** (the allowlist path) does **not** satisfy custom `server:` channels, so it isn't an alternative.

## The fix — poll + send-keys
Our sessions are **interactive tmux panes** (the operator attaches via the web terminal), so the mechanism is `tmux send-keys`, not stdin piping. New `confirmDevChannelsPrompt` helper runs a **bounded poll loop** — `tmux capture-pane -t <session> -p` every ~400ms, up to ~15s:

- prompt marker **`"I am using this for local development"`** present → `tmux send-keys -t <session> Enter` → `"confirmed"`.
- ready marker **`"bypass permissions on"`** present (CC already running — our sessions always use `--dangerously-skip-permissions`) → `"already-running"`, no keystroke. This short-circuits so a future CC build that drops the prompt doesn't make us wait the whole timeout.
- timeout → `console.warn(...)` (references channel#70 + "press Enter in its terminal if `mcp_sessions` stays 0") → `"timeout"`. **Never throws** — a spawn must not fail because the prompt didn't show. tmux subprocess calls are wrapped so a capture/send failure degrades to best-effort (a send-keys failure degrades to `"timeout"`, never a false `"confirmed"`).

Added to the `TmuxLauncher` interface + implemented in `realTmuxLauncher`; the standalone helper is exported and unit-testable. Called in `spawnAgent` **after** `newSession` succeeds (non-fatal — the result carries the outcome as the new optional `SpawnAgentResult.devChannelsPrompt`). `newSession` is **unchanged** (the existing `calls.toHaveLength(1)` test stays green). `spawnFn` / `timeoutMs` / `intervalMs` / `sleepFn` are injectable for fast hermetic tests.

## Files changed
- `src/spawn-agent.ts` — interface method + `realTmuxLauncher` impl + standalone `confirmDevChannelsPrompt` helper + markers; wired into `spawnAgent`; fixed the misleading skip-permissions comment.
- `src/spawn-agent.test.ts` — `recordingTmux` stub updated; 5 new tests (prompt→confirmed+send-keys, ready→already-running+no-send, neither→timeout+no-throw+no-send, capture-throws→timeout, send-keys-throws→timeout) + idempotent-path assertion that the gate is untouched.
- `src/agents.test.ts` — `TmuxLauncher` restart stub updated with a no-op `confirmDevChannelsPrompt`.

## Markers used
- prompt: `I am using this for local development`
- ready: `bypass permissions on`

## Gates
- `bun test ./src` → **514 pass, 0 fail** (baseline 509).
- `bun run typecheck` → only the **2 known pre-existing** `TS2589` errors in `src/bridge.ts`; **zero new**.
- `bunx biome check .` → clean (exit 0).
- Version left at `0.1.0` (preview module, no rc cadence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)