### PR TITLE
feat(channel): default to programmatic backend; gate interactive behind advanced

### DIFF
--- a/design/2026-06-16-pluggable-agent-backend.md
+++ b/design/2026-06-16-pluggable-agent-backend.md
@@ -124,7 +124,13 @@ interactive side's silent-loss footgun leak into the programmatic contract.
 | Continuity | free (long-lived process) | `resume=session_id` / streaming input |
 
 ## Phasing
-1. Keep **interactive as the default** backend (it works; #67/#68/#71 make it solid).
+1. ~~Keep **interactive as the default** backend~~ — **SUPERSEDED (2026-06-16):** once
+   the programmatic backend landed + was live-verified, the operator chose to make
+   **programmatic the default** and gate interactive behind an "Advanced" affordance
+   (it's the buggier path, kept available to "bring back out" if Anthropic's SDK
+   pricing change returns). New spawns default to programmatic; existing persisted
+   interactive specs are preserved via the context-split default (see #76 /
+   `interpretPersistedBackend`).
 2. Extract the **AgentBackend seam** without changing interactive behavior.
 3. Build the **programmatic backend** behind the seam; reproduce the watch-it-work
    view by streaming SDK output into the in-page terminal if we want parity.

--- a/src/agents-ui.ts
+++ b/src/agents-ui.ts
@@ -182,9 +182,10 @@ ${THEME_CSS}
     <!-- Spawn -->
     <section id="spawn-section">
       <h2>Spawn an agent</h2>
-      <p class="hint">Launches a sandboxed Claude Code session in tmux, wired to a channel.
-        The common case is one agent per channel — pick a channel and spawn. Open Advanced for
-        extra channels, a vault, network, or mounts.</p>
+      <p class="hint">Launches a sandboxed Claude agent wired to a channel. The default backend is
+        Programmatic (reliable per-message turns); the live-terminal Interactive backend is under
+        Advanced. The common case is one agent per channel — pick a channel and spawn. Open the
+        lower Advanced section for extra channels, a vault, network, or mounts.</p>
 
       <div class="grid3">
         <div>
@@ -207,10 +208,25 @@ ${THEME_CSS}
       <div style="margin-top:12px;">
         <label for="spawn-backend">Backend</label>
         <select id="spawn-backend">
-          <option value="interactive" selected>Interactive — watch / drive a live tmux session</option>
-          <option value="programmatic">Programmatic — clean per-message turns, no live terminal</option>
+          <option value="programmatic" selected>Programmatic — clean per-message turns, reliable (recommended)</option>
+          <option value="interactive">Interactive — watch / drive a live tmux session (advanced)</option>
         </select>
         <div id="backend-note" class="muted" style="font-size:12px; margin-top:8px;"></div>
+        <details id="backend-advanced" style="margin-top:10px;">
+          <summary>Advanced — interactive (live terminal) backend</summary>
+          <div class="sub">
+            <p class="muted" style="font-size:12px; margin:0;">
+              Interactive runs a live Claude Code in a terminal you can attach to —
+              currently less stable (the deaf-on-restart / reconnect class). Use
+              Programmatic unless you specifically want to watch / drive a live session.
+              Selecting it below switches the backend to interactive.
+            </p>
+            <div class="row" style="margin-top:8px;">
+              <button id="backend-use-interactive" class="ghost" type="button">Use interactive backend</button>
+              <span class="muted" id="backend-current" style="font-size:12px;"></span>
+            </div>
+          </div>
+        </details>
       </div>
 
       <details id="advanced">
@@ -526,24 +542,38 @@ ${SHELL_JS}
   netMode.addEventListener("change", syncNetMode);
   syncNetMode(); // default is open → show the note, hide the hosts field
 
-  // Backend toggle: a one-line explanation of each. Interactive = the existing
-  // tmux session you watch/drive (terminal attach). Programmatic = no live
-  // terminal; each inbound message becomes one clean claude -p turn whose reply
-  // is posted back (resume keeps the conversation). The note updates on change.
+  // Backend toggle. PROGRAMMATIC is the default + recommended path (reliable — no
+  // deaf-on-restart / reconnect class). INTERACTIVE (the original tmux session you
+  // watch/drive via terminal attach) is the buggier opt-in, gated behind the
+  // "Advanced — interactive" disclosure; it stays fully selectable once expanded.
+  // The note updates on change; the advanced button switches to interactive.
   var backendMode = document.getElementById("spawn-backend");
   function syncBackendMode() {
     var note = document.getElementById("backend-note");
+    var cur = document.getElementById("backend-current");
     if (backendMode.value === "programmatic") {
-      note.textContent = "Programmatic: no live terminal. Each message runs one on-demand claude -p turn " +
+      note.textContent = "Programmatic (default): no live terminal. Each message runs one on-demand claude -p turn " +
         "(resumes the prior conversation) and its reply is posted back to the channel. No idle session to go " +
-        "deaf, no reconnect — ideal for fire-and-forget 'do a task, report back'. The Terminal link won't apply.";
+        "deaf, no reconnect — reliable, ideal for fire-and-forget 'do a task, report back'. The Terminal link won't apply.";
+      if (cur) cur.textContent = "Current: programmatic.";
     } else {
-      note.textContent = "Interactive: an idle Claude Code session in a tmux pane you can attach to (Terminal ↗). " +
-        "Messages inject into the live session; you watch it work.";
+      note.textContent = "Interactive (advanced): an idle Claude Code session in a tmux pane you can attach to (Terminal ↗). " +
+        "Messages inject into the live session; you watch it work — but it's currently less stable (deaf-on-restart / " +
+        "reconnect class). Use Programmatic unless you specifically want a live session.";
+      if (cur) cur.textContent = "Current: interactive (advanced).";
     }
   }
   backendMode.addEventListener("change", syncBackendMode);
-  syncBackendMode(); // default is interactive
+  // The Advanced disclosure's button switches the selector to interactive (and
+  // updates the note) — interactive stays fully selectable, just opt-in.
+  var useInteractiveBtn = document.getElementById("backend-use-interactive");
+  if (useInteractiveBtn) {
+    useInteractiveBtn.addEventListener("click", function () {
+      backendMode.value = "interactive";
+      syncBackendMode();
+    });
+  }
+  syncBackendMode(); // default is programmatic
 
   function collectSpec() {
     var wake = chanEl.value;
@@ -581,8 +611,11 @@ ${SHELL_JS}
       mounts.push({ hostPath: host, mountPath: mount, mode: row.querySelector(".mt-mode").value });
     });
     if (mounts.length) spec.mounts = mounts;
-    // Backend selector — default interactive (omit so the server default applies).
-    if (backendMode.value === "programmatic") spec.backend = "programmatic";
+    // Backend selector — programmatic is the default; send the selected backend
+    // EXPLICITLY. Programmatic could be omitted (it's now the server default for a
+    // new request), but interactive MUST be passed explicitly to opt out of that
+    // default, so send the value either way for clarity.
+    spec.backend = backendMode.value === "interactive" ? "interactive" : "programmatic";
     return spec;
   }
 

--- a/src/agents.test.ts
+++ b/src/agents.test.ts
@@ -108,9 +108,10 @@ describe("agentInfoFromSessions", () => {
 });
 
 describe("buildSpecFromBody", () => {
-  test("minimal valid body (one channel, defaults to write)", () => {
+  test("minimal valid body (one channel, defaults to write + programmatic backend)", () => {
     const spec = buildSpecFromBody({ name: "aaron", channels: ["aaron"] });
-    expect(spec).toEqual({ name: "aaron", channels: ["aaron"] });
+    // backend now defaults to "programmatic" for a new request (the default flip).
+    expect(spec).toEqual({ name: "aaron", channels: ["aaron"], backend: "programmatic" });
   });
   test("full body — channels (object form), vault+tags, egress, mounts", () => {
     const spec = buildSpecFromBody({
@@ -170,6 +171,23 @@ describe("buildSpecFromBody", () => {
     expect(() =>
       buildSpecFromBody({ name: "a", channels: ["c"], mounts: [{ hostPath: "/h", mountPath: "rel", mode: "ro" }] }),
     ).toThrow(/mountPath must be an absolute path/);
+  });
+  // Backend default flip (design 2026-06-16 + Aaron's gating decision): a NEW
+  // request that OMITS `backend` now defaults to "programmatic" (the reliable
+  // primary path), NOT "interactive". Explicit values are still honored.
+  test("omitted backend → programmatic (the new-request default)", () => {
+    expect(buildSpecFromBody({ name: "a", channels: ["c"] }).backend).toBe("programmatic");
+    // null is treated as omitted.
+    expect(buildSpecFromBody({ name: "a", channels: ["c"], backend: null }).backend).toBe("programmatic");
+  });
+  test("explicit backend:\"interactive\" is still honored (opt-out of the default)", () => {
+    expect(buildSpecFromBody({ name: "a", channels: ["c"], backend: "interactive" }).backend).toBe("interactive");
+  });
+  test("explicit backend:\"programmatic\" is honored", () => {
+    expect(buildSpecFromBody({ name: "a", channels: ["c"], backend: "programmatic" }).backend).toBe("programmatic");
+  });
+  test("rejects an invalid backend value", () => {
+    expect(() => buildSpecFromBody({ name: "a", channels: ["c"], backend: "weird" })).toThrow(/backend/);
   });
 });
 
@@ -441,6 +459,27 @@ describe("GET /agents — the management page (loads open)", () => {
       srv.stop(true);
     }
   });
+
+  // UI gating (design 2026-06-16 + Aaron's gating decision): the backend selector
+  // DEFAULTS to programmatic; interactive is moved behind an "Advanced" disclosure
+  // (a collapsed <details>) but stays fully selectable.
+  test("spawn form defaults the backend selector to programmatic + gates interactive under Advanced", async () => {
+    const { srv, base } = buildServer();
+    try {
+      const html = await (await fetch(`${base}/agents`)).text();
+      // The programmatic <option> carries `selected` (the default); interactive does not.
+      expect(html).toMatch(/<option value="programmatic" selected>/);
+      expect(html).not.toMatch(/<option value="interactive" selected>/);
+      expect(html).toContain('<option value="interactive">');
+      // Interactive lives behind an Advanced disclosure (a <details>) with the caveat.
+      expect(html).toContain('<details id="backend-advanced"');
+      expect(html).toContain("Advanced — interactive");
+      expect(html).toContain("less stable");
+      expect(html).toContain("Use Programmatic unless you specifically want");
+    } finally {
+      srv.stop(true);
+    }
+  });
 });
 
 describe("/api/agents — operator-gated on channel:admin", () => {
@@ -504,7 +543,7 @@ describe("/api/agents — operator-gated on channel:admin", () => {
     }
   });
 
-  test("POST with admin token + valid spec → 200 redacted result (no token values)", async () => {
+  test("POST with admin token + valid interactive spec → 200 redacted result (no token values)", async () => {
     const { srv, base } = buildServer({
       async spawn(spec) {
         return {
@@ -522,10 +561,12 @@ describe("/api/agents — operator-gated on channel:admin", () => {
       },
     });
     try {
+      // backend:"interactive" is now an explicit opt-in (the default flipped to
+      // programmatic) — this exercises the interactive (agentOps.spawn) path.
       const res = await fetch(`${base}/api/agents`, {
         method: "POST",
         headers: { ...adminAuth, "content-type": "application/json" },
-        body: JSON.stringify({ name: "aaron", channels: ["aaron"] }),
+        body: JSON.stringify({ name: "aaron", channels: ["aaron"], backend: "interactive" }),
       });
       expect(res.status).toBe(200);
       const text = await res.text();
@@ -560,7 +601,7 @@ describe("/api/agents — operator-gated on channel:admin", () => {
     }
   });
 
-  test("spawn throws CredentialNotConfiguredError → 400 with the fix", async () => {
+  test("interactive spawn throws CredentialNotConfiguredError → 400 with the fix", async () => {
     const { srv, base } = buildServer({
       async spawn() {
         throw new CredentialNotConfiguredError("aaron");
@@ -570,7 +611,7 @@ describe("/api/agents — operator-gated on channel:admin", () => {
       const res = await fetch(`${base}/api/agents`, {
         method: "POST",
         headers: { ...adminAuth, "content-type": "application/json" },
-        body: JSON.stringify({ name: "aaron", channels: ["aaron"] }),
+        body: JSON.stringify({ name: "aaron", channels: ["aaron"], backend: "interactive" }),
       });
       expect(res.status).toBe(400);
       expect(((await res.json()) as { error: string }).error).toContain("no Claude credential");
@@ -579,7 +620,7 @@ describe("/api/agents — operator-gated on channel:admin", () => {
     }
   });
 
-  test("spawn throws SpawnDepsError (no operator token) → 503", async () => {
+  test("interactive spawn throws SpawnDepsError (no operator token) → 503", async () => {
     const { srv, base } = buildServer({
       async spawn() {
         throw new SpawnDepsError("no operator token");
@@ -589,7 +630,7 @@ describe("/api/agents — operator-gated on channel:admin", () => {
       const res = await fetch(`${base}/api/agents`, {
         method: "POST",
         headers: { ...adminAuth, "content-type": "application/json" },
-        body: JSON.stringify({ name: "aaron", channels: ["aaron"] }),
+        body: JSON.stringify({ name: "aaron", channels: ["aaron"], backend: "interactive" }),
       });
       expect(res.status).toBe(503);
     } finally {
@@ -597,7 +638,7 @@ describe("/api/agents — operator-gated on channel:admin", () => {
     }
   });
 
-  test("spawn throws MintError → forwards the hub status", async () => {
+  test("interactive spawn throws MintError → forwards the hub status", async () => {
     const { srv, base } = buildServer({
       async spawn() {
         throw new MintError("over-broad scope", 403, "forbidden");
@@ -607,7 +648,7 @@ describe("/api/agents — operator-gated on channel:admin", () => {
       const res = await fetch(`${base}/api/agents`, {
         method: "POST",
         headers: { ...adminAuth, "content-type": "application/json" },
-        body: JSON.stringify({ name: "aaron", channels: ["aaron"] }),
+        body: JSON.stringify({ name: "aaron", channels: ["aaron"], backend: "interactive" }),
       });
       expect(res.status).toBe(403);
       expect(((await res.json()) as { error: string }).error).toContain("mint failed");

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -289,14 +289,26 @@ export function buildSpecFromBody(body: unknown): AgentSpec {
     if (mounts.length > 0) spec.mounts = mounts;
   }
 
-  // Backend selector — the pluggable agent backend (design 2026-06-16). Default
-  // `"interactive"` (existing behavior); `"programmatic"` routes to on-demand
-  // `claude -p` turns. Persisted in spec.json so a restart re-registers it.
+  // Backend selector — the pluggable agent backend (design 2026-06-16). A NEW
+  // request that OMITS `backend` now defaults to `"programmatic"` (Aaron's gating
+  // decision 2026-06-16): programmatic is the reliable primary path (no
+  // deaf-on-restart / reconnect class); `"interactive"` (the original tmux path) is
+  // the buggier opt-in, gated behind "Advanced" in the UI but still fully selectable
+  // by passing `backend: "interactive"` explicitly here. The selected backend is
+  // persisted in spec.json so a restart re-registers it.
+  //
+  // CRITICAL — this NEW-request default is DISTINCT from the PERSISTED-spec default:
+  // a stored spec.json with NO `backend` field predates the field and is an
+  // INTERACTIVE agent ({@link interpretPersistedBackend}). Do NOT unify these — a
+  // missing field means "programmatic" for a fresh request but "interactive" for a
+  // file on disk, so existing interactive agents are never silently migrated.
   if (b.backend !== undefined && b.backend !== null) {
     if (b.backend !== "interactive" && b.backend !== "programmatic") {
       throw new SpawnRequestError('body.backend must be "interactive" or "programmatic"');
     }
     spec.backend = b.backend;
+  } else {
+    spec.backend = "programmatic";
   }
 
   return spec;

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -103,7 +103,7 @@ import {
   type WriteOutbound,
 } from "./backends/registry.ts";
 import { AgentSessionState } from "./agent-session-state.ts";
-import { readPersistedSpec, sessionWorkspace } from "./spawn-agent.ts";
+import { readPersistedSpec, interpretPersistedBackend, sessionWorkspace } from "./spawn-agent.ts";
 import { normalizeChannel } from "./sandbox/types.ts";
 import { CredentialNotConfiguredError } from "./credentials.ts";
 import { MintError } from "./mint-token.ts";
@@ -612,7 +612,12 @@ export async function reregisterProgrammaticAgents(
   for (const name of entries) {
     const workspace = sessionWorkspace(sessionsDirPath, name);
     const spec = readPersistedSpec(workspace);
-    if (!spec || spec.backend !== "programmatic") continue;
+    // A persisted spec with NO `backend` field predates the field → INTERACTIVE
+    // (interpretPersistedBackend) and is SKIPPED here — its tmux session survives a
+    // restart on its own. Only specs that explicitly persisted `backend:
+    // "programmatic"` are re-registered. This is the back-compat guard that keeps an
+    // existing interactive agent (e.g. uni-dev) from being migrated to programmatic.
+    if (!spec || interpretPersistedBackend(spec) !== "programmatic") continue;
     try {
       await programmatic.register(spec);
       count++;

--- a/src/programmatic-wiring.test.ts
+++ b/src/programmatic-wiring.test.ts
@@ -433,7 +433,7 @@ describe("mutual exclusion (design step 7)", () => {
       const res = await fetch(`${base}/api/agents`, {
         method: "POST",
         headers: { ...adminAuth, "content-type": "application/json" },
-        body: JSON.stringify({ name: "eng", channels: ["eng"] }), // interactive (default)
+        body: JSON.stringify({ name: "eng", channels: ["eng"], backend: "interactive" }), // explicit interactive (default is now programmatic)
       });
       expect(res.status).toBe(409);
       expect(ops.spawned).toHaveLength(0);
@@ -443,8 +443,47 @@ describe("mutual exclusion (design step 7)", () => {
   });
 });
 
-describe("interactive path untouched", () => {
-  test("a default (no backend) spawn still hits the interactive tmux AgentOps", async () => {
+describe("backend default flip + interactive path", () => {
+  // Default flip (design 2026-06-16 + Aaron's gating decision): a NEW request that
+  // OMITS `backend` now routes to the PROGRAMMATIC registry, not the interactive
+  // tmux AgentOps. Interactive is still fully reachable by passing it explicitly.
+  test("a default (no backend) spawn now hits the PROGRAMMATIC registry (not tmux)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "prog-default-"));
+    const prevStateDir = process.env.PARACHUTE_CHANNEL_STATE_DIR;
+    try {
+      const backend = new FakeBackend();
+      const rec = recorder();
+      const programmatic = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+      const ops = stubAgentOps();
+      // Point the state dir at the temp + seed a default Claude credential so
+      // setupProgrammaticSpawn's early credential resolve succeeds (no real store).
+      process.env.PARACHUTE_CHANNEL_STATE_DIR = dir;
+      const { writeFileSync } = await import("node:fs");
+      writeFileSync(join(dir, "credentials.json"), JSON.stringify({ claude: { default: "oat_test" } }), { mode: 0o600 });
+
+      const { srv, base } = buildServer({ channels: new Map(), agentOps: ops, programmatic });
+      try {
+        const res = await fetch(`${base}/api/agents`, {
+          method: "POST",
+          headers: { ...adminAuth, "content-type": "application/json" },
+          body: JSON.stringify({ name: "aaron", channels: ["aaron"] }), // no backend → programmatic now
+        });
+        expect(res.status).toBe(200);
+        expect(((await res.json()) as { backend: string }).backend).toBe("programmatic");
+        // It landed in the programmatic registry; the interactive tmux AgentOps was untouched.
+        expect(programmatic.hasName("aaron")).toBe(true);
+        expect(ops.spawned).toHaveLength(0);
+      } finally {
+        srv.stop(true);
+      }
+    } finally {
+      if (prevStateDir === undefined) delete process.env.PARACHUTE_CHANNEL_STATE_DIR;
+      else process.env.PARACHUTE_CHANNEL_STATE_DIR = prevStateDir;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("an explicit backend:\"interactive\" spawn still hits the interactive tmux AgentOps", async () => {
     const backend = new FakeBackend();
     const rec = recorder();
     const programmatic = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
@@ -454,7 +493,7 @@ describe("interactive path untouched", () => {
       const res = await fetch(`${base}/api/agents`, {
         method: "POST",
         headers: { ...adminAuth, "content-type": "application/json" },
-        body: JSON.stringify({ name: "aaron", channels: ["aaron"] }),
+        body: JSON.stringify({ name: "aaron", channels: ["aaron"], backend: "interactive" }),
       });
       expect(res.status).toBe(200);
       // The interactive AgentOps.spawn ran; nothing landed in the programmatic registry.

--- a/src/sandbox/types.ts
+++ b/src/sandbox/types.ts
@@ -101,15 +101,24 @@ export type AgentChannel = string | AgentChannelSpec;
 /**
  * Which backend drives the agent (design 2026-06-16-pluggable-agent-backend.md):
  *
- *  - `"interactive"` (DEFAULT — existing behavior, unchanged): an idle interactive
- *    `claude` in a tmux pane, fed inbound by pushing onto a subscribed MCP
- *    development channel. Carries the deaf-on-restart machinery (#67/#68/#70/#71).
- *    Best for "watch / drive a live session" — the operator attaches the terminal.
- *  - `"programmatic"`: NO resident process. An inbound message becomes one
+ *  - `"programmatic"` (the DEFAULT for a NEW spawn request, per Aaron's gating
+ *    decision 2026-06-16): NO resident process. An inbound message becomes one
  *    on-demand `claude -p --resume <sid>` turn ({@link AgentBackend}); the reply is
  *    posted back as an outbound `#channel-message/outbound` note. No idle session →
- *    nothing to go deaf, no reconnect, no replay, no consent gate. Best for clean
- *    per-message "do a task, report back" turns.
+ *    nothing to go deaf, no reconnect, no replay, no consent gate. The reliable
+ *    primary path; best for clean per-message "do a task, report back" turns.
+ *  - `"interactive"` (the original tmux path; now the opt-in/"advanced" backend): an
+ *    idle interactive `claude` in a tmux pane, fed inbound by pushing onto a
+ *    subscribed MCP development channel. Carries the deaf-on-restart machinery
+ *    (#67/#68/#70/#71) — currently less stable, kept for "watch / drive a live
+ *    session" (operator attaches the terminal) and to hedge the billing uncertainty.
+ *
+ * DEFAULT-RESOLUTION NOTE — the omitted-field default differs by context, on
+ * purpose: a NEW request that omits `backend` resolves to `"programmatic"`
+ * ({@link buildSpecFromBody} in `agents.ts`), but a PERSISTED `spec.json` that omits
+ * `backend` predates the field and resolves to `"interactive"`
+ * ({@link interpretPersistedBackend} in `spawn-agent.ts`) — so the flip applies going
+ * forward without silently migrating already-running interactive agents.
  */
 export type AgentBackendKind = "interactive" | "programmatic";
 
@@ -188,10 +197,13 @@ export interface AgentSpec {
   credentialRef?: string;
   /**
    * Which backend drives the agent (design 2026-06-16-pluggable-agent-backend.md).
-   * Default `"interactive"` (the existing tmux path, unchanged). `"programmatic"`
-   * routes inbound to on-demand `claude -p` turns with no resident process. See
-   * {@link AgentBackendKind}. Persisted in spec.json so a daemon restart re-registers
-   * a programmatic agent on boot.
+   * A NEW spawn request that omits this defaults to `"programmatic"` (on-demand
+   * `claude -p` turns, no resident process — the reliable primary path, per Aaron's
+   * gating decision 2026-06-16); `"interactive"` (the original tmux path) is the
+   * opt-in/"advanced" backend. A PERSISTED spec.json that omits this resolves to
+   * `"interactive"` instead (back-compat — it predates the field). See
+   * {@link AgentBackendKind} for the full default-resolution note. Persisted in
+   * spec.json so a daemon restart re-registers a programmatic agent on boot.
    */
   backend?: AgentBackendKind;
 }

--- a/src/spawn-agent.test.ts
+++ b/src/spawn-agent.test.ts
@@ -16,6 +16,7 @@ import {
   shellJoin,
   persistSpec,
   readPersistedSpec,
+  interpretPersistedBackend,
   specFilePath,
   type SpawnAgentDeps,
   type TmuxLauncher,
@@ -912,6 +913,41 @@ describe("persistSpec / readPersistedSpec — spawn-spec recovery for restart", 
       // Corrupt it -> null (the restart path treats this as "no spec").
       writeFileSync(specFilePath(ws), "{not json");
       expect(readPersistedSpec(ws)).toBeNull();
+    } finally {
+      rmSync(ws, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("interpretPersistedBackend — persisted-spec backend back-compat", () => {
+  // A PERSISTED spec.json with NO `backend` field predates the field and is an
+  // INTERACTIVE agent (the original tmux path) — it must NEVER read as programmatic.
+  // This is the OPPOSITE default from a NEW request (buildSpecFromBody → programmatic),
+  // so existing interactive agents (e.g. the live uni-dev) are never silently migrated.
+  test("a spec with NO backend field → interactive (not programmatic)", () => {
+    expect(interpretPersistedBackend({ name: "uni-dev", channels: ["uni-dev"] })).toBe("interactive");
+  });
+  test("a spec with backend:\"programmatic\" → programmatic", () => {
+    expect(
+      interpretPersistedBackend({ name: "eng", channels: ["eng"], backend: "programmatic" }),
+    ).toBe("programmatic");
+  });
+  test("a spec with explicit backend:\"interactive\" → interactive", () => {
+    expect(
+      interpretPersistedBackend({ name: "a", channels: ["c"], backend: "interactive" }),
+    ).toBe("interactive");
+  });
+  test("a persisted spec.json round-trips through disk then reads as interactive (the uni-dev case)", () => {
+    const ws = mkdtempSync(join(tmpdir(), "spec-backcompat-"));
+    try {
+      // Simulate a pre-field spec.json on disk (no `backend` key), exactly like an
+      // existing interactive agent's persisted spec.
+      writeFileSync(specFilePath(ws), JSON.stringify({ name: "uni-dev", channels: ["uni-dev"] }) + "\n", { mode: 0o600 });
+      const spec = readPersistedSpec(ws);
+      expect(spec).not.toBeNull();
+      expect(spec!.backend).toBeUndefined();
+      // The interpreted backend is interactive — NOT migrated to programmatic.
+      expect(interpretPersistedBackend(spec!)).toBe("interactive");
     } finally {
       rmSync(ws, { recursive: true, force: true });
     }

--- a/src/spawn-agent.ts
+++ b/src/spawn-agent.ts
@@ -292,6 +292,29 @@ export function readPersistedSpec(workspace: string): AgentSpec | null {
 }
 
 /**
+ * Interpret the backend of a PERSISTED spec (backward-compat, design
+ * 2026-06-16 + Aaron's gating decision 2026-06-16).
+ *
+ * A stored `spec.json` with NO `backend` field predates the field — it was written
+ * by an OLDER build whose only backend was the tmux/interactive path (e.g. the live
+ * `uni-dev` agent). Such a spec MUST read as `"interactive"`, never `"programmatic"`:
+ * an existing interactive agent is never silently migrated to programmatic by a
+ * daemon restart.
+ *
+ * This is DELIBERATELY the OPPOSITE default from a NEW spawn request, where an
+ * omitted `backend` now means `"programmatic"` ({@link buildSpecFromBody} in
+ * `agents.ts`). The two defaults are distinct on purpose — "omitted" means
+ * "programmatic" for a fresh request but "interactive" for a file on disk — so the
+ * flip applies only going forward and never reinterprets already-running agents.
+ *
+ * Use this anywhere a stored spec's backend is interpreted (boot re-register, etc.)
+ * rather than reading `spec.backend` raw, so the back-compat default is in one place.
+ */
+export function interpretPersistedBackend(spec: AgentSpec): "interactive" | "programmatic" {
+  return spec.backend === "programmatic" ? "programmatic" : "interactive";
+}
+
+/**
  * Build the scrubbed child env for the sandboxed claude. Mirrors runner's
  * passthrough allowlist MINUS `ANTHROPIC_API_KEY` (and the `ANTHROPIC_*`/`CLAUDE_*`
  * wildcards, which would re-admit it) — the channel session runs on the


### PR DESCRIPTION
## What

Makes the **programmatic** agent backend the default for new spawns and gates the **interactive** (tmux Claude Code) backend behind an "Advanced" opt-in.

Per Aaron's gating decision (2026-06-16): programmatic is the reliable primary path — no deaf-on-restart / reconnect class. Interactive stays fully available (watch/drive a live session; hedge against an Agent SDK pricing change) but it's the buggier path today, so it's opt-in rather than the default.

Design: [`design/2026-06-16-pluggable-agent-backend.md`](./design/2026-06-16-pluggable-agent-backend.md).

## The default flip

- **`buildSpecFromBody`** (`src/agents.ts`): a NEW request that **omits** `backend` now defaults to `"programmatic"` (was `"interactive"`). An explicit `backend:"interactive"` is still honored, so interactive remains fully reachable via the API and the advanced UI path.

## Backward-compat split (the load-bearing part)

A **persisted** `spec.json` with **no** `backend` field predates the field and is an **interactive** agent. It must **not** be silently migrated to programmatic. So the omitted-field default is **distinct by context**:

| Source | `backend` omitted resolves to |
|---|---|
| NEW spawn request (`buildSpecFromBody`) | `programmatic` |
| PERSISTED `spec.json` on disk (`interpretPersistedBackend`) | `interactive` |

- Added `interpretPersistedBackend()` (`src/spawn-agent.ts`) to centralize the persisted-spec default in one place, and wired it into the boot re-register path (`src/daemon.ts` `reregisterProgrammaticAgents` — was a raw `spec.backend !== "programmatic"` check, now `interpretPersistedBackend(spec) !== "programmatic"`). Legacy interactive specs (no field) are skipped from programmatic re-registration exactly as before. **Existing interactive agents are never reinterpreted.**
- Note: the live `~/.parachute/channel/sessions/uni-dev/spec.json` on the dev box already carries `backend: "programmatic"` explicitly, so it reads as programmatic both before and after this change — unchanged. The back-compat guard protects any legacy/future spec that genuinely lacks the field (covered synthetically by tests, including a disk round-trip).

## UI gating (`src/agents-ui.ts`)

- The backend `<select>` now defaults to **Programmatic** (`<option value="programmatic" selected>`).
- **Interactive** is moved behind a collapsed `<details id="backend-advanced">` "Advanced — interactive (live terminal) backend" disclosure carrying the caveat: *"Interactive runs a live Claude Code in a terminal you can attach to — currently less stable; use Programmatic unless you specifically want to watch/drive a live session."* A button switches the selector to interactive; it stays fully selectable.
- `collectSpec` now sends the selected backend **explicitly** (interactive must be passed to opt out of the server default).
- The per-agent backend/status display (#74) is kept intact.

## Out of scope (intentionally)

Boot-reregister logic changes beyond the back-compat read, and the #75 leak — separate issue/PR. The interactive spawn/tmux machinery is untouched except for the default.

## Tests

- `buildSpecFromBody`: omitted → `programmatic`; explicit `interactive` honored; explicit `programmatic` honored; invalid value rejected.
- `interpretPersistedBackend`: missing field → `interactive` (incl. a disk round-trip simulating a pre-field spec); explicit `programmatic` → `programmatic`; explicit `interactive` → `interactive`.
- Daemon route: a default (no backend) spawn now lands in the **programmatic registry** (not tmux); an explicit `backend:"interactive"` still hits the interactive `AgentOps.spawn`; existing interactive-path error-mapping tests pinned to explicit interactive.
- UI: served `/agents` HTML asserts the selector defaults to programmatic and renders interactive under the Advanced `<details>`.

## Gates

- `bun test ./src` — **586 pass / 0 fail** (baseline 576; +10 net new).
- `bun run typecheck` — only the 2 pre-existing TS2589 in `src/bridge.ts` (unrelated); zero new.
- `bunx biome check --write .` — clean, no changes.
- Version: left at `0.1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)