### PR TITLE
feat(channel): programmatic agent backend core — claude -p turn runner

### DIFF
--- a/src/agent-session-state.test.ts
+++ b/src/agent-session-state.test.ts
@@ -1,0 +1,113 @@
+/**
+ * AgentSessionState tests — the per-channel `claude -p` session-id store that
+ * powers `--resume` continuity.
+ *
+ * Covered:
+ *  - get() returns undefined for an unknown channel (→ first turn omits --resume);
+ *  - set() persists + last-write-wins; a blank id is a no-op; reports whether it changed;
+ *  - per-channel independence;
+ *  - persist + reload across a simulated restart (a new instance reads the file);
+ *  - clear() drops a channel's id (next turn starts fresh);
+ *  - a corrupt file is tolerated (starts empty).
+ *
+ * Each test points the store at a throwaway temp dir — no shared global state, no
+ * touch of the real `~/.parachute/channel/`.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, statSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { AgentSessionState } from "./agent-session-state.ts";
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "channel-agent-session-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("get / set", () => {
+  test("an unknown channel returns undefined (so the first turn omits --resume)", () => {
+    const s = new AgentSessionState({ stateDir: dir });
+    expect(s.get("never-seen")).toBeUndefined();
+  });
+
+  test("set stores the id; get returns it; the change is reported", () => {
+    const s = new AgentSessionState({ stateDir: dir });
+    expect(s.set("eng", "sess-abc")).toBe(true);
+    expect(s.get("eng")).toBe("sess-abc");
+  });
+
+  test("set is last-write-wins; re-setting the SAME id is a no-op reporting false", () => {
+    const s = new AgentSessionState({ stateDir: dir });
+    expect(s.set("eng", "sess-1")).toBe(true);
+    expect(s.set("eng", "sess-1")).toBe(false); // unchanged
+    expect(s.set("eng", "sess-2")).toBe(true); // a fresh id overwrites
+    expect(s.get("eng")).toBe("sess-2");
+  });
+
+  test("a blank/empty id is a no-op (never store a blank — would `--resume \"\"`)", () => {
+    const s = new AgentSessionState({ stateDir: dir });
+    expect(s.set("eng", "")).toBe(false);
+    expect(s.get("eng")).toBeUndefined();
+  });
+
+  test("per-channel ids are independent", () => {
+    const s = new AgentSessionState({ stateDir: dir });
+    s.set("a", "sess-a");
+    s.set("b", "sess-b");
+    expect(s.get("a")).toBe("sess-a");
+    expect(s.get("b")).toBe("sess-b");
+  });
+});
+
+describe("clear", () => {
+  test("drops a channel's id so the next turn starts fresh; reports whether one existed", () => {
+    const s = new AgentSessionState({ stateDir: dir });
+    expect(s.clear("eng")).toBe(false); // nothing to clear
+    s.set("eng", "sess-x");
+    expect(s.clear("eng")).toBe(true);
+    expect(s.get("eng")).toBeUndefined();
+  });
+});
+
+describe("persist + reload (simulated restart)", () => {
+  test("a fresh instance reads the persisted ids", () => {
+    const s1 = new AgentSessionState({ stateDir: dir });
+    s1.set("eng", "sess-eng");
+    s1.set("ops", "sess-ops");
+    expect(existsSync(join(dir, "agent-session-state.json"))).toBe(true);
+
+    const s2 = new AgentSessionState({ stateDir: dir });
+    expect(s2.get("eng")).toBe("sess-eng");
+    expect(s2.get("ops")).toBe("sess-ops");
+    expect(s2.get("brand-new")).toBeUndefined();
+  });
+
+  test("the persisted file is valid JSON of channel→id, written 0600", () => {
+    const s = new AgentSessionState({ stateDir: dir });
+    s.set("eng", "sess-eng");
+    const path = join(dir, "agent-session-state.json");
+    expect(JSON.parse(readFileSync(path, "utf8"))).toEqual({ eng: "sess-eng" });
+    // A session id is a continuation handle — treat it as sensitive (0600).
+    expect(statSync(path).mode & 0o777).toBe(0o600);
+  });
+
+  test("clear is persisted (a restart doesn't resurrect a cleared id)", () => {
+    const s1 = new AgentSessionState({ stateDir: dir });
+    s1.set("eng", "sess-eng");
+    s1.clear("eng");
+    const s2 = new AgentSessionState({ stateDir: dir });
+    expect(s2.get("eng")).toBeUndefined();
+  });
+
+  test("a corrupt file is tolerated — starts empty, still usable", () => {
+    writeFileSync(join(dir, "agent-session-state.json"), "{ not json");
+    const s = new AgentSessionState({ stateDir: dir });
+    expect(s.get("eng")).toBeUndefined();
+    expect(s.set("eng", "sess-fresh")).toBe(true); // overwrites the corrupt file
+    const s2 = new AgentSessionState({ stateDir: dir });
+    expect(s2.get("eng")).toBe("sess-fresh");
+  });
+});

--- a/src/agent-session-state.ts
+++ b/src/agent-session-state.ts
@@ -1,0 +1,140 @@
+/**
+ * Per-channel `claude -p` session-id store — the spine of programmatic-backend
+ * conversation continuity (design 2026-06-16-pluggable-agent-backend.md, the
+ * `resume=session_id` row of the tradeoff table).
+ *
+ * THE MECHANIC (verified against claude 2.1.179). `claude -p "<msg>"
+ * --output-format stream-json --verbose` runs ONE turn and emits a `session_id`
+ * in its `system/init` + `result` events. To carry the conversation forward, the
+ * NEXT turn passes `--resume <session_id>` — which restores full conversation
+ * continuity. So:
+ *
+ *   - FIRST turn for a channel: no stored id → omit `--resume`; capture the
+ *     `session_id` from the turn's output; persist it here.
+ *   - SUBSEQUENT turns: read the stored id → pass `--resume <id>`; the reply
+ *     continues the same conversation. The id is stable across turns.
+ *
+ * This store is the per-channel `<channel> → <session_id>` map that makes that
+ * work across daemon restarts. It is modeled directly on `delivery-state.ts`: a
+ * single small JSON file under the channel state dir, an injectable path for
+ * tests, write-through-but-resilient persistence (a failed write is logged and
+ * swallowed — losing the id only costs starting a fresh conversation, never a
+ * crash), load-on-construct.
+ *
+ * NOT a high-water-mark — unlike delivery-state's monotonic ISO-timestamp mark,
+ * a session-id is an opaque string with no ordering. `set` is a plain
+ * last-write-wins overwrite (a newer turn for a channel may legitimately produce
+ * a fresh session id — e.g. the prior conversation expired — and we want to track
+ * the latest). `clear` drops a channel's id so the next turn starts fresh.
+ *
+ * SERIALIZATION is the daemon's job, not this store's. The programmatic backend
+ * runs ONE turn at a time per channel (never two concurrent `claude -p` for the
+ * same channel — that would fork the conversation); the daemon owns that serial
+ * processing (the wiring follow-up). This store just records the latest id; it
+ * does not itself guard against concurrent turns.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync } from "fs";
+import { join, dirname } from "path";
+import { defaultStateDir } from "./registry.ts";
+
+/** The on-disk shape: `{ "<channel>": "<session_id>", ... }`. */
+type AgentSessionStateFile = Record<string, string>;
+
+export interface AgentSessionStateOptions {
+  /** State dir for the persisted file. Defaults to the channel state dir. */
+  stateDir?: string;
+}
+
+/**
+ * Per-channel `claude -p` session-id store. One instance per daemon (or one per
+ * backend); each owns its own file + in-memory map, so tests construct throwaway
+ * instances pointed at a temp dir with no global state to reset.
+ */
+export class AgentSessionState {
+  private readonly file: string;
+  private readonly ids: Map<string, string> = new Map();
+
+  constructor(opts: AgentSessionStateOptions = {}) {
+    const stateDir = opts.stateDir ?? defaultStateDir();
+    this.file = join(stateDir, "agent-session-state.json");
+    this.load();
+  }
+
+  /** Read the persisted ids once at construction. Missing/corrupt file → empty. */
+  private load(): void {
+    let raw: string;
+    try {
+      raw = readFileSync(this.file, "utf8");
+    } catch {
+      // No file yet (first boot) — start empty; an unknown channel has no session.
+      return;
+    }
+    try {
+      const parsed = JSON.parse(raw) as unknown;
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        for (const [k, v] of Object.entries(parsed as AgentSessionStateFile)) {
+          if (typeof v === "string" && v) this.ids.set(k, v);
+        }
+      }
+    } catch (err) {
+      // Corrupt file — log and start empty rather than crash. The cost is that
+      // every channel starts a fresh conversation on the next turn, not a loss.
+      console.warn(
+        `parachute-channel: agent-session-state file ${this.file} is unreadable ` +
+          `(${(err as Error).message}); starting with no resume ids.`,
+      );
+    }
+  }
+
+  /** Write the current ids through to disk. Best-effort: a failure is logged, never thrown. */
+  private persist(): void {
+    try {
+      mkdirSync(dirname(this.file), { recursive: true });
+      const obj: AgentSessionStateFile = {};
+      for (const [k, v] of this.ids) obj[k] = v;
+      // 0600 — a session id is a continuation handle to a conversation; treat it
+      // as sensitive (same posture as the other channel state files).
+      writeFileSync(this.file, JSON.stringify(obj, null, 2), { mode: 0o600 });
+    } catch (err) {
+      console.warn(
+        `parachute-channel: failed to persist agent-session-state to ${this.file} ` +
+          `(${(err as Error).message}); the session id is held in memory only.`,
+      );
+    }
+  }
+
+  /**
+   * The stored `session_id` for a channel, or undefined when this channel has
+   * never run a turn (→ the first turn omits `--resume`).
+   */
+  get(channel: string): string | undefined {
+    return this.ids.get(channel);
+  }
+
+  /**
+   * Record a channel's latest `session_id` (last-write-wins; write-through).
+   * Called after a turn captures the id from `claude -p`'s output, so the NEXT
+   * turn for the channel resumes it. A blank/empty id is a no-op (we never store a
+   * blank — that would make the next turn pass `--resume ""`). Returns true if the
+   * stored id changed (and was persisted).
+   */
+  set(channel: string, sessionId: string): boolean {
+    if (!sessionId) return false;
+    if (this.ids.get(channel) === sessionId) return false;
+    this.ids.set(channel, sessionId);
+    this.persist();
+    return true;
+  }
+
+  /**
+   * Drop a channel's stored id so its next turn starts a fresh conversation.
+   * Returns true if an id existed (and the drop was persisted), false otherwise.
+   */
+  clear(channel: string): boolean {
+    if (!this.ids.has(channel)) return false;
+    this.ids.delete(channel);
+    this.persist();
+    return true;
+  }
+}

--- a/src/backends/programmatic.test.ts
+++ b/src/backends/programmatic.test.ts
@@ -1,0 +1,517 @@
+/**
+ * ProgrammaticBackend tests — the single `claude -p` turn runner.
+ *
+ * Inject a FAKE spawnFn that emits canned stream-json (never spawn real claude),
+ * a fake sandbox engine (records the wrapped argv), and a fake mint hub. Covered:
+ *
+ *  - FIRST turn (no stored sid): argv has NO `--resume`; session_id captured +
+ *    PERSISTED to the state store; reply extracted from the `result` event.
+ *  - SECOND turn (sid stored): argv includes `--resume <sid>`; reply extracted; sid stable.
+ *  - ERROR turn (is_error / non-success subtype): returns `{ ok:false, error }`, no throw.
+ *  - argv shape: `-p`, `--output-format stream-json`, `--strict-mcp-config`,
+ *    `--mcp-config`, `--dangerously-skip-permissions` present; NO
+ *    `--dangerously-load-development-channels`.
+ *  - env: `CLAUDE_CODE_OAUTH_TOKEN` injected; `ANTHROPIC_API_KEY`/`CLAUDE_API_KEY`
+ *    NOT present (the #68 denylist).
+ *  - robustness: stream-json with interleaved hook/rate_limit_event lines + a
+ *    trailing partial line still parses the result.
+ *  - the vault-only `.mcp.json` (no channel MCP entry — the daemon mediates messaging).
+ *  - a missing Claude credential / a refused mint return `{ ok:false }` (no throw).
+ *  - stop() clears the resume id; status() is live.
+ */
+import { describe, test, expect, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  ProgrammaticBackend,
+  buildProgrammaticClaudeArgs,
+  PROGRAMMATIC_BACKEND_KIND,
+  type ProgrammaticBackendDeps,
+  type ProgrammaticSpawnFn,
+} from "./programmatic.ts";
+import { AgentSessionState } from "../agent-session-state.ts";
+import type { SandboxEngine } from "../sandbox/index.ts";
+import type { SandboxRuntimeConfig } from "@anthropic-ai/sandbox-runtime";
+import type { AgentSpec } from "../sandbox/types.ts";
+import { vaultEntryKey, channelEntryKey } from "../agent-mcp-config.ts";
+
+let sessionsDir: string;
+let stateDir: string;
+afterEach(() => {
+  if (sessionsDir) rmSync(sessionsDir, { recursive: true, force: true });
+  if (stateDir) rmSync(stateDir, { recursive: true, force: true });
+});
+
+// ---- fakes -----------------------------------------------------------------
+
+/** Join NDJSON event objects into the blob claude emits on stdout. */
+function ndjson(...events: unknown[]): string {
+  return events.map((e) => JSON.stringify(e)).join("\n") + "\n";
+}
+
+/** A success stream-json turn with the given session id + reply. */
+function successTurn(sessionId: string, reply: string): string {
+  return ndjson(
+    { type: "system", subtype: "init", session_id: sessionId, apiKeySource: "none", mcp_servers: [] },
+    { type: "assistant", message: { content: [{ type: "text", text: reply }] }, session_id: sessionId },
+    {
+      type: "result",
+      subtype: "success",
+      is_error: false,
+      result: reply,
+      session_id: sessionId,
+      usage: { input_tokens: 10, output_tokens: 5 },
+      total_cost_usd: 0.001,
+    },
+  );
+}
+
+/**
+ * A recording spawnFn that returns a configurable stdout/stderr/exit and records
+ * the argv + env + cwd it was called with. Mirrors `Bun.spawn`'s stream shape via
+ * `Response(...).body`.
+ */
+function recordingSpawn(opts: { stdout?: string; stderr?: string; code?: number } = {}): {
+  fn: ProgrammaticSpawnFn;
+  calls: Array<{ argv: string[]; env: Record<string, string | undefined>; cwd: string }>;
+} {
+  const calls: Array<{ argv: string[]; env: Record<string, string | undefined>; cwd: string }> = [];
+  const fn: ProgrammaticSpawnFn = (argv, o) => {
+    calls.push({ argv, env: o.env, cwd: o.cwd });
+    return {
+      stdout: new Response(opts.stdout ?? "").body,
+      stderr: new Response(opts.stderr ?? "").body,
+      exited: Promise.resolve(opts.code ?? 0),
+    };
+  };
+  return { fn, calls };
+}
+
+/** A spawnFn that returns a DIFFERENT canned stdout per call (turn 1, turn 2, …). */
+function sequencedSpawn(stdouts: string[]): {
+  fn: ProgrammaticSpawnFn;
+  calls: Array<{ argv: string[]; env: Record<string, string | undefined> }>;
+} {
+  const calls: Array<{ argv: string[]; env: Record<string, string | undefined> }> = [];
+  let i = 0;
+  const fn: ProgrammaticSpawnFn = (argv, o) => {
+    calls.push({ argv, env: o.env });
+    const out = stdouts[Math.min(i, stdouts.length - 1)] ?? "";
+    i += 1;
+    return { stdout: new Response(out).body, stderr: new Response("").body, exited: Promise.resolve(0) };
+  };
+  return { fn, calls };
+}
+
+/** A fake sandbox engine — records config, returns a deterministic wrap (echoes the command). */
+function fakeEngine(): SandboxEngine & { initializedWith: SandboxRuntimeConfig | null } {
+  const rec = {
+    initializedWith: null as SandboxRuntimeConfig | null,
+    isSupportedPlatform: () => true,
+    isSandboxingEnabled: () => true,
+    async initialize(cfg: SandboxRuntimeConfig) {
+      rec.initializedWith = cfg;
+    },
+    async wrapWithSandboxArgv(command: string) {
+      // Emulate the real shape: a bash -c wrapper carrying the command + proxy env.
+      // The "argv" the runner spawns is therefore `["/bin/bash","-c","SBX <command>"]`;
+      // assertions parse `argv[2]` for the claude flags.
+      return {
+        argv: ["/bin/bash", "-c", `SBX ${command}`],
+        env: { SANDBOX_RUNTIME: "1", HTTPS_PROXY: "http://localhost:5555", TMPDIR: "/tmp/claude" },
+      };
+    },
+    async reset() {},
+  };
+  return rec;
+}
+
+/** A fake mint hub: returns a distinct token per scope. */
+function fakeMintFetch(): typeof fetch {
+  let n = 0;
+  return (async (_url: string | URL | Request, init?: RequestInit) => {
+    const body = JSON.parse(String(init?.body ?? "{}")) as { scope: string };
+    n += 1;
+    return new Response(
+      JSON.stringify({ jti: `j${n}`, token: `TOK-${n}`, expires_at: "2026-09-01T00:00:00Z", scope: body.scope }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  }) as unknown as typeof fetch;
+}
+
+function baseDeps(
+  spawnFn: ProgrammaticSpawnFn,
+  over: Partial<ProgrammaticBackendDeps> = {},
+): ProgrammaticBackendDeps {
+  return {
+    hubOrigin: "https://hub.example.com",
+    managerBearer: "MANAGER",
+    vaultUrl: "http://127.0.0.1:1940",
+    sessionsDir,
+    runtimeReadOnly: ["/cfg/.claude"],
+    sessionState: new AgentSessionState({ stateDir }),
+    resolveClaudeToken: () => "OAUTH-CRED-PLACEHOLDER",
+    sandboxEngine: fakeEngine(),
+    fetchFn: fakeMintFetch(),
+    spawnFn,
+    parentEnv: {
+      PATH: "/usr/bin",
+      HOME: "/home/op",
+      ANTHROPIC_API_KEY: "sk-ant-SHOULD-NOT-LEAK",
+      CLAUDE_API_KEY: "also-should-not-leak",
+      SECRET_THING: "do-not-pass",
+    },
+    claudeBin: "claude",
+    ...over,
+  };
+}
+
+function specWithVault(name = "eng"): AgentSpec {
+  return {
+    name,
+    channels: [name],
+    vault: { name: "default", access: "read", tags: ["#channel-message"] },
+  };
+}
+
+function mkDirs(tag: string): void {
+  sessionsDir = mkdtempSync(join(tmpdir(), `prog-sessions-${tag}-`));
+  stateDir = mkdtempSync(join(tmpdir(), `prog-state-${tag}-`));
+}
+
+// ---- pure-helper tests -----------------------------------------------------
+
+describe("buildProgrammaticClaudeArgs", () => {
+  test("FIRST turn (no resume): -p + stream-json + strict MCP; NO --resume, NO dev-channels", () => {
+    const argv = buildProgrammaticClaudeArgs({ message: "hello", mcpConfigPath: "/ws/.mcp.json" });
+    expect(argv).toContain("-p");
+    expect(argv).toContain("hello");
+    expect(argv.join(" ")).toContain("--output-format stream-json");
+    expect(argv).toContain("--verbose");
+    expect(argv).toContain("--strict-mcp-config");
+    expect(argv).toContain("--mcp-config");
+    expect(argv).toContain("/ws/.mcp.json");
+    expect(argv).toContain("--dangerously-skip-permissions");
+    // The daemon mediates messaging — NO channel dev-channels flag here.
+    expect(argv.some((a) => a.includes("dangerously-load-development-channels"))).toBe(false);
+    // First turn → no --resume.
+    expect(argv).not.toContain("--resume");
+  });
+
+  test("SECOND turn (resume): --resume <sid> appended", () => {
+    const argv = buildProgrammaticClaudeArgs({
+      message: "next",
+      mcpConfigPath: "/ws/.mcp.json",
+      resumeSessionId: "sess-xyz",
+    });
+    expect(argv).toContain("--resume");
+    expect(argv[argv.indexOf("--resume") + 1]).toBe("sess-xyz");
+  });
+});
+
+// ---- single-turn runner tests ----------------------------------------------
+
+describe("ProgrammaticBackend.deliver — first turn (no stored sid)", () => {
+  test("argv has NO --resume; session_id captured + persisted; reply from the result event", async () => {
+    mkDirs("first");
+    const { fn, calls } = recordingSpawn({ stdout: successTurn("sess-FIRST", "the reply text") });
+    const engine = fakeEngine();
+    const state = new AgentSessionState({ stateDir });
+    const backend = new ProgrammaticBackend(baseDeps(fn, { sandboxEngine: engine, sessionState: state }));
+
+    const handle = await backend.start(specWithVault("eng"));
+    const result = await backend.deliver(handle, "hi agent");
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.reply).toBe("the reply text");
+      expect(result.sessionId).toBe("sess-FIRST");
+      expect(result.usage).toEqual({ inputTokens: 10, outputTokens: 5, totalCostUsd: 0.001 });
+    }
+
+    // The wrapped argv (engine echoes the claude command in argv[2]) has NO --resume.
+    expect(calls).toHaveLength(1);
+    const cmd = calls[0]!.argv[2]!;
+    expect(cmd).toContain("SBX claude -p");
+    expect(cmd).not.toContain("--resume");
+
+    // session_id PERSISTED to the state store (so the next turn resumes it).
+    expect(state.get("eng")).toBe("sess-FIRST");
+    // …and it survives a "restart" (a fresh store instance reads the file).
+    expect(new AgentSessionState({ stateDir }).get("eng")).toBe("sess-FIRST");
+  });
+});
+
+describe("ProgrammaticBackend.deliver — second turn (sid stored)", () => {
+  test("argv includes --resume <sid>; reply extracted; sid stable across turns", async () => {
+    mkDirs("second");
+    const state = new AgentSessionState({ stateDir });
+    // Turn 1 establishes the session; turn 2 must resume it.
+    const { fn, calls } = sequencedSpawn([
+      successTurn("sess-RESUME", "first reply"),
+      successTurn("sess-RESUME", "second reply"),
+    ]);
+    const backend = new ProgrammaticBackend(baseDeps(fn, { sessionState: state }));
+    const handle = await backend.start(specWithVault("eng"));
+
+    const r1 = await backend.deliver(handle, "turn one");
+    expect(r1.ok).toBe(true);
+    expect(state.get("eng")).toBe("sess-RESUME");
+
+    const r2 = await backend.deliver(handle, "turn two");
+    expect(r2.ok).toBe(true);
+    if (r2.ok) expect(r2.reply).toBe("second reply");
+
+    // Turn 1 argv: no --resume. Turn 2 argv: --resume sess-RESUME.
+    const cmd1 = calls[0]!.argv[2]!;
+    const cmd2 = calls[1]!.argv[2]!;
+    expect(cmd1).not.toContain("--resume");
+    expect(cmd2).toContain("--resume sess-RESUME");
+    // The sid is stable (same conversation continued, not forked).
+    expect(state.get("eng")).toBe("sess-RESUME");
+  });
+});
+
+describe("ProgrammaticBackend.deliver — error turn", () => {
+  test("is_error:true → returns { ok:false, error }, no throw; sid still captured", async () => {
+    mkDirs("err");
+    const state = new AgentSessionState({ stateDir });
+    const errBlob = ndjson(
+      { type: "system", subtype: "init", session_id: "sess-ERR", apiKeySource: "none" },
+      { type: "result", subtype: "error_during_execution", is_error: true, result: "boom in the agent", session_id: "sess-ERR" },
+    );
+    const { fn } = recordingSpawn({ stdout: errBlob });
+    const backend = new ProgrammaticBackend(baseDeps(fn, { sessionState: state }));
+    const handle = await backend.start(specWithVault("eng"));
+
+    const result = await backend.deliver(handle, "do a thing");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("boom in the agent");
+      expect(result.sessionId).toBe("sess-ERR");
+    }
+    // The id is still persisted (a turn can fail AFTER establishing a session).
+    expect(state.get("eng")).toBe("sess-ERR");
+  });
+
+  test("a non-success subtype → { ok:false } (no throw)", async () => {
+    mkDirs("err2");
+    const blob = ndjson(
+      { type: "system", subtype: "init", session_id: "s" },
+      { type: "result", subtype: "error_max_turns", is_error: false, result: "ran out", session_id: "s" },
+    );
+    const { fn } = recordingSpawn({ stdout: blob });
+    const backend = new ProgrammaticBackend(baseDeps(fn));
+    const handle = await backend.start(specWithVault());
+    const result = await backend.deliver(handle, "x");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain("error_max_turns");
+  });
+
+  test("a turn that fails BEFORE any session is established has no sessionId on the result", async () => {
+    mkDirs("err-presession");
+    const state = new AgentSessionState({ stateDir });
+    // No init event, no session_id anywhere — an immediate non-success result.
+    const blob = ndjson({ type: "result", subtype: "error_during_execution", is_error: true, result: "died early" });
+    const { fn } = recordingSpawn({ stdout: blob });
+    const backend = new ProgrammaticBackend(baseDeps(fn, { sessionState: state }));
+    const handle = await backend.start(specWithVault("eng"));
+    const result = await backend.deliver(handle, "x");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("died early");
+      expect(result.sessionId).toBeUndefined();
+    }
+    // Nothing persisted (no id to resume).
+    expect(state.get("eng")).toBeUndefined();
+  });
+
+  test("no result event (truncated/crashed turn) + non-zero exit → { ok:false }", async () => {
+    mkDirs("err3");
+    const blob = ndjson({ type: "system", subtype: "init", session_id: "s", apiKeySource: "none" });
+    const { fn } = recordingSpawn({ stdout: blob, stderr: "claude crashed", code: 1 });
+    const backend = new ProgrammaticBackend(baseDeps(fn));
+    const handle = await backend.start(specWithVault());
+    const result = await backend.deliver(handle, "x");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/no success result|exited 1|crashed/);
+  });
+});
+
+describe("ProgrammaticBackend.deliver — argv + env shape", () => {
+  test("argv shape: -p, stream-json, strict-mcp-config, mcp-config, skip-permissions; NO dev-channels", async () => {
+    mkDirs("argv");
+    const { fn, calls } = recordingSpawn({ stdout: successTurn("s", "ok") });
+    const backend = new ProgrammaticBackend(baseDeps(fn));
+    const handle = await backend.start(specWithVault());
+    await backend.deliver(handle, "hello");
+
+    const cmd = calls[0]!.argv[2]!; // the engine echoes the claude command here
+    expect(cmd).toContain(" -p ");
+    expect(cmd).toContain("--output-format stream-json");
+    expect(cmd).toContain("--strict-mcp-config");
+    expect(cmd).toContain("--mcp-config");
+    expect(cmd).toContain("--dangerously-skip-permissions");
+    expect(cmd).not.toContain("dangerously-load-development-channels");
+  });
+
+  test("env: CLAUDE_CODE_OAUTH_TOKEN injected; ANTHROPIC_API_KEY / CLAUDE_API_KEY NOT present (#68 denylist)", async () => {
+    mkDirs("env");
+    const { fn, calls } = recordingSpawn({ stdout: successTurn("s", "ok") });
+    const backend = new ProgrammaticBackend(baseDeps(fn));
+    const handle = await backend.start(specWithVault());
+    await backend.deliver(handle, "hello");
+
+    const env = calls[0]!.env;
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe("OAUTH-CRED-PLACEHOLDER");
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(env.CLAUDE_API_KEY).toBeUndefined();
+    // the sandbox proxy env is layered on top
+    expect(env.SANDBOX_RUNTIME).toBe("1");
+  });
+
+  test("the per-channel env injection (GH_TOKEN) reaches the child; a planted API key is dropped", async () => {
+    mkDirs("env-inject");
+    const { fn, calls } = recordingSpawn({ stdout: successTurn("s", "ok") });
+    const backend = new ProgrammaticBackend(
+      baseDeps(fn, {
+        resolveChannelEnv: () => ({ GH_TOKEN: "ghp_INJECTED", ANTHROPIC_API_KEY: "sk-ant-SMUGGLED" }),
+      }),
+    );
+    const handle = await backend.start(specWithVault());
+    await backend.deliver(handle, "hello");
+
+    const env = calls[0]!.env;
+    expect(env.GH_TOKEN).toBe("ghp_INJECTED");
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined(); // denylist drops it defensively
+  });
+});
+
+describe("ProgrammaticBackend.deliver — MCP config (vault only, no channel)", () => {
+  test("writes a vault-only .mcp.json 0600 — NO channel MCP entry (daemon mediates messaging)", async () => {
+    mkDirs("mcp");
+    const { fn } = recordingSpawn({ stdout: successTurn("s", "ok") });
+    const backend = new ProgrammaticBackend(baseDeps(fn));
+    const handle = await backend.start(specWithVault("eng"));
+    await backend.deliver(handle, "hello");
+
+    const mcpPath = join(sessionsDir, "eng", ".mcp.json");
+    expect(statSync(mcpPath).mode & 0o777).toBe(0o600);
+    const parsed = JSON.parse(readFileSync(mcpPath, "utf8")) as { mcpServers: Record<string, unknown> };
+    // The vault entry is present…
+    expect(parsed.mcpServers[vaultEntryKey("default")]).toBeDefined();
+    // …and NO channel entry (the daemon, not the agent, handles inbound/outbound).
+    expect(parsed.mcpServers[channelEntryKey("eng")]).toBeUndefined();
+    expect(Object.keys(parsed.mcpServers)).toEqual([vaultEntryKey("default")]);
+  });
+
+  test("a spec with no vault → an EMPTY mcpServers config (agent still runs)", async () => {
+    mkDirs("novault");
+    const { fn } = recordingSpawn({ stdout: successTurn("s", "ok") });
+    const backend = new ProgrammaticBackend(baseDeps(fn));
+    const handle = await backend.start({ name: "bare", channels: ["bare"] });
+    const result = await backend.deliver(handle, "hello");
+    expect(result.ok).toBe(true);
+    const parsed = JSON.parse(readFileSync(join(sessionsDir, "bare", ".mcp.json"), "utf8")) as {
+      mcpServers: Record<string, unknown>;
+    };
+    expect(Object.keys(parsed.mcpServers)).toEqual([]);
+  });
+});
+
+describe("ProgrammaticBackend.deliver — robustness", () => {
+  test("interleaved hook/rate_limit lines + a trailing partial line still parse the result", async () => {
+    mkDirs("robust");
+    const messyStdout =
+      "running a user hook...\n" +
+      JSON.stringify({ type: "system", subtype: "init", session_id: "sess-R", apiKeySource: "none" }) + "\n" +
+      JSON.stringify({ type: "system", subtype: "rate_limit_event", rate_limit: { five_hour: { overageStatus: "rejected" } } }) + "\n" +
+      JSON.stringify({ type: "assistant", message: { content: [{ type: "text", text: "..." }] }, session_id: "sess-R" }) + "\n" +
+      JSON.stringify({ type: "result", subtype: "success", is_error: false, result: "robust reply", session_id: "sess-R" }) + "\n" +
+      '{"type":"system","subtype":"in'; // a cut-off trailing partial line
+    const { fn } = recordingSpawn({ stdout: messyStdout });
+    const state = new AgentSessionState({ stateDir });
+    const backend = new ProgrammaticBackend(baseDeps(fn, { sessionState: state }));
+    const handle = await backend.start(specWithVault("eng"));
+    const result = await backend.deliver(handle, "hello");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.reply).toBe("robust reply");
+      expect(result.sessionId).toBe("sess-R");
+    }
+    expect(state.get("eng")).toBe("sess-R");
+  });
+});
+
+describe("ProgrammaticBackend.deliver — credential / mint failures (value, not throw)", () => {
+  test("a missing Claude credential returns { ok:false } and never spawns", async () => {
+    mkDirs("nocred");
+    const { fn, calls } = recordingSpawn({ stdout: successTurn("s", "ok") });
+    const backend = new ProgrammaticBackend(
+      baseDeps(fn, {
+        resolveClaudeToken: () => {
+          throw new Error("no Claude credential for channel \"eng\"");
+        },
+      }),
+    );
+    const handle = await backend.start(specWithVault("eng"));
+    const result = await backend.deliver(handle, "hello");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain("no Claude credential");
+    expect(calls).toHaveLength(0); // never spawned
+  });
+
+  test("a refused vault mint (hub 400) returns { ok:false } and never spawns", async () => {
+    mkDirs("badmint");
+    const { fn, calls } = recordingSpawn({ stdout: successTurn("s", "ok") });
+    const refusingFetch = (async () =>
+      new Response(
+        JSON.stringify({ error: "invalid_scope", error_description: "not grantable by this bearer" }),
+        { status: 400, headers: { "content-type": "application/json" } },
+      )) as unknown as typeof fetch;
+    const backend = new ProgrammaticBackend(baseDeps(fn, { fetchFn: refusingFetch }));
+    const handle = await backend.start(specWithVault("eng"));
+    const result = await backend.deliver(handle, "hello");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/mint refused/);
+    expect(calls).toHaveLength(0); // mint failed before any spawn
+  });
+});
+
+describe("ProgrammaticBackend — start / stop / status", () => {
+  test("start validates the name + channels and carries the spec on the handle", async () => {
+    mkDirs("start");
+    const { fn } = recordingSpawn();
+    const backend = new ProgrammaticBackend(baseDeps(fn));
+    const spec = specWithVault("eng");
+    const handle = await backend.start(spec);
+    expect(handle.backend).toBe(PROGRAMMATIC_BACKEND_KIND);
+    expect(handle.channel).toBe("eng");
+    expect(handle.name).toBe("eng");
+    expect(handle.spec).toEqual(spec);
+
+    await expect(backend.start({ name: "bad name", channels: ["c"] })).rejects.toThrow(/slug/);
+    await expect(backend.start({ name: "ok", channels: [] })).rejects.toThrow(/no channels/);
+  });
+
+  test("stop() clears the persisted resume id (next turn starts fresh)", async () => {
+    mkDirs("stop");
+    const state = new AgentSessionState({ stateDir });
+    const { fn } = recordingSpawn({ stdout: successTurn("sess-STOP", "ok") });
+    const backend = new ProgrammaticBackend(baseDeps(fn, { sessionState: state }));
+    const handle = await backend.start(specWithVault("eng"));
+    await backend.deliver(handle, "hello");
+    expect(state.get("eng")).toBe("sess-STOP");
+    await backend.stop(handle);
+    expect(state.get("eng")).toBeUndefined();
+  });
+
+  test("status() is live (no resident process to keep alive)", async () => {
+    mkDirs("status");
+    const { fn } = recordingSpawn();
+    const backend = new ProgrammaticBackend(baseDeps(fn));
+    const handle = await backend.start(specWithVault());
+    expect(await backend.status(handle)).toEqual({ live: true });
+  });
+});

--- a/src/backends/programmatic.ts
+++ b/src/backends/programmatic.ts
@@ -1,0 +1,435 @@
+/**
+ * The PROGRAMMATIC agent backend (design 2026-06-16-pluggable-agent-backend.md).
+ *
+ * Drives a channel agent by running ONE sandboxed `claude -p` turn per inbound
+ * message and capturing the reply — NO idle interactive session, so the whole
+ * deaf-on-restart fragility class (no-loss replay #67, per-session restart #68,
+ * dev-channels consent gate #70/#71) simply does not exist here. "Wake" is "run the
+ * next turn."
+ *
+ * ── The verified mechanic (spike against claude 2.1.179) ────────────────────────
+ *   claude -p "<message>" \
+ *     --output-format stream-json --verbose \
+ *     --strict-mcp-config --mcp-config <path> \
+ *     --dangerously-skip-permissions \
+ *     [--resume <session_id>]
+ *
+ *   - Runs on the SUBSCRIPTION (`apiKeySource: "none"` in the init event; the
+ *     rate_limit_event shows the `five_hour` subscription pool) — NOT metered API,
+ *     as long as no `ANTHROPIC_API_KEY`/`CLAUDE_API_KEY` is in the env. The
+ *     `total_cost_usd` in the result is an equivalent-cost figure, not a charge.
+ *   - `--resume <session_id>` restores full conversation continuity. FIRST turn:
+ *     omit `--resume`, capture `session_id` from the init/result event, persist it
+ *     (AgentSessionState); subsequent turns pass `--resume <stored id>`.
+ *   - `-p` has NO TUI → no consent gates at all (this backend avoids the #70/#71
+ *     class by construction). Hence NO `--dangerously-load-development-channels`.
+ *
+ * ── What's deliberately ABSENT vs the interactive spawn ─────────────────────────
+ *   - NO channel MCP entry. The daemon mediates messaging in this backend: it
+ *     hands the agent the inbound text as the `-p` prompt, and turns the returned
+ *     reply into an outbound `#channel-message/outbound` note itself (the wiring
+ *     follow-up). The agent's `.mcp.json` carries the VAULT MCP only — so the agent
+ *     has memory + tools, but inbound/outbound is the daemon's job, not the agent's.
+ *   - NO `--dangerously-load-development-channels`, NO consent-gate auto-confirm.
+ *
+ * ── What's REUSED (not reinvented) ──────────────────────────────────────────────
+ *   - `buildAgentChildEnv` — env scrub + `CLAUDE_CODE_OAUTH_TOKEN` inject + the #68
+ *     per-channel env injection + the ANTHROPIC_API_KEY/CLAUDE_API_KEY denylist.
+ *   - `resolveClaudeCredential` + `resolveChannelEnv` (credentials.ts) — the
+ *     per-channel secret/env stores.
+ *   - `seedAgentHome` — the per-session writable HOME/config/tmp (stability keystone).
+ *   - `wrapArgvInSandbox` (spawn-agent.ts) — the SHARED sandbox seam: same egress
+ *     floor + scoped-read confinement the interactive spawn gets.
+ *   - `mintScopedToken` + `buildAgentMcpConfigJson` — the vault token mint + the
+ *     inline MCP config writer.
+ *
+ * ── Single turn, serial per channel ─────────────────────────────────────────────
+ * {@link ProgrammaticBackend.deliver} runs ONE turn. The DAEMON (wiring follow-up)
+ * owns per-channel SERIAL processing — never two concurrent `claude -p` for the
+ * same channel/session, which would FORK the conversation. This backend does not
+ * itself enforce that ordering; it records the latest session id and runs the turn
+ * it is handed.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { AgentSpec } from "../sandbox/types.ts";
+import { normalizeChannel } from "../sandbox/types.ts";
+import type { SandboxEngine } from "../sandbox/index.ts";
+import {
+  buildAgentChildEnv,
+  seedAgentHome,
+  sessionWorkspace,
+  shellJoin,
+  wrapArgvInSandbox,
+} from "../spawn-agent.ts";
+import {
+  mintScopedToken,
+  vaultScope,
+  type MintTokenDeps,
+} from "../mint-token.ts";
+import { buildAgentMcpConfigJson, vaultEntryKey } from "../agent-mcp-config.ts";
+import { resolveClaudeCredential, resolveChannelEnv } from "../credentials.ts";
+import { AgentSessionState } from "../agent-session-state.ts";
+import { parseStreamJson } from "./stream-json.ts";
+import type {
+  AgentBackend,
+  AgentHandle,
+  AgentStatus,
+  DeliverResult,
+  DeliverUsage,
+} from "./types.ts";
+
+/** Same slug shape `spawnAgent` enforces — a name lands in a path segment. */
+const AGENT_NAME_SLUG = /^[a-z0-9_-]+$/i;
+
+export const PROGRAMMATIC_BACKEND_KIND = "programmatic" as const;
+
+/**
+ * The minimal subprocess shape the runner awaits — a slice of `Bun.spawn`'s return
+ * (stdout/stderr streams + `exited`). Tests inject a fake that emits canned
+ * stream-json so no real `claude` is ever spawned.
+ */
+export interface SpawnedProc {
+  stdout: ReadableStream<Uint8Array> | null;
+  stderr: ReadableStream<Uint8Array> | null;
+  exited: Promise<number>;
+}
+export type ProgrammaticSpawnFn = (
+  argv: string[],
+  opts: { env: Record<string, string | undefined>; cwd: string },
+) => SpawnedProc;
+
+/** Wiring the programmatic backend resolves its launch side-effects from. */
+export interface ProgrammaticBackendDeps {
+  /** Hub origin + manager bearer for minting the vault token (§4.3). */
+  hubOrigin: string;
+  managerBearer: string;
+  /** Vault base URL (if the spec binds a vault). Defaults to hubOrigin. */
+  vaultUrl?: string;
+  /** Base for session workspaces (e.g. `~/.parachute/channel/sessions`). */
+  sessionsDir: string;
+  /** Read-only runtime/config binds the sandbox always grants (the claude config dir, …). */
+  runtimeReadOnly: string[];
+  /**
+   * The per-channel session-id store (resume continuity). Injected so tests point
+   * it at a throwaway dir; the daemon constructs one at boot.
+   */
+  sessionState: AgentSessionState;
+  /** Resolve the Claude OAuth token (channel override ?? default ?? throw). Stub in tests. */
+  resolveClaudeToken?: (channel: string) => string;
+  /** Resolve the per-channel env injection (GH_TOKEN, CLOUDFLARE_API_TOKEN, …). Stub in tests. */
+  resolveChannelEnv?: (channel: string) => Record<string, string>;
+  /** Sandbox engine override (tests inject a fake). */
+  sandboxEngine?: SandboxEngine;
+  /** fetch override for the mint client (tests). */
+  fetchFn?: typeof fetch;
+  /**
+   * The subprocess spawner — runs the sandbox-wrapped `claude -p`. Tests inject a
+   * fake that emits canned stream-json; the daemon uses the real Bun.spawn adapter.
+   */
+  spawnFn: ProgrammaticSpawnFn;
+  /** Parent env to scrub from. Defaults to process.env. */
+  parentEnv?: Record<string, string | undefined>;
+  /** claude binary. Defaults to "claude". */
+  claudeBin?: string;
+  /** Optional ripgrep override threaded to the sandbox (macOS deny-path scan). */
+  ripgrep?: { command: string; args?: string[] };
+}
+
+/**
+ * Build the `claude -p` invocation argv (PRE-sandbox-wrap) for one turn.
+ *
+ * The verified shape (claude 2.1.179): headless `-p` with the message as the
+ * prompt, stream-json output, the strict multi-entry MCP config, and
+ * skip-permissions (the turn is autonomous; the sandbox is the containment). When a
+ * `resumeSessionId` is present, `--resume <id>` continues the prior conversation;
+ * the FIRST turn omits it.
+ *
+ * DELIBERATELY ABSENT: `--dangerously-load-development-channels` (no channel MCP in
+ * this backend — the daemon mediates messaging), and any TUI flag (`-p` has none).
+ */
+export function buildProgrammaticClaudeArgs(opts: {
+  message: string;
+  mcpConfigPath: string;
+  resumeSessionId?: string;
+  claudeBin?: string;
+}): string[] {
+  const bin = opts.claudeBin ?? "claude";
+  const argv = [
+    bin,
+    "-p",
+    opts.message,
+    "--output-format",
+    "stream-json",
+    "--verbose",
+    "--strict-mcp-config",
+    "--mcp-config",
+    opts.mcpConfigPath,
+    "--dangerously-skip-permissions",
+  ];
+  if (opts.resumeSessionId) {
+    argv.push("--resume", opts.resumeSessionId);
+  }
+  return argv;
+}
+
+/** Read the full text of a (possibly null) byte stream; null/error → "". */
+async function drainStream(stream: ReadableStream<Uint8Array> | null): Promise<string> {
+  if (!stream) return "";
+  try {
+    return await new Response(stream).text();
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * The programmatic backend — one sandboxed `claude -p` turn per message.
+ *
+ * `start` is lightweight (no resident process; a "session" is just the persisted
+ * resume id). `deliver` runs the turn and returns a {@link DeliverResult} — a
+ * failure is a VALUE (`{ ok: false, error }`), never a throw. `stop` clears the
+ * resume id. `status` is always live (there is nothing to keep alive).
+ */
+export class ProgrammaticBackend implements AgentBackend {
+  readonly kind = PROGRAMMATIC_BACKEND_KIND;
+  private readonly deps: ProgrammaticBackendDeps;
+
+  constructor(deps: ProgrammaticBackendDeps) {
+    this.deps = deps;
+  }
+
+  /**
+   * Bring an agent up for a channel. There is no resident process — this validates
+   * the spec and returns a handle keyed on the wake channel (the first channel).
+   * The actual `claude -p` invocation happens per-message in {@link deliver}.
+   */
+  async start(spec: AgentSpec): Promise<AgentHandle> {
+    if (!AGENT_NAME_SLUG.test(spec.name)) {
+      throw new Error(
+        `ProgrammaticBackend.start: spec name "${spec.name}" must be a slug ` +
+          `(alphanumeric, dash, underscore only)`,
+      );
+    }
+    if (spec.channels.length === 0) {
+      throw new Error(`ProgrammaticBackend.start: spec "${spec.name}" declares no channels`);
+    }
+    const channel = normalizeChannel(spec.channels[0]!).name;
+    return { backend: this.kind, channel, name: spec.name, spec };
+  }
+
+  /**
+   * Run ONE `claude -p` turn for the handle's channel and return its reply.
+   *
+   * Order: resolve the Claude credential (throws → the daemon surfaces it) → mint
+   * the VAULT token (if the spec binds a vault) → write the vault-only `.mcp.json`
+   * → build the `-p` argv (with `--resume <sid>` when a session id is stored) →
+   * sandbox-wrap via the shared seam → spawn → drain + parse the stream-json →
+   * persist the captured session id → return the DeliverResult.
+   *
+   * A failure (mint refused, non-zero exit, `is_error: true`, non-success subtype,
+   * empty output) returns `{ ok: false, error }` — it does NOT throw, so the daemon
+   * always learns the outcome inline.
+   */
+  async deliver(handle: AgentHandle, message: string): Promise<DeliverResult> {
+    const spec = handle.spec;
+    if (!spec) {
+      return { ok: false, error: `ProgrammaticBackend.deliver: handle for "${handle.name}" carries no spec` };
+    }
+    const channel = handle.channel;
+    const workspace = sessionWorkspace(this.deps.sessionsDir, spec.name);
+
+    // Resolve the Claude OAuth credential keyed on the wake channel. A missing
+    // credential throws (CredentialNotConfigured) BEFORE any mint/spawn side effect.
+    const resolveToken = this.deps.resolveClaudeToken ?? ((ch: string) => resolveClaudeCredential(ch));
+    let claudeOauthToken: string;
+    try {
+      claudeOauthToken = resolveToken(channel);
+    } catch (err) {
+      return { ok: false, error: (err as Error).message };
+    }
+
+    // Per-channel env injection (GH_TOKEN, CLOUDFLARE_API_TOKEN, …), read at turn time.
+    const resolveEnv = this.deps.resolveChannelEnv ?? ((ch: string) => resolveChannelEnv(ch));
+    const channelEnv = resolveEnv(channel);
+
+    // Mint the VAULT token only — no channel MCP in this backend (the daemon
+    // mediates messaging). A spec with no vault gets an EMPTY mcpServers config
+    // (the agent still runs; it just has no vault tools this turn).
+    let vaultArg: { url: string; entry: { name: string; token: string } } | undefined;
+    if (spec.vault) {
+      const v = spec.vault;
+      const mintDeps: MintTokenDeps = {
+        hubOrigin: this.deps.hubOrigin,
+        managerBearer: this.deps.managerBearer,
+        ...(this.deps.fetchFn ? { fetchFn: this.deps.fetchFn } : {}),
+      };
+      try {
+        const minted = await mintScopedToken(
+          {
+            scope: vaultScope(v.name, v.access),
+            audience: `vault.${v.name}`,
+            ...(v.tags && v.tags.length > 0 ? { permissions: { scoped_tags: v.tags } } : {}),
+          },
+          mintDeps,
+        );
+        vaultArg = {
+          url: this.deps.vaultUrl ?? this.deps.hubOrigin,
+          entry: { name: v.name, token: minted.token },
+        };
+      } catch (err) {
+        // A refused/over-broad mint aborts the turn with a clean error — no spawn.
+        return { ok: false, error: (err as Error).message };
+      }
+    }
+
+    // Write the (vault-only) strict MCP config 0600 — it inlines the vault token.
+    // No channels[] entry: messaging is the daemon's job, not the agent's. With an
+    // empty `channels`, `channelUrl` is never read (it only builds `/mcp/<channel>`
+    // entry URLs), so we pass "" rather than thread an unrelated origin into a slot
+    // that goes nowhere.
+    const mcpConfigJson = buildAgentMcpConfigJson({
+      channelUrl: "",
+      channels: [],
+      ...(vaultArg ? { vault: vaultArg } : {}),
+    });
+    mkdirSync(workspace, { recursive: true });
+    const mcpConfigPath = join(workspace, ".mcp.json");
+    writeFileSync(mcpConfigPath, mcpConfigJson, { mode: 0o600 });
+
+    // Build the -p argv with --resume when a session id is stored for this channel.
+    const resumeSessionId = this.deps.sessionState.get(channel);
+    const argv = buildProgrammaticClaudeArgs({
+      message,
+      mcpConfigPath,
+      ...(resumeSessionId ? { resumeSessionId } : {}),
+      ...(this.deps.claudeBin ? { claudeBin: this.deps.claudeBin } : {}),
+    });
+
+    // Sandbox-wrap via the SHARED seam — same egress floor + scoped-read
+    // confinement the interactive spawn gets. The wrapped argv carries the policy.
+    const wrapped = await wrapArgvInSandbox({
+      spec,
+      workspace,
+      runtimeReadOnly: this.deps.runtimeReadOnly,
+      hubOrigin: this.deps.hubOrigin,
+      ...(this.deps.vaultUrl ? { vaultUrl: this.deps.vaultUrl } : {}),
+      argv,
+      ...(this.deps.sandboxEngine ? { sandboxEngine: this.deps.sandboxEngine } : {}),
+      ...(this.deps.ripgrep ? { ripgrep: this.deps.ripgrep } : {}),
+    });
+
+    // The agent's private, writable, pre-seeded HOME + temp dirs (stability
+    // keystone). The vault MCP server name is pre-approved so claude doesn't prompt.
+    const mcpServerNames = Object.keys(
+      (JSON.parse(mcpConfigJson) as { mcpServers?: Record<string, unknown> }).mcpServers ?? {},
+    );
+    const homeEnv = seedAgentHome(workspace, { mcpServers: mcpServerNames });
+
+    // Layer the scrubbed agent env UNDER the sandbox wrapper's env; the HOME/config/
+    // temp vars layer LAST so they win. CLAUDE_CODE_OAUTH_TOKEN injected;
+    // ANTHROPIC_API_KEY/CLAUDE_API_KEY absent (the subscription-billing guarantee).
+    const childEnv = buildAgentChildEnv(
+      this.deps.parentEnv ?? process.env,
+      claudeOauthToken,
+      channelEnv,
+    );
+    const launchEnv: Record<string, string | undefined> = {
+      ...childEnv,
+      ...wrapped.env,
+      ...homeEnv,
+    };
+
+    // Run the turn. A spawn/IO fault is a value (not a throw) — the daemon learns it.
+    let stdout: string;
+    let stderr: string;
+    let code: number;
+    try {
+      const proc = this.deps.spawnFn(wrapped.argv, { env: launchEnv, cwd: workspace });
+      [stdout, stderr] = await Promise.all([drainStream(proc.stdout), drainStream(proc.stderr)]);
+      code = await proc.exited;
+    } catch (err) {
+      return { ok: false, error: `claude -p spawn failed: ${(err as Error).message}` };
+    }
+
+    const parsed = parseStreamJson(stdout);
+
+    // Persist the captured session id so the NEXT turn resumes it — even on a
+    // failed turn (a turn can fail AFTER establishing a session; the id is still
+    // the continuation handle). A blank id is a no-op in the store.
+    if (parsed.sessionId) this.deps.sessionState.set(channel, parsed.sessionId);
+
+    const usage: DeliverUsage | undefined = parsed.usage
+      ? {
+          ...(typeof parsed.usage.input_tokens === "number" ? { inputTokens: parsed.usage.input_tokens } : {}),
+          ...(typeof parsed.usage.output_tokens === "number" ? { outputTokens: parsed.usage.output_tokens } : {}),
+          ...(typeof parsed.totalCostUsd === "number" ? { totalCostUsd: parsed.totalCostUsd } : {}),
+        }
+      : typeof parsed.totalCostUsd === "number"
+        ? { totalCostUsd: parsed.totalCostUsd }
+        : undefined;
+
+    // FAILURE paths — all return a value, never throw:
+    //   - non-zero exit with no parseable success result;
+    //   - a result event with is_error / a non-success subtype;
+    //   - no result event at all (crashed/truncated turn).
+    if (parsed.success !== true) {
+      const reason =
+        parsed.errorMessage ??
+        (parsed.subtype ? `claude -p turn failed (subtype: ${parsed.subtype})` : undefined) ??
+        (code !== 0
+          ? `claude -p exited ${code}${stderr.trim() ? `: ${stderr.trim().slice(0, 500)}` : ""}`
+          : "claude -p produced no success result (no result event in output)");
+      return {
+        ok: false,
+        error: reason,
+        ...(parsed.sessionId ? { sessionId: parsed.sessionId } : {}),
+      };
+    }
+
+    return {
+      ok: true,
+      reply: parsed.reply ?? "",
+      ...(parsed.sessionId ? { sessionId: parsed.sessionId } : {}),
+      ...(usage ? { usage } : {}),
+    };
+  }
+
+  /**
+   * Tear the agent down — clear the persisted resume id so the channel's next
+   * message starts a FRESH conversation. There is no process to kill.
+   */
+  async stop(handle: AgentHandle): Promise<void> {
+    this.deps.sessionState.clear(handle.channel);
+  }
+
+  /**
+   * The programmatic backend has no resident process to keep alive — it is always
+   * available to run the next turn, so `live` is true.
+   */
+  async status(_handle: AgentHandle): Promise<AgentStatus> {
+    return { live: true };
+  }
+}
+
+/**
+ * The real `Bun.spawn` adapter for the programmatic backend — pipes stdout/stderr
+ * so the runner can drain the stream-json, applies the launch env + cwd. Used by
+ * the daemon; tests inject a fake `spawnFn` instead.
+ */
+export function realProgrammaticSpawn(spawnFn: typeof Bun.spawn = Bun.spawn): ProgrammaticSpawnFn {
+  return (argv, opts) => {
+    const proc = spawnFn(argv, {
+      env: opts.env,
+      cwd: opts.cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    return {
+      stdout: proc.stdout as ReadableStream<Uint8Array> | null,
+      stderr: proc.stderr as ReadableStream<Uint8Array> | null,
+      exited: proc.exited,
+    };
+  };
+}

--- a/src/backends/stream-json.test.ts
+++ b/src/backends/stream-json.test.ts
@@ -1,0 +1,159 @@
+/**
+ * parseStreamJson tests — the `claude -p --output-format stream-json --verbose`
+ * NDJSON parser. Built to the VERIFIED event shapes (claude 2.1.179).
+ *
+ * Covered:
+ *  - a success turn: session_id from init, reply from result, success/subtype, usage, cost;
+ *  - apiKeySource "none" surfaced (the subscription-auth signal);
+ *  - an error turn (is_error / non-success subtype) → success=false, error message;
+ *  - session_id captured from the FIRST event (init precedes result);
+ *  - robustness: interleaved hook / rate_limit_event lines + a trailing PARTIAL line;
+ *  - no result event at all → success undefined (a truncated/crashed turn);
+ *  - blank/garbage input → an empty parse, never a throw.
+ */
+import { describe, test, expect } from "bun:test";
+import { parseStreamJson } from "./stream-json.ts";
+
+/** Join NDJSON event objects into the line-delimited blob claude emits. */
+function ndjson(...events: unknown[]): string {
+  return events.map((e) => JSON.stringify(e)).join("\n") + "\n";
+}
+
+describe("parseStreamJson — success turn", () => {
+  test("captures session_id (from init), reply (from result), subtype, usage, cost", () => {
+    const blob = ndjson(
+      { type: "system", subtype: "init", session_id: "sess-123", apiKeySource: "none", mcp_servers: [] },
+      { type: "assistant", message: { content: [{ type: "text", text: "hi there" }] }, session_id: "sess-123" },
+      {
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        result: "Here is the final reply.",
+        session_id: "sess-123",
+        usage: { input_tokens: 42, output_tokens: 7 },
+        total_cost_usd: 0.0012,
+      },
+    );
+    const t = parseStreamJson(blob);
+    expect(t.sessionId).toBe("sess-123");
+    expect(t.reply).toBe("Here is the final reply.");
+    expect(t.success).toBe(true);
+    expect(t.subtype).toBe("success");
+    expect(t.isError).toBe(false);
+    expect(t.usage).toEqual({ input_tokens: 42, output_tokens: 7 });
+    expect(t.totalCostUsd).toBe(0.0012);
+  });
+
+  test("surfaces apiKeySource 'none' — the subscription-auth signal (design §1)", () => {
+    const blob = ndjson(
+      { type: "system", subtype: "init", session_id: "s", apiKeySource: "none" },
+      { type: "result", subtype: "success", is_error: false, result: "ok", session_id: "s" },
+    );
+    expect(parseStreamJson(blob).apiKeySource).toBe("none");
+  });
+});
+
+describe("parseStreamJson — error turn", () => {
+  test("is_error true → success=false, error message captured from result", () => {
+    const blob = ndjson(
+      { type: "system", subtype: "init", session_id: "sess-err", apiKeySource: "none" },
+      {
+        type: "result",
+        subtype: "error_during_execution",
+        is_error: true,
+        result: "something went wrong",
+        session_id: "sess-err",
+      },
+    );
+    const t = parseStreamJson(blob);
+    expect(t.success).toBe(false);
+    expect(t.isError).toBe(true);
+    expect(t.subtype).toBe("error_during_execution");
+    expect(t.errorMessage).toBe("something went wrong");
+    // The session id is still captured (a turn can fail AFTER establishing a session).
+    expect(t.sessionId).toBe("sess-err");
+  });
+
+  test("a non-success subtype with is_error false is STILL not success", () => {
+    const blob = ndjson(
+      { type: "system", subtype: "init", session_id: "s" },
+      { type: "result", subtype: "error_max_turns", is_error: false, result: "partial", session_id: "s" },
+    );
+    const t = parseStreamJson(blob);
+    expect(t.success).toBe(false);
+    expect(t.subtype).toBe("error_max_turns");
+  });
+});
+
+describe("parseStreamJson — session_id capture", () => {
+  test("captured from the FIRST event that carries one (init precedes result)", () => {
+    const blob = ndjson(
+      { type: "system", subtype: "init", session_id: "first-id" },
+      { type: "result", subtype: "success", is_error: false, result: "ok", session_id: "first-id" },
+    );
+    expect(parseStreamJson(blob).sessionId).toBe("first-id");
+  });
+
+  test("falls through to the result event's session_id when there's no init", () => {
+    const blob = ndjson({ type: "result", subtype: "success", is_error: false, result: "ok", session_id: "from-result" });
+    expect(parseStreamJson(blob).sessionId).toBe("from-result");
+  });
+});
+
+describe("parseStreamJson — robustness", () => {
+  test("interleaved hook / rate_limit_event lines + a trailing PARTIAL line still parse the result", () => {
+    const blob =
+      // a non-JSON hook line (plain text from a user hook)
+      "running PreToolUse hook...\n" +
+      ndjson({ type: "system", subtype: "init", session_id: "sess-robust", apiKeySource: "none" }).trimEnd() +
+      "\n" +
+      // a rate_limit_event interleaved (the subscription five_hour pool signal)
+      ndjson({ type: "system", subtype: "rate_limit_event", rate_limit: { five_hour: { overageStatus: "rejected" } } }).trimEnd() +
+      "\n" +
+      ndjson({ type: "assistant", message: { content: [{ type: "text", text: "thinking" }] }, session_id: "sess-robust" }).trimEnd() +
+      "\n" +
+      JSON.stringify({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        result: "robust reply",
+        session_id: "sess-robust",
+        usage: { input_tokens: 1, output_tokens: 2 },
+      }) +
+      "\n" +
+      // a TRAILING PARTIAL line — a JSON object cut off mid-stream (no closing brace)
+      '{"type":"system","subtype":"in';
+    const t = parseStreamJson(blob);
+    expect(t.sessionId).toBe("sess-robust");
+    expect(t.reply).toBe("robust reply");
+    expect(t.success).toBe(true);
+    expect(t.apiKeySource).toBe("none");
+  });
+
+  test("blank lines + a leading non-{ line are skipped", () => {
+    const blob =
+      "\n\nsome banner text\n" +
+      JSON.stringify({ type: "result", subtype: "success", is_error: false, result: "ok", session_id: "s" }) +
+      "\n\n";
+    const t = parseStreamJson(blob);
+    expect(t.reply).toBe("ok");
+    expect(t.success).toBe(true);
+  });
+
+  test("no result event at all → success is undefined (a truncated/crashed turn)", () => {
+    const blob = ndjson(
+      { type: "system", subtype: "init", session_id: "sess-trunc", apiKeySource: "none" },
+      { type: "assistant", message: { content: [{ type: "text", text: "started…" }] }, session_id: "sess-trunc" },
+    );
+    const t = parseStreamJson(blob);
+    expect(t.success).toBeUndefined();
+    expect(t.reply).toBeUndefined();
+    expect(t.sessionId).toBe("sess-trunc"); // id still available for a resume
+  });
+
+  test("fully blank / garbage input → an empty parse, never a throw", () => {
+    expect(parseStreamJson("")).toEqual({});
+    expect(parseStreamJson("   \n  \n")).toEqual({});
+    expect(parseStreamJson("not json at all\nmore noise")).toEqual({});
+  });
+});

--- a/src/backends/stream-json.ts
+++ b/src/backends/stream-json.ts
@@ -1,0 +1,139 @@
+/**
+ * Parse `claude -p --output-format stream-json --verbose` output.
+ *
+ * VERIFIED against claude 2.1.179 (spike). The output is NDJSON — one JSON object
+ * per line — but the stream also carries lines we must tolerate without breaking:
+ * hook output, `rate_limit_event`s, blank lines, and (at the tail of a still-open
+ * pipe) a partial final line. The parser is therefore DEFENSIVE: it parses what it
+ * can, ignores any line that isn't a JSON object, and never throws.
+ *
+ * The event types we key on (others are passed over):
+ *
+ *   { "type": "system", "subtype": "init", "session_id": "...",
+ *     "apiKeySource": "none", "mcp_servers": [...], ... }
+ *
+ *   { "type": "assistant", "message": { "content": [{ "type": "text",
+ *     "text": "..." }], ... }, "session_id": "..." }
+ *
+ *   { "type": "result", "subtype": "success", "is_error": false,
+ *     "result": "<final reply text>", "session_id": "...",
+ *     "usage": {...}, "total_cost_usd": ... }
+ *
+ * The `result` event is authoritative: its `result` field is the final reply and
+ * its `is_error` / `subtype` decide success. We also capture `session_id` from the
+ * FIRST event that carries one (the `init` event arrives before `result`), so a
+ * turn that fails AFTER establishing a session still yields the id for a resume.
+ *
+ * `apiKeySource: "none"` on the init event is the SUBSCRIPTION-auth signal — the
+ * turn ran on the operator's subscription, not a metered API key (design §1 / the
+ * Billing caveat). We surface it so a caller / test can assert it.
+ */
+
+/** A parsed `claude -p` stream-json turn. */
+export interface ParsedTurn {
+  /** The session id (from the first event carrying one — init, else result). */
+  sessionId?: string;
+  /** The final reply text (the `result` event's `result` field). */
+  reply?: string;
+  /**
+   * The `result` event's success verdict. `true` only when a `result` event with
+   * `subtype: "success"` and `is_error: false` was seen. Absent (undefined) when no
+   * `result` event arrived at all (a crashed / truncated turn).
+   */
+  success?: boolean;
+  /** The `result` event's `subtype` (e.g. "success", "error_max_turns"). */
+  subtype?: string;
+  /** The `result` event's `is_error` flag, verbatim. */
+  isError?: boolean;
+  /** `apiKeySource` from the init event ("none" = subscription auth — design §1). */
+  apiKeySource?: string;
+  /** Usage from the result event (token counts), passed through verbatim. */
+  usage?: { input_tokens?: number; output_tokens?: number; [k: string]: unknown };
+  /** `total_cost_usd` from the result event (equivalent-cost, NOT a charge — §1). */
+  totalCostUsd?: number;
+  /**
+   * Any error message the result event carried (some failures put the message in
+   * the `result` field even with `is_error: true`). Best-effort.
+   */
+  errorMessage?: string;
+}
+
+interface SystemInitEvent {
+  type: "system";
+  subtype?: string;
+  session_id?: string;
+  apiKeySource?: string;
+}
+interface ResultEvent {
+  type: "result";
+  subtype?: string;
+  is_error?: boolean;
+  result?: string;
+  session_id?: string;
+  usage?: { input_tokens?: number; output_tokens?: number; [k: string]: unknown };
+  total_cost_usd?: number;
+}
+interface AnyEvent {
+  type?: string;
+  session_id?: string;
+  [k: string]: unknown;
+}
+
+/**
+ * Parse a complete stream-json blob (the full stdout of one `claude -p` turn).
+ * Splits on newlines, JSON-parses each non-blank line, and folds the recognized
+ * events into a {@link ParsedTurn}. Lines that aren't a JSON object (hook text, a
+ * trailing partial line, blanks) are silently skipped — robustness is the point.
+ */
+export function parseStreamJson(stdout: string): ParsedTurn {
+  const turn: ParsedTurn = {};
+
+  for (const rawLine of stdout.split("\n")) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    // Fast reject: NDJSON events are objects. A non-`{` line (hook plain text, a
+    // partial line that got cut mid-token) can't be one — skip without a try/catch.
+    if (line[0] !== "{") continue;
+
+    let obj: AnyEvent;
+    try {
+      obj = JSON.parse(line) as AnyEvent;
+    } catch {
+      // A partial/truncated final line, or any non-JSON noise — tolerate it.
+      continue;
+    }
+    if (!obj || typeof obj !== "object") continue;
+
+    // Capture session_id from the FIRST event that has one (init precedes result),
+    // so a turn that errors after init still yields the id for a resume.
+    if (turn.sessionId === undefined && typeof obj.session_id === "string" && obj.session_id) {
+      turn.sessionId = obj.session_id;
+    }
+
+    if (obj.type === "system" && (obj as SystemInitEvent).subtype === "init") {
+      const init = obj as SystemInitEvent;
+      if (typeof init.apiKeySource === "string") turn.apiKeySource = init.apiKeySource;
+      continue;
+    }
+
+    if (obj.type === "result") {
+      const r = obj as ResultEvent;
+      turn.subtype = typeof r.subtype === "string" ? r.subtype : undefined;
+      turn.isError = r.is_error === true;
+      turn.success = r.subtype === "success" && r.is_error !== true;
+      if (typeof r.result === "string") {
+        // `result` carries the reply on success; on some failures it carries the
+        // error message. Record it as both; the caller picks per success/isError.
+        turn.reply = r.result;
+        if (turn.isError) turn.errorMessage = r.result;
+      }
+      if (r.usage && typeof r.usage === "object") turn.usage = r.usage;
+      if (typeof r.total_cost_usd === "number") turn.totalCostUsd = r.total_cost_usd;
+      // Don't `break` — there's only one result event, but draining the rest is
+      // cheap and keeps session_id capture robust if ordering ever surprises us.
+      continue;
+    }
+  }
+
+  return turn;
+}

--- a/src/backends/types.ts
+++ b/src/backends/types.ts
@@ -1,0 +1,155 @@
+/**
+ * The `AgentBackend` seam (design 2026-06-16-pluggable-agent-backend.md).
+ *
+ * A channel agent is "driven" in one of two ways, and the way is a swappable
+ * choice behind ONE interface:
+ *
+ *   - **Interactive** (today's path): an idle interactive `claude` in a tmux pane,
+ *     fed inbound messages by pushing onto a subscribed MCP "development channel."
+ *     `start` = the tmux spawn (`spawnAgent`); `deliver` = a push onto the MCP GET
+ *     stream. This backend carries the whole deaf-on-restart fragility class
+ *     (no-loss high-water-mark + backlog replay #67, per-session restart #68, the
+ *     dev-channels consent-gate auto-confirm #70/#71).
+ *
+ *   - **Programmatic** (this seam's first new implementor — `ProgrammaticBackend`):
+ *     run ONE sandboxed `claude -p` turn per inbound message and capture the reply.
+ *     There is no idle session, so there is nothing to go deaf, nothing to
+ *     reconnect, no backlog to replay, no TUI gate to answer. `deliver` is a direct
+ *     turn into a fresh `claude -p` invocation that resumes the channel's prior
+ *     conversation (`--resume <session_id>`). The daemon turns the returned reply
+ *     into an outbound `#channel-message/outbound` note (the wiring follow-up).
+ *
+ * Everything ABOVE this seam is backend-agnostic: the vault message transport
+ * (`#channel-message/{inbound,outbound}`), the chat UI, the sandbox/isolation
+ * envelope, and the per-channel env/credential injection. Only the
+ * "drive-the-agent" layer differs.
+ *
+ * ── The asymmetric delivery guarantee (design's load-bearing caveat) ────────────
+ * The interactive `deliver` (push onto the MCP GET stream) can SILENTLY fail if
+ * the session is deaf — it is `void` there only because the #67 high-water-mark +
+ * backlog replay catches the gap out-of-band. The programmatic `deliver` is a
+ * direct turn into a fresh invocation, so failure is observable INLINE. To stop the
+ * interactive side's silent-loss footgun leaking into the programmatic contract,
+ * `deliver` returns a {@link DeliverResult} discriminated union — the programmatic
+ * backend reports `{ ok: false, error }` rather than swallowing a failure, and a
+ * future interactive retrofit reports `{ ok: true }` once the push is enqueued
+ * (its real durability staying in the #67 machinery, as today).
+ *
+ * NOTE: this PR defines the contract and ships the PROGRAMMATIC implementor only.
+ * The interactive spawn (`spawnAgent`) is NOT refactored to implement this
+ * interface here — that retrofit is the wiring follow-up. The shape is deliberately
+ * chosen to fit both: `start(spec)` maps to either the tmux spawn or "open a
+ * programmatic session," and `deliver(handle, message)` maps to either a push or a
+ * `claude -p` turn.
+ */
+
+import type { AgentSpec } from "../sandbox/types.ts";
+
+/**
+ * An opaque handle to a started agent, returned by {@link AgentBackend.start} and
+ * passed back to `deliver`/`stop`/`status`. The only field the seam itself depends
+ * on is `channel` (the wake channel a turn/push targets) + the backend's own
+ * `backend` tag; a backend may carry additional private fields it needs.
+ */
+export interface AgentHandle {
+  /** Which backend produced this handle (so a multiplexer can route correctly). */
+  backend: string;
+  /** The wake channel this agent serves (the first channel of its spec). */
+  channel: string;
+  /** The agent's slug name (the spec name). */
+  name: string;
+  /**
+   * The spec the agent was started from. The programmatic backend reproduces each
+   * turn (its mint scope + sandbox policy) from this; a backend that keeps a
+   * resident process (interactive) need not read it. Optional so the seam doesn't
+   * force every backend to round-trip the whole spec on its handle.
+   */
+  spec?: AgentSpec;
+}
+
+/**
+ * Token usage for one turn, surfaced for observability (cost/quota awareness — the
+ * programmatic backend draws on the operator's subscription quota, a real capacity
+ * limit per the design). Shape mirrors what `claude -p`'s `result` event reports;
+ * fields are optional because a backend may not have them.
+ */
+export interface DeliverUsage {
+  inputTokens?: number;
+  outputTokens?: number;
+  /**
+   * The `result` event's `total_cost_usd` — an EQUIVALENT-cost figure on the
+   * subscription path (NOT a charge; the turn draws on the subscription, design §1
+   * of the pluggable-backend doc). Surfaced for observability only.
+   */
+  totalCostUsd?: number;
+}
+
+/**
+ * The result of delivering one message — a discriminated union so a failure is
+ * always observable inline (never a silent drop). On success the daemon turns
+ * `reply` into an outbound `#channel-message/outbound` note (the wiring follow-up).
+ */
+export type DeliverResult =
+  | {
+      ok: true;
+      /** The agent's reply text (the `result` event's `result` field). */
+      reply: string;
+      /**
+       * The session id this turn ran under — captured + persisted so the NEXT turn
+       * resumes the same conversation (`--resume <sessionId>`). Absent if the turn
+       * produced no id (degenerate output).
+       */
+      sessionId?: string;
+      /** Optional token/cost usage for observability. */
+      usage?: DeliverUsage;
+    }
+  | {
+      ok: false;
+      /** A human-readable failure reason (does NOT throw — failure is a value). */
+      error: string;
+      /**
+       * The session id, if one was captured before the failure — so a follow-up
+       * turn can still resume (a turn can fail AFTER establishing a session).
+       */
+      sessionId?: string;
+    };
+
+/** The live/health status of a started agent (for `/health`). */
+export interface AgentStatus {
+  live: boolean;
+}
+
+/**
+ * The pluggable agent-driving seam. A channel chooses a backend; the daemon calls
+ * this interface and stays strategy-agnostic.
+ */
+export interface AgentBackend {
+  /** A stable identifier for the backend kind (e.g. "programmatic", "interactive"). */
+  readonly kind: string;
+
+  /**
+   * Bring an agent up for a channel from its spec. For the programmatic backend
+   * this is lightweight (there is no resident process to launch — a "session" is
+   * just the persisted resume id); for the interactive backend it is the tmux
+   * spawn. Returns an opaque handle the other methods take.
+   */
+  start(spec: AgentSpec): Promise<AgentHandle>;
+
+  /**
+   * Hand the agent one inbound message and get its reply. Returns a
+   * {@link DeliverResult} — a failure is a value (`{ ok: false, error }`), NEVER a
+   * throw, so the caller always learns the outcome inline (the asymmetric-guarantee
+   * fix). The daemon serializes deliveries per channel (one turn at a time).
+   */
+  deliver(handle: AgentHandle, message: string): Promise<DeliverResult>;
+
+  /**
+   * Tear the agent down. For the programmatic backend this clears the persisted
+   * resume id (the next message starts a fresh conversation); for the interactive
+   * backend it kills the tmux session.
+   */
+  stop(handle: AgentHandle): Promise<void>;
+
+  /** Report whether the agent is live (for `/health`). */
+  status(handle: AgentHandle): Promise<AgentStatus>;
+}

--- a/src/spawn-agent.ts
+++ b/src/spawn-agent.ts
@@ -80,6 +80,67 @@ async function withSpawnLock<T>(fn: () => Promise<T>): Promise<T> {
   }
 }
 
+/**
+ * Inputs to {@link wrapArgvInSandbox} — the spec (carries network/filesystem/
+ * mounts/egress), the workspace + runtime read binds, the egress base origins, the
+ * argv to run, and the engine + ripgrep overrides.
+ */
+export interface WrapArgvInSandboxInput {
+  /** The agent spec — its network/filesystem/egress/mounts drive the sandbox config. */
+  spec: AgentSpec;
+  /** Private per-session workspace (rw). */
+  workspace: string;
+  /** Read-only runtime/claude-config binds the session needs to run `claude`. */
+  runtimeReadOnly: string[];
+  /** Hub origin for the non-removable egress base. */
+  hubOrigin: string;
+  /** Vault origin for the egress base (if the spec binds a vault). */
+  vaultUrl?: string;
+  /** The argv to sandbox-wrap (e.g. the `claude …` invocation). */
+  argv: string[];
+  /** Sandbox engine override (tests inject a fake). */
+  sandboxEngine?: SandboxEngine;
+  /**
+   * Optional ripgrep override threaded to the sandbox (macOS deny-path scan needs a
+   * real `rg`; pass one when the host has none on PATH).
+   */
+  ripgrep?: { command: string; args?: string[] };
+}
+
+/**
+ * Sandbox-wrap an argv for one launch — the SHARED sandbox seam both the
+ * interactive {@link spawnAgent} (tmux `claude`) and the programmatic backend
+ * (`claude -p`) call. Extracted so the sandbox/egress/filesystem policy lives in
+ * exactly ONE place: every launch, regardless of backend, gets the same egress
+ * floor (§4.4) + scoped-read confinement (§4.5) baked into its argv.
+ *
+ * It owns the process-wide serialization of the sandbox-runtime singleton's
+ * initialize→wrap window (`withSpawnLock`): the engine is global (one set of host
+ * proxies), so two concurrent wraps would race the initialize→wrap window. Only
+ * that brief window holds the lock — the policy is baked into the returned argv at
+ * `wrap`, after which the spawned process runs independently.
+ */
+export async function wrapArgvInSandbox(input: WrapArgvInSandboxInput): Promise<WrappedCommand> {
+  const baseBinds: BaseBinds = {
+    workspace: input.workspace,
+    runtimeReadOnly: input.runtimeReadOnly,
+  };
+  const egressBase: EgressBaseInput = {
+    hubOrigin: input.hubOrigin,
+    ...(input.vaultUrl ? { vaultOrigin: input.vaultUrl } : {}),
+  };
+  const sandbox = new Sandbox(input.sandboxEngine);
+  return withSpawnLock(() =>
+    sandbox.wrap({
+      spec: input.spec,
+      baseBinds,
+      egressBase,
+      command: shellJoin(input.argv),
+      ...(input.ripgrep ? { ripgrep: input.ripgrep } : {}),
+    }),
+  );
+}
+
 /** A tmux launcher seam — real impl spawns tmux; tests inject a recorder. */
 export interface TmuxLauncher {
   /**
@@ -605,28 +666,21 @@ export async function spawnAgent(
     ...(deps.claudeBin ? { claudeBin: deps.claudeBin } : {}),
   });
 
-  const baseBinds: BaseBinds = {
+  // Sandbox-wrap via the shared seam (also used by the programmatic backend) so
+  // both backends get the identical egress floor + scoped-read confinement, and
+  // the sandbox-runtime singleton's initialize→wrap window is serialized
+  // process-wide. The policy is baked into the returned argv; outside the lock the
+  // spawned process runs independently.
+  const wrapped = await wrapArgvInSandbox({
+    spec,
     workspace,
     runtimeReadOnly: deps.runtimeReadOnly,
-  };
-  const egressBase: EgressBaseInput = {
     hubOrigin: deps.hubOrigin,
-    ...(deps.vaultUrl ? { vaultOrigin: deps.vaultUrl } : {}),
-  };
-
-  // Serialize the sandbox-runtime singleton's initialize→wrap window across
-  // concurrent spawns (the policy is baked into the argv at wrap, so only this
-  // window races). Outside the lock the spawned process runs independently.
-  const sandbox = new Sandbox(deps.sandboxEngine);
-  const wrapped = await withSpawnLock(() =>
-    sandbox.wrap({
-      spec,
-      baseBinds,
-      egressBase,
-      command: shellJoin(claudeArgs),
-      ...(deps.ripgrep ? { ripgrep: deps.ripgrep } : {}),
-    }),
-  );
+    ...(deps.vaultUrl ? { vaultUrl: deps.vaultUrl } : {}),
+    argv: claudeArgs,
+    ...(deps.sandboxEngine ? { sandboxEngine: deps.sandboxEngine } : {}),
+    ...(deps.ripgrep ? { ripgrep: deps.ripgrep } : {}),
+  });
 
   // The agent's private, writable, pre-seeded HOME + temp dirs (the stability
   // keystone — see seedAgentHome). Everything claude reads/writes about itself


### PR DESCRIPTION
## What this is

The **core** of a new *programmatic* agent backend for parachute-channel: run **one sandboxed `claude -p` turn** for a channel and capture the reply, behind a new pluggable **`AgentBackend`** seam. Core only — **no daemon wiring, no UI** (that's the follow-up). Companion to the three design docs: [`pluggable-agent-backend`](design/2026-06-16-pluggable-agent-backend.md), [`sandboxed-agent-sessions`](design/2026-06-14-sandboxed-agent-sessions.md), [`session-environment-and-credentials`](design/2026-06-16-session-environment-and-credentials.md).

The programmatic path deletes the whole interactive fragility class: there's no idle session, so nothing goes deaf, nothing to reconnect, no backlog to replay, no TUI consent gate to auto-answer. "Wake" becomes "run the next turn."

## The verified mechanic (spike against claude 2.1.179 — built to these facts)

```
claude -p "<msg>" --output-format stream-json --verbose \
  --strict-mcp-config --mcp-config <path> --dangerously-skip-permissions \
  [--resume <session_id>]
```

- **Runs on the SUBSCRIPTION** (`apiKeySource:"none"` in the init event; the `rate_limit_event` shows the `five_hour` pool, `overageStatus:"rejected"`) — **NOT metered API**, as long as no `ANTHROPIC_API_KEY`/`CLAUDE_API_KEY` is in the env. The `total_cost_usd` in the result is an equivalent-cost figure, not a charge.
- **stream-json events** (NDJSON, one object per line): `system/init` (`session_id`, `apiKeySource`, `mcp_servers`), `assistant`, `result` (`subtype`, `is_error`, `result` text, `session_id`, `usage`, `total_cost_usd`).
- **`--resume <sid>`** restores full conversation continuity. FIRST turn omits it, captures `session_id`, persists it; subsequent turns resume.
- **`-p` has no TUI → no consent gates** — this backend avoids the #70/#71 class by construction. **No `--dangerously-load-development-channels`, no channel MCP**: the daemon mediates messaging; the agent's `.mcp.json` carries the **VAULT MCP only** (memory + tools, but inbound/outbound is the daemon's job).

## The `AgentBackend` interface (`src/backends/types.ts`)

```ts
interface AgentBackend {
  readonly kind: string;
  start(spec): Promise<AgentHandle>;
  deliver(handle, message): Promise<DeliverResult>; // failure is a VALUE, never a throw
  stop(handle): Promise<void>;
  status(handle): Promise<AgentStatus>;
}
type DeliverResult =
  | { ok: true;  reply: string; sessionId?: string; usage?: DeliverUsage }
  | { ok: false; error: string; sessionId?: string };
```

Shaped to fit **both** the existing interactive push path (`deliver` = push onto the MCP GET stream) and this invoke-and-capture path (`deliver` = a `claude -p` turn). `deliver` returns a discriminated union rather than `void`, so the interactive side's silent-loss footgun (safe only because of the #67 high-water-mark + replay) can't leak into the programmatic contract. **Interactive is NOT retrofitted here** — that's the wiring follow-up; this PR just defines the contract the programmatic side honors.

## What I reused vs. extracted

**Reused (not reinvented):**
- `buildAgentChildEnv` — env scrub + `CLAUDE_CODE_OAUTH_TOKEN` inject + the #68 per-channel env injection + the `ANTHROPIC_API_KEY`/`CLAUDE_API_KEY` denylist.
- `resolveClaudeCredential` + `resolveChannelEnv` (per-channel secret/env stores).
- `seedAgentHome` (per-session writable HOME/config/tmp).
- `mintScopedToken` + `buildAgentMcpConfigJson` (vault token mint + inline MCP config).

**Extracted from `spawnAgent`:** `wrapArgvInSandbox` — a small shared sandbox-wrap helper that owns the `withSpawnLock` serialization of the sandbox-runtime singleton's initialize→wrap window, and that **both** `spawnAgent` and the programmatic backend call. So every launch — interactive or programmatic — gets the identical egress floor + scoped-read confinement baked into its argv. **`spawnAgent`'s behavior is unchanged** (its 41 existing tests still pass).

## Session-state design (`src/agent-session-state.ts`)

Per-channel `<channel> → <session_id>` map, **modeled directly on `src/delivery-state.ts`**: single small JSON file under the channel state dir, **injectable path/dir for tests**, write-through-but-resilient (a failed write is logged + swallowed), load-on-construct, written `0600` (a session id is a continuation handle). Unlike delivery-state's monotonic timestamp mark, `set` is last-write-wins (a fresh session id legitimately replaces a stale one); `clear` drops a channel's id so its next turn starts fresh.

The runner is a **single-turn** function. The daemon (follow-up) owns per-channel **serial** processing — never two concurrent `claude -p` for the same channel/session, which would fork the conversation.

## Files

| File | Role |
|---|---|
| `src/backends/types.ts` | the `AgentBackend` interface + `DeliverResult` union |
| `src/backends/programmatic.ts` | `ProgrammaticBackend` — the single-turn runner |
| `src/backends/stream-json.ts` | defensive NDJSON parser (tolerates interleaved/partial lines; never throws) |
| `src/agent-session-state.ts` | per-channel `session_id` store |
| `src/spawn-agent.ts` | **refactor** — extracted shared `wrapArgvInSandbox` |
| `*.test.ts` (×3) | inject a fake `spawnFn` emitting canned stream-json — never spawns real claude |

## Gates

- **`bun test ./src`**: **553 pass / 0 fail** (baseline 514; **+39 new** across 3 files).
- **`bun run typecheck`**: only the **2 pre-existing `TS2589` in `src/bridge.ts`** (unrelated); **zero new**.
- **`bunx biome check`**: clean.
- Version left at **0.1.0** (preview, no rc bump).

Reviewed by an independent reviewer subagent: **LGTM, no blocking issues**; two cheap nits folded inline (vault-only MCP config no longer threads an unrelated origin; added the inverse test for a pre-session failure → no `sessionId`).

## Deferred to the wiring follow-up

- Daemon ownership of **per-channel serial processing** + turning `reply` into an outbound `#channel-message/outbound` note.
- Retrofitting the **interactive** `spawnAgent` to implement `AgentBackend`.
- Mutual-exclusion so the two backends don't share a workspace for the same agent name.
- An integration test of the real `realProgrammaticSpawn` Bun.spawn adapter (unit suite injects a fake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)