### PR TITLE
feat(channel): workspace seam — agents can work from a shared host directory

### DIFF
--- a/design/2026-06-16-agent-filesystem-and-sharing.md
+++ b/design/2026-06-16-agent-filesystem-and-sharing.md
@@ -1,6 +1,8 @@
 # Agent filesystem & sharing — workspace, shared library, private runtime
 
-**Status:** direction (not yet built). 2026-06-16. Companion to
+**Status:** the **working-directory axis (seam #1) SHIPPED 2026-06-16** (the
+`workspace` spec field — PR #82); the shared-library axis (#2) + step-up auth (#3)
+remain direction (not yet built). Companion to
 [`2026-06-14-sandboxed-agent-sessions.md`](./2026-06-14-sandboxed-agent-sessions.md)
 (sandbox/isolation), [`2026-06-16-pluggable-agent-backend.md`](./2026-06-16-pluggable-agent-backend.md)
 (how an agent is driven), and
@@ -92,10 +94,14 @@ reinvent them.
 
 ## Minimal seams to land (good-enough-now — don't over-build)
 
-1. **`workspace` (host path) on the agent spec** — decouple the working dir from the
-   private runtime home. Set → that dir is the cwd (mounted rw), private home still
-   per-agent at `sessions/<name>/`. Unset → today's private synthetic workspace. Small;
-   unblocks shared real-dir work + runner.
+1. **`workspace` (host path) on the agent spec** — ✅ **SHIPPED (PR #82, 2026-06-16).**
+   Decouples the working dir from the private runtime home. Set → that dir is the cwd
+   + an rw working-root in the sandbox; the private home (`.mcp.json`/`spec.json`/
+   `system-prompt.txt`/seeded `CLAUDE_CONFIG_DIR`/`tmp`) stays per-agent at
+   `sessions/<name>/`, 0600, never written into the shared dir. Unset → today's
+   private synthetic workspace. Both backends honor it via a shared `resolveAgentCwd`;
+   `buildSpecFromBody` requires an absolute, existing directory. Unblocks shared
+   real-dir work + runner.
 2. **A shared-library dir** — an operator-curated `skills/` (+ commands/agents) path,
    mounted **read-only** into agents that opt in. Could start as a single configurable
    shared-skills path that `seedAgentHome` layers in read-only.

--- a/src/agents-ui.ts
+++ b/src/agents-ui.ts
@@ -304,6 +304,17 @@ ${THEME_CSS}
           </div>
 
           <div>
+            <label for="spawn-workspace">Working directory <span class="muted">(optional — absolute host path)</span></label>
+            <input type="text" id="spawn-workspace" placeholder="/Users/you/Code/my-repo" autocomplete="off" />
+            <div class="muted" style="font-size:12px; margin-top:8px;">
+              The directory the agent works in (its cwd, read-write). Leave blank and it works in its own
+              private session dir. Set a real repo path to have it work there — that dir can be shared with
+              other agents, runner jobs, or scripts. Its private config &amp; tokens (<code>.mcp.json</code>)
+              always stay in the per-agent session dir, never written here.
+            </div>
+          </div>
+
+          <div>
             <label>Filesystem mounts</label>
             <div id="mounts-rows" class="mounts-rows"></div>
             <button id="add-mount" class="ghost" type="button" style="margin-top:8px;">+ mount</button>
@@ -618,6 +629,12 @@ ${SHELL_JS}
     }
     // defaults (omitted): filesystem "workspace" (scoped reads) + network "open".
 
+    // Working directory (the working-directory axis). Only send when non-blank —
+    // the server treats a blank value as unset (the agent works in its private
+    // session dir). An absolute path is required server-side; we send as-is.
+    var workspace = document.getElementById("spawn-workspace").value.trim();
+    if (workspace) spec.workspace = workspace;
+
     var mounts = [];
     document.querySelectorAll("#mounts-rows .mrow").forEach(function (row) {
       var host = row.querySelector(".mt-host").value.trim();
@@ -756,8 +773,14 @@ ${SHELL_JS}
           ? " <span class='pill' title='system prompt set (" + esc(a.systemPromptMode) +
             " mode)' style='font-size:11px;'>role: " + esc(a.systemPromptMode) + "</span>"
           : "";
+        // A badge when the agent works from a shared working dir (the workspace
+        // seam) — the path is the title so it's visible on hover without crowding.
+        var wdBadge = a.workingDir
+          ? " <span class='pill' title='working dir: " + esc(a.workingDir) +
+            "' style='font-size:11px;'>workdir</span>"
+          : "";
         return "<tr>" +
-          "<td><strong>" + esc(a.name) + "</strong>" + promptBadge + "</td>" +
+          "<td><strong>" + esc(a.name) + "</strong>" + promptBadge + wdBadge + "</td>" +
           "<td>" + backendCell + "</td>" +
           "<td>" + stateCell + "</td>" +
           "<td>" + connCell + "</td>" +

--- a/src/agents.test.ts
+++ b/src/agents.test.ts
@@ -132,27 +132,39 @@ describe("agentInfoFromSessions", () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
-  test("surfaces workingDir from the persisted spec when a workspace is set; absent otherwise", () => {
+  test("surfaces workingDir from the persisted spec when the workspace is set AND exists; absent otherwise", () => {
     const dir = mkdtempSync(join(tmpdir(), "agent-info-workdir-"));
+    // A REAL working dir on disk — the badge is gated on existence (a deleted dir
+    // post-spawn shouldn't surface a dead-path badge).
+    const workdir = mkdtempSync(join(tmpdir(), "agent-info-real-workdir-"));
     try {
       persistSpec(sessionWorkspace(dir, "withdir"), {
         name: "withdir",
         channels: ["withdir"],
-        workspace: "/Users/op/Code/repo",
+        workspace: workdir,
       } as AgentSpec);
       persistSpec(sessionWorkspace(dir, "nodir"), { name: "nodir", channels: ["nodir"] } as AgentSpec);
+      // A spec whose working dir no longer exists on disk → NOT surfaced.
+      persistSpec(sessionWorkspace(dir, "gonedir"), {
+        name: "gonedir",
+        channels: ["gonedir"],
+        workspace: "/Users/op/Code/deleted-repo",
+      } as AgentSpec);
       const infos = agentInfoFromSessions(
         [
           { name: "withdir-agent", attached: false },
           { name: "nodir-agent", attached: false },
+          { name: "gonedir-agent", attached: false },
         ],
         dir,
       );
       const byName = Object.fromEntries(infos.map((i) => [i.name, i]));
-      expect(byName.withdir!.workingDir).toBe("/Users/op/Code/repo");
+      expect(byName.withdir!.workingDir).toBe(workdir);
       expect(byName.nodir!.workingDir).toBeUndefined();
+      expect(byName.gonedir!.workingDir).toBeUndefined(); // path gone → no dead-path badge
     } finally {
       rmSync(dir, { recursive: true, force: true });
+      rmSync(workdir, { recursive: true, force: true });
     }
   });
 });

--- a/src/agents.test.ts
+++ b/src/agents.test.ts
@@ -132,6 +132,29 @@ describe("agentInfoFromSessions", () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+  test("surfaces workingDir from the persisted spec when a workspace is set; absent otherwise", () => {
+    const dir = mkdtempSync(join(tmpdir(), "agent-info-workdir-"));
+    try {
+      persistSpec(sessionWorkspace(dir, "withdir"), {
+        name: "withdir",
+        channels: ["withdir"],
+        workspace: "/Users/op/Code/repo",
+      } as AgentSpec);
+      persistSpec(sessionWorkspace(dir, "nodir"), { name: "nodir", channels: ["nodir"] } as AgentSpec);
+      const infos = agentInfoFromSessions(
+        [
+          { name: "withdir-agent", attached: false },
+          { name: "nodir-agent", attached: false },
+        ],
+        dir,
+      );
+      const byName = Object.fromEntries(infos.map((i) => [i.name, i]));
+      expect(byName.withdir!.workingDir).toBe("/Users/op/Code/repo");
+      expect(byName.nodir!.workingDir).toBeUndefined();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("buildSpecFromBody", () => {
@@ -198,6 +221,34 @@ describe("buildSpecFromBody", () => {
     expect(() =>
       buildSpecFromBody({ name: "a", channels: ["c"], mounts: [{ hostPath: "/h", mountPath: "rel", mode: "ro" }] }),
     ).toThrow(/mountPath must be an absolute path/);
+  });
+
+  // Working-directory axis (design 2026-06-16-agent-filesystem-and-sharing.md):
+  // an absolute `workspace` host path is parsed; a relative path 400s; absent /
+  // blank → undefined (the private-dir cwd default).
+  test("workspace (absolute) is parsed onto the spec", () => {
+    const spec = buildSpecFromBody({ name: "a", channels: ["c"], workspace: "/Users/op/Code/repo" });
+    expect(spec.workspace).toBe("/Users/op/Code/repo");
+  });
+  test("workspace is trimmed", () => {
+    const spec = buildSpecFromBody({ name: "a", channels: ["c"], workspace: "  /Users/op/Code/repo  " });
+    expect(spec.workspace).toBe("/Users/op/Code/repo");
+  });
+  test("a relative workspace is rejected (must be absolute)", () => {
+    expect(() =>
+      buildSpecFromBody({ name: "a", channels: ["c"], workspace: "Code/repo" }),
+    ).toThrow(/workspace must be an absolute path/);
+  });
+  test("absent workspace → undefined (private-dir cwd default)", () => {
+    expect(buildSpecFromBody({ name: "a", channels: ["c"] }).workspace).toBeUndefined();
+  });
+  test("a blank / whitespace-only workspace is treated as unset", () => {
+    expect(buildSpecFromBody({ name: "a", channels: ["c"], workspace: "   " }).workspace).toBeUndefined();
+  });
+  test("a non-string workspace is rejected", () => {
+    expect(() =>
+      buildSpecFromBody({ name: "a", channels: ["c"], workspace: 42 }),
+    ).toThrow(/workspace must be a string/);
   });
   // Backend default flip (design 2026-06-16 + Aaron's gating decision): a NEW
   // request that OMITS `backend` now defaults to "programmatic" (the reliable

--- a/src/agents.test.ts
+++ b/src/agents.test.ts
@@ -13,7 +13,7 @@
  *      and every error→status mapping, without a hub, a sandbox, or tmux.
  */
 
-import { describe, test, expect, mock } from "bun:test";
+import { describe, test, expect, mock, afterEach } from "bun:test";
 // Re-export the REAL error class + helper in the mock below so this process-wide
 // `mock.module` doesn't break hub-jwt.test.ts's assertions on the genuine shapes
 // (same discipline daemon-config-api.test.ts keeps).
@@ -35,7 +35,7 @@ mock.module("./hub-jwt.ts", () => ({
   resetRevocationCache() {},
 }));
 
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -236,20 +236,41 @@ describe("buildSpecFromBody", () => {
   });
 
   // Working-directory axis (design 2026-06-16-agent-filesystem-and-sharing.md):
-  // an absolute `workspace` host path is parsed; a relative path 400s; absent /
-  // blank → undefined (the private-dir cwd default).
-  test("workspace (absolute) is parsed onto the spec", () => {
-    const spec = buildSpecFromBody({ name: "a", channels: ["c"], workspace: "/Users/op/Code/repo" });
-    expect(spec.workspace).toBe("/Users/op/Code/repo");
+  // an absolute, EXISTING `workspace` dir is parsed; a relative path 400s; a
+  // non-existent path / a file 400s; absent / blank → undefined (private-dir cwd).
+  // The real-dir cases use a temp dir (the spawn cwd must pre-exist).
+  let wsDir: string;
+  afterEach(() => {
+    if (wsDir) rmSync(wsDir, { recursive: true, force: true });
+    wsDir = "";
+  });
+  test("workspace (absolute, existing dir) is parsed onto the spec", () => {
+    wsDir = mkdtempSync(join(tmpdir(), "buildspec-ws-"));
+    const spec = buildSpecFromBody({ name: "a", channels: ["c"], workspace: wsDir });
+    expect(spec.workspace).toBe(wsDir);
   });
   test("workspace is trimmed", () => {
-    const spec = buildSpecFromBody({ name: "a", channels: ["c"], workspace: "  /Users/op/Code/repo  " });
-    expect(spec.workspace).toBe("/Users/op/Code/repo");
+    wsDir = mkdtempSync(join(tmpdir(), "buildspec-ws-trim-"));
+    const spec = buildSpecFromBody({ name: "a", channels: ["c"], workspace: `  ${wsDir}  ` });
+    expect(spec.workspace).toBe(wsDir);
   });
   test("a relative workspace is rejected (must be absolute)", () => {
     expect(() =>
       buildSpecFromBody({ name: "a", channels: ["c"], workspace: "Code/repo" }),
     ).toThrow(/workspace must be an absolute path/);
+  });
+  test("a non-existent workspace is rejected (cwd must pre-exist)", () => {
+    expect(() =>
+      buildSpecFromBody({ name: "a", channels: ["c"], workspace: "/Users/op/Code/does-not-exist-xyz" }),
+    ).toThrow(/does not exist/);
+  });
+  test("a workspace pointing at a FILE (not a dir) is rejected", () => {
+    wsDir = mkdtempSync(join(tmpdir(), "buildspec-ws-file-"));
+    const filePath = join(wsDir, "afile.txt");
+    writeFileSync(filePath, "x");
+    expect(() =>
+      buildSpecFromBody({ name: "a", channels: ["c"], workspace: filePath }),
+    ).toThrow(/is not a directory/);
   });
   test("absent workspace → undefined (private-dir cwd default)", () => {
     expect(buildSpecFromBody({ name: "a", channels: ["c"] }).workspace).toBeUndefined();

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -197,7 +197,13 @@ export function agentInfoFromSessions(
     // spec when one is set — so the list shows the agent carries a role.
     const persisted = readPersistedSpec(workspace);
     const hasPrompt = typeof persisted?.systemPrompt === "string" && persisted.systemPrompt.length > 0;
-    const hasWorkingDir = typeof persisted?.workspace === "string" && persisted.workspace.length > 0;
+    // Surface the working dir only when it's set AND still present on disk — an
+    // operator who deleted the dir post-spawn shouldn't see a dead-path badge
+    // (mirrors how `hasWorkspace` gates on existence rather than the bare path).
+    const hasWorkingDir =
+      typeof persisted?.workspace === "string" &&
+      persisted.workspace.length > 0 &&
+      existsSync(persisted.workspace);
     agents.push({
       name,
       session: s.name,

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -18,7 +18,7 @@
  * list/kill logic is unit-testable without a real tmux server.
  */
 
-import { existsSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import { join } from "node:path";
 import type {
   AgentSpec,
@@ -335,6 +335,23 @@ export function buildSpecFromBody(body: unknown): AgentSpec {
     if (workspace.length > 0) {
       if (!workspace.startsWith("/")) {
         throw new SpawnRequestError('body.workspace must be an absolute path (start with "/")');
+      }
+      // The working dir becomes the agent's cwd — it MUST pre-exist as a directory,
+      // or the spawn would boot the agent into a missing dir (tmux `-c` / Bun.spawn
+      // `cwd` fault) with a confusing downstream error. A clean 400 at parse time is
+      // friendlier than that runtime failure. This endpoint is channel:admin-gated,
+      // so the operator owns the path they pass; we only assert it's a real dir.
+      let st: ReturnType<typeof statSync> | undefined;
+      try {
+        st = statSync(workspace);
+      } catch {
+        throw new SpawnRequestError(
+          `body.workspace "${workspace}" does not exist — the working directory must be a real ` +
+            `directory on disk (the agent's cwd).`,
+        );
+      }
+      if (!st.isDirectory()) {
+        throw new SpawnRequestError(`body.workspace "${workspace}" is not a directory.`);
       }
       spec.workspace = workspace;
     }

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -85,6 +85,15 @@ export interface AgentInfo {
    * (it can be long / role-sensitive) — only that one is set + how it composes.
    */
   systemPromptMode?: "append" | "replace";
+  /**
+   * The agent's WORKING directory when the spec sets one (design
+   * 2026-06-16-agent-filesystem-and-sharing.md — the working-directory axis): the
+   * shared host path it operates from (its cwd + rw working-root). Absent = the
+   * agent works in its private session dir (today's default). This is the WORKING
+   * dir, NOT the private `workspace` field above (which is always the per-agent
+   * session dir on disk).
+   */
+  workingDir?: string;
 }
 
 /** A redacted mint summary — scope + audience + expiry, NEVER the token value. */
@@ -188,6 +197,7 @@ export function agentInfoFromSessions(
     // spec when one is set — so the list shows the agent carries a role.
     const persisted = readPersistedSpec(workspace);
     const hasPrompt = typeof persisted?.systemPrompt === "string" && persisted.systemPrompt.length > 0;
+    const hasWorkingDir = typeof persisted?.workspace === "string" && persisted.workspace.length > 0;
     agents.push({
       name,
       session: s.name,
@@ -196,6 +206,7 @@ export function agentInfoFromSessions(
       hasWorkspace: existsSync(join(workspace, ".mcp.json")),
       backend: "interactive",
       ...(hasPrompt ? { systemPromptMode: persisted!.systemPromptMode ?? "append" } : {}),
+      ...(hasWorkingDir ? { workingDir: persisted!.workspace } : {}),
     });
   }
   agents.sort((a, b) => a.name.localeCompare(b.name));
@@ -300,6 +311,27 @@ export function buildSpecFromBody(body: unknown): AgentSpec {
     }
     const mounts = b.mounts.map((raw, i) => parseMountEntry(raw, i));
     if (mounts.length > 0) spec.mounts = mounts;
+  }
+
+  // Working directory — the WORKING-DIRECTORY axis (design
+  // 2026-06-16-agent-filesystem-and-sharing.md). When set, this absolute host path
+  // is the agent's cwd + an rw working-root; it's shareable across agents. Require
+  // an ABSOLUTE path (mirrors parseMountEntry's guard — a relative path would
+  // resolve against the daemon's cwd in surprising ways; the trust boundary stays
+  // explicit). Trimmed. A blank/whitespace-only value is treated as unset (today's
+  // private-dir cwd). The credential-bearing private home (`.mcp.json` etc.) is
+  // NEVER this dir — it stays per-agent under sessions/<name>/.
+  if (b.workspace !== undefined && b.workspace !== null) {
+    if (typeof b.workspace !== "string") {
+      throw new SpawnRequestError("body.workspace must be a string (an absolute host path)");
+    }
+    const workspace = b.workspace.trim();
+    if (workspace.length > 0) {
+      if (!workspace.startsWith("/")) {
+        throw new SpawnRequestError('body.workspace must be an absolute path (start with "/")');
+      }
+      spec.workspace = workspace;
+    }
   }
 
   // Backend selector — the pluggable agent backend (design 2026-06-16). A NEW

--- a/src/backends/programmatic.test.ts
+++ b/src/backends/programmatic.test.ts
@@ -515,6 +515,90 @@ describe("ProgrammaticBackend.deliver — system prompt (file-backed, per-turn)"
   });
 });
 
+// ---- the workspace seam (working-directory axis) ---------------------------
+// design 2026-06-16-agent-filesystem-and-sharing.md — `workspace` is the agent's
+// cwd + an rw working-root; .mcp.json (scoped vault token = secret) /
+// system-prompt.txt / seeded home STAY in the per-agent private sessions/<name> dir.
+
+function specWithWorkspace(workspace: string, name = "eng"): AgentSpec {
+  return {
+    name,
+    channels: [name],
+    vault: { name: "default", access: "read", tags: ["#channel-message"] },
+    workspace,
+  };
+}
+
+describe("ProgrammaticBackend.deliver — workspace seam: cwd = workspace, secrets stay private", () => {
+  test("workspace SET → the turn's cwd is the workspace; the workspace is the sandbox rw working-root", async () => {
+    mkDirs("ws-set");
+    const workspaceDir = mkdtempSync(join(tmpdir(), "prog-shared-workdir-"));
+    try {
+      const { fn, calls } = recordingSpawn({ stdout: successTurn("s", "ok") });
+      const engine = fakeEngine();
+      const backend = new ProgrammaticBackend(baseDeps(fn, { sandboxEngine: engine }));
+      const handle = await backend.start(specWithWorkspace(workspaceDir, "eng"));
+      await backend.deliver(handle, "hello");
+
+      const privateDir = join(sessionsDir, "eng");
+      // The spawned turn's cwd is the SHARED workspace, NOT the private dir.
+      expect(calls[0]!.cwd).toBe(workspaceDir);
+      // The workspace is an rw working-root in the sandbox (read + write); the
+      // private dir stays writable too (it holds .mcp.json/home/tmp).
+      expect(engine.initializedWith!.filesystem.allowWrite).toContain(workspaceDir);
+      expect(engine.initializedWith!.filesystem.allowWrite).toContain(privateDir);
+      expect(engine.initializedWith!.filesystem.allowRead).toContain(workspaceDir);
+    } finally {
+      rmSync(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  test("SECRETS-STAY-PRIVATE: .mcp.json / system-prompt.txt live in the PRIVATE dir, NEVER the shared workspace", async () => {
+    mkDirs("ws-private");
+    const workspaceDir = mkdtempSync(join(tmpdir(), "prog-shared-secrets-"));
+    try {
+      const { fn } = recordingSpawn({ stdout: successTurn("s", "ok") });
+      const backend = new ProgrammaticBackend(baseDeps(fn));
+      const spec: AgentSpec = {
+        name: "eng",
+        channels: ["eng"],
+        vault: { name: "default", access: "read", tags: ["#channel-message"] },
+        workspace: workspaceDir,
+        systemPrompt: "Work in the repo.",
+      };
+      const handle = await backend.start(spec);
+      await backend.deliver(handle, "hello");
+
+      const privateDir = join(sessionsDir, "eng");
+      // Private artifacts are under the per-agent dir…
+      expect(statSync(join(privateDir, ".mcp.json")).mode & 0o777).toBe(0o600);
+      expect(existsSync(join(privateDir, "system-prompt.txt"))).toBe(true);
+      // …and the shared workspace has NONE of them (no secrets crossing the boundary).
+      expect(existsSync(join(workspaceDir, ".mcp.json"))).toBe(false);
+      expect(existsSync(join(workspaceDir, "system-prompt.txt"))).toBe(false);
+      expect(existsSync(join(workspaceDir, "home"))).toBe(false);
+      // The private .mcp.json DOES carry the minted vault token; the shared dir does not.
+      const privateMcp = readFileSync(join(privateDir, ".mcp.json"), "utf8");
+      expect(privateMcp).toContain("Bearer TOK-");
+    } finally {
+      rmSync(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  test("workspace UNSET → the turn's cwd is the private dir (unchanged); only the private dir is writable", async () => {
+    mkDirs("ws-unset");
+    const { fn, calls } = recordingSpawn({ stdout: successTurn("s", "ok") });
+    const engine = fakeEngine();
+    const backend = new ProgrammaticBackend(baseDeps(fn, { sandboxEngine: engine }));
+    const handle = await backend.start(specWithVault("eng"));
+    await backend.deliver(handle, "hello");
+
+    const privateDir = join(sessionsDir, "eng");
+    expect(calls[0]!.cwd).toBe(privateDir);
+    expect(engine.initializedWith!.filesystem.allowWrite).toEqual([privateDir]);
+  });
+});
+
 describe("ProgrammaticBackend.deliver — MCP config (vault only, no channel)", () => {
   test("writes a vault-only .mcp.json 0600 — NO channel MCP entry (daemon mediates messaging)", async () => {
     mkDirs("mcp");

--- a/src/backends/programmatic.ts
+++ b/src/backends/programmatic.ts
@@ -58,6 +58,7 @@ import { normalizeChannel } from "../sandbox/types.ts";
 import type { SandboxEngine } from "../sandbox/index.ts";
 import {
   buildAgentChildEnv,
+  resolveAgentCwd,
   seedAgentHome,
   sessionWorkspace,
   shellJoin,
@@ -355,12 +356,22 @@ export class ProgrammaticBackend implements AgentBackend {
       ...(this.deps.ripgrep ? { ripgrep: this.deps.ripgrep } : {}),
     });
 
+    // The agent's WORKING dir (design 2026-06-16-agent-filesystem-and-sharing.md):
+    // the spec's `workspace` (a shared real dir) when set, else the private session
+    // dir (today's behavior). The cwd is decoupled from the private dir —
+    // `.mcp.json`/`system-prompt.txt`/seeded home stay PRIVATE under the session
+    // dir (passed by absolute path), so a shared workspace never receives the
+    // agent's secrets even when two agents point at the same dir.
+    const cwd = resolveAgentCwd(spec, workspace);
+
     // The agent's private, writable, pre-seeded HOME + temp dirs (stability
-    // keystone). The vault MCP server name is pre-approved so claude doesn't prompt.
+    // keystone) — always UNDER the private workspace, regardless of the cwd. The
+    // vault MCP server name is pre-approved so claude doesn't prompt; the pre-trusted
+    // project is the agent's actual cwd (the shared working dir when set).
     const mcpServerNames = Object.keys(
       (JSON.parse(mcpConfigJson) as { mcpServers?: Record<string, unknown> }).mcpServers ?? {},
     );
-    const homeEnv = seedAgentHome(workspace, { mcpServers: mcpServerNames });
+    const homeEnv = seedAgentHome(workspace, { mcpServers: mcpServerNames, projectRoot: cwd });
 
     // Layer the scrubbed agent env UNDER the sandbox wrapper's env; the HOME/config/
     // temp vars layer LAST so they win. CLAUDE_CODE_OAUTH_TOKEN injected;
@@ -381,7 +392,7 @@ export class ProgrammaticBackend implements AgentBackend {
     let stderr: string;
     let code: number;
     try {
-      const proc = this.deps.spawnFn(wrapped.argv, { env: launchEnv, cwd: workspace });
+      const proc = this.deps.spawnFn(wrapped.argv, { env: launchEnv, cwd });
       [stdout, stderr] = await Promise.all([drainStream(proc.stdout), drainStream(proc.stderr)]);
       code = await proc.exited;
     } catch (err) {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -568,7 +568,10 @@ export function listProgrammaticAgents(programmatic: ProgrammaticAgentRegistry):
       const status = s.state === "queued" ? `queued:${s.queued}` : s.state;
       const workspace = sessionWorkspace(dir, h.name);
       const hasPrompt = typeof h.spec.systemPrompt === "string" && h.spec.systemPrompt.length > 0;
-      const hasWorkingDir = typeof h.spec.workspace === "string" && h.spec.workspace.length > 0;
+      // Surface the working dir only when set AND still present on disk (a deleted
+      // dir post-spawn shouldn't show a dead-path badge — mirrors `hasWorkspace`).
+      const hasWorkingDir =
+        typeof h.spec.workspace === "string" && h.spec.workspace.length > 0 && existsSync(h.spec.workspace);
       return {
         name: h.name,
         session: `${h.name}-agent`,

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -568,6 +568,7 @@ export function listProgrammaticAgents(programmatic: ProgrammaticAgentRegistry):
       const status = s.state === "queued" ? `queued:${s.queued}` : s.state;
       const workspace = sessionWorkspace(dir, h.name);
       const hasPrompt = typeof h.spec.systemPrompt === "string" && h.spec.systemPrompt.length > 0;
+      const hasWorkingDir = typeof h.spec.workspace === "string" && h.spec.workspace.length > 0;
       return {
         name: h.name,
         session: `${h.name}-agent`,
@@ -577,6 +578,7 @@ export function listProgrammaticAgents(programmatic: ProgrammaticAgentRegistry):
         backend: "programmatic" as const,
         status,
         ...(hasPrompt ? { systemPromptMode: h.spec.systemPromptMode ?? "append" } : {}),
+        ...(hasWorkingDir ? { workingDir: h.spec.workspace } : {}),
       };
     })
     .sort((a, b) => a.name.localeCompare(b.name));

--- a/src/sandbox/config.ts
+++ b/src/sandbox/config.ts
@@ -61,11 +61,22 @@ export function buildSandboxConfig(input: BuildSandboxConfigInput): SandboxRunti
   const scopedReads = input.spec.filesystem !== "full"; // default "workspace" = scoped
   const restrictedNet = input.spec.network === "restricted"; // default "open"
 
-  // Filesystem: scoped reads (deny home tree, re-allow workspace + claude runtime +
-  // mounts) unless explicitly "full". Writes are confined to the workspace + rw
-  // mounts in BOTH cases. The scoped default is what keeps the operator's secrets
-  // (e.g. ~/.parachute/operator.token) unreadable even with the network open.
-  const fs = composeFilesystemView(input.baseBinds, input.spec.mounts, platform, scopedReads);
+  // Filesystem: scoped reads (deny home tree, re-allow private home + claude
+  // runtime + the working dir + mounts) unless explicitly "full". Writes are
+  // confined to the private home + the working dir + rw mounts in BOTH cases. The
+  // scoped default is what keeps the operator's secrets (e.g.
+  // ~/.parachute/operator.token) unreadable even with the network open. The spec's
+  // `workspace` (the shared real dir the agent works from) is threaded in as an rw
+  // working-root — decoupled from the private home, so `.mcp.json`'s secrets stay
+  // per-agent even when the working dir is shared (design
+  // 2026-06-16-agent-filesystem-and-sharing.md).
+  const fs = composeFilesystemView(
+    input.baseBinds,
+    input.spec.mounts,
+    platform,
+    scopedReads,
+    input.spec.workspace,
+  );
 
   // Network: "open" (default) OMITS `allowedDomains` — the runtime treats an absent
   // allowedDomains as "no restriction" (verified: present-but-empty = block all,

--- a/src/sandbox/mounts.test.ts
+++ b/src/sandbox/mounts.test.ts
@@ -85,6 +85,47 @@ describe("composeFilesystemView — scoped reads + write confinement", () => {
     const fs = composeFilesystemView(BASE, mounts, "darwin");
     expect(fs.allowWrite.filter((p) => p === "/state/sessions/arm")).toHaveLength(1);
   });
+
+  // The working-directory axis (design 2026-06-16-agent-filesystem-and-sharing.md):
+  // the spec's `workspace` (a shared real dir) is bound rw — readable + writable —
+  // decoupled from the private home (which stays the per-agent session dir).
+  describe("the working dir (workspace) as an rw working-root", () => {
+    test("a working dir is BOTH readable and writable (an rw working-root)", () => {
+      const fs = composeFilesystemView(BASE, undefined, "darwin", true, "/Users/op/Code/repo");
+      expect(fs.allowRead).toContain("/Users/op/Code/repo");
+      expect(fs.allowWrite).toContain("/Users/op/Code/repo");
+    });
+
+    test("the PRIVATE home is ALSO writable alongside the working dir (decoupled, both rw)", () => {
+      const fs = composeFilesystemView(BASE, undefined, "darwin", true, "/Users/op/Code/repo");
+      // The private session dir stays in the write surface (it holds .mcp.json/home/tmp).
+      expect(fs.allowWrite).toContain("/state/sessions/arm");
+      expect(fs.allowWrite).toContain("/Users/op/Code/repo");
+    });
+
+    test("unset working dir → only the private home is writable (today's behavior)", () => {
+      const fs = composeFilesystemView(BASE, undefined, "darwin", true, undefined);
+      expect(fs.allowWrite).toEqual(["/state/sessions/arm"]);
+    });
+
+    test("a blank working dir is ignored (treated as unset)", () => {
+      const fs = composeFilesystemView(BASE, undefined, "darwin", true, "");
+      expect(fs.allowWrite).toEqual(["/state/sessions/arm"]);
+    });
+
+    test("under filesystem 'full' (broad reads) the working dir is still in the write surface", () => {
+      const fs = composeFilesystemView(BASE, undefined, "darwin", false, "/Users/op/Code/repo");
+      expect(fs.denyRead).toEqual([]); // broad reads — no home-tree deny
+      expect(fs.allowWrite).toContain("/Users/op/Code/repo");
+      expect(fs.allowWrite).toContain("/state/sessions/arm");
+    });
+
+    test("a working dir equal to a declared mount dedupes in the write surface", () => {
+      const mounts: AgentMount[] = [{ hostPath: "/Users/op/Code/repo", mountPath: "/repo", mode: "rw" }];
+      const fs = composeFilesystemView(BASE, mounts, "darwin", true, "/Users/op/Code/repo");
+      expect(fs.allowWrite.filter((p) => p === "/Users/op/Code/repo")).toHaveLength(1);
+    });
+  });
 });
 
 describe("sharedMounts — the named cross-session relaxation", () => {

--- a/src/sandbox/mounts.ts
+++ b/src/sandbox/mounts.ts
@@ -46,25 +46,44 @@ export interface FilesystemView {
  * Compose the filesystem view for an arm from the always-present base binds and
  * the spec's additive mounts.
  *
- * Read surface  = workspace (rw) + runtime/config (ro) + every declared mount
- *                 (ro and rw alike — you can read what you can write).
- * Write surface = workspace (rw) + every `rw` mount.
+ * Read surface  = private home (rw) + the working dir (rw, when set) + runtime/
+ *                 config (ro) + every declared mount (ro and rw alike — you can
+ *                 read what you can write).
+ * Write surface = private home (rw) + the working dir (rw, when set) + every
+ *                 `rw` mount.
+ *
+ * `base.workspace` is the agent's PRIVATE per-session home (always rw — it holds
+ * `.mcp.json`/`tmp`/seeded `CLAUDE_CONFIG_DIR`). `workingRoot` is the OPTIONAL
+ * shared real dir the agent works from (the `workspace` spec field, design
+ * 2026-06-16-agent-filesystem-and-sharing.md): when set it's bound rw + readable,
+ * so writes are confined to (private home + working dir + rw mounts). Both are
+ * decoupled — the private home is never the shared dir, so `.mcp.json`'s secrets
+ * stay per-agent even when the working dir is shared.
  *
  * The home tree is denied and the read surface re-allowed within it, giving the
  * scoped-read policy (§4.5). The base binds are always included regardless of
- * the spec, so a spec cannot strip its own workspace or the runtime/config.
+ * the spec, so a spec cannot strip its own private home or the runtime/config.
  */
 export function composeFilesystemView(
   base: BaseBinds,
   mounts: readonly AgentMount[] | undefined,
   platform: SandboxPlatform,
   scopedReads = true,
+  workingRoot?: string,
 ): FilesystemView {
   const declared = mounts ?? [];
 
-  // Every bind is readable; only workspace + rw mounts are writable.
+  // The private home + the (optional) working dir are readable AND writable;
+  // every other bind is readable, and only rw mounts add to the write surface.
   const readPaths: string[] = [base.workspace, ...base.runtimeReadOnly];
   const writePaths: string[] = [base.workspace];
+  if (workingRoot && workingRoot.length > 0) {
+    // The shared working dir is bound rw — the agent's cwd lives here AND it can
+    // write to it (it's effectively an rw mount that is also the cwd). dedupe
+    // below handles the case where it coincides with the private home / a mount.
+    readPaths.push(workingRoot);
+    writePaths.push(workingRoot);
+  }
 
   for (const m of declared) {
     readPaths.push(m.hostPath);

--- a/src/sandbox/types.ts
+++ b/src/sandbox/types.ts
@@ -150,6 +150,28 @@ export interface AgentSpec {
    * back-compat) or `{ name, access: "read" }` to scope a channel read-only.
    */
   channels: AgentChannel[];
+  /**
+   * WORKING DIRECTORY — a real host path the agent operates from (design
+   * 2026-06-16-agent-filesystem-and-sharing.md, the working-directory axis). When
+   * set, this absolute path becomes the agent's CWD and an rw working-root in the
+   * sandbox (it's bound rw + readable, exactly like an `rw` mount that is also the
+   * cwd). It is SHAREABLE — two agents (or a runner job, or a plain script) can
+   * point at the same dir (shared-rw concurrency is a known, deferred caveat; the
+   * agents step on each other like humans in a repo without git discipline).
+   *
+   * CRITICAL — the working dir is DECOUPLED from the agent's PRIVATE RUNTIME HOME.
+   * The seeded `CLAUDE_CONFIG_DIR` (`seedAgentHome`), `tmp`, `spec.json`,
+   * `system-prompt.txt`, and ESPECIALLY `.mcp.json` (which inlines the scoped
+   * vault/channel tokens — secrets) STAY in the per-agent private `sessions/<name>/`
+   * dir, 0600, NEVER written into this shared `workspace`. The governing principle
+   * (the design note's "line"): capability/credential/state is per-agent private;
+   * the working dir is shareable. `--mcp-config` / `--system-prompt-file` point at
+   * the private dir by ABSOLUTE path, so they're unaffected by the cwd change.
+   *
+   * Unset → today's behavior EXACTLY: the cwd is the private `sessions/<name>` dir
+   * (which is also the synthetic workspace).
+   */
+  workspace?: string;
   /** Optional vault binding. */
   vault?: AgentVaultSpec;
   /** Additional MCP servers, by URL. */

--- a/src/spawn-agent.test.ts
+++ b/src/spawn-agent.test.ts
@@ -11,8 +11,10 @@ import {
   DEV_CHANNELS_PROMPT_MARKER,
   DEV_CHANNELS_READY_MARKER,
   realTmuxLauncher,
+  resolveAgentCwd,
   seedAgentHome,
   sessionName,
+  sessionWorkspace,
   shellJoin,
   persistSpec,
   readPersistedSpec,
@@ -39,7 +41,13 @@ afterEach(() => {
 
 /** A recording tmux launcher. */
 function recordingTmux(existing = new Set<string>()): TmuxLauncher & {
-  launched: Array<{ name: string; argv: string[]; env: Record<string, string | undefined>; cwd: string }>;
+  launched: Array<{
+    name: string;
+    argv: string[];
+    env: Record<string, string | undefined>;
+    cwd: string;
+    scriptDir?: string;
+  }>;
   confirmed: string[];
 } {
   const launched: Array<{
@@ -47,6 +55,7 @@ function recordingTmux(existing = new Set<string>()): TmuxLauncher & {
     argv: string[];
     env: Record<string, string | undefined>;
     cwd: string;
+    scriptDir?: string;
   }> = [];
   const confirmed: string[] = [];
   return {
@@ -323,6 +332,23 @@ describe("seedAgentHome — the per-session writable HOME (stability keystone)",
       };
       expect(seed.hasCompletedOnboarding).toBe(true);
       expect(seed.projects[ws]!.hasTrustDialogAccepted).toBe(true);
+    } finally {
+      rmSync(ws, { recursive: true, force: true });
+    }
+  });
+
+  test("projectRoot override → the SHARED working dir is the pre-trusted project, not the private home", () => {
+    const ws = mkdtempSync(join(tmpdir(), "seed-home-projroot-"));
+    const noop = join(ws, "no-operator.json");
+    try {
+      // The cwd (a shared working dir) is pre-trusted; the seed still lives UNDER ws.
+      seedAgentHome(ws, { operatorConfigPath: noop, projectRoot: "/Users/op/Code/repo", mcpServers: ["vault-default"] });
+      const seed = JSON.parse(readFileSync(join(ws, "home", ".claude", ".claude.json"), "utf8")) as {
+        projects: Record<string, { hasTrustDialogAccepted: boolean }>;
+      };
+      // The PROJECT (pre-trusted) is the shared working dir, NOT the private ws.
+      expect(Object.keys(seed.projects)).toEqual(["/Users/op/Code/repo"]);
+      expect(seed.projects["/Users/op/Code/repo"]!.hasTrustDialogAccepted).toBe(true);
     } finally {
       rmSync(ws, { recursive: true, force: true });
     }
@@ -681,6 +707,154 @@ describe("spawnAgent — full wiring with stubs (no real token)", () => {
       spawnAgent({ name: "s-c", channels: ["c"] }, baseDeps({ sandboxEngine: slowEngine(), tmux: recordingTmux() })),
     ]);
     expect(maxActive).toBe(1);
+  });
+});
+
+// ---- the workspace seam (working-directory axis) ---------------------------
+// design 2026-06-16-agent-filesystem-and-sharing.md — a `workspace` host path is
+// the agent's cwd + an rw working-root; the credential-bearing private home
+// (.mcp.json / system-prompt.txt / spec.json / seeded CLAUDE_CONFIG_DIR) STAYS in
+// the per-agent sessions/<name> dir, never written into the shared workspace.
+
+describe("resolveAgentCwd — cwd is the workspace when set, else the private dir", () => {
+  test("workspace set → that path; the private dir is untouched as the cwd", () => {
+    expect(resolveAgentCwd({ name: "a", channels: ["c"], workspace: "/ws/repo" }, "/private/a")).toBe("/ws/repo");
+  });
+  test("workspace unset → the private dir (today's behavior)", () => {
+    expect(resolveAgentCwd({ name: "a", channels: ["c"] }, "/private/a")).toBe("/private/a");
+  });
+  test("a blank workspace falls back to the private dir", () => {
+    expect(resolveAgentCwd({ name: "a", channels: ["c"], workspace: "" }, "/private/a")).toBe("/private/a");
+  });
+});
+
+describe("spawnAgent — workspace seam (interactive): cwd = workspace, secrets stay private", () => {
+  test("workspace SET → tmux cwd is the workspace; .mcp.json/system-prompt/spec/home stay in the PRIVATE dir; workspace is in the sandbox rw set", async () => {
+    sessionsDir = mkdtempSync(join(tmpdir(), "spawn-ws-set-"));
+    const workspaceDir = mkdtempSync(join(tmpdir(), "shared-workdir-"));
+    const tmux = recordingTmux();
+    const engine = fakeEngine();
+    try {
+      const spec: AgentSpec = {
+        name: "worker",
+        channels: ["worker"],
+        workspace: workspaceDir,
+        systemPrompt: "You work in the repo.",
+      };
+      const res = await spawnAgent(spec, baseDeps({ tmux, sandboxEngine: engine }));
+      const privateDir = sessionWorkspace(sessionsDir, "worker");
+      // res.workspace is still the PRIVATE session dir (the home of secrets).
+      expect(res.workspace).toBe(privateDir);
+
+      // 1. The tmux session's cwd is the SHARED workspace, NOT the private dir.
+      const launch = tmux.launched[0]!;
+      expect(launch.cwd).toBe(workspaceDir);
+      // …and the launch script (private) is written to the PRIVATE dir, never the shared one.
+      expect(launch.scriptDir).toBe(privateDir);
+
+      // 2. SECRETS-STAY-PRIVATE invariant: .mcp.json / system-prompt.txt / spec.json /
+      // the seeded home all live UNDER the private dir, and NONE under the workspace.
+      expect(existsSync(join(privateDir, ".mcp.json"))).toBe(true);
+      expect(existsSync(join(privateDir, "system-prompt.txt"))).toBe(true);
+      expect(existsSync(join(privateDir, "spec.json"))).toBe(true);
+      expect(existsSync(join(privateDir, "home", ".claude", ".claude.json"))).toBe(true);
+      // The workspace dir is NOT littered with any private artifact.
+      expect(existsSync(join(workspaceDir, ".mcp.json"))).toBe(false);
+      expect(existsSync(join(workspaceDir, "system-prompt.txt"))).toBe(false);
+      expect(existsSync(join(workspaceDir, "spec.json"))).toBe(false);
+      expect(existsSync(join(workspaceDir, ".launch.sh"))).toBe(false);
+      expect(existsSync(join(workspaceDir, "home"))).toBe(false);
+
+      // 3. --mcp-config / --append-system-prompt-file point at the PRIVATE absolute
+      // paths (unaffected by the cwd change).
+      const cmd = launch.argv[2]!;
+      expect(cmd).toContain(join(privateDir, ".mcp.json"));
+      expect(cmd).toContain(join(privateDir, "system-prompt.txt"));
+
+      // 4. The workspace IS an rw working-root in the sandbox (read + write).
+      expect(engine.initializedWith!.filesystem.allowWrite).toContain(workspaceDir);
+      expect(engine.initializedWith!.filesystem.allowWrite).toContain(privateDir);
+      expect(engine.initializedWith!.filesystem.allowRead).toContain(workspaceDir);
+
+      // 5. CLAUDE_CONFIG_DIR / TMPDIR still point at the PRIVATE home (not the workspace).
+      expect(launch.env.CLAUDE_CONFIG_DIR).toBe(join(privateDir, "home", ".claude"));
+      expect(launch.env.TMPDIR).toBe(join(privateDir, "tmp"));
+
+      // 6. The seeded project (pre-trusted) is the agent's CWD (the shared workspace).
+      const seed = JSON.parse(
+        readFileSync(join(privateDir, "home", ".claude", ".claude.json"), "utf8"),
+      ) as { projects: Record<string, unknown> };
+      expect(Object.keys(seed.projects)).toEqual([workspaceDir]);
+    } finally {
+      rmSync(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  test("workspace UNSET → cwd is the private dir (unchanged); workspace not in the rw set beyond the private dir", async () => {
+    sessionsDir = mkdtempSync(join(tmpdir(), "spawn-ws-unset-"));
+    const tmux = recordingTmux();
+    const engine = fakeEngine();
+    const res = await spawnAgent({ name: "plain", channels: ["plain"] }, baseDeps({ tmux, sandboxEngine: engine }));
+    const launch = tmux.launched[0]!;
+    // The cwd is the private session dir (today's behavior, exactly).
+    expect(launch.cwd).toBe(res.workspace);
+    expect(launch.scriptDir).toBe(res.workspace);
+    // The only writable dir is the private session dir.
+    expect(engine.initializedWith!.filesystem.allowWrite).toEqual([res.workspace]);
+    // The pre-trusted project is the private dir (no shared working dir).
+    const seed = JSON.parse(
+      readFileSync(join(res.workspace, "home", ".claude", ".claude.json"), "utf8"),
+    ) as { projects: Record<string, unknown> };
+    expect(Object.keys(seed.projects)).toEqual([res.workspace]);
+  });
+
+  test("SECRETS-STAY-PRIVATE: .mcp.json (scoped tokens) is NEVER written into a shared workspace dir", async () => {
+    sessionsDir = mkdtempSync(join(tmpdir(), "spawn-ws-secrets-"));
+    const workspaceDir = mkdtempSync(join(tmpdir(), "shared-secrets-"));
+    try {
+      const spec: AgentSpec = {
+        name: "secretkeeper",
+        channels: ["secretkeeper"],
+        vault: { name: "default", access: "read" },
+        workspace: workspaceDir,
+      };
+      await spawnAgent(spec, baseDeps({ tmux: recordingTmux() }));
+      // The shared workspace holds NO .mcp.json (the file that inlines the minted
+      // vault/channel tokens). It only ever lives in the per-agent private dir.
+      expect(existsSync(join(workspaceDir, ".mcp.json"))).toBe(false);
+      // Belt-and-suspenders: no file under the shared workspace contains the minted
+      // token marker the fake hub stamps (TOK-).
+      const privateMcp = readFileSync(join(sessionWorkspace(sessionsDir, "secretkeeper"), ".mcp.json"), "utf8");
+      expect(privateMcp).toContain("Bearer TOK-"); // the secret IS in the private file…
+      // …and the shared dir has no such file at all (asserted above) — so the token
+      // never crosses into the shareable dir.
+    } finally {
+      rmSync(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  test("two agents can SHARE one workspace dir (allowed, not solved) — each keeps its OWN private home", async () => {
+    sessionsDir = mkdtempSync(join(tmpdir(), "spawn-ws-shared-"));
+    const shared = mkdtempSync(join(tmpdir(), "shared-by-two-"));
+    try {
+      const tmuxA = recordingTmux();
+      const tmuxB = recordingTmux();
+      await spawnAgent({ name: "agent-a", channels: ["a"], workspace: shared }, baseDeps({ tmux: tmuxA }));
+      await spawnAgent({ name: "agent-b", channels: ["b"], workspace: shared }, baseDeps({ tmux: tmuxB }));
+      // Both cwd into the SAME shared dir…
+      expect(tmuxA.launched[0]!.cwd).toBe(shared);
+      expect(tmuxB.launched[0]!.cwd).toBe(shared);
+      // …but each has its OWN private home (distinct .mcp.json under distinct dirs).
+      const aPriv = sessionWorkspace(sessionsDir, "agent-a");
+      const bPriv = sessionWorkspace(sessionsDir, "agent-b");
+      expect(aPriv).not.toBe(bPriv);
+      expect(existsSync(join(aPriv, ".mcp.json"))).toBe(true);
+      expect(existsSync(join(bPriv, ".mcp.json"))).toBe(true);
+      // The shared dir holds NEITHER agent's secrets.
+      expect(existsSync(join(shared, ".mcp.json"))).toBe(false);
+    } finally {
+      rmSync(shared, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/spawn-agent.ts
+++ b/src/spawn-agent.ts
@@ -146,12 +146,20 @@ export interface TmuxLauncher {
   /**
    * Create a detached tmux session `name` that runs `argv` with `env` from `cwd`.
    * Returns the spawned argv (for assertion). Must not block on the session.
+   *
+   * `cwd` is the agent's WORKING dir (the spec's `workspace` when set, else the
+   * private session dir). `scriptDir` is the agent's PRIVATE session dir, where the
+   * per-session `.launch.sh` is written 0600 — kept separate so a SHARED working
+   * dir is never littered with the (private) launch script. When `scriptDir` is
+   * omitted it defaults to `cwd` (back-compat: today's callers that don't set a
+   * `workspace` pass the private dir as the cwd anyway).
    */
   newSession(opts: {
     name: string;
     argv: string[];
     env: Record<string, string | undefined>;
     cwd: string;
+    scriptDir?: string;
   }): Promise<void>;
   /** Whether a session by this name already exists (idempotency). */
   hasSession(name: string): Promise<boolean>;
@@ -248,6 +256,25 @@ export function sessionName(specName: string): string {
 /** Per-session workspace dir under the sessions base. */
 export function sessionWorkspace(sessionsDir: string, specName: string): string {
   return join(sessionsDir, specName);
+}
+
+/**
+ * Resolve an agent's CWD (the working-directory axis, design
+ * 2026-06-16-agent-filesystem-and-sharing.md). When the spec sets `workspace`
+ * (the shared real dir the agent works from) the cwd is that dir; otherwise it's
+ * the agent's PRIVATE per-session dir (today's behavior, exactly).
+ *
+ * This is ONLY the cwd. The private dir always remains the home for `.mcp.json`,
+ * `spec.json`, `system-prompt.txt`, the seeded `CLAUDE_CONFIG_DIR`, and `tmp` —
+ * those are passed to `claude` by ABSOLUTE path (`--mcp-config`,
+ * `--system-prompt-file`, `CLAUDE_CONFIG_DIR`/`TMPDIR` env) so they're unaffected
+ * by the cwd change. The decoupling keeps the working dir shareable while the
+ * credential-bearing private home stays per-agent.
+ */
+export function resolveAgentCwd(spec: AgentSpec, privateWorkspace: string): string {
+  return typeof spec.workspace === "string" && spec.workspace.length > 0
+    ? spec.workspace
+    : privateWorkspace;
 }
 
 /** Path to the persisted spawn-spec for a session (recovered by restart). */
@@ -429,10 +456,17 @@ export function buildAgentChildEnv(
  */
 export function seedAgentHome(
   workspace: string,
-  opts: { mcpServers?: string[]; operatorConfigPath?: string } = {},
+  opts: { mcpServers?: string[]; operatorConfigPath?: string; projectRoot?: string } = {},
 ): Record<string, string> {
   const mcpServerNames = opts.mcpServers ?? [];
   const operatorConfigPath = opts.operatorConfigPath ?? join(homedir(), ".claude.json");
+  // The project root claude pre-trusts in the seed. Defaults to the private
+  // workspace (today's behavior), but when the agent's CWD is a shared working dir
+  // (the spec's `workspace`), the CALLER passes that path here so claude's project
+  // (= its cwd) is pre-trusted + its MCP servers pre-approved — otherwise the agent
+  // would hit the per-folder trust / "new MCP server" prompts for the shared dir.
+  // The seeded HOME/config/tmp still live UNDER the private `workspace` regardless.
+  const projectRoot = opts.projectRoot ?? workspace;
   const home = join(workspace, "home");
   const claudeDir = join(home, ".claude");
   const tmp = join(workspace, "tmp");
@@ -456,12 +490,14 @@ export function seedAgentHome(
     const seed = {
       ...base,
       hasCompletedOnboarding: true,
-      // Replace the operator's project history with ONLY this workspace, pre-trusted
-      // AND with our own configured MCP servers pre-approved (claude otherwise
-      // prompts "New MCP server found in this project" for the workspace .mcp.json
-      // we wrote — these are operator-configured, not foreign, so pre-approve them).
+      // Replace the operator's project history with ONLY the agent's project root
+      // (its cwd — the private workspace by default, or the shared working dir when
+      // the spec sets one), pre-trusted AND with our own configured MCP servers
+      // pre-approved (claude otherwise prompts "New MCP server found in this
+      // project" / the per-folder trust dialog — these are operator-configured, not
+      // foreign, so pre-approve them).
       projects: {
-        [workspace]: {
+        [projectRoot]: {
           hasTrustDialogAccepted: true,
           hasCompletedProjectOnboarding: true,
           enabledMcpjsonServers: mcpServerNames,
@@ -734,15 +770,23 @@ export async function spawnAgent(
     ...(deps.ripgrep ? { ripgrep: deps.ripgrep } : {}),
   });
 
+  // The agent's WORKING dir: the spec's `workspace` (a shared real dir) when set,
+  // else the private session dir (today's behavior). The cwd is decoupled from the
+  // private session dir — `.mcp.json`/`system-prompt.txt`/seeded home all stay in
+  // the private dir (passed by absolute path), so a shared workspace never receives
+  // the agent's secrets. The launch script also stays private via `scriptDir`.
+  const cwd = resolveAgentCwd(spec, workspace);
+
   // The agent's private, writable, pre-seeded HOME + temp dirs (the stability
-  // keystone — see seedAgentHome). Everything claude reads/writes about itself
-  // lives here, inside the workspace (the sandbox's writable region). The MCP
-  // server names (from the config we just wrote) are pre-approved in the seed so
-  // claude doesn't prompt to trust the project's .mcp.json.
+  // keystone — see seedAgentHome). Everything claude reads/writes about ITSELF
+  // lives under the PRIVATE workspace (the sandbox's writable region) regardless of
+  // the cwd. The MCP server names (from the config we just wrote) are pre-approved
+  // in the seed so claude doesn't prompt to trust the project's .mcp.json — and the
+  // pre-trusted project is the agent's actual cwd (the shared working dir when set).
   const mcpServerNames = Object.keys(
     (JSON.parse(mcpConfigJson) as { mcpServers?: Record<string, unknown> }).mcpServers ?? {},
   );
-  const homeEnv = seedAgentHome(workspace, { mcpServers: mcpServerNames });
+  const homeEnv = seedAgentHome(workspace, { mcpServers: mcpServerNames, projectRoot: cwd });
 
   // Layer the scrubbed agent env UNDER the sandbox wrapper's env: the engine's
   // proxy vars / sandbox markers win over our childEnv on conflict;
@@ -762,7 +806,8 @@ export async function spawnAgent(
     name: session,
     argv: wrapped.argv,
     env: launchEnv,
-    cwd: workspace,
+    cwd,
+    scriptDir: workspace,
   });
 
   // Auto-answer claude's `--dangerously-load-development-channels` consent gate
@@ -981,10 +1026,10 @@ export function realTmuxLauncher(spawnFn: typeof Bun.spawn = Bun.spawn): TmuxLau
     async newSession(opts): Promise<void> {
       // Write the wrapped command to a per-session launch script so tmux receives
       // a short argv (the ~84 KB macOS Seatbelt profile would overrun tmux's
-      // command buffer if passed inline). The script lives in the session
-      // workspace alongside .mcp.json, 0600 — it carries no secret (the OAuth
-      // token rides the env via `-e`, below).
-      const scriptPath = launchScriptPath(opts.cwd);
+      // command buffer if passed inline). The script lives in the agent's PRIVATE
+      // session dir alongside .mcp.json, 0600 — NEVER in a shared working dir — and
+      // it carries no secret (the OAuth token rides the env via `-e`, below).
+      const scriptPath = launchScriptPath(opts.scriptDir ?? opts.cwd);
       writeFileSync(scriptPath, buildLaunchScript(opts.argv), { mode: 0o600 });
       // Defensive: guarantee 0600 even under a permissive umask (the file is
       // freshly created per-launch, so there's no looser-perms predecessor).


### PR DESCRIPTION
Implements the **working-directory axis** from [`design/2026-06-16-agent-filesystem-and-sharing.md`](./design/2026-06-16-agent-filesystem-and-sharing.md) — a `workspace` spec field that lets a channel's agent work from a real host directory (a repo) instead of its private synthetic session dir. This is seam #2 of the build order in the post-programmatic architecture note, and it unblocks runner. Only the working-directory axis lands here; the shared-library axis stays **deferred**.

## The cwd-vs-private-home decoupling (the heart of this change)

- **Working dir (new `workspace`)** — when set, an absolute host path becomes the agent's **CWD** + an **rw working-root** in the sandbox (bound read+write, like an `rw` mount that is also the cwd). It's a real dir on disk, **shareable**: two agents / runner jobs / scripts can point at the same path. Threaded into `composeFilesystemView` as the rw working-root, decoupled from the private home.
- **Private runtime home stays per-agent + private** — the seeded `CLAUDE_CONFIG_DIR` (`seedAgentHome`), `tmp`, `spec.json`, `system-prompt.txt`, and **especially `.mcp.json`** (it inlines the scoped vault/channel tokens — secrets) stay in the per-agent `sessions/<name>/` dir, **0600, never written into the shared workspace**.
- So: **CWD = workspace**, but `--mcp-config` / `--system-prompt-file` / `CLAUDE_CONFIG_DIR` / `TMPDIR` all point at the **private** dir by **absolute path**, unaffected by the cwd change. The interactive launch script (`.launch.sh`) also stays private via a new `scriptDir` on the tmux-launcher seam — a shared dir is never littered with it.

## The secrets-stay-private invariant

`.mcp.json` (which carries the minted vault/channel Bearer tokens) is **never** written into the shared workspace dir. Tests assert the private artifacts (`.mcp.json` / `system-prompt.txt` / `spec.json` / `home/`) are present under `sessions/<name>/` and **absent** under the workspace path — in both backends — plus a dedicated test that the token marker only ever lands in the private file.

The governing principle: **capability/credential/state = per-agent private; the working dir = shareable.** `seedAgentHome` now pre-trusts the agent's actual cwd (the shared working dir when set) so claude doesn't hit per-folder trust / "new MCP server" prompts for the shared project — while the seeded home still lives under the private dir.

## Sharing is allowed, not solved

Two agents may set the same `workspace` — that's intended (covered by a test: same cwd, distinct private homes, no secrets in the shared dir). **Shared-rw concurrency** (agents stepping on each other like humans in a repo without git discipline) is a known, **deferred** caveat — noted, not built. Shared **private** home is never allowed (always per-agent).

## Per-backend cwd

Both backends use a shared `resolveAgentCwd(spec, privateDir)` helper:
- **Programmatic** (`claude -p`): the turn's `spawnFn` runs with `cwd = workspace`.
- **Interactive** (tmux): `tmux new-session -c <workspace>`; the launch script writes to the private `scriptDir`.
- **Unset** → today's behavior exactly (cwd = private `sessions/<name>` dir).

`filesystem: "full"` still allows broad reads; the workspace is in the sandbox's allowed-write set in both fs modes.

## Spec + UI

`buildSpecFromBody` validates `workspace` as an **absolute** path (mirrors `parseMountEntry`'s guard — relative → 400; blank/whitespace → unset; non-string → 400), trims, and persists it in `spec.json`. The agents UI adds an optional **"Working directory"** input under Advanced (with a hint that it's the dir the agent works in / can be shared, and that private config stays per-agent) and a `workdir` badge in the running-agents list.

## Gates

- `bun test ./src`: **636 pass, 0 fail** (baseline was 612 → 24 new tests).
- `bun run typecheck`: only the **2 pre-existing TS2589** in `src/bridge.ts` (zero new).
- `bunx biome check --write .`: clean.
- Version left at **0.1.0** (preview module).
- Tests use temp dirs only; the real `~/.parachute` is never touched (the #75 backstop stays green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)