### PR TITLE
feat(channel): per-channel system prompt (append/replace, file-backed)

### DIFF
--- a/design/2026-06-16-channel-system-prompt.md
+++ b/design/2026-06-16-channel-system-prompt.md
@@ -1,0 +1,99 @@
+# Per-channel system prompt — give a channel a role
+
+**Status:** built 2026-06-16. Companion to
+[`2026-06-16-pluggable-agent-backend.md`](./2026-06-16-pluggable-agent-backend.md)
+(how an agent is driven), [`2026-06-16-agent-filesystem-and-sharing.md`](./2026-06-16-agent-filesystem-and-sharing.md)
+(workspace / shared library / private runtime), and
+[`2026-06-16-session-environment-and-credentials.md`](./2026-06-16-session-environment-and-credentials.md)
+(env/credential injection).
+
+## The feature
+
+An operator gives a channel a **specific role** via a system prompt, set when
+creating/configuring the channel — **backend-visible**, so the agent gets strong
+specificity. Two new fields on the `AgentSpec` (`src/sandbox/types.ts`):
+
+- `systemPrompt?: string` — the role text.
+- `systemPromptMode?: "append" | "replace"` — how it composes with Claude Code's
+  own default system prompt. **Default `"append"`.**
+
+Parsed from the untrusted spawn body in `buildSpecFromBody` (`src/agents.ts`): the
+mode is validated to exactly the two allowed values (anything else → 400); a
+blank/whitespace-only prompt is treated as unset (no flag); an orphan mode with no
+prompt is dropped. The spec is persisted in `spec.json`, so a daemon restart
+re-registers the role.
+
+### The two modes (verified empirically, claude 2.1.179, + against docs)
+
+- **Append** (`--append-system-prompt` / `--append-system-prompt-file`): **KEEPS**
+  Claude Code's capable default system prompt (~2.4k tokens of agentic/tool
+  instruction) and **adds** the channel's role on top. The default — the channel
+  gets specificity without losing CC's base competence.
+- **Replace** (`--system-prompt` / `--system-prompt-file`): **REPLACES** the
+  default entirely with the channel's prompt. A fully-custom persona; also leaner on
+  the subscription (fewer base tokens per turn).
+- **CLAUDE.md is a SEPARATE context layer**, unaffected by either flag — only
+  `--bare` would drop it (and `--bare` is not implemented; see below). So the role
+  (system prompt) and the workspace conventions (CLAUDE.md) are independent knobs:
+  the role gives channel specificity **decoupled** from the workspace/CLAUDE.md.
+
+### File-backed, re-applied per turn
+
+The flags are **per-invocation, not persistent** — `claude -p` re-reads them each
+run. The programmatic backend runs a **fresh `claude -p` per turn** (including
+`--resume` turns), so it MUST re-pass the flag on **every** turn. We write the
+prompt to a per-session file (`<workspace>/system-prompt.txt`, `0600`) and pass the
+**`-file` variant** (`--append-system-prompt-file` / `--system-prompt-file`):
+
+- robust to long / multiline prompts (no shell-quoting a giant arg);
+- keeps the prompt **visible-on-disk** to the backend;
+- the file is **(re)written every `deliver`** and the flag rebuilt in the per-turn
+  argv (`buildProgrammaticClaudeArgs`) — so a resume turn carries the role too.
+
+The **interactive** backend (`buildAgentClaudeArgs` / `spawnAgent`) passes the same
+`-file` flag once at launch (the session is long-lived, so per-turn re-pass is
+unnecessary) — for backend-parity/agnosticism. Unset `systemPrompt` → no file, no
+flag, today's behavior unchanged.
+
+### UI + surfacing
+
+The Agents page spawn form (`src/agents-ui.ts`) gets a **System prompt** textarea +
+an **Append (default) / Replace** mode control with the one-line hint *"Append keeps
+Claude Code's capable base and adds your channel's role; Replace gives full
+control."* `collectSpec` sends `systemPrompt` + `systemPromptMode` only when the
+textarea is non-blank. `GET /api/agents` surfaces a `systemPromptMode` on each agent
+when a prompt is set (the **mode**, not the text — the prompt can be long /
+role-sensitive); the running-agents list shows a small `role: append|replace` badge.
+
+## The `--bare` finding (so we never re-litigate)
+
+`--bare` is **API-key-only BY DESIGN.** It skips OAuth/keychain and does **not** read
+`CLAUDE_CODE_OAUTH_TOKEN`
+(doc: code.claude.com/docs/en/authentication, 2026-06-16 — *"Bare mode does not read
+`CLAUDE_CODE_OAUTH_TOKEN`; authenticate with `ANTHROPIC_API_KEY`."*). Confirmed
+programmatically (claude 2.1.179): `--bare` + an injected subscription token →
+"Not logged in"; non-bare `-p` + the same token → works on the subscription
+(`apiKeySource: none`, `five_hour` rate-limit pool). Using `--bare` would therefore
+force **metered/API billing off the subscription**.
+
+**Decision: `bare` is intentionally NOT implemented** — it would silently flip
+billing, exactly the footgun the env-credential model
+([session-environment note](./2026-06-16-session-environment-and-credentials.md))
+exists to prevent. Keep it out unless Anthropic changes the policy. If `--bare` is
+ever wanted, it couples to the metered/API-key path (the "guarded" provider keys
+from the session-environment note) as an advanced, explicitly-opt-into-metered mode
+— never a silent default.
+
+## Leanness on the subscription (the bare-alternative)
+
+You don't need `--bare` to run a lean agent on the subscription. The programmatic
+backend already runs `--strict-mcp-config` with a **vault-only** `.mcp.json` (no MCP
+/ tool bloat). Further leanness, all subscription-compatible:
+
+- `--system-prompt` (**replace** mode) — drops CC's ~2.4k-token default for a small
+  custom prompt;
+- `--allowedTools` — trim the tool surface (future knob);
+- a minimal workspace CLAUDE.md.
+
+These cut per-turn tokens **without** leaving the subscription — the opposite of
+`--bare`, which leaves it entirely.

--- a/src/agents-ui.ts
+++ b/src/agents-ui.ts
@@ -229,6 +229,21 @@ ${THEME_CSS}
         </details>
       </div>
 
+      <div style="margin-top:12px;">
+        <label for="spawn-system-prompt">System prompt <span class="muted">(optional — the channel's role)</span></label>
+        <textarea id="spawn-system-prompt" rows="3" placeholder="e.g. You are the eng channel's release assistant. Keep replies terse and action-oriented." style="width:100%; box-sizing:border-box; font:inherit; padding:8px 10px; border:1px solid var(--border); border-radius:6px; background:var(--card); color:var(--fg); resize:vertical;"></textarea>
+        <div class="row" style="margin-top:8px; align-items:center;">
+          <div>
+            <label for="spawn-prompt-mode" style="display:inline; margin-right:6px;">Mode</label>
+            <select id="spawn-prompt-mode">
+              <option value="append" selected>Append (default)</option>
+              <option value="replace">Replace</option>
+            </select>
+          </div>
+          <span class="muted" style="font-size:12px;">Append keeps Claude Code's capable base and adds your channel's role; Replace gives full control.</span>
+        </div>
+      </div>
+
       <details id="advanced">
         <summary>Advanced — extra channels, vault, network, mounts</summary>
         <div class="sub">
@@ -616,6 +631,14 @@ ${SHELL_JS}
     // new request), but interactive MUST be passed explicitly to opt out of that
     // default, so send the value either way for clarity.
     spec.backend = backendMode.value === "interactive" ? "interactive" : "programmatic";
+    // System prompt (the channel's role). Only send when non-blank — the server
+    // treats a blank prompt as unset (CC's default, untouched). The mode rides
+    // along so append (default) vs replace is the operator's choice.
+    var sysPrompt = document.getElementById("spawn-system-prompt").value.trim();
+    if (sysPrompt) {
+      spec.systemPrompt = sysPrompt;
+      spec.systemPromptMode = document.getElementById("spawn-prompt-mode").value === "replace" ? "replace" : "append";
+    }
     return spec;
   }
 
@@ -727,8 +750,14 @@ ${SHELL_JS}
           (prog ? "Reset the conversation (next message starts fresh)" : "Re-source env + reconnect this session") + "'>" +
           (prog ? "reset" : "restart / reconnect") + "</button>" +
           "<button class='ghost danger' data-kill='" + esc(a.name) + "' type='button'>" + (prog ? "deregister" : "kill") + "</button>";
+        // A small badge when the agent carries a per-channel system prompt (the role),
+        // showing the composition mode (append/replace) — the text itself isn't surfaced.
+        var promptBadge = a.systemPromptMode
+          ? " <span class='pill' title='system prompt set (" + esc(a.systemPromptMode) +
+            " mode)' style='font-size:11px;'>role: " + esc(a.systemPromptMode) + "</span>"
+          : "";
         return "<tr>" +
-          "<td><strong>" + esc(a.name) + "</strong></td>" +
+          "<td><strong>" + esc(a.name) + "</strong>" + promptBadge + "</td>" +
           "<td>" + backendCell + "</td>" +
           "<td>" + stateCell + "</td>" +
           "<td>" + connCell + "</td>" +

--- a/src/agents.test.ts
+++ b/src/agents.test.ts
@@ -105,6 +105,33 @@ describe("agentInfoFromSessions", () => {
   test("a bare `-agent` (empty slug) is dropped", () => {
     expect(agentInfoFromSessions([{ name: "-agent", attached: false }], "/tmp/s")).toEqual([]);
   });
+  test("surfaces systemPromptMode from the persisted spec when a prompt is set; absent otherwise", () => {
+    const dir = mkdtempSync(join(tmpdir(), "agent-info-sysprompt-"));
+    try {
+      // "withprompt" has a persisted spec carrying a systemPrompt; "noprompt" has one without.
+      persistSpec(sessionWorkspace(dir, "withprompt"), {
+        name: "withprompt",
+        channels: ["withprompt"],
+        systemPrompt: "You are a focused bot.",
+        systemPromptMode: "replace",
+      } as AgentSpec);
+      persistSpec(sessionWorkspace(dir, "noprompt"), { name: "noprompt", channels: ["noprompt"] } as AgentSpec);
+      const infos = agentInfoFromSessions(
+        [
+          { name: "withprompt-agent", attached: false },
+          { name: "noprompt-agent", attached: false },
+        ],
+        dir,
+      );
+      const byName = Object.fromEntries(infos.map((i) => [i.name, i]));
+      // The mode is surfaced for the prompted agent…
+      expect(byName.withprompt!.systemPromptMode).toBe("replace");
+      // …and absent for the one with no prompt.
+      expect(byName.noprompt!.systemPromptMode).toBeUndefined();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("buildSpecFromBody", () => {
@@ -188,6 +215,54 @@ describe("buildSpecFromBody", () => {
   });
   test("rejects an invalid backend value", () => {
     expect(() => buildSpecFromBody({ name: "a", channels: ["c"], backend: "weird" })).toThrow(/backend/);
+  });
+
+  // Per-channel system prompt (design 2026-06-16-channel-system-prompt.md):
+  // systemPrompt + mode parsed; default mode = append; invalid mode rejected;
+  // absent → undefined.
+  test("systemPrompt parsed + default mode is append", () => {
+    const spec = buildSpecFromBody({ name: "a", channels: ["c"], systemPrompt: "You are the eng bot." });
+    expect(spec.systemPrompt).toBe("You are the eng bot.");
+    expect(spec.systemPromptMode).toBe("append"); // default
+  });
+  test("explicit systemPromptMode:\"replace\" is honored", () => {
+    const spec = buildSpecFromBody({
+      name: "a",
+      channels: ["c"],
+      systemPrompt: "Full custom persona.",
+      systemPromptMode: "replace",
+    });
+    expect(spec.systemPrompt).toBe("Full custom persona.");
+    expect(spec.systemPromptMode).toBe("replace");
+  });
+  test("absent systemPrompt → both fields undefined", () => {
+    const spec = buildSpecFromBody({ name: "a", channels: ["c"] });
+    expect(spec.systemPrompt).toBeUndefined();
+    expect(spec.systemPromptMode).toBeUndefined();
+  });
+  test("blank / whitespace-only systemPrompt is treated as unset (no flag)", () => {
+    const spec = buildSpecFromBody({ name: "a", channels: ["c"], systemPrompt: "   \n  " });
+    expect(spec.systemPrompt).toBeUndefined();
+    expect(spec.systemPromptMode).toBeUndefined();
+  });
+  test("an orphan systemPromptMode with no prompt is dropped (no-op)", () => {
+    const spec = buildSpecFromBody({ name: "a", channels: ["c"], systemPromptMode: "replace" });
+    expect(spec.systemPrompt).toBeUndefined();
+    expect(spec.systemPromptMode).toBeUndefined();
+  });
+  test("rejects an invalid systemPromptMode value", () => {
+    expect(() =>
+      buildSpecFromBody({ name: "a", channels: ["c"], systemPrompt: "x", systemPromptMode: "merge" }),
+    ).toThrow(/systemPromptMode/);
+  });
+  test("rejects a non-string systemPrompt", () => {
+    expect(() =>
+      buildSpecFromBody({ name: "a", channels: ["c"], systemPrompt: 42 }),
+    ).toThrow(/systemPrompt must be a string/);
+  });
+  test("systemPrompt is trimmed", () => {
+    const spec = buildSpecFromBody({ name: "a", channels: ["c"], systemPrompt: "  hi  " });
+    expect(spec.systemPrompt).toBe("hi");
   });
 });
 
@@ -480,6 +555,23 @@ describe("GET /agents — the management page (loads open)", () => {
       srv.stop(true);
     }
   });
+
+  // Per-channel system prompt (design 2026-06-16-channel-system-prompt.md): the
+  // spawn form carries a System prompt textarea + an Append (default)/Replace mode
+  // control with the one-line hint.
+  test("spawn form has a System prompt textarea + Append(default)/Replace mode control", async () => {
+    const { srv, base } = buildServer();
+    try {
+      const html = await (await fetch(`${base}/agents`)).text();
+      expect(html).toContain('id="spawn-system-prompt"');
+      expect(html).toContain("System prompt");
+      expect(html).toContain('<option value="append" selected>Append (default)</option>');
+      expect(html).toContain('<option value="replace">Replace</option>');
+      expect(html).toContain("Append keeps Claude Code's capable base");
+    } finally {
+      srv.stop(true);
+    }
+  });
 });
 
 describe("/api/agents — operator-gated on channel:admin", () => {
@@ -517,6 +609,40 @@ describe("/api/agents — operator-gated on channel:admin", () => {
       const body = (await res.json()) as { agents: { name: string }[] };
       expect(body.agents).toHaveLength(1);
       expect(body.agents[0]!.name).toBe("aaron");
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  // The /api/agents response surfaces the system-prompt MODE but NEVER the prompt
+  // text (the AgentInfo contract carries mode only — design 2026-06-16). A raw-body
+  // scan proves the text can't leak through the list endpoint.
+  test("GET surfaces systemPromptMode but never the prompt text", async () => {
+    const secretPrompt = "TOP-SECRET-PROMPT-TEXT-do-not-leak";
+    const { srv, base } = buildServer({
+      async list() {
+        return [
+          {
+            name: "aaron",
+            session: "aaron-agent",
+            attached: true,
+            workspace: "/s/aaron",
+            hasWorkspace: true,
+            backend: "interactive" as const,
+            systemPromptMode: "replace" as const,
+          },
+        ];
+      },
+    });
+    try {
+      const res = await fetch(`${base}/api/agents`, { headers: adminAuth });
+      expect(res.status).toBe(200);
+      const raw = await res.text();
+      // The mode IS surfaced…
+      expect(raw).toContain("systemPromptMode");
+      expect(raw).toContain("replace");
+      // …and the prompt TEXT never appears in the response (it isn't on AgentInfo).
+      expect(raw).not.toContain(secretPrompt);
     } finally {
       srv.stop(true);
     }

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -77,6 +77,14 @@ export interface AgentInfo {
    * /health's `mcp_sessions`). Present for programmatic agents in place of those.
    */
   status?: string;
+  /**
+   * The agent's system-prompt COMPOSITION mode when a per-channel system prompt is
+   * set (design 2026-06-16-channel-system-prompt.md) — `"append"` (kept CC's base +
+   * the role) or `"replace"` (full custom persona). Absent = no system prompt (CC's
+   * default, untouched). The prompt TEXT itself is deliberately NOT surfaced here
+   * (it can be long / role-sensitive) — only that one is set + how it composes.
+   */
+  systemPromptMode?: "append" | "replace";
 }
 
 /** A redacted mint summary — scope + audience + expiry, NEVER the token value. */
@@ -176,6 +184,10 @@ export function agentInfoFromSessions(
     const name = s.name.slice(0, -AGENT_SESSION_SUFFIX.length);
     if (name.length === 0) continue;
     const workspace = sessionWorkspace(sessionsDirPath, name);
+    // Surface the system-prompt composition mode (not the text) from the persisted
+    // spec when one is set — so the list shows the agent carries a role.
+    const persisted = readPersistedSpec(workspace);
+    const hasPrompt = typeof persisted?.systemPrompt === "string" && persisted.systemPrompt.length > 0;
     agents.push({
       name,
       session: s.name,
@@ -183,6 +195,7 @@ export function agentInfoFromSessions(
       workspace,
       hasWorkspace: existsSync(join(workspace, ".mcp.json")),
       backend: "interactive",
+      ...(hasPrompt ? { systemPromptMode: persisted!.systemPromptMode ?? "append" } : {}),
     });
   }
   agents.sort((a, b) => a.name.localeCompare(b.name));
@@ -309,6 +322,31 @@ export function buildSpecFromBody(body: unknown): AgentSpec {
     spec.backend = b.backend;
   } else {
     spec.backend = "programmatic";
+  }
+
+  // Per-channel system prompt — the operator gives the channel a role (design
+  // 2026-06-16-channel-system-prompt.md). It is passed (file-backed) on every
+  // `claude -p` turn. `systemPromptMode` decides composition with CC's default:
+  // "append" (default — keep CC's base + add the role) or "replace" (full custom
+  // persona). The mode is validated to the two allowed values; anything else 400s.
+  // A blank/whitespace-only prompt is treated as unset (no flag). The mode is only
+  // recorded when there's a prompt to qualify (an orphan mode with no prompt is a
+  // no-op, so we drop it to keep the spec minimal).
+  if (b.systemPrompt !== undefined && b.systemPrompt !== null) {
+    if (typeof b.systemPrompt !== "string") {
+      throw new SpawnRequestError("body.systemPrompt must be a string");
+    }
+  }
+  if (b.systemPromptMode !== undefined && b.systemPromptMode !== null) {
+    if (b.systemPromptMode !== "append" && b.systemPromptMode !== "replace") {
+      throw new SpawnRequestError('body.systemPromptMode must be "append" or "replace"');
+    }
+  }
+  const promptText = typeof b.systemPrompt === "string" ? b.systemPrompt.trim() : "";
+  if (promptText.length > 0) {
+    spec.systemPrompt = promptText;
+    // Default mode is "append" — keep CC's capable base, add the channel's role.
+    spec.systemPromptMode = b.systemPromptMode === "replace" ? "replace" : "append";
   }
 
   return spec;

--- a/src/backends/programmatic.test.ts
+++ b/src/backends/programmatic.test.ts
@@ -20,7 +20,7 @@
  *  - stop() clears the resume id; status() is live.
  */
 import { describe, test, expect, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, readFileSync, statSync } from "node:fs";
+import { mkdtempSync, rmSync, readFileSync, statSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -175,6 +175,20 @@ function specWithVault(name = "eng"): AgentSpec {
   };
 }
 
+function specWithSystemPrompt(
+  prompt: string,
+  mode: "append" | "replace" | undefined,
+  name = "eng",
+): AgentSpec {
+  return {
+    name,
+    channels: [name],
+    vault: { name: "default", access: "read", tags: ["#channel-message"] },
+    systemPrompt: prompt,
+    ...(mode ? { systemPromptMode: mode } : {}),
+  };
+}
+
 function mkDirs(tag: string): void {
   sessionsDir = mkdtempSync(join(tmpdir(), `prog-sessions-${tag}-`));
   stateDir = mkdtempSync(join(tmpdir(), `prog-state-${tag}-`));
@@ -207,6 +221,45 @@ describe("buildProgrammaticClaudeArgs", () => {
     });
     expect(argv).toContain("--resume");
     expect(argv[argv.indexOf("--resume") + 1]).toBe("sess-xyz");
+  });
+
+  test("system prompt (append, default): --append-system-prompt-file <path>", () => {
+    const argv = buildProgrammaticClaudeArgs({
+      message: "hi",
+      mcpConfigPath: "/ws/.mcp.json",
+      systemPromptFile: "/ws/system-prompt.txt",
+      systemPromptMode: "append",
+    });
+    expect(argv).toContain("--append-system-prompt-file");
+    expect(argv[argv.indexOf("--append-system-prompt-file") + 1]).toBe("/ws/system-prompt.txt");
+    expect(argv).not.toContain("--system-prompt-file");
+  });
+
+  test("system prompt (replace): --system-prompt-file <path>", () => {
+    const argv = buildProgrammaticClaudeArgs({
+      message: "hi",
+      mcpConfigPath: "/ws/.mcp.json",
+      systemPromptFile: "/ws/system-prompt.txt",
+      systemPromptMode: "replace",
+    });
+    expect(argv).toContain("--system-prompt-file");
+    expect(argv[argv.indexOf("--system-prompt-file") + 1]).toBe("/ws/system-prompt.txt");
+    expect(argv).not.toContain("--append-system-prompt-file");
+  });
+
+  test("system prompt with no mode → append (the -file flag defaults to append)", () => {
+    const argv = buildProgrammaticClaudeArgs({
+      message: "hi",
+      mcpConfigPath: "/ws/.mcp.json",
+      systemPromptFile: "/ws/system-prompt.txt",
+    });
+    expect(argv).toContain("--append-system-prompt-file");
+  });
+
+  test("no systemPromptFile → neither system-prompt flag", () => {
+    const argv = buildProgrammaticClaudeArgs({ message: "hi", mcpConfigPath: "/ws/.mcp.json" });
+    expect(argv).not.toContain("--append-system-prompt-file");
+    expect(argv).not.toContain("--system-prompt-file");
   });
 });
 
@@ -385,6 +438,80 @@ describe("ProgrammaticBackend.deliver — argv + env shape", () => {
     const env = calls[0]!.env;
     expect(env.GH_TOKEN).toBe("ghp_INJECTED");
     expect(env.ANTHROPIC_API_KEY).toBeUndefined(); // denylist drops it defensively
+  });
+});
+
+describe("ProgrammaticBackend.deliver — system prompt (file-backed, per-turn)", () => {
+  test("append mode → --append-system-prompt-file <path> + the file is written 0600 with the prompt", async () => {
+    mkDirs("sysprompt-append");
+    const { fn, calls } = recordingSpawn({ stdout: successTurn("s", "ok") });
+    const backend = new ProgrammaticBackend(baseDeps(fn));
+    const handle = await backend.start(specWithSystemPrompt("You are the eng release bot.", "append", "eng"));
+    await backend.deliver(handle, "hello");
+
+    const promptPath = join(sessionsDir, "eng", "system-prompt.txt");
+    // The file exists, is 0600, and carries the EXACT prompt text.
+    expect(statSync(promptPath).mode & 0o777).toBe(0o600);
+    expect(readFileSync(promptPath, "utf8")).toBe("You are the eng release bot.");
+    // The wrapped claude command (engine echoes it in argv[2]) carries the -file flag.
+    const cmd = calls[0]!.argv[2]!;
+    expect(cmd).toContain("--append-system-prompt-file");
+    expect(cmd).toContain(promptPath);
+    // `--system-prompt-file` is a substring of `--append-system-prompt-file`, so a
+    // bare `not.toContain("--system-prompt-file")` would always fail. Assert the
+    // replace-mode flag was NOT the one applied to the prompt path instead.
+    expect(cmd).not.toContain("--system-prompt-file " + promptPath);
+  });
+
+  test("replace mode → --system-prompt-file <path>", async () => {
+    mkDirs("sysprompt-replace");
+    const { fn, calls } = recordingSpawn({ stdout: successTurn("s", "ok") });
+    const backend = new ProgrammaticBackend(baseDeps(fn));
+    const handle = await backend.start(specWithSystemPrompt("Full custom persona.", "replace", "eng"));
+    await backend.deliver(handle, "hello");
+
+    const promptPath = join(sessionsDir, "eng", "system-prompt.txt");
+    expect(readFileSync(promptPath, "utf8")).toBe("Full custom persona.");
+    const cmd = calls[0]!.argv[2]!;
+    expect(cmd).toContain("--system-prompt-file");
+    expect(cmd).not.toContain("--append-system-prompt-file");
+  });
+
+  test("no systemPrompt → no file, no system-prompt flag (today's behavior)", async () => {
+    mkDirs("sysprompt-none");
+    const { fn, calls } = recordingSpawn({ stdout: successTurn("s", "ok") });
+    const backend = new ProgrammaticBackend(baseDeps(fn));
+    const handle = await backend.start(specWithVault("eng"));
+    await backend.deliver(handle, "hello");
+
+    expect(existsSync(join(sessionsDir, "eng", "system-prompt.txt"))).toBe(false);
+    const cmd = calls[0]!.argv[2]!;
+    expect(cmd).not.toContain("system-prompt-file");
+  });
+
+  test("the prompt file is (re)written + the flag re-passed on EVERY turn — incl. a resume turn", async () => {
+    mkDirs("sysprompt-perturn");
+    const state = new AgentSessionState({ stateDir });
+    const { fn, calls } = sequencedSpawn([
+      successTurn("sess-SP", "turn one reply"),
+      successTurn("sess-SP", "turn two reply"),
+    ]);
+    const backend = new ProgrammaticBackend(baseDeps(fn, { sessionState: state }));
+    const handle = await backend.start(specWithSystemPrompt("Per-turn role.", "append", "eng"));
+
+    await backend.deliver(handle, "turn one");
+    await backend.deliver(handle, "turn two");
+
+    const promptPath = join(sessionsDir, "eng", "system-prompt.txt");
+    // The file is present after the resume turn too (re-written each deliver).
+    expect(readFileSync(promptPath, "utf8")).toBe("Per-turn role.");
+    // Turn 1: -file flag, NO --resume. Turn 2 (resume): -file flag AND --resume.
+    const cmd1 = calls[0]!.argv[2]!;
+    const cmd2 = calls[1]!.argv[2]!;
+    expect(cmd1).toContain("--append-system-prompt-file");
+    expect(cmd1).not.toContain("--resume");
+    expect(cmd2).toContain("--append-system-prompt-file"); // re-passed on the resume turn
+    expect(cmd2).toContain("--resume sess-SP");
   });
 });
 

--- a/src/backends/programmatic.ts
+++ b/src/backends/programmatic.ts
@@ -148,12 +148,25 @@ export interface ProgrammaticBackendDeps {
  *
  * DELIBERATELY ABSENT: `--dangerously-load-development-channels` (no channel MCP in
  * this backend — the daemon mediates messaging), and any TUI flag (`-p` has none).
+ *
+ * SYSTEM PROMPT (design 2026-06-16-channel-system-prompt.md): when the spec carries
+ * a `systemPrompt`, the per-session prompt FILE path is passed via the `-file`
+ * variant — `--append-system-prompt-file <path>` (append mode, keeps CC's default)
+ * or `--system-prompt-file <path>` (replace mode). The flags are PER-INVOCATION, so
+ * this is added on EVERY turn (including `--resume` turns) — the argv is rebuilt per
+ * `deliver`, and the file is (re)written each turn (see {@link ProgrammaticBackend.deliver}).
+ * The `-file` form (over the inline string form) is robust to long/multiline prompts
+ * and keeps the prompt visible-on-disk to the backend.
  */
 export function buildProgrammaticClaudeArgs(opts: {
   message: string;
   mcpConfigPath: string;
   resumeSessionId?: string;
   claudeBin?: string;
+  /** Path to the per-session system-prompt file (omitted = no system-prompt flag). */
+  systemPromptFile?: string;
+  /** How the system prompt composes — append (default) keeps CC's base; replace overrides it. */
+  systemPromptMode?: "append" | "replace";
 }): string[] {
   const bin = opts.claudeBin ?? "claude";
   const argv = [
@@ -168,6 +181,12 @@ export function buildProgrammaticClaudeArgs(opts: {
     opts.mcpConfigPath,
     "--dangerously-skip-permissions",
   ];
+  // System prompt (file-backed). Append KEEPS CC's capable default + adds the role;
+  // replace overrides it entirely. Re-passed every turn (the flag isn't persistent).
+  if (opts.systemPromptFile) {
+    const flag = opts.systemPromptMode === "replace" ? "--system-prompt-file" : "--append-system-prompt-file";
+    argv.push(flag, opts.systemPromptFile);
+  }
   if (opts.resumeSessionId) {
     argv.push("--resume", opts.resumeSessionId);
   }
@@ -298,6 +317,19 @@ export class ProgrammaticBackend implements AgentBackend {
     const mcpConfigPath = join(workspace, ".mcp.json");
     writeFileSync(mcpConfigPath, mcpConfigJson, { mode: 0o600 });
 
+    // System prompt (design 2026-06-16-channel-system-prompt.md). When the spec
+    // carries one, write it to a per-session file (0600) and pass the `-file` flag.
+    // The flag is PER-INVOCATION (not persistent), so we (re)write the file + pass
+    // it EVERY turn — including a `--resume` turn — so the role is always applied.
+    // Unset → no flag, no file (today's behavior unchanged). The `-file` form is
+    // robust to long/multiline prompts and keeps the prompt visible-on-disk. Its
+    // lifecycle is tied to the workspace (like .mcp.json) — it disappears with it.
+    let systemPromptFile: string | undefined;
+    if (typeof spec.systemPrompt === "string" && spec.systemPrompt.length > 0) {
+      systemPromptFile = join(workspace, "system-prompt.txt");
+      writeFileSync(systemPromptFile, spec.systemPrompt, { mode: 0o600 });
+    }
+
     // Build the -p argv with --resume when a session id is stored for this channel.
     const resumeSessionId = this.deps.sessionState.get(channel);
     const argv = buildProgrammaticClaudeArgs({
@@ -305,6 +337,9 @@ export class ProgrammaticBackend implements AgentBackend {
       mcpConfigPath,
       ...(resumeSessionId ? { resumeSessionId } : {}),
       ...(this.deps.claudeBin ? { claudeBin: this.deps.claudeBin } : {}),
+      ...(systemPromptFile
+        ? { systemPromptFile, systemPromptMode: spec.systemPromptMode ?? "append" }
+        : {}),
     });
 
     // Sandbox-wrap via the SHARED seam — same egress floor + scoped-read

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -567,6 +567,7 @@ export function listProgrammaticAgents(programmatic: ProgrammaticAgentRegistry):
       const s = programmatic.statusOf(h.channel);
       const status = s.state === "queued" ? `queued:${s.queued}` : s.state;
       const workspace = sessionWorkspace(dir, h.name);
+      const hasPrompt = typeof h.spec.systemPrompt === "string" && h.spec.systemPrompt.length > 0;
       return {
         name: h.name,
         session: `${h.name}-agent`,
@@ -575,6 +576,7 @@ export function listProgrammaticAgents(programmatic: ProgrammaticAgentRegistry):
         hasWorkspace: existsSync(join(workspace, "spec.json")),
         backend: "programmatic" as const,
         status,
+        ...(hasPrompt ? { systemPromptMode: h.spec.systemPromptMode ?? "append" } : {}),
       };
     })
     .sort((a, b) => a.name.localeCompare(b.name));

--- a/src/sandbox/types.ts
+++ b/src/sandbox/types.ts
@@ -122,6 +122,26 @@ export type AgentChannel = string | AgentChannelSpec;
  */
 export type AgentBackendKind = "interactive" | "programmatic";
 
+/**
+ * How a channel's {@link AgentSpec.systemPrompt} composes with Claude Code's own
+ * default system prompt (design 2026-06-16-channel-system-prompt.md):
+ *
+ *   - `"append"` (DEFAULT): KEEP Claude Code's capable default system prompt
+ *     (~2.4k tokens of tool/agentic instruction) and ADD the channel's role on top
+ *     — `claude -p --append-system-prompt(-file) <X>`. The right default: the
+ *     channel gets strong specificity without losing CC's base competence.
+ *   - `"replace"`: REPLACE the default entirely with the channel's prompt —
+ *     `claude -p --system-prompt(-file) <X>`. A fully-custom persona for an
+ *     operator who wants total control of the system layer (and leanness on the
+ *     subscription — fewer base tokens per turn).
+ *
+ * Either mode is orthogonal to CLAUDE.md, which is a SEPARATE context layer
+ * unaffected by both flags (only `--bare` would drop it — and `--bare` is
+ * deliberately NOT implemented; see the design note: it is API-key-only by design
+ * and would force metered billing off the subscription).
+ */
+export type SystemPromptMode = "append" | "replace";
+
 export interface AgentSpec {
   /** Human-readable arm name; used as the tmux session + workspace slug. */
   name: string;
@@ -206,6 +226,23 @@ export interface AgentSpec {
    * spec.json so a daemon restart re-registers a programmatic agent on boot.
    */
   backend?: AgentBackendKind;
+  /**
+   * Per-channel system prompt — the operator gives the channel a specific role,
+   * backend-visible, so the agent gets strong specificity decoupled from the
+   * workspace + CLAUDE.md (design 2026-06-16-channel-system-prompt.md). Set when
+   * creating/configuring the channel; written to a per-session file and passed on
+   * EVERY `claude -p` turn (the flags are per-invocation, not persistent — a
+   * `--resume` turn re-passes it too). Unset → today's behavior (CC's default
+   * prompt, untouched). Persisted in spec.json.
+   */
+  systemPrompt?: string;
+  /**
+   * How {@link systemPrompt} composes with Claude Code's default system prompt —
+   * `"append"` (DEFAULT, keep CC's base + add the role) or `"replace"` (full
+   * custom persona). Only meaningful when `systemPrompt` is set. See
+   * {@link SystemPromptMode}.
+   */
+  systemPromptMode?: SystemPromptMode;
 }
 
 /**

--- a/src/spawn-agent.test.ts
+++ b/src/spawn-agent.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, readFileSync, statSync, writeFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -234,6 +234,32 @@ describe("buildAgentClaudeArgs", () => {
     // NOT headless: no `-p`.
     expect(argv).not.toContain("-p");
   });
+  test("no systemPromptFile → neither system-prompt flag (today's behavior)", () => {
+    const argv = buildAgentClaudeArgs({ mcpConfigPath: "/ws/.mcp.json", firstChannelEntryKey: "channel-c" });
+    expect(argv).not.toContain("--append-system-prompt-file");
+    expect(argv).not.toContain("--system-prompt-file");
+  });
+  test("systemPromptFile (append, default) → --append-system-prompt-file <path>", () => {
+    const argv = buildAgentClaudeArgs({
+      mcpConfigPath: "/ws/.mcp.json",
+      firstChannelEntryKey: "channel-c",
+      systemPromptFile: "/ws/system-prompt.txt",
+      systemPromptMode: "append",
+    });
+    expect(argv).toContain("--append-system-prompt-file");
+    expect(argv[argv.indexOf("--append-system-prompt-file") + 1]).toBe("/ws/system-prompt.txt");
+    expect(argv).not.toContain("--system-prompt-file");
+  });
+  test("systemPromptFile (replace) → --system-prompt-file <path>", () => {
+    const argv = buildAgentClaudeArgs({
+      mcpConfigPath: "/ws/.mcp.json",
+      firstChannelEntryKey: "channel-c",
+      systemPromptFile: "/ws/system-prompt.txt",
+      systemPromptMode: "replace",
+    });
+    expect(argv).toContain("--system-prompt-file");
+    expect(argv).not.toContain("--append-system-prompt-file");
+  });
 });
 
 describe("shellJoin", () => {
@@ -391,6 +417,35 @@ describe("spawnAgent — full wiring with stubs (no real token)", () => {
     expect(engine.initializedWith!.network.allowedDomains).toContain("api.anthropic.com");
     expect(engine.initializedWith!.network.allowedDomains).toContain("hub.example.com");
     expect(engine.initializedWith!.filesystem.allowWrite).toContain(res.workspace);
+  });
+
+  test("a spec with systemPrompt writes system-prompt.txt 0600 + passes the -file flag in the launch argv", async () => {
+    sessionsDir = mkdtempSync(join(tmpdir(), "spawn-agent-sysprompt-"));
+    const tmux = recordingTmux();
+    const spec: AgentSpec = {
+      name: "eng",
+      channels: ["eng"],
+      systemPrompt: "You are the eng channel's assistant.",
+      systemPromptMode: "append",
+    };
+    const res = await spawnAgent(spec, baseDeps({ tmux }));
+
+    // The prompt file is written 0600 with the exact text.
+    const promptPath = join(res.workspace, "system-prompt.txt");
+    expect(statSync(promptPath).mode & 0o777).toBe(0o600);
+    expect(readFileSync(promptPath, "utf8")).toBe("You are the eng channel's assistant.");
+    // The launched claude command carries --append-system-prompt-file <path>.
+    const cmd = tmux.launched[0]!.argv[2]!;
+    expect(cmd).toContain("--append-system-prompt-file");
+    expect(cmd).toContain(promptPath);
+  });
+
+  test("a spec with NO systemPrompt writes no prompt file + no system-prompt flag", async () => {
+    sessionsDir = mkdtempSync(join(tmpdir(), "spawn-agent-nosysprompt-"));
+    const tmux = recordingTmux();
+    const res = await spawnAgent({ name: "bare", channels: ["bare"] }, baseDeps({ tmux }));
+    expect(existsSync(join(res.workspace, "system-prompt.txt"))).toBe(false);
+    expect(tmux.launched[0]!.argv[2]!).not.toContain("system-prompt-file");
   });
 
   test("mints ONE token per channel for a multi-channel spec", async () => {

--- a/src/spawn-agent.ts
+++ b/src/spawn-agent.ts
@@ -531,14 +531,24 @@ export function seedAgentHome(
  * for local development"), which has no skip flag and which `--channels` (the
  * allowlist path) doesn't satisfy for custom `server:` channels. That gate is
  * auto-answered post-launch by `confirmDevChannelsPrompt` (channel#70), not here.
+ *
+ * SYSTEM PROMPT (design 2026-06-16-channel-system-prompt.md): for backend-parity
+ * with the programmatic path, when the spec carries a `systemPrompt` the per-session
+ * prompt FILE is passed via the `-file` variant — `--append-system-prompt-file`
+ * (append, keeps CC's default) or `--system-prompt-file` (replace). Interactive is a
+ * long-lived session, so one-time at launch is sufficient (no per-turn re-pass).
  */
 export function buildAgentClaudeArgs(opts: {
   mcpConfigPath: string;
   firstChannelEntryKey: string;
   claudeBin?: string;
+  /** Path to the per-session system-prompt file (omitted = no system-prompt flag). */
+  systemPromptFile?: string;
+  /** How the system prompt composes — append (default) keeps CC's base; replace overrides it. */
+  systemPromptMode?: "append" | "replace";
 }): string[] {
   const bin = opts.claudeBin ?? "claude";
-  return [
+  const argv = [
     bin,
     "--dangerously-skip-permissions",
     "--strict-mcp-config",
@@ -546,6 +556,11 @@ export function buildAgentClaudeArgs(opts: {
     opts.mcpConfigPath,
     `--dangerously-load-development-channels=server:${opts.firstChannelEntryKey}`,
   ];
+  if (opts.systemPromptFile) {
+    const flag = opts.systemPromptMode === "replace" ? "--system-prompt-file" : "--append-system-prompt-file";
+    argv.push(flag, opts.systemPromptFile);
+  }
+  return argv;
 }
 
 /**
@@ -680,6 +695,17 @@ export async function spawnAgent(
   // looser-perms file to tighten (unlike registry.ts's read-modify-write).
   writeFileSync(mcpConfigPath, mcpConfigJson, { mode: 0o600 });
 
+  // Per-channel system prompt (design 2026-06-16-channel-system-prompt.md). When the
+  // spec carries one, write it 0600 to a per-session file and pass the `-file` flag.
+  // The interactive session is long-lived, so this is one-time at launch (the
+  // programmatic backend re-writes + re-passes per turn). Unset → no flag, no file.
+  // The file's lifecycle is tied to the workspace (like .mcp.json), 0600 alike.
+  let systemPromptFile: string | undefined;
+  if (typeof spec.systemPrompt === "string" && spec.systemPrompt.length > 0) {
+    systemPromptFile = join(workspace, "system-prompt.txt");
+    writeFileSync(systemPromptFile, spec.systemPrompt, { mode: 0o600 });
+  }
+
   // 3. Build the claude argv, sandbox-wrap it, launch in tmux with scrubbed env.
   // `wakeChannel` (resolved above) is the first channel — the dev-channel flag's
   // server name + the key the credential was resolved under.
@@ -687,6 +713,9 @@ export async function spawnAgent(
     mcpConfigPath,
     firstChannelEntryKey: `channel-${wakeChannel}`,
     ...(deps.claudeBin ? { claudeBin: deps.claudeBin } : {}),
+    ...(systemPromptFile
+      ? { systemPromptFile, systemPromptMode: spec.systemPromptMode ?? "append" }
+      : {}),
   });
 
   // Sandbox-wrap via the shared seam (also used by the programmatic backend) so


### PR DESCRIPTION
## What

Let an operator give a channel a **specific role** via a system prompt, set when creating/configuring the channel — **backend-visible**, so the agent gets strong specificity **decoupled** from the workspace/CLAUDE.md. The default mode **APPENDS** to Claude Code's capable default system prompt (~2.4k tokens); an opt-in **REPLACE** mode gives a fully-custom persona.

## Spec fields (`src/sandbox/types.ts`)

- `systemPrompt?: string` — the channel's role text.
- `systemPromptMode?: "append" | "replace"` — composition with CC's default. **Default `"append"`.**

Parsed in `buildSpecFromBody` (`src/agents.ts`): mode validated to the two values (else 400); blank/whitespace-only prompt → unset; orphan mode with no prompt dropped. Persisted in `spec.json` so a restart re-registers the role.

## Flag wiring (append vs replace, file-backed)

When `systemPrompt` is set, the prompt is written to a per-session file (`<workspace>/system-prompt.txt`, `0600`) and the **`-file` variant** is passed:
- **append** → `--append-system-prompt-file <path>` (keeps CC's default + adds the role)
- **replace** → `--system-prompt-file <path>` (overrides CC's default)

The `-file` form (over the inline string) is robust to long/multiline prompts and keeps the prompt visible-on-disk to the backend. Unset → no file, no flag (today's behavior unchanged).

## Per-turn re-application

The flags are **per-invocation, not persistent**. The **programmatic** backend runs a fresh `claude -p` per turn, so it **(re)writes the file and re-passes the flag on EVERY turn — including `--resume` turns** (the argv is rebuilt per `deliver`). A test exercises two sequential turns and asserts `--append-system-prompt-file` + `--resume <sid>` coexist on turn 2.

The **interactive** backend (`buildAgentClaudeArgs` / `spawnAgent`) passes the same `-file` flag **once at launch** (long-lived session) for backend parity.

## UI + surfacing

- Spawn form (`src/agents-ui.ts`): a **System prompt** textarea + **Append (default) / Replace** mode control with the hint *"Append keeps Claude Code's capable base and adds your channel's role; Replace gives full control."* `collectSpec` sends the fields only when non-blank.
- `GET /api/agents` (`AgentInfo`, populated in `agentInfoFromSessions` + `listProgrammaticAgents`) surfaces the **mode only** (not the prompt text — it can be long/role-sensitive); the running-agents list shows a `role: append|replace` badge.

**Interactive wired too:** yes — both backends get the flag.

## Why `--bare` is excluded

`--bare` is **API-key-only BY DESIGN** — it skips OAuth/keychain and does **not** read `CLAUDE_CODE_OAUTH_TOKEN` (docs: code.claude.com/docs/en/authentication, 2026-06-16; confirmed empirically on claude 2.1.179: `--bare` + injected subscription token → "Not logged in"; non-bare `-p` + same token → works on the subscription). It would force **metered billing off the subscription**, so `bare` is intentionally **not implemented** — kept out unless Anthropic changes the policy. The subscription-compatible leanness path is `--system-prompt` (replace) + a vault-only `--strict-mcp-config` + minimal CLAUDE.md. Full rationale: `design/2026-06-16-channel-system-prompt.md`.

## Gates

- `bun test ./src`: **611 pass / 0 fail** (588 baseline + 23 new).
- `bun run typecheck`: zero new errors (2 pre-existing `TS2589` in `src/bridge.ts` unrelated).
- `bunx biome check .`: clean.
- Version: left at `0.1.0`.

Tests do **not** touch the real `~/.parachute` — temp `sessionsDir`/`stateDir` per test (the #75 backstop).

## Review

Reviewer dispatched before this PR — verdict LGTM, no critical issues. Folded in: collapsed double object-spread, added an `agentInfoFromSessions` unit test for the surfaced mode, lifecycle comments near the file writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)