### PR TITLE
fix(channel): harden boot re-register against orphaned specs + fix test-state leak (#75)

### DIFF
--- a/design/2026-06-16-agent-filesystem-and-sharing.md
+++ b/design/2026-06-16-agent-filesystem-and-sharing.md
@@ -10,10 +10,15 @@ reuse these primitives.
 
 ## The problem
 
-Today an agent's `~/.parachute/channel/sessions/<name>/` fuses four different things
-into one private blob:
+Today an agent's session dir (`~/.parachute/channel/sessions/<name>/` by default;
+overridable via `PARACHUTE_CHANNEL_STATE_DIR` / the injected `sessionsDir` dep) fuses
+four different things into one private blob:
 - the **working directory** (cwd),
-- the seeded `~/.claude` **config + library** (skills, slash commands, sub-agents),
+- a seeded **per-agent `CLAUDE_CONFIG_DIR`** (`<workspace>/home/.claude`, written by
+  `seedAgentHome`) holding **config + library** (skills, slash commands, sub-agents).
+  Note: the operator's real `~/.claude` is never written — only `~/.claude.json` is
+  *read* as a seed source, and the agent always runs with `CLAUDE_CONFIG_DIR` pointed
+  at its own dir, so CC's "user-level" config layer is fully controlled per-agent,
 - the **`.mcp.json`** (with the agent's scoped vault/channel tokens), and
 - **mutable runtime state** (sessions, history, locks, cache, tmp).
 
@@ -106,9 +111,15 @@ repo's `GH_TOKEN` travelling with its workspace).
 ## Open questions
 - **Shared-rw working dir concurrency** — multiple agents editing one dir step on each
   other like humans in a repo without git discipline. The `AgentMount.shared?` hook
-  exists; the *policy* (when shared-rw is allowed vs requires coordination) is open.
-  Shared-ro is always safe.
+  exists (v1 doc-level only — "plumbed through so a future use is a considered
+  decision," per `sandbox/types.ts`); the *policy* (when shared-rw is allowed vs
+  requires coordination) is open. Shared-ro is always safe.
 - **CC skills-sharing mechanism** — the exact way to share `skills/` while isolating
   `.mcp.json` (spike when building seam #2).
+- **Working dir vs library collision** — when a real repo is mounted as the working
+  dir, CC treats that repo as the project root and will read *its* `.claude/` (skills,
+  settings) too. The working-dir seam and the shared-library seam can interact
+  non-obviously there (repo-local `.claude/` layering on top of the shared library) —
+  resolve the precedence when building the library seam.
 - **One library or many** — a single global library vs per-purpose / per-"team"
   libraries an agent selects from.

--- a/design/2026-06-16-agent-filesystem-and-sharing.md
+++ b/design/2026-06-16-agent-filesystem-and-sharing.md
@@ -1,0 +1,114 @@
+# Agent filesystem & sharing — workspace, shared library, private runtime
+
+**Status:** direction (not yet built). 2026-06-16. Companion to
+[`2026-06-14-sandboxed-agent-sessions.md`](./2026-06-14-sandboxed-agent-sessions.md)
+(sandbox/isolation), [`2026-06-16-pluggable-agent-backend.md`](./2026-06-16-pluggable-agent-backend.md)
+(how an agent is driven), and
+[`2026-06-16-session-environment-and-credentials.md`](./2026-06-16-session-environment-and-credentials.md)
+(env/cred injection). Written ahead of resuming **parachute-runner**, which will
+reuse these primitives.
+
+## The problem
+
+Today an agent's `~/.parachute/channel/sessions/<name>/` fuses four different things
+into one private blob:
+- the **working directory** (cwd),
+- the seeded `~/.claude` **config + library** (skills, slash commands, sub-agents),
+- the **`.mcp.json`** (with the agent's scoped vault/channel tokens), and
+- **mutable runtime state** (sessions, history, locks, cache, tmp).
+
+Two emerging needs break that monolith:
+1. An agent often wants to **work from a real directory** on the computer (a repo), and
+   that directory should be **shareable** — with other agents, with runner jobs, with
+   plain scripts. (A runner job might kickstart an agent via channel *and* run scripts
+   in the same place.)
+2. Agents should **share curated library content** — an operator curates a set of
+   **skills** (and slash commands, sub-agents) once and wants *all* their agents to
+   have them.
+
+…while some things must stay **strictly per-agent and never shared** — above all the
+**MCP config and its scoped tokens** (vault access), which is the security/capability
+boundary between agents.
+
+## The decomposition: three independent axes
+
+An agent's filesystem context is really **three** things, not one:
+
+| Axis | What | Sharing |
+|---|---|---|
+| **Working directory** | where the agent operates (cwd) | shareable real dir (ro safe; rw needs a concurrency story) |
+| **Shared library** | curated, inert content: skills, slash commands, sub-agent defs, output styles | **shareable** read-only across agents |
+| **Private runtime** | `.mcp.json` + scoped tokens; mutable state (sessions, cache, locks, tmp); trust/onboarding flags | **never shared** — per-agent |
+
+## The governing principle (the line)
+
+> **Anything that carries a credential or a scoped capability is per-agent and never
+> shared. Anything that is inert, curated content can be shared.**
+
+- `.mcp.json` (scoped vault/channel tokens), the injected `CLAUDE_CODE_OAUTH_TOKEN`,
+  any per-agent secret → **private**. Sharing them collapses the per-agent isolation
+  that the whole sandbox model exists to provide.
+- Skills, slash commands, sub-agent definitions, output styles → **shareable** (they're
+  curated text/content, not capabilities).
+
+That one rule decides where any *future* piece of config belongs — no case-by-case
+agonizing.
+
+## Mapping to Claude Code's own config model
+
+CC already layers config: user-level (`~/.claude` / `CLAUDE_CONFIG_DIR`) + project-level
+(`.claude` in the cwd) + managed. Skills load from user + project `skills/`; MCP from
+`.mcp.json`; settings layer user→project→local. So we lean on CC's layering rather than
+inventing one:
+- **Shared library** → an operator-curated `skills/` (+ commands, agents) dir surfaced
+  into each opted-in agent **read-only**.
+- **Private runtime** → today's per-agent `CLAUDE_CONFIG_DIR` (`seedAgentHome`) with its
+  own `.mcp.json` + mutable state — unchanged.
+
+The implementation trick is composing a **shared read-only library source** with a
+**per-agent private config** (via mount / symlink / a skills path) so skills are shared
+but `.mcp.json` + state stay isolated. The exact mechanism wants a small spike against
+CC's skills-discovery (does it follow a symlinked `skills/`? a configurable path? a
+read-only mount layered under the private config?) — TBD when we build it, not now.
+
+## Composition with the other seams
+
+All orthogonal, all compose:
+- **Backend** (how driven: interactive ↔ programmatic) ×
+- **Working dir** (where it works) ×
+- **Shared library** (what skills it has) ×
+- **Runner** (what triggers it).
+
+A **runner job** becomes: pick a *working dir* + a *backend*, inherit the *shared
+library*, get *per-agent scoped credentials*, triggered by a `tag:job` note or cron —
+with **channel** as the comms fabric. Runner reuses the agent/sandbox/credential
+primitives (`AgentBackend`, `wrapArgvInSandbox`, the #68 env injection); it doesn't
+reinvent them.
+
+## Minimal seams to land (good-enough-now — don't over-build)
+
+1. **`workspace` (host path) on the agent spec** — decouple the working dir from the
+   private runtime home. Set → that dir is the cwd (mounted rw), private home still
+   per-agent at `sessions/<name>/`. Unset → today's private synthetic workspace. Small;
+   unblocks shared real-dir work + runner.
+2. **A shared-library dir** — an operator-curated `skills/` (+ commands/agents) path,
+   mounted **read-only** into agents that opt in. Could start as a single configurable
+   shared-skills path that `seedAgentHome` layers in read-only.
+3. **Keep `.mcp.json` + scoped tokens + mutable state strictly per-agent** — no change;
+   just make the boundary *explicit and documented* so future config lands in the right
+   layer (per the governing principle).
+
+**Defer until a concrete need:** a named-workspace registry; a library
+package/versioning system; shared-**rw** working-dir concurrency coordination; a
+workspace bundling its own scoped env/creds (ties into #68 — natural later, e.g. a
+repo's `GH_TOKEN` travelling with its workspace).
+
+## Open questions
+- **Shared-rw working dir concurrency** — multiple agents editing one dir step on each
+  other like humans in a repo without git discipline. The `AgentMount.shared?` hook
+  exists; the *policy* (when shared-rw is allowed vs requires coordination) is open.
+  Shared-ro is always safe.
+- **CC skills-sharing mechanism** — the exact way to share `skills/` while isolating
+  `.mcp.json` (spike when building seam #2).
+- **One library or many** — a single global library vs per-purpose / per-"team"
+  libraries an agent selects from.

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -594,9 +594,23 @@ export function listProgrammaticAgents(programmatic: ProgrammaticAgentRegistry):
  * would be wrong (they aren't programmatic). Best-effort: an unreadable spec / a
  * register failure is logged per-agent and never aborts boot. Returns the count
  * re-registered. `sessionsDirPath` is injectable for tests.
+ *
+ * ORPHAN GUARD (channel#75 — defense-in-depth). A spec dir is durable cruft: it can
+ * outlive the channel it was spawned for (a deleted agent whose workspace wasn't
+ * swept, a crash mid-spawn, a leaked test fixture, a hand-copied dir). Re-registering
+ * a programmatic agent whose wake channel ISN'T in the live channels config would
+ * resurrect a PHANTOM agent — one with nothing to receive for (no live channel feeds
+ * it inbound), confusing the operator and the agent list. So we re-register ONLY a
+ * spec whose wake channel STILL EXISTS in `channels` (the live channels.json-derived
+ * map); a spec for a missing channel is SKIPPED with a one-line notice, making any
+ * orphaned/leaked spec dir inert. The wake channel is keyed exactly as the registry
+ * keys it (`normalizeChannel(spec.channels[0]).name` — see `ProgrammaticAgentRegistry`).
+ * A spec with an EMPTY channels array is also skipped (it has no wake channel to key /
+ * route on — re-registering it would throw at the registry's channelOf).
  */
 export async function reregisterProgrammaticAgents(
   programmatic: ProgrammaticAgentRegistry,
+  channels: Map<string, Channel>,
   sessionsDirPath: string = defaultSessionsDir(),
 ): Promise<number> {
   let entries: string[];
@@ -618,10 +632,28 @@ export async function reregisterProgrammaticAgents(
     // "programmatic"` are re-registered. This is the back-compat guard that keeps an
     // existing interactive agent (e.g. uni-dev) from being migrated to programmatic.
     if (!spec || interpretPersistedBackend(spec) !== "programmatic") continue;
+    // ORPHAN GUARD: a spec with no wake channel, or whose wake channel isn't a live
+    // channel, has nothing to receive for — skip it so a leaked/stale spec dir can't
+    // resurrect a phantom agent. Keyed exactly as the registry keys the channel.
+    const wakeChannel = spec.channels[0]
+      ? normalizeChannel(spec.channels[0]).name
+      : undefined;
+    if (!wakeChannel) {
+      console.log(
+        `parachute-channel: skipping re-register of "${spec.name}" — spec declares no channel.`,
+      );
+      continue;
+    }
+    if (!channels.has(wakeChannel)) {
+      console.log(
+        `parachute-channel: skipping re-register of "${spec.name}" — channel "${wakeChannel}" not configured.`,
+      );
+      continue;
+    }
     try {
       await programmatic.register(spec);
       count++;
-      console.log(`parachute-channel: re-registered programmatic agent "${spec.name}" (channel ${normalizeChannel(spec.channels[0]!).name}).`);
+      console.log(`parachute-channel: re-registered programmatic agent "${spec.name}" (channel ${wakeChannel}).`);
     } catch (err) {
       console.error(
         `parachute-channel: failed to re-register programmatic agent "${name}" from spec.json: ${(err as Error).message}`,
@@ -2611,8 +2643,10 @@ function main(): void {
   // the per-session workspaces and re-register every programmatic spec so inbound
   // for its channel resumes routing to an on-demand turn (the persisted session_id
   // makes the next turn `--resume` the prior conversation — no deaf problem). Best-
-  // effort: a single bad spec is logged and skipped.
-  void reregisterProgrammaticAgents(programmatic);
+  // effort: a single bad spec is logged and skipped. The live `channels` map gates
+  // it: only a spec whose wake channel is a configured channel is re-registered, so
+  // a leaked/orphaned spec dir can't resurrect a phantom agent (channel#75).
+  void reregisterProgrammaticAgents(programmatic, channels);
 
   // Graceful shutdown — stop all transports.
   async function shutdown(): Promise<void> {

--- a/src/programmatic-wiring.test.ts
+++ b/src/programmatic-wiring.test.ts
@@ -21,7 +21,7 @@
  *     the tmux AgentOps).
  */
 
-import { describe, test, expect, mock } from "bun:test";
+import { describe, test, expect, mock, afterEach } from "bun:test";
 
 const ADMIN_TOKEN = "test-admin-token"; // channel:read + send + admin
 import { HubJwtError, looksLikeJwt } from "@openparachute/scope-guard";
@@ -58,6 +58,79 @@ import type { Channel } from "./registry.ts";
 import type { AgentOps, AgentInfo, SpawnRequestError } from "./agents.ts";
 
 const adminAuth = { authorization: "Bearer " + ADMIN_TOKEN };
+
+// ---------------------------------------------------------------------------
+// Real-home safety guard (channel#75)
+//
+// A phantom `eng` programmatic agent appeared on a LIVE box because a test write
+// escaped isolation into the real `~/.parachute/channel/sessions/`. Boot re-register
+// then scanned it and resurrected the agent. Every test here that persists a spec /
+// touches the channel state dir MUST write ONLY to a per-test temp dir. The `afterEach`
+// real-home assertion below is the backstop; `withTempStateDir` is the easy-path helper
+// future state-touching tests should reach for.
+//
+// `realSessionsDir()` is the operator's REAL sessions dir, derived the SAME way the
+// daemon derives it (`~/.parachute/channel/sessions`) but WITHOUT honoring
+// PARACHUTE_CHANNEL_STATE_DIR — so it's the genuine home even while a test has the env
+// var pointed at a temp dir. A new test session/spec dir appearing under it is the
+// leak signature.
+import { homedir } from "node:os";
+import { readdirSync } from "node:fs";
+
+function realSessionsDir(): string {
+  return join(homedir(), ".parachute", "channel", "sessions");
+}
+
+function listRealSessions(): string[] {
+  try {
+    return readdirSync(realSessionsDir(), { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name)
+      .sort();
+  } catch {
+    return []; // no real sessions dir on this machine → nothing to leak into
+  }
+}
+
+// Snapshot the real sessions dir before the suite; after EACH test assert nothing new
+// landed in it. Catches any spec write (or `setupProgrammaticSpawn` / boot re-register
+// path) that escaped its temp-dir guard. We compare set membership, not exact equality,
+// so a concurrently-running operator daemon spawning a legit agent doesn't false-fail
+// — only a NEW dir attributable to a test trips it (the test-fixture names are distinct
+// slugs like `eng`/`watcher`/`prog-test` that wouldn't normally be live).
+const realSessionsBaseline = new Set(listRealSessions());
+
+afterEach(() => {
+  const now = listRealSessions();
+  const leaked = now.filter((n) => !realSessionsBaseline.has(n));
+  expect(
+    leaked,
+    `test wrote ${leaked.length} new session dir(s) into the REAL ${realSessionsDir()} ` +
+      `(${leaked.join(", ")}) — every spec/state write must be inside a temp dir ` +
+      `(PARACHUTE_CHANNEL_STATE_DIR + mkdtemp). See channel#75.`,
+  ).toEqual([]);
+});
+
+/**
+ * Run `fn` with PARACHUTE_CHANNEL_STATE_DIR pointed at a fresh mkdtemp dir, so
+ * `defaultStateDir()` / `defaultSessionsDir()` (and anything that derives from them —
+ * `setupProgrammaticSpawn`, the credentials store, boot re-register's default arg)
+ * resolve UNDER the temp dir, never the operator's real home. Restores the prior env
+ * value and removes the temp dir in `finally`, even on throw. This is the temp-dir
+ * discipline the prompt calls the model — use it for any test that may write state.
+ */
+async function withTempStateDir<T>(fn: (dir: string) => Promise<T> | T): Promise<T> {
+  const dir = mkdtempSync(join(tmpdir(), "channel-state-"));
+  const prev = process.env.PARACHUTE_CHANNEL_STATE_DIR;
+  process.env.PARACHUTE_CHANNEL_STATE_DIR = dir;
+  try {
+    return await fn(dir);
+  } finally {
+    if (prev === undefined) delete process.env.PARACHUTE_CHANNEL_STATE_DIR;
+    else process.env.PARACHUTE_CHANNEL_STATE_DIR = prev;
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
 
 /** A controllable fake backend (no `claude -p`). */
 class FakeBackend implements AgentBackend {
@@ -156,17 +229,15 @@ async function until(pred: () => boolean, tries = 200): Promise<void> {
 
 describe("spawn with backend:'programmatic'", () => {
   test("→ no tmux spawn, agent registered, spec.json carries backend", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "prog-spawn-"));
-    try {
+    // withTempStateDir points PARACHUTE_CHANNEL_STATE_DIR at a fresh mkdtemp dir so
+    // defaultStateDir/defaultSessionsDir resolve under <dir> (NOT the operator's real
+    // ~/.parachute) and restores + cleans up on exit — the temp-dir discipline a
+    // state-touching test must follow (channel#75). The afterEach backstop double-checks.
+    await withTempStateDir(async (dir) => {
       const backend = new FakeBackend();
       const rec = recorder();
       const programmatic = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
       const ops = stubAgentOps();
-      // Point the channel state dir at our temp via PARACHUTE_CHANNEL_STATE_DIR so
-      // defaultStateDir → <dir> and the sessions dir + credentials store land under
-      // it (NOT the operator's real ~/.parachute).
-      const prevStateDir = process.env.PARACHUTE_CHANNEL_STATE_DIR;
-      process.env.PARACHUTE_CHANNEL_STATE_DIR = dir;
       // Seed a default Claude credential so setupProgrammaticSpawn's early resolve
       // succeeds against the temp store (no real store touched).
       const { writeFileSync } = await import("node:fs");
@@ -201,12 +272,8 @@ describe("spawn with backend:'programmatic'", () => {
         expect(persisted.backend).toBe("programmatic");
       } finally {
         srv.stop(true);
-        if (prevStateDir === undefined) delete process.env.PARACHUTE_CHANNEL_STATE_DIR;
-        else process.env.PARACHUTE_CHANNEL_STATE_DIR = prevStateDir;
       }
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
+    });
   });
 });
 
@@ -300,8 +367,20 @@ describe("inbound for a programmatic channel → deliver → outbound note", () 
   });
 });
 
+/** A live channels map containing `names` as keys — only membership matters to the
+ *  boot re-register channel-existence guard (`channels.has(wakeChannel)`), so the
+ *  transport is an inert stub. Mirrors a channels.json-derived map at the keys level. */
+function liveChannels(names: string[]): Map<string, Channel> {
+  const m = new Map<string, Channel>();
+  for (const name of names) {
+    const transport = { kind: "vault" } as unknown as Channel["transport"];
+    m.set(name, { name, transport, entry: { name, transport: "vault" } });
+  }
+  return m;
+}
+
 describe("boot re-register", () => {
-  test("a persisted programmatic spec.json → re-registered on start", async () => {
+  test("a persisted programmatic spec whose channel IS configured → re-registered on start", async () => {
     const dir = mkdtempSync(join(tmpdir(), "prog-boot-"));
     try {
       const sessionsDir = join(dir, "sessions");
@@ -313,7 +392,9 @@ describe("boot re-register", () => {
       const rec = recorder();
       const programmatic = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
 
-      const count = await reregisterProgrammaticAgents(programmatic, sessionsDir);
+      // Both wake channels ("eng", "watch") are live — so the ONLY skip is the
+      // back-compat interactive one, not the channel-existence guard.
+      const count = await reregisterProgrammaticAgents(programmatic, liveChannels(["eng", "watch"]), sessionsDir);
       expect(count).toBe(1);
       expect(programmatic.hasName("eng")).toBe(true);
       // The interactive spec was NOT re-registered as programmatic.
@@ -323,11 +404,77 @@ describe("boot re-register", () => {
     }
   });
 
+  test("orphan guard: a programmatic spec whose channel is NOT configured → SKIPPED (no phantom)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "prog-boot-orphan-"));
+    try {
+      const sessionsDir = join(dir, "sessions");
+      // Three spec dirs in the SAME temp sessions dir:
+      //  (a) programmatic, channel "eng" — CONFIGURED → re-registered.
+      //  (b) programmatic, channel "ghost" — NOT configured (orphaned/leaked) → SKIPPED.
+      //  (c) legacy no-backend spec — interactive → SKIPPED regardless of channel.
+      persistSpec(sessionWorkspace(sessionsDir, "eng"), { name: "eng", channels: ["eng"], backend: "programmatic" });
+      persistSpec(sessionWorkspace(sessionsDir, "stray"), { name: "stray", channels: ["ghost"], backend: "programmatic" });
+      persistSpec(sessionWorkspace(sessionsDir, "legacy"), { name: "legacy", channels: ["eng"] });
+
+      const backend = new FakeBackend();
+      const rec = recorder();
+      const programmatic = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+
+      // Only "eng" is a live channel; "ghost" is not configured.
+      const logs: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: unknown[]) => { logs.push(args.join(" ")); };
+      let count: number;
+      try {
+        count = await reregisterProgrammaticAgents(programmatic, liveChannels(["eng"]), sessionsDir);
+      } finally {
+        console.log = origLog;
+      }
+
+      // Exactly the configured-channel agent was re-registered.
+      expect(count).toBe(1);
+      expect(programmatic.hasName("eng")).toBe(true);
+      // The orphan (channel not configured) was SKIPPED — no phantom agent.
+      expect(programmatic.hasName("stray")).toBe(false);
+      expect(programmatic.hasChannel("ghost")).toBe(false);
+      // The legacy no-backend (interactive) spec was SKIPPED too.
+      expect(programmatic.hasName("legacy")).toBe(false);
+      // And the orphan skip emitted the one-line notice naming the missing channel.
+      expect(
+        logs.some((l) => l.includes('skipping re-register of "stray"') && l.includes('channel "ghost" not configured')),
+      ).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a programmatic spec with NO channel → SKIPPED (nothing to key/route on)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "prog-boot-nochan-"));
+    try {
+      const sessionsDir = join(dir, "sessions");
+      persistSpec(sessionWorkspace(sessionsDir, "headless"), { name: "headless", channels: [], backend: "programmatic" });
+
+      const backend = new FakeBackend();
+      const rec = recorder();
+      const programmatic = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+
+      const count = await reregisterProgrammaticAgents(programmatic, liveChannels([]), sessionsDir);
+      expect(count).toBe(0);
+      expect(programmatic.hasName("headless")).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test("no sessions dir → 0 re-registered (clean first boot)", async () => {
     const backend = new FakeBackend();
     const rec = recorder();
     const programmatic = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
-    const count = await reregisterProgrammaticAgents(programmatic, join(tmpdir(), "does-not-exist-" + Date.now()));
+    const count = await reregisterProgrammaticAgents(
+      programmatic,
+      liveChannels([]),
+      join(tmpdir(), "does-not-exist-" + Date.now()),
+    );
     expect(count).toBe(0);
   });
 });
@@ -448,16 +595,15 @@ describe("backend default flip + interactive path", () => {
   // OMITS `backend` now routes to the PROGRAMMATIC registry, not the interactive
   // tmux AgentOps. Interactive is still fully reachable by passing it explicitly.
   test("a default (no backend) spawn now hits the PROGRAMMATIC registry (not tmux)", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "prog-default-"));
-    const prevStateDir = process.env.PARACHUTE_CHANNEL_STATE_DIR;
-    try {
+    // Temp-dir isolation via withTempStateDir (channel#75) — the spawn persists a
+    // spec.json under defaultSessionsDir, which must resolve under the temp dir.
+    await withTempStateDir(async (dir) => {
       const backend = new FakeBackend();
       const rec = recorder();
       const programmatic = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
       const ops = stubAgentOps();
-      // Point the state dir at the temp + seed a default Claude credential so
-      // setupProgrammaticSpawn's early credential resolve succeeds (no real store).
-      process.env.PARACHUTE_CHANNEL_STATE_DIR = dir;
+      // Seed a default Claude credential so setupProgrammaticSpawn's early credential
+      // resolve succeeds (no real store).
       const { writeFileSync } = await import("node:fs");
       writeFileSync(join(dir, "credentials.json"), JSON.stringify({ claude: { default: "oat_test" } }), { mode: 0o600 });
 
@@ -476,11 +622,7 @@ describe("backend default flip + interactive path", () => {
       } finally {
         srv.stop(true);
       }
-    } finally {
-      if (prevStateDir === undefined) delete process.env.PARACHUTE_CHANNEL_STATE_DIR;
-      else process.env.PARACHUTE_CHANNEL_STATE_DIR = prevStateDir;
-      rmSync(dir, { recursive: true, force: true });
-    }
+    });
   });
 
   test("an explicit backend:\"interactive\" spawn still hits the interactive tmux AgentOps", async () => {


### PR DESCRIPTION
Fixes #75.

After #74 the daemon's boot re-register scans `~/.parachute/channel/sessions/*/spec.json` and re-registers any with `backend: "programmatic"`. A leftover `sessions/eng/spec.json` in the **real** state dir caused a phantom `eng` programmatic agent to appear on boot (seen live, cleaned manually). Two root causes, both fixed.

## 1. Boot re-register hardening (the real fix — defense-in-depth)

`reregisterProgrammaticAgents` now takes the live `channels` map and re-registers **only** a programmatic agent whose wake channel **still exists** in the current channels config. A spec whose channel isn't configured has nothing to receive for, so it's **skipped** with a one-line notice:

```
parachute-channel: skipping re-register of "<name>" — channel "<ch>" not configured.
```

This makes any leaked / orphaned / stray spec dir (deleted agent, crash mid-spawn, hand-copied cruft) **inert** — it can never resurrect a phantom agent.

- The wake channel is keyed exactly as the registry keys it: `normalizeChannel(spec.channels[0]).name` (matches `ProgrammaticAgentRegistry.channelOf`).
- A spec with an **empty** channels array is also skipped (no channel to key/route on — would otherwise throw at the registry's `channelOf`).
- Still uses `interpretPersistedBackend` (#76) for the backend read (missing field → interactive → already skipped).
- `main` threads the live `channels` map through.

## 2. Test-state-leak guard

A test write escaped isolation into the real `~/.parachute/channel/sessions/`, which boot re-register then resurrected. Audit found the boot-reregister + spawn tests were already temp-dir-isolated, but there was no backstop. Added:

- An `afterEach` that snapshots the **real** sessions dir (derived **without** honoring `PARACHUTE_CHANNEL_STATE_DIR`, so it's the genuine home even while a test points the env var at a temp dir) and **fails any test that creates a new session dir there**. Set-membership compare, so a concurrently-running operator daemon spawning a legit agent doesn't false-fail.
- A `withTempStateDir` helper that points `PARACHUTE_CHANNEL_STATE_DIR` at a fresh `mkdtemp` dir, restores the prior value, and `rmSync`-cleans up — the easy-path discipline future state-touching tests should follow. The two existing spawn tests now use it (removing the hand-rolled env dance).

Audited the whole suite (`persistSpec` / `sessionWorkspace` / `AgentSessionState` / `defaultStateDir` / `sessionsDir` calls) — every state write is under a temp dir.

## Tests

Boot re-register with a temp sessions dir:
- (a) programmatic spec whose channel **IS** configured → re-registered
- (b) programmatic spec whose channel is **NOT** configured → **SKIPPED** with the notice (no phantom)
- (c) legacy no-backend spec → skipped (interactive)
- plus a no-channel programmatic spec → skipped

The orphan-guard test is **load-bearing** — verified it fails when the channel-existence check is removed, passes with it.

## Gates

- `bun test ./src`: **588 pass / 0 fail** (baseline 586; +2 net new tests)
- `bun run typecheck`: clean except the 2 pre-existing TS2589 in `src/bridge.ts:77-78` (unrelated; zero new)
- `bunx biome check --write .`: clean
- Version: left at 0.1.0 (preview)

🤖 Generated with [Claude Code](https://claude.com/claude-code)