### PR TITLE
feat(channel): wire programmatic agent backend into the daemon

### DIFF
--- a/src/agents-ui.ts
+++ b/src/agents-ui.ts
@@ -204,6 +204,15 @@ ${THEME_CSS}
         </div>
       </div>
 
+      <div style="margin-top:12px;">
+        <label for="spawn-backend">Backend</label>
+        <select id="spawn-backend">
+          <option value="interactive" selected>Interactive — watch / drive a live tmux session</option>
+          <option value="programmatic">Programmatic — clean per-message turns, no live terminal</option>
+        </select>
+        <div id="backend-note" class="muted" style="font-size:12px; margin-top:8px;"></div>
+      </div>
+
       <details id="advanced">
         <summary>Advanced — extra channels, vault, network, mounts</summary>
         <div class="sub">
@@ -517,6 +526,25 @@ ${SHELL_JS}
   netMode.addEventListener("change", syncNetMode);
   syncNetMode(); // default is open → show the note, hide the hosts field
 
+  // Backend toggle: a one-line explanation of each. Interactive = the existing
+  // tmux session you watch/drive (terminal attach). Programmatic = no live
+  // terminal; each inbound message becomes one clean claude -p turn whose reply
+  // is posted back (resume keeps the conversation). The note updates on change.
+  var backendMode = document.getElementById("spawn-backend");
+  function syncBackendMode() {
+    var note = document.getElementById("backend-note");
+    if (backendMode.value === "programmatic") {
+      note.textContent = "Programmatic: no live terminal. Each message runs one on-demand claude -p turn " +
+        "(resumes the prior conversation) and its reply is posted back to the channel. No idle session to go " +
+        "deaf, no reconnect — ideal for fire-and-forget 'do a task, report back'. The Terminal link won't apply.";
+    } else {
+      note.textContent = "Interactive: an idle Claude Code session in a tmux pane you can attach to (Terminal ↗). " +
+        "Messages inject into the live session; you watch it work.";
+    }
+  }
+  backendMode.addEventListener("change", syncBackendMode);
+  syncBackendMode(); // default is interactive
+
   function collectSpec() {
     var wake = chanEl.value;
     if (!wake) throw new Error("pick a channel");
@@ -553,6 +581,8 @@ ${SHELL_JS}
       mounts.push({ hostPath: host, mountPath: mount, mode: row.querySelector(".mt-mode").value });
     });
     if (mounts.length) spec.mounts = mounts;
+    // Backend selector — default interactive (omit so the server default applies).
+    if (backendMode.value === "programmatic") spec.backend = "programmatic";
     return spec;
   }
 
@@ -565,7 +595,13 @@ ${SHELL_JS}
     btn.disabled = true; btn.textContent = "Spawning…";
     apiJson("/api/agents", { method: "POST", body: JSON.stringify(spec) }).then(function (r) {
       var lines = [];
-      if (r.alreadyRunning) {
+      if (r.backend === "programmatic") {
+        // Programmatic spawn returns { name, channel, backend, workspace, alreadyRunning }.
+        lines.push((r.alreadyRunning ? "Re-registered" : "Registered") + " programmatic agent " + r.name + ".");
+        lines.push("channel: " + r.channel);
+        lines.push("workspace: " + r.workspace);
+        lines.push("No tmux session — inbound messages run on-demand claude -p turns; replies post back to the channel.");
+      } else if (r.alreadyRunning) {
         lines.push("Session " + r.session + " is already running (no-op).");
       } else {
         lines.push("Launched " + r.session + ".");
@@ -632,20 +668,40 @@ ${SHELL_JS}
         return;
       }
       var rows = agents.map(function (a) {
-        var att = a.attached ? "<span class='pill attached'>attached</span>" : "<span class='pill detached'>idle</span>";
+        var prog = a.backend === "programmatic";
+        // Backend column: a small label so it's obvious which agents are which.
+        var backendCell = prog
+          ? "<span class='pill connected' title='no tmux — on-demand claude -p turns'>programmatic</span>"
+          : "<span class='pill detached' title='tmux session you can attach to'>interactive</span>";
+        // State column: interactive uses tmux attached; programmatic uses its live
+        // turn status (idle | working | queued:N) reported by the server.
+        var stateCell = prog
+          ? "<span class='pill' title='turn status'>" + esc(a.status || "idle") + "</span>"
+          : (a.attached ? "<span class='pill attached'>attached</span>" : "<span class='pill detached'>idle</span>");
+        // Connection column: programmatic has no live subscriber to count — show
+        // its turn status instead of the SSE/MCP counts. Interactive uses /health.
+        var connCell = prog
+          ? "<span class='pill connected'>● " + esc(a.status || "idle") + "</span>"
+          : connectionCell(liveByChannel[a.name]);
+        // Actions: programmatic has no terminal to attach (no tmux). "restart" maps
+        // to a conversation reset server-side. Chat link still applies (the channel
+        // transcript shows its replies).
+        var actions = "<a href='" + esc(chatUrl(a.name)) + "'>chat →</a>";
+        if (!prog) {
+          actions += "<a href='" + esc(terminalUrl(a.name)) + "' target='_blank' rel='noopener'>terminal ↗</a>";
+        }
+        actions += "<button class='ghost' data-restart='" + esc(a.name) + "' type='button' title='" +
+          (prog ? "Reset the conversation (next message starts fresh)" : "Re-source env + reconnect this session") + "'>" +
+          (prog ? "reset" : "restart / reconnect") + "</button>" +
+          "<button class='ghost danger' data-kill='" + esc(a.name) + "' type='button'>" + (prog ? "deregister" : "kill") + "</button>";
         return "<tr>" +
           "<td><strong>" + esc(a.name) + "</strong></td>" +
-          "<td><code>" + esc(a.session) + "</code></td>" +
-          "<td>" + att + "</td>" +
-          "<td>" + connectionCell(liveByChannel[a.name]) + "</td>" +
-          "<td class='actions'>" +
-            "<a href='" + esc(chatUrl(a.name)) + "'>chat →</a>" +
-            "<a href='" + esc(terminalUrl(a.name)) + "' target='_blank' rel='noopener'>terminal ↗</a>" +
-            "<button class='ghost' data-restart='" + esc(a.name) + "' type='button' title='Re-source env + reconnect this session'>restart / reconnect</button>" +
-            "<button class='ghost danger' data-kill='" + esc(a.name) + "' type='button'>kill</button>" +
-          "</td></tr>";
+          "<td>" + backendCell + "</td>" +
+          "<td>" + stateCell + "</td>" +
+          "<td>" + connCell + "</td>" +
+          "<td class='actions'>" + actions + "</td></tr>";
       }).join("");
-      host.innerHTML = "<table><thead><tr><th>Agent</th><th>tmux session</th><th>State</th><th>Connection</th><th></th></tr></thead><tbody>" +
+      host.innerHTML = "<table><thead><tr><th>Agent</th><th>Backend</th><th>State</th><th>Connection</th><th></th></tr></thead><tbody>" +
         rows + "</tbody></table>";
       host.querySelectorAll("[data-kill]").forEach(function (btn) {
         btn.addEventListener("click", function () { killAgent(btn.getAttribute("data-kill")); });

--- a/src/agents.test.ts
+++ b/src/agents.test.ts
@@ -468,7 +468,7 @@ describe("/api/agents — operator-gated on channel:admin", () => {
     const { srv, base } = buildServer({
       async list() {
         return [
-          { name: "aaron", session: "aaron-agent", attached: true, workspace: "/s/aaron", hasWorkspace: true },
+          { name: "aaron", session: "aaron-agent", attached: true, workspace: "/s/aaron", hasWorkspace: true, backend: "interactive" as const },
         ];
       },
     });

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -30,11 +30,14 @@ import {
   spawnAgent,
   sessionName,
   sessionWorkspace,
+  persistSpec,
   readPersistedSpec,
   type SpawnAgentResult,
   type SpawnAgentDeps,
 } from "./spawn-agent.ts";
 import { resolveSpawnDeps, sessionsDir as defaultSessionsDir } from "./spawn-deps.ts";
+import { normalizeChannel } from "./sandbox/types.ts";
+import { resolveClaudeCredential } from "./credentials.ts";
 
 /** The `-agent` suffix tmux sessions launched by `spawnAgent` carry. */
 const AGENT_SESSION_SUFFIX = "-agent";
@@ -62,6 +65,18 @@ export interface AgentInfo {
   workspace: string;
   /** Whether the session's workspace (with its .mcp.json) is present on disk. */
   hasWorkspace: boolean;
+  /**
+   * Which backend drives this agent. `"interactive"` (the default — a tmux session)
+   * or `"programmatic"` (no tmux; on-demand `claude -p` turns). The list merges
+   * interactive tmux sessions + registered programmatic agents (design 2026-06-16).
+   */
+  backend: "interactive" | "programmatic";
+  /**
+   * Programmatic-only live status — `idle` | `working` | `queued:N` (N = pending).
+   * Absent for interactive agents (their liveness is the tmux `attached` flag +
+   * /health's `mcp_sessions`). Present for programmatic agents in place of those.
+   */
+  status?: string;
 }
 
 /** A redacted mint summary — scope + audience + expiry, NEVER the token value. */
@@ -167,6 +182,7 @@ export function agentInfoFromSessions(
       attached: s.attached,
       workspace,
       hasWorkspace: existsSync(join(workspace, ".mcp.json")),
+      backend: "interactive",
     });
   }
   agents.sort((a, b) => a.name.localeCompare(b.name));
@@ -271,6 +287,16 @@ export function buildSpecFromBody(body: unknown): AgentSpec {
     }
     const mounts = b.mounts.map((raw, i) => parseMountEntry(raw, i));
     if (mounts.length > 0) spec.mounts = mounts;
+  }
+
+  // Backend selector — the pluggable agent backend (design 2026-06-16). Default
+  // `"interactive"` (existing behavior); `"programmatic"` routes to on-demand
+  // `claude -p` turns. Persisted in spec.json so a restart re-registers it.
+  if (b.backend !== undefined && b.backend !== null) {
+    if (b.backend !== "interactive" && b.backend !== "programmatic") {
+      throw new SpawnRequestError('body.backend must be "interactive" or "programmatic"');
+    }
+    spec.backend = b.backend;
   }
 
   return spec;
@@ -466,5 +492,80 @@ export function createRealAgentOps(opts?: {
       const result = await spawnAgent(spec, depsFactory());
       return { ...redactSpawnResult(result), killed };
     },
+  };
+}
+
+/**
+ * The redacted result a PROGRAMMATIC spawn returns to the wire — there is no tmux
+ * session and no per-launch minted-token set (the programmatic backend mints the
+ * vault token per-turn, not at spawn), so this is a thin "registered" acknowledgment
+ * mirroring the interactive result's non-secret fields.
+ */
+export interface ProgrammaticSpawnResult {
+  /** The agent slug. */
+  name: string;
+  /** The wake channel the agent serves. */
+  channel: string;
+  /** Always "programmatic" — lets the page render the right status affordances. */
+  backend: "programmatic";
+  /** Per-session workspace dir (where .mcp.json is written per-turn + spec.json lives). */
+  workspace: string;
+  /** Whether an agent was already registered under this name (idempotent replace). */
+  alreadyRunning: boolean;
+}
+
+/**
+ * Validate + set up a PROGRAMMATIC agent spawn — the no-tmux counterpart to
+ * {@link spawnAgent} (design 2026-06-16 step 2). It does the spawn-time, NON-turn
+ * work: slug-guard the name, require a wake channel, resolve the Claude credential
+ * EARLY (a missing one throws {@link CredentialNotConfiguredError} BEFORE registering
+ * — so a programmatic agent never registers without auth, exactly like the
+ * interactive spawn never launches without it), and persist spec.json (carrying
+ * `backend: "programmatic"`) so a daemon restart re-registers it on boot.
+ *
+ * It does NOT itself register the agent in the live registry or mint any token — the
+ * daemon owns the {@link ProgrammaticAgentRegistry} instance and calls
+ * `registry.register(spec)` after this returns; the per-turn workspace/.mcp.json/mint
+ * are the backend's per-`deliver` job. Returns the (non-secret) workspace + channel.
+ *
+ * `resolveClaudeToken` + `sessionsDirPath` are injectable so tests run hermetically
+ * (no real credential store, a temp sessions dir).
+ */
+export function setupProgrammaticSpawn(
+  spec: AgentSpec,
+  opts?: {
+    resolveClaudeToken?: (channel: string) => string;
+    sessionsDirPath?: string;
+  },
+): ProgrammaticSpawnResult {
+  if (!AGENT_NAME_SLUG.test(spec.name)) {
+    throw new SpawnRequestError(
+      `agent name "${spec.name}" must be a slug (alphanumeric, dash, underscore only)`,
+    );
+  }
+  if (spec.channels.length === 0) {
+    throw new SpawnRequestError(`spec "${spec.name}" declares no channels (the first is the wake channel)`);
+  }
+  const channel = normalizeChannel(spec.channels[0]!).name;
+  const dir = opts?.sessionsDirPath ?? defaultSessionsDir();
+  const workspace = sessionWorkspace(dir, spec.name);
+
+  // Resolve the Claude credential EARLY — a missing one throws
+  // CredentialNotConfiguredError, which the daemon maps to a 400 with the fix, so a
+  // programmatic agent never registers (and never runs a turn) without auth.
+  const resolveToken = opts?.resolveClaudeToken ?? ((ch: string) => resolveClaudeCredential(ch));
+  resolveToken(channel);
+
+  // Was a spec already persisted (an idempotent re-spawn)? Persist the (possibly
+  // updated) spec carrying backend:"programmatic" so a restart re-registers it.
+  const prior = readPersistedSpec(workspace);
+  persistSpec(workspace, { ...spec, backend: "programmatic" });
+
+  return {
+    name: spec.name,
+    channel,
+    backend: "programmatic",
+    workspace,
+    alreadyRunning: prior !== null,
   };
 }

--- a/src/backends/registry.test.ts
+++ b/src/backends/registry.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Tests for the daemon-level PROGRAMMATIC-AGENT registry + per-channel serial queue
+ * (`src/backends/registry.ts`) — the wiring that drives the {@link ProgrammaticBackend}.
+ *
+ * A FAKE backend (implements {@link AgentBackend}) lets us control each turn's
+ * outcome + timing without a real `claude -p`: a deferred-promise gate makes a turn
+ * "run" until the test releases it, so the FIFO / never-concurrent invariant is
+ * directly observable. The outbound writes go to a recorder array. No tmux, no
+ * vault, no hub.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { ProgrammaticAgentRegistry, type WriteOutbound } from "./registry.ts";
+import type { AgentBackend, AgentHandle, AgentStatus, DeliverResult } from "./types.ts";
+import type { AgentSpec } from "../sandbox/types.ts";
+
+/** A deferred promise — resolve it externally to release a gated turn. */
+function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((r) => (resolve = r));
+  return { promise, resolve };
+}
+
+/**
+ * A controllable fake backend. `deliver` records each (channel, message), tracks how
+ * many turns are CONCURRENTLY in flight (the serial-queue invariant asserts this
+ * never exceeds 1), and resolves with whatever `nextResult` says. When `gate` is set,
+ * a turn blocks on it until the test releases it — so we can hold a turn "running"
+ * while we enqueue more.
+ */
+class FakeBackend implements AgentBackend {
+  readonly kind = "programmatic";
+  /** Per-call records, in arrival order. */
+  readonly calls: { channel: string; message: string }[] = [];
+  /** Max concurrent in-flight turns observed (must stay ≤ 1 for serial). */
+  maxConcurrent = 0;
+  private inFlight = 0;
+  /** Whether `stop` was called, per channel. */
+  readonly stopped = new Set<string>();
+  /** A gate the next turn waits on (release to let it finish). Reset per use. */
+  gate: { promise: Promise<void>; resolve: () => void } | null = null;
+  /** The result function — given the message, returns the DeliverResult to resolve. */
+  resultFor: (message: string) => DeliverResult = (m) => ({ ok: true, reply: "reply:" + m });
+  /** If set, `deliver` THROWS this (to test the defensive catch). */
+  throwOnce: Error | null = null;
+
+  async start(spec: AgentSpec): Promise<AgentHandle> {
+    return { backend: this.kind, channel: spec.channels[0] as string, name: spec.name, spec };
+  }
+
+  async deliver(handle: AgentHandle, message: string): Promise<DeliverResult> {
+    this.calls.push({ channel: handle.channel, message });
+    this.inFlight++;
+    this.maxConcurrent = Math.max(this.maxConcurrent, this.inFlight);
+    try {
+      if (this.gate) await this.gate.promise;
+      if (this.throwOnce) {
+        const e = this.throwOnce;
+        this.throwOnce = null;
+        throw e;
+      }
+      return this.resultFor(message);
+    } finally {
+      this.inFlight--;
+    }
+  }
+
+  async stop(handle: AgentHandle): Promise<void> {
+    this.stopped.add(handle.channel);
+  }
+
+  async status(_handle: AgentHandle): Promise<AgentStatus> {
+    return { live: true };
+  }
+}
+
+/** A recorder WriteOutbound — captures every posted reply. */
+function recorder(): { calls: { channel: string; reply: string; inReplyTo?: string }[]; fn: WriteOutbound } {
+  const calls: { channel: string; reply: string; inReplyTo?: string }[] = [];
+  const fn: WriteOutbound = async (channel, reply, inReplyTo) => {
+    calls.push({ channel, reply, ...(inReplyTo ? { inReplyTo } : {}) });
+  };
+  return { calls, fn };
+}
+
+const specFor = (name: string, channel = name): AgentSpec => ({ name, channels: [channel] });
+
+/** Spin the microtask/timer queue until `pred()` is true or we give up. */
+async function until(pred: () => boolean, tries = 200): Promise<void> {
+  for (let i = 0; i < tries && !pred(); i++) {
+    await new Promise<void>((r) => setTimeout(r, 1));
+  }
+}
+
+describe("ProgrammaticAgentRegistry — registration + indexes", () => {
+  test("register indexes by channel + name; has/get reflect it", async () => {
+    const backend = new FakeBackend();
+    const { fn } = recorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: fn });
+
+    expect(reg.hasChannel("eng")).toBe(false);
+    const h = await reg.register(specFor("eng"));
+    expect(h.name).toBe("eng");
+    expect(h.channel).toBe("eng");
+    expect(reg.hasChannel("eng")).toBe(true);
+    expect(reg.hasName("eng")).toBe(true);
+    expect(reg.getByChannel("eng")?.name).toBe("eng");
+    expect(reg.getByName("eng")?.channel).toBe("eng");
+    expect(reg.list().map((x) => x.name)).toEqual(["eng"]);
+  });
+
+  test("deregister drops the indexes + clears the backend session", async () => {
+    const backend = new FakeBackend();
+    const { fn } = recorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: fn });
+    await reg.register(specFor("eng"));
+    expect(await reg.deregister("eng")).toBe(true);
+    expect(reg.hasChannel("eng")).toBe(false);
+    expect(reg.hasName("eng")).toBe(false);
+    expect(backend.stopped.has("eng")).toBe(true);
+    // A second deregister is a no-op false.
+    expect(await reg.deregister("eng")).toBe(false);
+  });
+
+  test("resetSession clears the session WITHOUT deregistering", async () => {
+    const backend = new FakeBackend();
+    const { fn } = recorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: fn });
+    await reg.register(specFor("eng"));
+    expect(await reg.resetSession("eng")).toBe(true);
+    expect(backend.stopped.has("eng")).toBe(true);
+    // Still registered.
+    expect(reg.hasName("eng")).toBe(true);
+    expect(await reg.resetSession("nope")).toBe(false);
+  });
+});
+
+describe("ProgrammaticAgentRegistry — inbound enqueue + outbound", () => {
+  test("a delivered turn writes a non-empty reply as an outbound note", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    await reg.register(specFor("eng"));
+
+    expect(reg.enqueue("eng", { content: "hello", inReplyTo: "note-1" })).toBe(true);
+    await until(() => rec.calls.length === 1);
+
+    expect(backend.calls).toEqual([{ channel: "eng", message: "hello" }]);
+    expect(rec.calls).toEqual([{ channel: "eng", reply: "reply:hello", inReplyTo: "note-1" }]);
+  });
+
+  test("enqueue for an UNREGISTERED channel is a no-op false (caller falls back)", () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    expect(reg.enqueue("ghost", { content: "x" })).toBe(false);
+    expect(backend.calls).toHaveLength(0);
+  });
+
+  test("an EMPTY reply writes NO outbound note (reviewer contract)", async () => {
+    const backend = new FakeBackend();
+    backend.resultFor = () => ({ ok: true, reply: "" });
+    const rec = recorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    await reg.register(specFor("eng"));
+
+    reg.enqueue("eng", { content: "tool-only work" });
+    await until(() => backend.calls.length === 1);
+    // Give any erroneous outbound write a chance to land, then assert none did.
+    await new Promise<void>((r) => setTimeout(r, 5));
+    expect(backend.calls).toHaveLength(1);
+    expect(rec.calls).toHaveLength(0);
+  });
+
+  test("an ok:false turn writes NO note + does not crash/loop", async () => {
+    const backend = new FakeBackend();
+    backend.resultFor = () => ({ ok: false, error: "mint refused" });
+    const rec = recorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    await reg.register(specFor("eng"));
+
+    reg.enqueue("eng", { content: "do it" });
+    await until(() => backend.calls.length === 1);
+    await new Promise<void>((r) => setTimeout(r, 5));
+    // Exactly ONE turn ran (no retry loop), and no note was written.
+    expect(backend.calls).toHaveLength(1);
+    expect(rec.calls).toHaveLength(0);
+  });
+
+  test("a deliver() that THROWS is caught — the worker survives + drains the rest", async () => {
+    const backend = new FakeBackend();
+    backend.throwOnce = new Error("surprise throw");
+    const rec = recorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    await reg.register(specFor("eng"));
+
+    reg.enqueue("eng", { content: "first (throws)" });
+    reg.enqueue("eng", { content: "second (ok)" });
+    await until(() => rec.calls.length === 1);
+    // Both turns ran; the throw on the first didn't strand the second.
+    expect(backend.calls.map((c) => c.message)).toEqual(["first (throws)", "second (ok)"]);
+    expect(rec.calls).toEqual([{ channel: "eng", reply: "reply:second (ok)" }]);
+  });
+});
+
+describe("ProgrammaticAgentRegistry — serial queue (the hard invariant)", () => {
+  test("two inbounds during a running turn are processed ONE AT A TIME, FIFO, never concurrent", async () => {
+    const backend = new FakeBackend();
+    const gate = deferred<void>();
+    backend.gate = { promise: gate.promise, resolve: gate.resolve };
+    const rec = recorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    await reg.register(specFor("eng"));
+
+    // First enqueue starts a turn that blocks on the gate.
+    reg.enqueue("eng", { content: "m1" });
+    await until(() => backend.calls.length === 1);
+    expect(reg.statusOf("eng").state).toBe("working");
+
+    // Two more arrive WHILE the first turn is in flight — they queue.
+    reg.enqueue("eng", { content: "m2" });
+    reg.enqueue("eng", { content: "m3" });
+    // Still exactly one call has STARTED (the gate holds the first; the others wait).
+    expect(backend.calls).toHaveLength(1);
+    expect(reg.statusOf("eng")).toEqual({ state: "queued", queued: 2 });
+
+    // Release the gate: the worker drains m1, then m2, then m3 in order. Because the
+    // gate's promise is already resolved, subsequent turns don't block.
+    gate.resolve();
+    await until(() => rec.calls.length === 3);
+
+    expect(backend.calls.map((c) => c.message)).toEqual(["m1", "m2", "m3"]);
+    expect(rec.calls.map((c) => c.reply)).toEqual(["reply:m1", "reply:m2", "reply:m3"]);
+    // The invariant: never two concurrent turns for the same channel.
+    expect(backend.maxConcurrent).toBe(1);
+    // Queue fully drained → idle.
+    expect(reg.statusOf("eng").state).toBe("idle");
+  });
+
+  test("statusOf — idle with no work, working with one in flight, queued:N with a backlog", async () => {
+    const backend = new FakeBackend();
+    const gate = deferred<void>();
+    backend.gate = { promise: gate.promise, resolve: gate.resolve };
+    const rec = recorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    await reg.register(specFor("eng"));
+    expect(reg.statusOf("eng")).toEqual({ state: "idle", queued: 0 });
+
+    reg.enqueue("eng", { content: "a" });
+    await until(() => backend.calls.length === 1);
+    expect(reg.statusOf("eng")).toEqual({ state: "working", queued: 0 });
+
+    reg.enqueue("eng", { content: "b" });
+    expect(reg.statusOf("eng")).toEqual({ state: "queued", queued: 1 });
+
+    gate.resolve();
+    await until(() => rec.calls.length === 2);
+    expect(reg.statusOf("eng")).toEqual({ state: "idle", queued: 0 });
+  });
+});

--- a/src/backends/registry.ts
+++ b/src/backends/registry.ts
@@ -169,8 +169,12 @@ export class ProgrammaticAgentRegistry {
     const priorChannel = this.nameToChannel.get(spec.name);
     if (priorChannel !== undefined && priorChannel !== channel) {
       // The name moved to a different wake channel — drop the old channel index.
+      // An in-flight drain on the old channel self-terminates (it re-reads
+      // `byChannel`, now empty for that channel); we drop its `draining` flag too so
+      // the entry doesn't leak until that promise happens to settle.
       this.byChannel.delete(priorChannel);
       this.queues.delete(priorChannel);
+      this.draining.delete(priorChannel);
     }
     const backendHandle = await this.backend.start(spec);
     const handle: ProgrammaticAgentHandle = {

--- a/src/backends/registry.ts
+++ b/src/backends/registry.ts
@@ -1,0 +1,320 @@
+/**
+ * The daemon-level PROGRAMMATIC-AGENT registry + per-channel serial queue — the
+ * wiring that makes the {@link ProgrammaticBackend} usable end-to-end (design
+ * 2026-06-16-pluggable-agent-backend.md, the wiring follow-up to PR #73).
+ *
+ * A programmatic agent has NO resident process (unlike the interactive tmux
+ * backend). It is just: a registered handle (workspace + spec + persisted
+ * session_id) and a per-channel serial worker. An inbound message for a registered
+ * channel is ENQUEUED here; the worker drains the queue ONE turn at a time, FIFO,
+ * running a single `claude -p --resume <sid>` turn per message and posting the
+ * reply back as an outbound `#channel-message/outbound` note.
+ *
+ * ── The serial-queue contract (HARD requirement — reviewer contract) ─────────────
+ * Each agent processes turns ONE AT A TIME, FIFO. There is NEVER two concurrent
+ * `claude -p` for the same channel/session — that would FORK the conversation (two
+ * turns resuming the same session_id, racing the session-id store). New inbound
+ * while a turn runs is queued; the worker drains in arrival order. This is enforced
+ * structurally: a single in-flight promise chain per agent (`#draining`), not a
+ * lock the caller must remember to take.
+ *
+ * ── Outbound (design step 5) ─────────────────────────────────────────────────────
+ * On a `deliver()` result that is `ok: true` AND `reply` is non-empty, the worker
+ * writes an outbound note via the injected {@link WriteOutbound} callback — which
+ * the daemon wires to the channel transport's `reply()` (the SAME vault-transport
+ * outbound path the interactive `reply` tool uses, so it's durable + shows in the
+ * chat UI). An EMPTY reply writes NO note (reviewer contract — `reply` can be `""`).
+ * On `ok: false` the error is logged and the turn is DROPPED (no infinite loop, no
+ * retry — a failed turn's session id is already persisted by the backend, so the
+ * next message resumes the conversation). The outbound write goes through `reply()`,
+ * which tags the note `#channel-message/outbound` — the vault inbound trigger keys on
+ * `#channel-message/inbound` only, so writing the reply CANNOT re-trigger the inbound
+ * webhook (no loop).
+ */
+
+import type { AgentSpec } from "../sandbox/types.ts";
+import { normalizeChannel } from "../sandbox/types.ts";
+import type { AgentBackend, AgentHandle } from "./types.ts";
+
+/**
+ * Write an outbound reply for a channel — the seam the registry posts a turn's
+ * reply through. The daemon wires this to the channel transport's `reply()` (a
+ * VaultTransport writes a `#channel-message/outbound` note). `inReplyTo` threads the
+ * reply to the inbound note id when one is known. Returns nothing; a write failure
+ * is the implementation's to surface (the registry logs whatever it throws).
+ */
+export type WriteOutbound = (
+  channel: string,
+  reply: string,
+  inReplyTo?: string,
+) => Promise<void>;
+
+/** A queued inbound message awaiting its serial turn. */
+interface QueuedMessage {
+  /** The inbound text handed to the `claude -p` turn as the prompt. */
+  content: string;
+  /** The inbound note id (if known), threaded into the outbound reply's `in_reply_to`. */
+  inReplyTo?: string;
+}
+
+/** A registered programmatic agent's live status (surfaced in /health + the list). */
+export type ProgrammaticAgentState = "idle" | "working" | "queued";
+
+/**
+ * One registered programmatic agent. Holds the backend handle, its serial queue +
+ * in-flight worker, and a tiny bit of observable state (`working` + queue depth).
+ */
+export interface ProgrammaticAgentHandle {
+  /** The agent slug (the spec name). */
+  name: string;
+  /** The wake channel this agent serves (the first channel of its spec). */
+  channel: string;
+  /** The spec the agent was registered from (carries the workspace/sandbox policy). */
+  spec: AgentSpec;
+  /** The backend's opaque handle (passed to `deliver`/`stop`/`status`). */
+  backendHandle: AgentHandle;
+}
+
+/**
+ * The daemon's registry of programmatic agents + their per-channel serial queues.
+ *
+ * Keyed by CHANNEL (the wake channel) so inbound routing — which only knows the
+ * channel — is an O(1) lookup. A second index by NAME backs the lifecycle ops
+ * (`deregister`, mutual-exclusion check). One instance per daemon, constructed at
+ * boot; injectable deps (`backend`, `writeOutbound`) so tests drive it with a fake
+ * backend + a recorder, no real `claude -p` or vault.
+ */
+export class ProgrammaticAgentRegistry {
+  /** channel → handle (the inbound-routing index). */
+  private readonly byChannel = new Map<string, ProgrammaticAgentHandle>();
+  /** name → channel (the lifecycle index; an agent has exactly one wake channel). */
+  private readonly nameToChannel = new Map<string, string>();
+  /** channel → FIFO queue of pending messages. */
+  private readonly queues = new Map<string, QueuedMessage[]>();
+  /** channel → the in-flight drain promise (its presence == a worker is running). */
+  private readonly draining = new Map<string, Promise<void>>();
+
+  private readonly backend: AgentBackend;
+  private readonly writeOutbound: WriteOutbound;
+
+  constructor(deps: { backend: AgentBackend; writeOutbound: WriteOutbound }) {
+    this.backend = deps.backend;
+    this.writeOutbound = deps.writeOutbound;
+  }
+
+  /** The wake channel for a spec (its first channel, normalized). */
+  private static channelOf(spec: AgentSpec): string {
+    if (spec.channels.length === 0) {
+      throw new Error(`programmatic registry: spec "${spec.name}" declares no channels`);
+    }
+    return normalizeChannel(spec.channels[0]!).name;
+  }
+
+  /** Is a programmatic agent registered for this channel? (the inbound-routing check) */
+  hasChannel(channel: string): boolean {
+    return this.byChannel.has(channel);
+  }
+
+  /** Is a programmatic agent registered under this name? (the mutual-exclusion check) */
+  hasName(name: string): boolean {
+    return this.nameToChannel.has(name);
+  }
+
+  /** The registered handle for a channel, or undefined. */
+  getByChannel(channel: string): ProgrammaticAgentHandle | undefined {
+    return this.byChannel.get(channel);
+  }
+
+  /** The registered handle for a name, or undefined. */
+  getByName(name: string): ProgrammaticAgentHandle | undefined {
+    const channel = this.nameToChannel.get(name);
+    return channel === undefined ? undefined : this.byChannel.get(channel);
+  }
+
+  /** All registered handles (for /health + the GET /api/agents list). */
+  list(): ProgrammaticAgentHandle[] {
+    return [...this.byChannel.values()];
+  }
+
+  /**
+   * The live status of an agent: `working` while a turn is in flight, `queued`
+   * (with the pending count) when messages are waiting, else `idle`. Used by
+   * /health + the agents list to render `programmatic · idle|working|queued:N`.
+   */
+  statusOf(channel: string): { state: ProgrammaticAgentState; queued: number } {
+    const queued = this.queues.get(channel)?.length ?? 0;
+    if (this.draining.has(channel)) {
+      // A worker is in flight. If there are messages waiting BEHIND the in-flight
+      // one, report queued:N (N = waiting, not counting the in-flight turn); else
+      // working. `queued` is the queue length, which excludes the message currently
+      // being processed (it's shifted off before the turn runs).
+      return queued > 0 ? { state: "queued", queued } : { state: "working", queued: 0 };
+    }
+    return { state: "idle", queued: 0 };
+  }
+
+  /**
+   * Register a programmatic agent from its spec — lightweight: validate, build the
+   * backend handle (no resident process), index it by channel + name. The caller
+   * (the spawn path) has already set up the workspace + .mcp.json + credentials +
+   * spec.json. Idempotent-replace: re-registering the same name swaps the handle
+   * (the boot re-register + a re-spawn both land here).
+   *
+   * Returns the registered handle. Throws if the spec declares no channels (a
+   * programmatic agent must have a wake channel to route inbound to).
+   */
+  async register(spec: AgentSpec): Promise<ProgrammaticAgentHandle> {
+    const channel = ProgrammaticAgentRegistry.channelOf(spec);
+    // Replace any prior registration for this name (a re-spawn / boot re-register).
+    const priorChannel = this.nameToChannel.get(spec.name);
+    if (priorChannel !== undefined && priorChannel !== channel) {
+      // The name moved to a different wake channel — drop the old channel index.
+      this.byChannel.delete(priorChannel);
+      this.queues.delete(priorChannel);
+    }
+    const backendHandle = await this.backend.start(spec);
+    const handle: ProgrammaticAgentHandle = {
+      name: spec.name,
+      channel,
+      spec,
+      backendHandle,
+    };
+    this.byChannel.set(channel, handle);
+    this.nameToChannel.set(spec.name, channel);
+    return handle;
+  }
+
+  /**
+   * Deregister a programmatic agent by NAME — drop its indexes + queue and clear
+   * its backend session (so a future re-spawn starts a fresh conversation). An
+   * in-flight turn is NOT cancelled (a `claude -p` turn is a fire-once subprocess;
+   * we just stop routing new inbound to it). Returns whether one was registered.
+   */
+  async deregister(name: string): Promise<boolean> {
+    const channel = this.nameToChannel.get(name);
+    if (channel === undefined) return false;
+    const handle = this.byChannel.get(channel);
+    this.byChannel.delete(channel);
+    this.nameToChannel.delete(name);
+    this.queues.delete(channel);
+    // Clear the persisted resume id so a re-spawn starts fresh (the backend's
+    // `stop` is a no-op beyond that — there's no process to kill).
+    if (handle) {
+      try {
+        await this.backend.stop(handle.backendHandle);
+      } catch (err) {
+        console.error(
+          `parachute-channel: programmatic backend.stop for "${name}" failed (continuing): ${(err as Error).message}`,
+        );
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Reset a programmatic agent's conversation — clear its persisted session id so
+   * the next message starts fresh, WITHOUT deregistering it. This is what the
+   * per-session restart endpoint maps to for a programmatic agent (the interactive
+   * restart's "kill + re-spawn" has no analog — there's no process). Returns whether
+   * an agent was registered under that name.
+   */
+  async resetSession(name: string): Promise<boolean> {
+    const handle = this.getByName(name);
+    if (!handle) return false;
+    try {
+      await this.backend.stop(handle.backendHandle);
+    } catch (err) {
+      console.error(
+        `parachute-channel: programmatic session reset for "${name}" failed: ${(err as Error).message}`,
+      );
+    }
+    return true;
+  }
+
+  /**
+   * ENQUEUE an inbound message for the channel's programmatic agent and ensure the
+   * serial worker is draining. A no-op (returns false) when no programmatic agent
+   * is registered for the channel — the caller falls back to the normal push path.
+   *
+   * The worker is a single in-flight promise chain per channel (`#draining`): if one
+   * is already running, this just appends to the queue and the running worker picks
+   * it up; otherwise it starts a new drain. Concurrency is impossible by
+   * construction — there is at most ONE drain promise per channel at a time, and the
+   * drain processes the queue strictly in order.
+   */
+  enqueue(channel: string, msg: QueuedMessage): boolean {
+    if (!this.byChannel.has(channel)) return false;
+    const queue = this.queues.get(channel) ?? [];
+    queue.push(msg);
+    this.queues.set(channel, queue);
+    // Start the worker if it isn't already running. The drain promise's PRESENCE in
+    // `draining` is the "a worker is running" flag — set it synchronously before any
+    // await so a second enqueue in the same tick can't start a second worker.
+    if (!this.draining.has(channel)) {
+      const p = this.drain(channel).finally(() => {
+        this.draining.delete(channel);
+      });
+      this.draining.set(channel, p);
+    }
+    return true;
+  }
+
+  /**
+   * Drain a channel's queue ONE turn at a time, FIFO, until empty. Each iteration
+   * shifts the oldest message, runs ONE `deliver()` turn, and posts a non-empty
+   * `ok` reply as an outbound note. Never two concurrent turns — the loop awaits each
+   * `deliver()` before shifting the next. Re-checks the queue after each turn so a
+   * message enqueued mid-turn is drained in the same run (no missed wake).
+   *
+   * Failure handling: a `deliver` that returns `{ ok: false }` is LOGGED and dropped
+   * (no retry, no loop — the design's "do NOT infinite-loop" contract). A throw from
+   * `deliver` (it shouldn't — the contract is failure-as-value) is caught so one bad
+   * turn can't kill the worker / strand the rest of the queue. An outbound-write
+   * failure is logged; the turn still counts as drained (the reply is durable-or-not
+   * at the transport's discretion; we don't re-run the turn, which would fork).
+   */
+  private async drain(channel: string): Promise<void> {
+    for (;;) {
+      const queue = this.queues.get(channel);
+      if (!queue || queue.length === 0) return;
+      const handle = this.byChannel.get(channel);
+      if (!handle) return; // deregistered mid-drain — stop.
+      const msg = queue.shift()!;
+
+      let result;
+      try {
+        result = await this.backend.deliver(handle.backendHandle, msg.content);
+      } catch (err) {
+        // The backend contract is failure-as-VALUE, never a throw — but defend so a
+        // surprise throw can't kill the worker and strand the queue.
+        console.error(
+          `parachute-channel: programmatic turn for channel "${channel}" threw ` +
+            `(should be a value): ${(err as Error).message}`,
+        );
+        continue;
+      }
+
+      if (!result.ok) {
+        // Logged + dropped — no retry, no loop. The backend already persisted the
+        // session id (a turn can fail after establishing a session), so the next
+        // message resumes the conversation.
+        console.warn(
+          `parachute-channel: programmatic turn for channel "${channel}" failed: ${result.error}`,
+        );
+        continue;
+      }
+
+      // Empty reply → NO note (reviewer contract — `reply` can be ""). A turn that
+      // legitimately produced no text (e.g. tool-only work) leaves the chat clean.
+      if (result.reply && result.reply.length > 0) {
+        try {
+          await this.writeOutbound(channel, result.reply, msg.inReplyTo);
+        } catch (err) {
+          console.error(
+            `parachute-channel: programmatic outbound write for channel "${channel}" failed: ${(err as Error).message}`,
+          );
+        }
+      }
+    }
+  }
+}

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1815,6 +1815,19 @@ export function createFetchHandler(
             409,
           );
         }
+        // Refuse if a DIFFERENT programmatic agent already claims this wake channel
+        // — a channel routes inbound to at most one agent, and re-registering a new
+        // name onto an occupied channel would orphan the prior one. Re-spawning the
+        // SAME name onto its OWN channel is the idempotent-replace path (allowed).
+        if (programmatic.hasChannel(wakeChannel) && programmatic.getByChannel(wakeChannel)?.name !== spec.name) {
+          return json(
+            {
+              error: `programmatic agent "${programmatic.getByChannel(wakeChannel)?.name}" already ` +
+                `serves channel "${wakeChannel}". Kill it first, or pick a different channel.`,
+            },
+            409,
+          );
+        }
       } else {
         // Interactive spawn — refuse if a PROGRAMMATIC agent already holds this
         // name OR the wake channel (a channel routes inbound to at most one backend).

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -18,7 +18,7 @@
  * disagree (channel#41).
  */
 
-import { mkdirSync, readFileSync } from "fs";
+import { mkdirSync, readFileSync, existsSync, readdirSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 import { timingSafeEqual } from "node:crypto";
@@ -86,11 +86,25 @@ import {
   createRealAgentOps,
   buildSpecFromBody,
   redactSpawnResult,
+  setupProgrammaticSpawn,
   SpawnRequestError,
   AGENT_NAME_SLUG,
   type AgentOps,
+  type AgentInfo,
 } from "./agents.ts";
-import { SpawnDepsError } from "./spawn-deps.ts";
+import { SpawnDepsError, sessionsDir as defaultSessionsDir, resolveSpawnDeps } from "./spawn-deps.ts";
+import {
+  ProgrammaticBackend,
+  realProgrammaticSpawn,
+  type ProgrammaticBackendDeps,
+} from "./backends/programmatic.ts";
+import {
+  ProgrammaticAgentRegistry,
+  type WriteOutbound,
+} from "./backends/registry.ts";
+import { AgentSessionState } from "./agent-session-state.ts";
+import { readPersistedSpec, sessionWorkspace } from "./spawn-agent.ts";
+import { normalizeChannel } from "./sandbox/types.ts";
 import { CredentialNotConfiguredError } from "./credentials.ts";
 import { MintError } from "./mint-token.ts";
 import { validateHubJwt } from "./hub-jwt.ts";
@@ -209,15 +223,31 @@ const START_CMD: string[] = resolveStartCmd(INSTALL_DIR);
 // Registry + routing
 // ---------------------------------------------------------------------------
 
-/** Build the per-channel context a transport routes through. */
-function contextFor(
+/** Build the per-channel context a transport routes through. Exported for tests
+ *  (the inbound-routing fork lives here). */
+export function contextFor(
   registry: ClientRegistry,
   channel: string,
   deliveryState: DeliveryState,
+  programmatic?: ProgrammaticAgentRegistry,
 ): TransportContext {
   return {
     channel,
     emit(msg: InboundMessage): void {
+      // PROGRAMMATIC ROUTING (design 2026-06-16 step 3). If a programmatic agent is
+      // registered for this channel, the inbound becomes one on-demand `claude -p`
+      // turn — ENQUEUE it (the per-channel serial worker drains it) and do NOT also
+      // push to SSE/MCP: a programmatic agent has no live subscriber, so a fan-out
+      // would reach no one AND the delivery high-water-mark must NOT advance (there's
+      // nothing to deliver to; the queue is the durability). The note's id rides in
+      // `meta.note_id` so the reply threads to it.
+      if (programmatic?.hasChannel(channel)) {
+        programmatic.enqueue(channel, {
+          content: msg.content,
+          ...(msg.meta?.note_id ? { inReplyTo: msg.meta.note_id } : {}),
+        });
+        return;
+      }
       // Route on the bound `channel`, NOT msg.channel — the transport's own
       // channel is authoritative. This makes it impossible for a transport to
       // emit onto another channel (closing a silent cross-channel-leak footgun)
@@ -396,6 +426,7 @@ async function addChannelLive(
   registry: ClientRegistry,
   entry: ChannelEntry,
   deliveryState: DeliveryState,
+  programmatic?: ProgrammaticAgentRegistry,
 ): Promise<Channel> {
   const existing = channels.get(entry.name);
   if (existing) {
@@ -411,7 +442,7 @@ async function addChannelLive(
   const transport = instantiateTransport(entry);
   const channel: Channel = { name: entry.name, transport, entry };
   channels.set(entry.name, channel);
-  await transport.start(contextFor(registry, entry.name, deliveryState));
+  await transport.start(contextFor(registry, entry.name, deliveryState, programmatic));
   return channel;
 }
 
@@ -433,6 +464,169 @@ async function removeChannelLive(
   }
   channels.delete(name);
   return true;
+}
+
+// ---------------------------------------------------------------------------
+// Programmatic-agent backend wiring (design 2026-06-16)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the {@link WriteOutbound} the programmatic registry posts a turn's reply
+ * through: resolve the channel's transport from the live `channels` map and call its
+ * `reply()` — the SAME outbound path the interactive `reply` tool uses, so a
+ * programmatic reply is durable + renders in the chat UI exactly like an
+ * interactive one. For a VaultTransport this writes a `#channel-message/outbound`
+ * note; the vault inbound trigger keys on `#channel-message/inbound`, so writing the
+ * reply CANNOT re-trigger the inbound webhook (verified: no loop). `inReplyTo`
+ * threads the reply to the inbound note id.
+ *
+ * A missing transport (channel deregistered between the turn + its reply) throws —
+ * the registry's drain logs it and moves on; it never re-runs the turn (which would
+ * fork the conversation).
+ */
+export function buildWriteOutbound(channels: Map<string, Channel>): WriteOutbound {
+  return async (channel, reply, inReplyTo) => {
+    const ch = channels.get(channel);
+    if (!ch) {
+      throw new Error(`no live transport for channel "${channel}" — cannot post the reply`);
+    }
+    await ch.transport.reply({
+      channel,
+      text: reply,
+      ...(inReplyTo ? { meta: { in_reply_to: inReplyTo } } : {}),
+    });
+  };
+}
+
+/**
+ * Build the REAL programmatic-agent registry — the {@link ProgrammaticBackend}
+ * wired to the env-resolved spawn deps + the per-channel session-id store, plus the
+ * outbound-write callback over the live `channels`. Lazily defaulted by
+ * `createFetchHandler` and constructed explicitly by `main` (so the same instance
+ * the routes use is the one the transports' `contextFor` enqueues onto).
+ *
+ * Best-effort on the backend deps: if the operator token / hub origin can't be
+ * resolved yet, the backend still constructs (its mint happens per-turn and will
+ * surface the error there as a `{ ok: false }` — not at boot), so a daemon with no
+ * hub provisioned yet still starts and can register programmatic agents.
+ */
+export function createDefaultProgrammaticRegistry(
+  channels: Map<string, Channel>,
+): ProgrammaticAgentRegistry {
+  const stateDir = defaultStateDir();
+  const sessionState = new AgentSessionState({ stateDir });
+  // Resolve the spawn deps lazily/defensively — a missing operator token must not
+  // crash boot (the interactive path resolves per-spawn too). We read what we can
+  // and let the per-turn mint surface any gap as a failure-value.
+  let backendDeps: ProgrammaticBackendDeps;
+  try {
+    const deps = resolveSpawnDeps();
+    backendDeps = {
+      hubOrigin: deps.hubOrigin,
+      managerBearer: deps.managerBearer,
+      ...(deps.vaultUrl ? { vaultUrl: deps.vaultUrl } : {}),
+      sessionsDir: deps.sessionsDir,
+      runtimeReadOnly: deps.runtimeReadOnly,
+      sessionState,
+      spawnFn: realProgrammaticSpawn(),
+      ...(deps.claudeBin ? { claudeBin: deps.claudeBin } : {}),
+    };
+  } catch {
+    // No operator token yet — construct with placeholders; a per-turn mint will
+    // fail cleanly (as a value) until the hub is provisioned. The registry + queue
+    // still work; only the actual `claude -p` turn needs the credential.
+    backendDeps = {
+      hubOrigin: "",
+      managerBearer: "",
+      sessionsDir: defaultSessionsDir(),
+      runtimeReadOnly: [],
+      sessionState,
+      spawnFn: realProgrammaticSpawn(),
+    };
+  }
+  const backend = new ProgrammaticBackend(backendDeps);
+  return new ProgrammaticAgentRegistry({
+    backend,
+    writeOutbound: buildWriteOutbound(channels),
+  });
+}
+
+/**
+ * Map the registered programmatic agents to the {@link AgentInfo} shape the
+ * `/api/agents` list returns — `backend: "programmatic"` + a live `status`
+ * (`idle` | `working` | `queued:N`) in place of the interactive `attached`/
+ * `mcp_sessions` liveness (design 2026-06-16 step 6). No tmux session, so `session`
+ * is the conventional `<name>-agent` label for display continuity and `attached` is
+ * always false.
+ */
+export function listProgrammaticAgents(programmatic: ProgrammaticAgentRegistry): AgentInfo[] {
+  const dir = defaultSessionsDir();
+  return programmatic
+    .list()
+    .map((h) => {
+      const s = programmatic.statusOf(h.channel);
+      const status = s.state === "queued" ? `queued:${s.queued}` : s.state;
+      const workspace = sessionWorkspace(dir, h.name);
+      return {
+        name: h.name,
+        session: `${h.name}-agent`,
+        attached: false,
+        workspace,
+        hasWorkspace: existsSync(join(workspace, "spec.json")),
+        backend: "programmatic" as const,
+        status,
+      };
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * BOOT RE-REGISTER (design 2026-06-16 step 2). Scan the per-session workspaces under
+ * the sessions dir, read each `spec.json`, and re-register every spec whose
+ * `backend === "programmatic"` into the live registry — so a programmatic agent,
+ * which has no resident process to survive a restart, resumes routing inbound to an
+ * on-demand turn after a daemon restart. The persisted session_id (a separate store)
+ * makes that next turn `--resume` the prior conversation, so no message is lost in
+ * the restart window beyond the normal inbound-trigger durability.
+ *
+ * INTERACTIVE specs are SKIPPED — their tmux sessions survive a daemon restart on
+ * their own (or are restarted via the supervisor), and re-registering them here
+ * would be wrong (they aren't programmatic). Best-effort: an unreadable spec / a
+ * register failure is logged per-agent and never aborts boot. Returns the count
+ * re-registered. `sessionsDirPath` is injectable for tests.
+ */
+export async function reregisterProgrammaticAgents(
+  programmatic: ProgrammaticAgentRegistry,
+  sessionsDirPath: string = defaultSessionsDir(),
+): Promise<number> {
+  let entries: string[];
+  try {
+    entries = readdirSync(sessionsDirPath, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name);
+  } catch {
+    // No sessions dir yet (first boot) — nothing to re-register.
+    return 0;
+  }
+  let count = 0;
+  for (const name of entries) {
+    const workspace = sessionWorkspace(sessionsDirPath, name);
+    const spec = readPersistedSpec(workspace);
+    if (!spec || spec.backend !== "programmatic") continue;
+    try {
+      await programmatic.register(spec);
+      count++;
+      console.log(`parachute-channel: re-registered programmatic agent "${spec.name}" (channel ${normalizeChannel(spec.channels[0]!).name}).`);
+    } catch (err) {
+      console.error(
+        `parachute-channel: failed to re-register programmatic agent "${name}" from spec.json: ${(err as Error).message}`,
+      );
+    }
+  }
+  if (count > 0) {
+    console.log(`parachute-channel: re-registered ${count} programmatic agent(s) from persisted specs.`);
+  }
+  return count;
 }
 
 // ---------------------------------------------------------------------------
@@ -1055,12 +1249,24 @@ function clampQueryDim(raw: string | null, fallback: number): number {
 export function createFetchHandler(
   channels: Map<string, Channel>,
   registry: ClientRegistry,
-  opts?: { agentOps?: AgentOps; deliveryState?: DeliveryState },
+  opts?: {
+    agentOps?: AgentOps;
+    deliveryState?: DeliveryState;
+    programmatic?: ProgrammaticAgentRegistry;
+  },
 ): (req: Request, server?: { upgrade: (req: Request, opts: { data: TerminalWsData }) => boolean }) => Promise<Response> {
   // Spawn/list/kill operations behind the web agents surface. Lazily defaulted to
   // the real ops (resolve-deps + real tmux); tests inject a stub so the routes are
   // exercised without a hub, a sandbox, or a tmux server. Built once per handler.
   const agentOps: AgentOps = opts?.agentOps ?? createRealAgentOps();
+
+  // The programmatic-agent registry (design 2026-06-16) — inbound for a registered
+  // channel routes to an on-demand `claude -p` turn instead of a push. `main`
+  // constructs the real one (with the real backend + the outbound-write wiring);
+  // tests inject a fake-backed instance. Defaulted lazily to the real registry so a
+  // plain `createFetchHandler(channels, registry)` still wires programmatic agents.
+  const programmatic: ProgrammaticAgentRegistry =
+    opts?.programmatic ?? createDefaultProgrammaticRegistry(channels);
 
   // Per-channel delivery high-water-mark store (the no-silent-loss spine). The
   // daemon's `main` passes the boot-time instance; tests that don't care get a
@@ -1206,7 +1412,10 @@ export function createFetchHandler(
       });
     }
 
-    // Health check — per-channel client counts.
+    // Health check — per-channel client counts. Programmatic agents (design
+    // 2026-06-16 step 6) are listed separately with their backend + live status
+    // (`programmatic · idle|working|queued:N`) instead of `mcp_sessions` — a
+    // programmatic agent has no live subscriber, so SSE/MCP counts don't describe it.
     if (url.pathname === "/health") {
       return json({
         status: "ok",
@@ -1217,6 +1426,15 @@ export function createFetchHandler(
           mcp_sessions: mcpSessionCount(c.name),
         })),
         total_clients: registry.size,
+        programmatic_agents: programmatic.list().map((h) => {
+          const s = programmatic.statusOf(h.channel);
+          return {
+            name: h.name,
+            channel: h.channel,
+            backend: "programmatic",
+            status: s.state === "queued" ? `queued:${s.queued}` : s.state,
+          };
+        }),
       });
     }
 
@@ -1342,7 +1560,7 @@ export function createFetchHandler(
         return json({ error: `failed to write channels.json: ${(err as Error).message}` }, 500);
       }
       try {
-        await addChannelLive(channels, registry, entry, deliveryState);
+        await addChannelLive(channels, registry, entry, deliveryState, programmatic);
       } catch (err) {
         return json(
           {
@@ -1547,7 +1765,13 @@ export function createFetchHandler(
 
       if (req.method === "GET") {
         try {
-          return json({ agents: await agentOps.list() });
+          // The list MERGES interactive tmux sessions + registered programmatic
+          // agents (design 2026-06-16 step 6). Programmatic agents have no tmux
+          // session, so they carry `backend: "programmatic"` + a live `status`
+          // (idle|working|queued:N) instead of `attached`/`mcp_sessions`.
+          const interactive = await agentOps.list();
+          const programmaticInfos = listProgrammaticAgents(programmatic);
+          return json({ agents: [...interactive, ...programmaticInfos] });
         } catch (err) {
           return json({ error: `failed to list agents: ${(err as Error).message}` }, 500);
         }
@@ -1567,6 +1791,61 @@ export function createFetchHandler(
         if (err instanceof SpawnRequestError) return json({ error: err.message }, 400);
         throw err;
       }
+
+      // MUTUAL EXCLUSION (design 2026-06-16 step 7). A given agent name must not run
+      // BOTH backends at once — they'd collide on the same per-session workspace +
+      // spec.json. The wake channel is shared too (one wake source). Reject a spawn
+      // that conflicts with the OTHER backend already active for this name/channel.
+      const wantsProgrammatic = spec.backend === "programmatic";
+      const wakeChannel = normalizeChannel(spec.channels[0]!).name;
+      if (wantsProgrammatic) {
+        // Refuse if an INTERACTIVE tmux session already holds this name.
+        let interactiveLive = false;
+        try {
+          interactiveLive = (await agentOps.list()).some((a) => a.name === spec.name);
+        } catch {
+          // A tmux-list failure shouldn't block a programmatic spawn — proceed.
+        }
+        if (interactiveLive) {
+          return json(
+            {
+              error: `agent "${spec.name}" is already running as an INTERACTIVE (tmux) session. ` +
+                `Kill it first, or spawn the programmatic agent under a different name.`,
+            },
+            409,
+          );
+        }
+      } else {
+        // Interactive spawn — refuse if a PROGRAMMATIC agent already holds this
+        // name OR the wake channel (a channel routes inbound to at most one backend).
+        if (programmatic.hasName(spec.name) || programmatic.hasChannel(wakeChannel)) {
+          return json(
+            {
+              error: `a PROGRAMMATIC agent is already registered for ` +
+                `${programmatic.hasName(spec.name) ? `name "${spec.name}"` : `channel "${wakeChannel}"`}. ` +
+                `Kill it first, or pick a different name/channel for the interactive session.`,
+            },
+            409,
+          );
+        }
+      }
+
+      // PROGRAMMATIC spawn — no tmux. Validate + persist spec.json (the no-tmux
+      // setup), then register in the live registry (so inbound for the channel
+      // enqueues). Boot re-registers from the persisted spec on the next restart.
+      if (wantsProgrammatic) {
+        try {
+          const setup = setupProgrammaticSpawn(spec);
+          await programmatic.register({ ...spec, backend: "programmatic" });
+          return json(setup);
+        } catch (err) {
+          if (err instanceof SpawnRequestError) return json({ error: err.message }, 400);
+          if (err instanceof CredentialNotConfiguredError) return json({ error: err.message }, 400);
+          return json({ error: (err as Error).message }, 400);
+        }
+      }
+
+      // INTERACTIVE spawn (the existing tmux path, UNCHANGED).
       try {
         const result = await agentOps.spawn(spec);
         return json(redactSpawnResult(result));
@@ -1599,6 +1878,21 @@ export function createFetchHandler(
       const denied = await requireScope(req, url, SCOPE_ADMIN);
       if (denied) return denied;
       const name = decodeURIComponent(restartMatch[1]!);
+      // PROGRAMMATIC restart — there is no tmux session to kill + re-spawn (the
+      // interactive restart's whole job). The closest analog is RESETTING the
+      // conversation: clear the persisted session id so the next message starts
+      // fresh. The agent stays registered. (design 2026-06-16 step 6 — the
+      // per-session restart is interactive-only; programmatic resets session-state.)
+      if (programmatic.hasName(name)) {
+        await programmatic.resetSession(name);
+        return json({
+          ok: true,
+          name,
+          backend: "programmatic",
+          session_reset: true,
+          note: "programmatic agent — conversation reset (next message starts a fresh session); no process to restart.",
+        });
+      }
       try {
         const result = await agentOps.restart(name);
         return json(result);
@@ -1618,6 +1912,12 @@ export function createFetchHandler(
       const denied = await requireScope(req, url, SCOPE_ADMIN);
       if (denied) return denied;
       const name = decodeURIComponent(agentMatch[1]!);
+      // PROGRAMMATIC delete — deregister (drop the channel/name indexes + queue,
+      // clear the backend session). No tmux to kill (design 2026-06-16 step 6).
+      if (programmatic.hasName(name)) {
+        const deregistered = await programmatic.deregister(name);
+        return json({ ok: true, name, backend: "programmatic", killed: deregistered });
+      }
       try {
         const { killed } = await agentOps.kill(name);
         return json({ ok: true, name, killed });
@@ -2183,13 +2483,21 @@ function main(): void {
     defaultMark: new Date().toISOString(),
   });
 
+  // The PROGRAMMATIC-agent registry (design 2026-06-16), constructed ONCE at boot
+  // and shared by the fetch handler (the /api/agents + /health routes), the
+  // transports' `contextFor` (inbound enqueue), and the boot re-register below — so
+  // the SAME instance the routes operate on is the one inbound enqueues onto. Built
+  // here (not lazily in createFetchHandler) precisely so the transports started
+  // below route inbound to it.
+  const programmatic = createDefaultProgrammaticRegistry(channels);
+
   // The terminal WS handler set (pty↔socket relay + backpressure flow control,
   // src/terminal.ts). One handler object serves every terminal connection;
   // per-connection state lives on `ws.data`. The fetch handler routes accepted
   // upgrades into these via `server.upgrade(req, { data })`.
   const terminalWs = createTerminalWsHandlers();
 
-  const fetchHandler = createFetchHandler(channels, registry, { deliveryState });
+  const fetchHandler = createFetchHandler(channels, registry, { deliveryState, programmatic });
   const server = Bun.serve<TerminalWsData, never>({
     port: PORT,
     hostname: "127.0.0.1",
@@ -2271,12 +2579,22 @@ function main(): void {
   // the channels (from `loadRegistry`); addChannelLive replaces-in-place, which
   // for a freshly-instantiated boot transport means stop()→re-instantiate→start.
   // Per-channel failures are logged and don't abort the others; the daemon must
-  // still serve the channels that did come up.
+  // still serve the channels that did come up. Pass the programmatic registry so a
+  // channel with a registered programmatic agent routes inbound to its serial queue.
   for (const channel of [...channels.values()]) {
-    addChannelLive(channels, registry, channel.entry, deliveryState).catch((err) => {
+    addChannelLive(channels, registry, channel.entry, deliveryState, programmatic).catch((err) => {
       console.error(`parachute-channel: transport "${channel.name}" start failed:`, err);
     });
   }
+
+  // BOOT RE-REGISTER (design 2026-06-16 step 2). A programmatic agent has NO
+  // resident process, so it doesn't survive a daemon restart as a tmux session
+  // would — but its spec.json (carrying `backend: "programmatic"`) persists. Scan
+  // the per-session workspaces and re-register every programmatic spec so inbound
+  // for its channel resumes routing to an on-demand turn (the persisted session_id
+  // makes the next turn `--resume` the prior conversation — no deaf problem). Best-
+  // effort: a single bad spec is logged and skipped.
+  void reregisterProgrammaticAgents(programmatic);
 
   // Graceful shutdown — stop all transports.
   async function shutdown(): Promise<void> {

--- a/src/programmatic-wiring.test.ts
+++ b/src/programmatic-wiring.test.ts
@@ -400,6 +400,28 @@ describe("mutual exclusion (design step 7)", () => {
     }
   });
 
+  test("a DIFFERENT programmatic name onto an already-claimed channel → 409 (no orphan)", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const programmatic = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    await programmatic.register({ name: "eng-a", channels: ["eng"], backend: "programmatic" });
+    const ops = stubAgentOps();
+    const { srv, base } = buildServer({ channels: new Map(), agentOps: ops, programmatic });
+    try {
+      const res = await fetch(`${base}/api/agents`, {
+        method: "POST",
+        headers: { ...adminAuth, "content-type": "application/json" },
+        body: JSON.stringify({ name: "eng-b", channels: ["eng"], backend: "programmatic" }),
+      });
+      expect(res.status).toBe(409);
+      // The prior agent is untouched (not orphaned by an overwrite).
+      expect(programmatic.getByChannel("eng")?.name).toBe("eng-a");
+      expect(programmatic.hasName("eng-b")).toBe(false);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
   test("interactive spawn when a programmatic agent holds the channel → 409 (tmux NOT spawned)", async () => {
     const backend = new FakeBackend();
     const rec = recorder();

--- a/src/programmatic-wiring.test.ts
+++ b/src/programmatic-wiring.test.ts
@@ -1,0 +1,466 @@
+/**
+ * Daemon-level wiring tests for the PROGRAMMATIC agent backend (design
+ * 2026-06-16-pluggable-agent-backend.md, the wiring follow-up to PR #73).
+ *
+ * Exercises the REAL daemon fetch handler + a real {@link ProgrammaticAgentRegistry}
+ * backed by a FAKE {@link AgentBackend} (no `claude -p`) + a recorder outbound write
+ * (no vault). The hub-jwt validator is mocked (the sentinel-token harness the other
+ * daemon tests use) so a known Bearer carries channel:admin/send WITHOUT a live hub.
+ *
+ * Covered (the prompt's test list):
+ *   - spawn with backend:"programmatic" → no tmux session, agent registered,
+ *     spec.json carries backend;
+ *   - inbound for a programmatic channel → deliver invoked, reply → outbound note;
+ *     EMPTY reply → NO note;
+ *   - ok:false → no outbound note + no crash/loop (the registry unit test covers the
+ *     queue mechanics; here we assert it end-to-end through the inbound route);
+ *   - boot re-register: a persisted programmatic spec.json → re-registered;
+ *   - /health + GET /api/agents include the programmatic agent with its status;
+ *   - mutual exclusion: programmatic vs interactive collision → 409;
+ *   - interactive path untouched (a backend:"interactive" / default spawn still hits
+ *     the tmux AgentOps).
+ */
+
+import { describe, test, expect, mock } from "bun:test";
+
+const ADMIN_TOKEN = "test-admin-token"; // channel:read + send + admin
+import { HubJwtError, looksLikeJwt } from "@openparachute/scope-guard";
+mock.module("./hub-jwt.ts", () => ({
+  CHANNEL_AUDIENCE: "channel",
+  async validateHubJwt(token: string) {
+    const base = { sub: "test", aud: "channel", jti: undefined, clientId: undefined, vaultScope: undefined };
+    if (token === ADMIN_TOKEN) return { ...base, scopes: ["channel:read", "channel:send", "channel:admin"] };
+    throw new HubJwtError("issuer", "invalid token");
+  },
+  HubJwtError,
+  looksLikeJwt,
+  resetJwksCache() {},
+  resetRevocationCache() {},
+}));
+
+import { mkdtempSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createFetchHandler,
+  contextFor,
+  reregisterProgrammaticAgents,
+  buildWriteOutbound,
+} from "./daemon.ts";
+import { ClientRegistry } from "./routing.ts";
+import { DeliveryState } from "./delivery-state.ts";
+import { ProgrammaticAgentRegistry, type WriteOutbound } from "./backends/registry.ts";
+import type { AgentBackend, AgentHandle, AgentStatus, DeliverResult } from "./backends/types.ts";
+import type { AgentSpec } from "./sandbox/types.ts";
+import { VaultTransport } from "./transports/vault.ts";
+import { persistSpec, sessionWorkspace } from "./spawn-agent.ts";
+import type { Channel } from "./registry.ts";
+import type { AgentOps, AgentInfo, SpawnRequestError } from "./agents.ts";
+
+const adminAuth = { authorization: "Bearer " + ADMIN_TOKEN };
+
+/** A controllable fake backend (no `claude -p`). */
+class FakeBackend implements AgentBackend {
+  readonly kind = "programmatic";
+  readonly calls: { channel: string; message: string }[] = [];
+  resultFor: (message: string) => DeliverResult = (m) => ({ ok: true, reply: "reply:" + m });
+  async start(spec: AgentSpec): Promise<AgentHandle> {
+    return { backend: this.kind, channel: spec.channels[0] as string, name: spec.name, spec };
+  }
+  async deliver(handle: AgentHandle, message: string): Promise<DeliverResult> {
+    this.calls.push({ channel: handle.channel, message });
+    return this.resultFor(message);
+  }
+  async stop(): Promise<void> {}
+  async status(): Promise<AgentStatus> {
+    return { live: true };
+  }
+}
+
+/** A stub interactive AgentOps that records spawns + lists, with no real tmux. */
+function stubAgentOps(initial: AgentInfo[] = []): AgentOps & { spawned: AgentSpec[]; killed: string[] } {
+  const spawned: AgentSpec[] = [];
+  const killed: string[] = [];
+  return {
+    spawned,
+    killed,
+    async spawn(spec) {
+      spawned.push(spec);
+      // Minimal SpawnAgentResult — enough for redactSpawnResult.
+      return {
+        session: spec.name + "-agent",
+        workspace: "/tmp/ws/" + spec.name,
+        tokens: {},
+        mcpConfigJson: "{}",
+        wrapped: { argv: [], env: {}, config: { network: { allowedDomains: [], deniedDomains: [] }, filesystem: { denyRead: [], allowWrite: [], denyWrite: [] } } },
+        alreadyRunning: false,
+      };
+    },
+    async list() {
+      return initial;
+    },
+    async kill(name) {
+      killed.push(name);
+      return { killed: true };
+    },
+    async restart() {
+      throw new Error("not used") as unknown as SpawnRequestError;
+    },
+  };
+}
+
+function recorder(): { calls: { channel: string; reply: string; inReplyTo?: string }[]; fn: WriteOutbound } {
+  const calls: { channel: string; reply: string; inReplyTo?: string }[] = [];
+  const fn: WriteOutbound = async (channel, reply, inReplyTo) => {
+    calls.push({ channel, reply, ...(inReplyTo ? { inReplyTo } : {}) });
+  };
+  return { calls, fn };
+}
+
+/** A VaultTransport whose ctx is bound to the programmatic-aware contextFor. */
+function vaultChannel(
+  name: string,
+  registry: ClientRegistry,
+  deliveryState: DeliveryState,
+  programmatic: ProgrammaticAgentRegistry,
+): Channel {
+  const t = new VaultTransport({ vault: "default", vaultUrl: "http://127.0.0.1:1940", token: "x" });
+  // Bind the REAL programmatic-aware ctx (no network: we don't call ensureSchema).
+  (t as unknown as { ctx: unknown }).ctx = contextFor(registry, name, deliveryState, programmatic);
+  return { name, transport: t, entry: { name, transport: "vault" } };
+}
+
+function buildServer(opts: {
+  channels: Map<string, Channel>;
+  agentOps?: AgentOps;
+  programmatic: ProgrammaticAgentRegistry;
+  deliveryState?: DeliveryState;
+}) {
+  const registry = new ClientRegistry();
+  const srv = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    idleTimeout: 0,
+    fetch: createFetchHandler(opts.channels, registry, {
+      ...(opts.agentOps ? { agentOps: opts.agentOps } : {}),
+      programmatic: opts.programmatic,
+      ...(opts.deliveryState ? { deliveryState: opts.deliveryState } : {}),
+    }),
+  });
+  return { srv, base: `http://127.0.0.1:${srv.port}` };
+}
+
+async function until(pred: () => boolean, tries = 200): Promise<void> {
+  for (let i = 0; i < tries && !pred(); i++) await new Promise<void>((r) => setTimeout(r, 1));
+}
+
+describe("spawn with backend:'programmatic'", () => {
+  test("→ no tmux spawn, agent registered, spec.json carries backend", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "prog-spawn-"));
+    try {
+      const backend = new FakeBackend();
+      const rec = recorder();
+      const programmatic = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+      const ops = stubAgentOps();
+      // Point the channel state dir at our temp via PARACHUTE_CHANNEL_STATE_DIR so
+      // defaultStateDir → <dir> and the sessions dir + credentials store land under
+      // it (NOT the operator's real ~/.parachute).
+      const prevStateDir = process.env.PARACHUTE_CHANNEL_STATE_DIR;
+      process.env.PARACHUTE_CHANNEL_STATE_DIR = dir;
+      // Seed a default Claude credential so setupProgrammaticSpawn's early resolve
+      // succeeds against the temp store (no real store touched).
+      const { writeFileSync } = await import("node:fs");
+      writeFileSync(join(dir, "credentials.json"), JSON.stringify({ claude: { default: "oat_test" } }), { mode: 0o600 });
+
+      const { srv, base } = buildServer({
+        channels: new Map(),
+        agentOps: ops,
+        programmatic,
+      });
+      try {
+        const res = await fetch(`${base}/api/agents`, {
+          method: "POST",
+          headers: { ...adminAuth, "content-type": "application/json" },
+          body: JSON.stringify({ name: "eng", channels: ["eng"], backend: "programmatic" }),
+        });
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as { backend: string; name: string; channel: string };
+        expect(body.backend).toBe("programmatic");
+        expect(body.name).toBe("eng");
+        expect(body.channel).toBe("eng");
+
+        // No tmux spawn happened (the interactive AgentOps.spawn was never called).
+        expect(ops.spawned).toHaveLength(0);
+        // The agent is registered in the live registry.
+        expect(programmatic.hasName("eng")).toBe(true);
+        expect(programmatic.hasChannel("eng")).toBe(true);
+        // spec.json on disk carries backend:"programmatic".
+        const specPath = join(sessionWorkspace(join(dir, "sessions"), "eng"), "spec.json");
+        expect(existsSync(specPath)).toBe(true);
+        const persisted = JSON.parse(readFileSync(specPath, "utf-8")) as AgentSpec;
+        expect(persisted.backend).toBe("programmatic");
+      } finally {
+        srv.stop(true);
+        if (prevStateDir === undefined) delete process.env.PARACHUTE_CHANNEL_STATE_DIR;
+        else process.env.PARACHUTE_CHANNEL_STATE_DIR = prevStateDir;
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("inbound for a programmatic channel → deliver → outbound note", () => {
+  async function inbound(base: string, channel: string, noteId: string, content: string) {
+    return fetch(`${base}/api/vault/inbound`, {
+      method: "POST",
+      headers: { ...adminAuth, "content-type": "application/json" },
+      body: JSON.stringify({
+        note: {
+          id: noteId,
+          content,
+          tags: ["#channel-message", "#channel-message/inbound"],
+          metadata: { channel, direction: "inbound", sender: "aaron", ts: "2026-06-16T00:00:01Z" },
+        },
+      }),
+    });
+  }
+
+  test("a registered programmatic channel: inbound → deliver invoked, reply → outbound note", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const programmatic = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    await programmatic.register({ name: "eng", channels: ["eng"], backend: "programmatic" });
+
+    const registry = new ClientRegistry();
+    const deliveryState = new DeliveryState();
+    const channels = new Map<string, Channel>([
+      ["eng", vaultChannel("eng", registry, deliveryState, programmatic)],
+    ]);
+    const { srv, base } = buildServer({ channels, programmatic, deliveryState });
+    try {
+      const res = await inbound(base, "eng", "note-1", "hello there");
+      expect(res.status).toBe(200);
+      await until(() => rec.calls.length === 1);
+      // deliver invoked with the inbound content.
+      expect(backend.calls).toEqual([{ channel: "eng", message: "hello there" }]);
+      // reply written as an outbound note, threaded to the inbound note id.
+      expect(rec.calls).toEqual([{ channel: "eng", reply: "reply:hello there", inReplyTo: "note-1" }]);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("EMPTY reply → NO outbound note", async () => {
+    const backend = new FakeBackend();
+    backend.resultFor = () => ({ ok: true, reply: "" });
+    const rec = recorder();
+    const programmatic = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    await programmatic.register({ name: "eng", channels: ["eng"], backend: "programmatic" });
+
+    const registry = new ClientRegistry();
+    const deliveryState = new DeliveryState();
+    const channels = new Map<string, Channel>([
+      ["eng", vaultChannel("eng", registry, deliveryState, programmatic)],
+    ]);
+    const { srv, base } = buildServer({ channels, programmatic, deliveryState });
+    try {
+      await inbound(base, "eng", "note-1", "tool-only work");
+      await until(() => backend.calls.length === 1);
+      await new Promise<void>((r) => setTimeout(r, 5));
+      expect(backend.calls).toHaveLength(1);
+      expect(rec.calls).toHaveLength(0);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("ok:false → no outbound note + no crash/loop", async () => {
+    const backend = new FakeBackend();
+    backend.resultFor = () => ({ ok: false, error: "mint refused" });
+    const rec = recorder();
+    const programmatic = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    await programmatic.register({ name: "eng", channels: ["eng"], backend: "programmatic" });
+
+    const registry = new ClientRegistry();
+    const deliveryState = new DeliveryState();
+    const channels = new Map<string, Channel>([
+      ["eng", vaultChannel("eng", registry, deliveryState, programmatic)],
+    ]);
+    const { srv, base } = buildServer({ channels, programmatic, deliveryState });
+    try {
+      await inbound(base, "eng", "note-1", "do it");
+      await until(() => backend.calls.length === 1);
+      await new Promise<void>((r) => setTimeout(r, 5));
+      expect(backend.calls).toHaveLength(1);
+      expect(rec.calls).toHaveLength(0);
+    } finally {
+      srv.stop(true);
+    }
+  });
+});
+
+describe("boot re-register", () => {
+  test("a persisted programmatic spec.json → re-registered on start", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "prog-boot-"));
+    try {
+      const sessionsDir = join(dir, "sessions");
+      // Persist an interactive spec (should be SKIPPED) + a programmatic spec.
+      persistSpec(sessionWorkspace(sessionsDir, "watcher"), { name: "watcher", channels: ["watch"] });
+      persistSpec(sessionWorkspace(sessionsDir, "eng"), { name: "eng", channels: ["eng"], backend: "programmatic" });
+
+      const backend = new FakeBackend();
+      const rec = recorder();
+      const programmatic = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+
+      const count = await reregisterProgrammaticAgents(programmatic, sessionsDir);
+      expect(count).toBe(1);
+      expect(programmatic.hasName("eng")).toBe(true);
+      // The interactive spec was NOT re-registered as programmatic.
+      expect(programmatic.hasName("watcher")).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("no sessions dir → 0 re-registered (clean first boot)", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const programmatic = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    const count = await reregisterProgrammaticAgents(programmatic, join(tmpdir(), "does-not-exist-" + Date.now()));
+    expect(count).toBe(0);
+  });
+});
+
+describe("/health + GET /api/agents include programmatic agents", () => {
+  test("/health lists the programmatic agent with backend + status", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const programmatic = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    await programmatic.register({ name: "eng", channels: ["eng"], backend: "programmatic" });
+
+    const { srv, base } = buildServer({ channels: new Map(), programmatic });
+    try {
+      const res = await fetch(`${base}/health`);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        programmatic_agents: { name: string; channel: string; backend: string; status: string }[];
+      };
+      expect(body.programmatic_agents).toEqual([
+        { name: "eng", channel: "eng", backend: "programmatic", status: "idle" },
+      ]);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("GET /api/agents merges interactive + programmatic agents", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const programmatic = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    await programmatic.register({ name: "eng", channels: ["eng"], backend: "programmatic" });
+
+    const ops = stubAgentOps([
+      { name: "aaron", session: "aaron-agent", attached: true, workspace: "/s/aaron", hasWorkspace: true, backend: "interactive" },
+    ]);
+    const { srv, base } = buildServer({ channels: new Map(), agentOps: ops, programmatic });
+    try {
+      const res = await fetch(`${base}/api/agents`, { headers: adminAuth });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { agents: AgentInfo[] };
+      const byName = Object.fromEntries(body.agents.map((a) => [a.name, a]));
+      expect(byName.aaron!.backend).toBe("interactive");
+      expect(byName.eng!.backend).toBe("programmatic");
+      expect(byName.eng!.status).toBe("idle");
+    } finally {
+      srv.stop(true);
+    }
+  });
+});
+
+describe("mutual exclusion (design step 7)", () => {
+  test("programmatic spawn when an interactive tmux session holds the name → 409", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const programmatic = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    const ops = stubAgentOps([
+      { name: "eng", session: "eng-agent", attached: true, workspace: "/s/eng", hasWorkspace: true, backend: "interactive" },
+    ]);
+    const { srv, base } = buildServer({ channels: new Map(), agentOps: ops, programmatic });
+    try {
+      const res = await fetch(`${base}/api/agents`, {
+        method: "POST",
+        headers: { ...adminAuth, "content-type": "application/json" },
+        body: JSON.stringify({ name: "eng", channels: ["eng"], backend: "programmatic" }),
+      });
+      expect(res.status).toBe(409);
+      expect(programmatic.hasName("eng")).toBe(false);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("interactive spawn when a programmatic agent holds the channel → 409 (tmux NOT spawned)", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const programmatic = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    await programmatic.register({ name: "eng", channels: ["eng"], backend: "programmatic" });
+    const ops = stubAgentOps();
+    const { srv, base } = buildServer({ channels: new Map(), agentOps: ops, programmatic });
+    try {
+      const res = await fetch(`${base}/api/agents`, {
+        method: "POST",
+        headers: { ...adminAuth, "content-type": "application/json" },
+        body: JSON.stringify({ name: "eng", channels: ["eng"] }), // interactive (default)
+      });
+      expect(res.status).toBe(409);
+      expect(ops.spawned).toHaveLength(0);
+    } finally {
+      srv.stop(true);
+    }
+  });
+});
+
+describe("interactive path untouched", () => {
+  test("a default (no backend) spawn still hits the interactive tmux AgentOps", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const programmatic = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    const ops = stubAgentOps();
+    const { srv, base } = buildServer({ channels: new Map(), agentOps: ops, programmatic });
+    try {
+      const res = await fetch(`${base}/api/agents`, {
+        method: "POST",
+        headers: { ...adminAuth, "content-type": "application/json" },
+        body: JSON.stringify({ name: "aaron", channels: ["aaron"] }),
+      });
+      expect(res.status).toBe(200);
+      // The interactive AgentOps.spawn ran; nothing landed in the programmatic registry.
+      expect(ops.spawned.map((s) => s.name)).toEqual(["aaron"]);
+      expect(programmatic.hasName("aaron")).toBe(false);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("DELETE a programmatic agent deregisters it (no tmux kill)", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const programmatic = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    await programmatic.register({ name: "eng", channels: ["eng"], backend: "programmatic" });
+    const ops = stubAgentOps();
+    const { srv, base } = buildServer({ channels: new Map(), agentOps: ops, programmatic });
+    try {
+      const res = await fetch(`${base}/api/agents/eng`, { method: "DELETE", headers: adminAuth });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { backend: string; killed: boolean };
+      expect(body.backend).toBe("programmatic");
+      expect(body.killed).toBe(true);
+      expect(programmatic.hasName("eng")).toBe(false);
+      // The interactive kill (tmux) was NOT called for the programmatic agent.
+      expect(ops.killed).toHaveLength(0);
+    } finally {
+      srv.stop(true);
+    }
+  });
+});

--- a/src/sandbox/types.ts
+++ b/src/sandbox/types.ts
@@ -98,6 +98,21 @@ export interface AgentChannelSpec {
 /** A channel entry: a bare name (= write access) or the scoped object form. */
 export type AgentChannel = string | AgentChannelSpec;
 
+/**
+ * Which backend drives the agent (design 2026-06-16-pluggable-agent-backend.md):
+ *
+ *  - `"interactive"` (DEFAULT — existing behavior, unchanged): an idle interactive
+ *    `claude` in a tmux pane, fed inbound by pushing onto a subscribed MCP
+ *    development channel. Carries the deaf-on-restart machinery (#67/#68/#70/#71).
+ *    Best for "watch / drive a live session" — the operator attaches the terminal.
+ *  - `"programmatic"`: NO resident process. An inbound message becomes one
+ *    on-demand `claude -p --resume <sid>` turn ({@link AgentBackend}); the reply is
+ *    posted back as an outbound `#channel-message/outbound` note. No idle session →
+ *    nothing to go deaf, no reconnect, no replay, no consent gate. Best for clean
+ *    per-message "do a task, report back" turns.
+ */
+export type AgentBackendKind = "interactive" | "programmatic";
+
 export interface AgentSpec {
   /** Human-readable arm name; used as the tmux session + workspace slug. */
   name: string;
@@ -171,6 +186,14 @@ export interface AgentSpec {
    * builds the real per-channel secret store.
    */
   credentialRef?: string;
+  /**
+   * Which backend drives the agent (design 2026-06-16-pluggable-agent-backend.md).
+   * Default `"interactive"` (the existing tmux path, unchanged). `"programmatic"`
+   * routes inbound to on-demand `claude -p` turns with no resident process. See
+   * {@link AgentBackendKind}. Persisted in spec.json so a daemon restart re-registers
+   * a programmatic agent on boot.
+   */
+  backend?: AgentBackendKind;
 }
 
 /**


### PR DESCRIPTION
Wires the already-merged `ProgrammaticBackend` (PR #73) into the daemon so a channel can run a programmatic agent **end-to-end**. Unlike the interactive backend (a tmux Claude Code subscribed over an MCP development channel), a programmatic agent has **no resident process**: an inbound message becomes one on-demand `claude -p --resume <sid>` turn whose reply is posted back as an outbound `#channel-message/outbound` note. No idle session → no deaf-on-restart, no reconnect, no replay, no consent gate.

Design: [`design/2026-06-16-pluggable-agent-backend.md`](./design/2026-06-16-pluggable-agent-backend.md).

## How inbound routes to a programmatic turn
`contextFor.emit` (the one inbound fan-out point every transport routes through) now checks the programmatic registry **first**: if a programmatic agent is registered for the channel, the message is **enqueued** for it and the function returns — it does **not** also push to SSE/MCP (programmatic has no live subscriber) and the delivery high-water-mark is deliberately **not** advanced (the queue is the durability). Otherwise the existing SSE+MCP push path runs unchanged. The vault inbound webhook (`/api/vault/inbound` → `ingestInbound` → `ctx.emit`) therefore drives a programmatic turn with no route change.

## The serial queue (hard requirement)
`ProgrammaticAgentRegistry` (`src/backends/registry.ts`) holds `Map<channel, handle>` + a **per-channel FIFO serial queue**. Each agent processes turns **one at a time** — NEVER two concurrent `claude -p` for the same channel/session (that forks the conversation). Enforced **structurally** by a single in-flight drain promise per channel (`#draining`), set synchronously before any await so a second enqueue in the same tick can't start a second worker — not a caller-held lock. The drain re-checks the queue after each turn so a message enqueued mid-turn still drains in the same run.

## The outbound path
On a `deliver()` result that is `ok: true` AND `reply` is non-empty, the worker writes the reply through the channel transport's `reply()` — the **same** vault outbound path the interactive `reply` tool uses, so it's durable + renders in the chat UI. **Empty reply → no note** (reviewer contract — `reply` can be `""`). **`ok: false` → logged + dropped**, no retry, no loop. The reply note is tagged `#channel-message/outbound`; the vault inbound trigger keys on `#channel-message/inbound` only, so writing the reply **cannot** re-trigger the inbound webhook (verified — no loop; `ingestInbound` also defensively drops outbound-tagged notes).

## Lifecycle + /health
- `DELETE /api/agents/:name` for a programmatic agent → deregister (drop indexes + queue, clear the backend session). No tmux to kill.
- The per-session restart (`POST /api/agents/:name/restart`) is interactive-only; for a programmatic agent it **resets the conversation** (clears the session id so the next message starts fresh).
- `/health` + `GET /api/agents` list programmatic agents with their backend + a live `status` (`programmatic · idle|working|queued:N`) instead of `mcp_sessions`.
- **Boot re-register**: a daemon restart scans persisted `spec.json`s and re-registers every `backend: "programmatic"` spec (the persisted session id makes the next turn `--resume` the prior conversation).

## Mutual exclusion
A given name/channel can't run **both** backends at once (they'd collide on the workspace) → **409** on the conflicting spawn (programmatic-when-interactive-live; interactive-when-programmatic-holds-name-or-channel). Documented in the route.

## UI
`agents-ui.ts` gains a **backend selector** (Interactive / Programmatic) with a one-line explanation of each, and shows the **backend + status** per agent in the running list (programmatic rows have no Terminal link; "restart" → "reset", "kill" → "deregister").

## Interactive path
Routed at the daemon level (registry check). The interactive spawn/push/MCP/tmux machinery is **unchanged** — a full interactive retrofit onto `AgentBackend` is a separate future step.

## Tests + gates
- 22 new tests (registry serial-queue/outbound/empty-reply/failure + daemon-level spawn/inbound/boot-reregister/health/list/mutual-exclusion/interactive-untouched) via an injected fake backend + a recorder — no real tmux/claude/vault/hub, matching the existing stub seams.
- `bun test ./src`: **575 pass, 0 fail** (baseline 553).
- `bun run typecheck`: **zero new errors** (the 2 pre-existing TS2589 in `src/bridge.ts` remain, unrelated).
- `bunx biome check`: clean.
- Version: **0.1.0** (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)