### PR TITLE
feat(channel): streaming turn view for programmatic channels

### DIFF
--- a/src/backends/programmatic.test.ts
+++ b/src/backends/programmatic.test.ts
@@ -655,6 +655,96 @@ describe("ProgrammaticBackend.deliver — robustness", () => {
   });
 });
 
+describe("ProgrammaticBackend.deliver — streaming interim events (the watch-it-work view)", () => {
+  /** A spawnFn whose stdout emits the given byte CHUNKS in order (multi-chunk stream). */
+  function chunkedSpawn(chunks: string[]): ProgrammaticSpawnFn {
+    const enc = new TextEncoder();
+    return () => ({
+      stdout: new ReadableStream<Uint8Array>({
+        start(controller) {
+          for (const c of chunks) controller.enqueue(enc.encode(c));
+          controller.close();
+        },
+      }),
+      stderr: new Response("").body,
+      exited: Promise.resolve(0),
+    });
+  }
+
+  test("onInterim receives init + text + tool_use; the durable result is unchanged", async () => {
+    mkDirs("stream");
+    const blob =
+      JSON.stringify({ type: "system", subtype: "init", session_id: "sess-STREAM", apiKeySource: "none" }) + "\n" +
+      JSON.stringify({ type: "assistant", message: { content: [{ type: "text", text: "looking…" }] }, session_id: "sess-STREAM" }) + "\n" +
+      JSON.stringify({ type: "assistant", message: { content: [{ type: "tool_use", name: "Grep" }] }, session_id: "sess-STREAM" }) + "\n" +
+      JSON.stringify({ type: "result", subtype: "success", is_error: false, result: "looking… found it", session_id: "sess-STREAM" }) + "\n";
+    // Split into two chunks at a mid-line boundary to exercise incremental decoding.
+    const cut = Math.floor(blob.length / 2);
+    const backend = new ProgrammaticBackend(
+      baseDeps(chunkedSpawn([blob.slice(0, cut), blob.slice(cut)]), {
+        sessionState: new AgentSessionState({ stateDir }),
+      }),
+    );
+    const handle = await backend.start(specWithVault("eng"));
+
+    const events: unknown[] = [];
+    const result = await backend.deliver(handle, "where is X", (e) => events.push(e));
+
+    expect(events).toEqual([
+      { kind: "init", sessionId: "sess-STREAM" },
+      { kind: "text", text: "looking…" },
+      { kind: "tool", tool: "Grep" },
+    ]);
+    // The DURABLE final result is exactly as the non-streaming path would produce it.
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.reply).toBe("looking… found it");
+      expect(result.sessionId).toBe("sess-STREAM");
+    }
+  });
+
+  test("a turn with NO onInterim runs identically (durable reply intact, no throw)", async () => {
+    mkDirs("nostream");
+    const { fn } = recordingSpawn({ stdout: successTurn("sess-NS", "plain reply") });
+    const backend = new ProgrammaticBackend(baseDeps(fn, { sessionState: new AgentSessionState({ stateDir }) }));
+    const handle = await backend.start(specWithVault("eng"));
+    const result = await backend.deliver(handle, "hi"); // no sink
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.reply).toBe("plain reply");
+  });
+
+  test("a THROWING onInterim sink cannot break the turn (durable result still returned)", async () => {
+    mkDirs("sinkthrow");
+    const { fn } = recordingSpawn({ stdout: successTurn("sess-THROW", "survives") });
+    const backend = new ProgrammaticBackend(baseDeps(fn, { sessionState: new AgentSessionState({ stateDir }) }));
+    const handle = await backend.start(specWithVault("eng"));
+    const result = await backend.deliver(handle, "hi", () => {
+      throw new Error("dead SSE stream");
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.reply).toBe("survives");
+  });
+
+  test("an ERROR turn still streams its init then returns { ok:false } (live view can resolve)", async () => {
+    mkDirs("streamerr");
+    const blob =
+      JSON.stringify({ type: "system", subtype: "init", session_id: "sess-ERR" }) + "\n" +
+      JSON.stringify({ type: "result", subtype: "error_during_execution", is_error: true, result: "boom", session_id: "sess-ERR" }) + "\n";
+    const backend = new ProgrammaticBackend(
+      baseDeps(chunkedSpawn([blob]), { sessionState: new AgentSessionState({ stateDir }) }),
+    );
+    const handle = await backend.start(specWithVault("eng"));
+    const events: unknown[] = [];
+    const result = await backend.deliver(handle, "go", (e) => events.push(e));
+    expect(events).toEqual([{ kind: "init", sessionId: "sess-ERR" }]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe("boom");
+      expect(result.sessionId).toBe("sess-ERR");
+    }
+  });
+});
+
 describe("ProgrammaticBackend.deliver — credential / mint failures (value, not throw)", () => {
   test("a missing Claude credential returns { ok:false } and never spawns", async () => {
     mkDirs("nocred");

--- a/src/backends/programmatic.ts
+++ b/src/backends/programmatic.ts
@@ -72,13 +72,14 @@ import {
 import { buildAgentMcpConfigJson, vaultEntryKey } from "../agent-mcp-config.ts";
 import { resolveClaudeCredential, resolveChannelEnv } from "../credentials.ts";
 import { AgentSessionState } from "../agent-session-state.ts";
-import { parseStreamJson } from "./stream-json.ts";
+import { parseStreamJsonStream } from "./stream-json.ts";
 import type {
   AgentBackend,
   AgentHandle,
   AgentStatus,
   DeliverResult,
   DeliverUsage,
+  InterimSink,
 } from "./types.ts";
 
 /** Same slug shape `spawnAgent` enforces — a name lands in a path segment. */
@@ -245,14 +246,21 @@ export class ProgrammaticBackend implements AgentBackend {
    * Order: resolve the Claude credential (throws → the daemon surfaces it) → mint
    * the VAULT token (if the spec binds a vault) → write the vault-only `.mcp.json`
    * → build the `-p` argv (with `--resume <sid>` when a session id is stored) →
-   * sandbox-wrap via the shared seam → spawn → drain + parse the stream-json →
+   * sandbox-wrap via the shared seam → spawn → STREAM + parse the stream-json →
    * persist the captured session id → return the DeliverResult.
+   *
+   * STREAMING (design build item #1): the stdout stream-json is read INCREMENTALLY
+   * via {@link parseStreamJsonStream}. When `onInterim` is given, interim events
+   * (assistant text chunks + tool_use) are emitted as the turn runs so the daemon
+   * can render "watch it work" live; the FINAL parse (the authoritative `result`)
+   * is identical whether or not a sink is wired — the durable outbound note path is
+   * unchanged. `onInterim` is best-effort and must not throw.
    *
    * A failure (mint refused, non-zero exit, `is_error: true`, non-success subtype,
    * empty output) returns `{ ok: false, error }` — it does NOT throw, so the daemon
    * always learns the outcome inline.
    */
-  async deliver(handle: AgentHandle, message: string): Promise<DeliverResult> {
+  async deliver(handle: AgentHandle, message: string, onInterim?: InterimSink): Promise<DeliverResult> {
     const spec = handle.spec;
     if (!spec) {
       return { ok: false, error: `ProgrammaticBackend.deliver: handle for "${handle.name}" carries no spec` };
@@ -388,18 +396,33 @@ export class ProgrammaticBackend implements AgentBackend {
     };
 
     // Run the turn. A spawn/IO fault is a value (not a throw) — the daemon learns it.
-    let stdout: string;
+    // STREAM stdout incrementally (interim events for the live view) while draining
+    // stderr in parallel. The interim sink is best-effort + must not throw: wrap the
+    // caller's `onInterim` so a dead-stream error from the daemon's push can't abort
+    // the drain (which would strand the durable final-result parse). A no-sink turn
+    // passes a no-op, so the stream is still parsed incrementally with zero overhead
+    // beyond the (cheap) per-line dispatch.
+    let parsed;
     let stderr: string;
     let code: number;
+    const safeInterim: InterimSink = (e) => {
+      if (!onInterim) return;
+      try {
+        onInterim(e);
+      } catch {
+        // A push to a closed SSE stream / a sink fault must never break the turn.
+      }
+    };
     try {
       const proc = this.deps.spawnFn(wrapped.argv, { env: launchEnv, cwd });
-      [stdout, stderr] = await Promise.all([drainStream(proc.stdout), drainStream(proc.stderr)]);
+      [parsed, stderr] = await Promise.all([
+        parseStreamJsonStream(proc.stdout, safeInterim),
+        drainStream(proc.stderr),
+      ]);
       code = await proc.exited;
     } catch (err) {
       return { ok: false, error: `claude -p spawn failed: ${(err as Error).message}` };
     }
-
-    const parsed = parseStreamJson(stdout);
 
     // Persist the captured session id so the NEXT turn resumes it — even on a
     // failed turn (a turn can fail AFTER establishing a session; the id is still

--- a/src/backends/registry.test.ts
+++ b/src/backends/registry.test.ts
@@ -10,8 +10,13 @@
  */
 
 import { describe, test, expect } from "bun:test";
-import { ProgrammaticAgentRegistry, type WriteOutbound } from "./registry.ts";
-import type { AgentBackend, AgentHandle, AgentStatus, DeliverResult } from "./types.ts";
+import {
+  ProgrammaticAgentRegistry,
+  type WriteOutbound,
+  type TurnEventSink,
+  type TurnLifecycleEvent,
+} from "./registry.ts";
+import type { AgentBackend, AgentHandle, AgentStatus, DeliverResult, InterimSink } from "./types.ts";
 import type { AgentSpec } from "../sandbox/types.ts";
 
 /** A deferred promise — resolve it externally to release a gated turn. */
@@ -43,16 +48,21 @@ class FakeBackend implements AgentBackend {
   resultFor: (message: string) => DeliverResult = (m) => ({ ok: true, reply: "reply:" + m });
   /** If set, `deliver` THROWS this (to test the defensive catch). */
   throwOnce: Error | null = null;
+  /** Interim events to emit (via `onInterim`) during the next turn — set per test. */
+  interimToEmit: Parameters<InterimSink>[0][] = [];
 
   async start(spec: AgentSpec): Promise<AgentHandle> {
     return { backend: this.kind, channel: spec.channels[0] as string, name: spec.name, spec };
   }
 
-  async deliver(handle: AgentHandle, message: string): Promise<DeliverResult> {
+  async deliver(handle: AgentHandle, message: string, onInterim?: InterimSink): Promise<DeliverResult> {
     this.calls.push({ channel: handle.channel, message });
     this.inFlight++;
     this.maxConcurrent = Math.max(this.maxConcurrent, this.inFlight);
     try {
+      // Emit any configured interim events (mirrors the real backend streaming text +
+      // tool_use as the turn runs) so the registry's forwarding can be asserted.
+      if (onInterim) for (const e of this.interimToEmit) onInterim(e);
       if (this.gate) await this.gate.promise;
       if (this.throwOnce) {
         const e = this.throwOnce;
@@ -81,6 +91,15 @@ function recorder(): { calls: { channel: string; reply: string; inReplyTo?: stri
     calls.push({ channel, reply, ...(inReplyTo ? { inReplyTo } : {}) });
   };
   return { calls, fn };
+}
+
+/** A recorder TurnEventSink — captures every (channel, event) the registry emits. */
+function turnRecorder(): { events: { channel: string; event: TurnLifecycleEvent }[]; fn: TurnEventSink } {
+  const events: { channel: string; event: TurnLifecycleEvent }[] = [];
+  const fn: TurnEventSink = (channel, event) => {
+    events.push({ channel, event });
+  };
+  return { events, fn };
 }
 
 const specFor = (name: string, channel = name): AgentSpec => ({ name, channels: [channel] });
@@ -256,5 +275,112 @@ describe("ProgrammaticAgentRegistry — serial queue (the hard invariant)", () =
     gate.resolve();
     await until(() => rec.calls.length === 2);
     expect(reg.statusOf("eng")).toEqual({ state: "idle", queued: 0 });
+  });
+});
+
+describe("ProgrammaticAgentRegistry — streaming turn view (onTurnEvent)", () => {
+  test("forwards the backend's interim events + a final 'done' (keyed by channel)", async () => {
+    const backend = new FakeBackend();
+    backend.interimToEmit = [
+      { kind: "init", sessionId: "s-1" },
+      { kind: "text", text: "thinking…" },
+      { kind: "tool", tool: "Read" },
+    ];
+    backend.resultFor = () => ({ ok: true, reply: "final answer" });
+    const rec = recorder();
+    const turns = turnRecorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn, onTurnEvent: turns.fn });
+    await reg.register(specFor("eng"));
+
+    reg.enqueue("eng", { content: "hi" });
+    await until(() => rec.calls.length === 1);
+    // Let the trailing 'done' (emitted after the outbound write) land.
+    await until(() => turns.events.some((e) => e.event.kind === "done"));
+
+    expect(turns.events.map((e) => e.channel)).toEqual(["eng", "eng", "eng", "eng"]);
+    expect(turns.events.map((e) => e.event)).toEqual([
+      { kind: "init", sessionId: "s-1" },
+      { kind: "text", text: "thinking…" },
+      { kind: "tool", tool: "Read" },
+      { kind: "done", reply: "final answer" },
+    ]);
+    // The durable outbound write is unchanged by the live view.
+    expect(rec.calls).toEqual([{ channel: "eng", reply: "final answer" }]);
+  });
+
+  test("an ok:false turn emits a 'error' lifecycle event (no stuck working state)", async () => {
+    const backend = new FakeBackend();
+    backend.resultFor = () => ({ ok: false, error: "mint refused" });
+    const rec = recorder();
+    const turns = turnRecorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn, onTurnEvent: turns.fn });
+    await reg.register(specFor("eng"));
+
+    reg.enqueue("eng", { content: "x" });
+    await until(() => turns.events.some((e) => e.event.kind === "error"));
+
+    expect(turns.events).toEqual([{ channel: "eng", event: { kind: "error", error: "mint refused" } }]);
+    // No outbound note for a failed turn.
+    expect(rec.calls).toHaveLength(0);
+  });
+
+  test("a backend THROW also emits 'error' (the defensive catch resolves the live view)", async () => {
+    const backend = new FakeBackend();
+    backend.throwOnce = new Error("boom");
+    const rec = recorder();
+    const turns = turnRecorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn, onTurnEvent: turns.fn });
+    await reg.register(specFor("eng"));
+
+    reg.enqueue("eng", { content: "x" });
+    await until(() => turns.events.some((e) => e.event.kind === "error"));
+
+    expect(turns.events).toEqual([{ channel: "eng", event: { kind: "error", error: "boom" } }]);
+  });
+
+  test("an empty reply still emits 'done' (with reply '') so the live view finalizes", async () => {
+    const backend = new FakeBackend();
+    backend.resultFor = () => ({ ok: true, reply: "" });
+    const rec = recorder();
+    const turns = turnRecorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn, onTurnEvent: turns.fn });
+    await reg.register(specFor("eng"));
+
+    reg.enqueue("eng", { content: "tool-only" });
+    await until(() => turns.events.some((e) => e.event.kind === "done"));
+
+    expect(turns.events).toEqual([{ channel: "eng", event: { kind: "done", reply: "" } }]);
+    // No durable note for an empty reply (the existing contract), but the view finalizes.
+    expect(rec.calls).toHaveLength(0);
+  });
+
+  test("a throwing sink can't break the worker (the durable write still lands)", async () => {
+    const backend = new FakeBackend();
+    backend.interimToEmit = [{ kind: "text", text: "hi" }];
+    const rec = recorder();
+    const reg = new ProgrammaticAgentRegistry({
+      backend,
+      writeOutbound: rec.fn,
+      onTurnEvent: () => {
+        throw new Error("dead stream");
+      },
+    });
+    await reg.register(specFor("eng"));
+
+    reg.enqueue("eng", { content: "hi" });
+    await until(() => rec.calls.length === 1);
+    expect(rec.calls).toEqual([{ channel: "eng", reply: "reply:hi" }]);
+  });
+
+  test("with NO sink wired, turns run exactly as before (no throw, durable write lands)", async () => {
+    const backend = new FakeBackend();
+    backend.interimToEmit = [{ kind: "text", text: "ignored" }];
+    const rec = recorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    await reg.register(specFor("eng"));
+
+    reg.enqueue("eng", { content: "hi" });
+    await until(() => rec.calls.length === 1);
+    expect(rec.calls).toEqual([{ channel: "eng", reply: "reply:hi" }]);
   });
 });

--- a/src/backends/registry.ts
+++ b/src/backends/registry.ts
@@ -364,15 +364,24 @@ export class ProgrammaticAgentRegistry {
         try {
           await this.writeOutbound(channel, result.reply, msg.inReplyTo);
         } catch (err) {
+          const reason = (err as Error).message;
           console.error(
-            `parachute-channel: programmatic outbound write for channel "${channel}" failed: ${(err as Error).message}`,
+            `parachute-channel: programmatic outbound write for channel "${channel}" failed: ${reason}`,
           );
+          // The reply was produced but NOT persisted. Resolve the live view to ERROR,
+          // not `done` — a `done` would drop the in-progress bubble and trigger a poll
+          // that finds no note, leaving the user with a silently vanished reply.
+          // (reviewer nit, PR #83)
+          this.emitTurnEvent(channel, { kind: "error", error: `reply produced but not saved: ${reason}` });
+          continue;
         }
       }
 
       // Resolve the live view: `done` carries the final reply text (empty when the
       // turn produced none) so the UI finalizes the in-progress bubble — the durable
       // note (written above) is what actually persists; this just ends the spinner.
+      // Reached only when the outbound write SUCCEEDED, or there was no reply to write
+      // (empty/tool-only turn → clean resolve, no note expected).
       this.emitTurnEvent(channel, { kind: "done", reply: result.reply ?? "" });
     }
   }

--- a/src/backends/registry.ts
+++ b/src/backends/registry.ts
@@ -34,7 +34,31 @@
 
 import type { AgentSpec } from "../sandbox/types.ts";
 import { normalizeChannel } from "../sandbox/types.ts";
-import type { AgentBackend, AgentHandle } from "./types.ts";
+import type { AgentBackend, AgentHandle, InterimTurnEvent } from "./types.ts";
+
+/**
+ * The streaming-view sink (design 2026-06-16 build item #1): the daemon wires this
+ * to push a turn's interim progress (assistant text chunks + tool_use) to the
+ * channel's live chat subscribers (the per-channel turn-event SSE). The registry's
+ * worker calls it per channel as the turn runs, plus a synthesized `done`/`error`
+ * lifecycle event so the live view can finalize cleanly even on an empty/failed
+ * turn. ADDITIVE: when omitted the worker behaves exactly as before (no live view).
+ */
+export type TurnEventSink = (channel: string, event: TurnLifecycleEvent) => void;
+
+/**
+ * A per-channel turn event the daemon fans out to the live chat. It's the backend's
+ * {@link InterimTurnEvent} (text / tool / init) PLUS two registry-synthesized
+ * lifecycle events that bracket every turn so the UI never gets stuck "working":
+ *  - `done`  — the turn finished; `reply` is the final outbound text (empty when the
+ *              turn produced no text). The UI finalizes the live bubble.
+ *  - `error` — the turn failed; `error` is the reason. The UI resolves the live view
+ *              to an error state rather than leaving a hung spinner.
+ */
+export type TurnLifecycleEvent =
+  | InterimTurnEvent
+  | { kind: "done"; reply: string }
+  | { kind: "error"; error: string };
 
 /**
  * Write an outbound reply for a channel — the seam the registry posts a turn's
@@ -96,10 +120,27 @@ export class ProgrammaticAgentRegistry {
 
   private readonly backend: AgentBackend;
   private readonly writeOutbound: WriteOutbound;
+  /** Optional streaming-view sink — push interim + lifecycle turn events per channel. */
+  private readonly onTurnEvent?: TurnEventSink;
 
-  constructor(deps: { backend: AgentBackend; writeOutbound: WriteOutbound }) {
+  constructor(deps: { backend: AgentBackend; writeOutbound: WriteOutbound; onTurnEvent?: TurnEventSink }) {
     this.backend = deps.backend;
     this.writeOutbound = deps.writeOutbound;
+    if (deps.onTurnEvent) this.onTurnEvent = deps.onTurnEvent;
+  }
+
+  /**
+   * Emit a turn event to the streaming-view sink, swallowing any throw — a live-view
+   * push must NEVER break the serial worker (the durable note path is what matters).
+   * A no-op when no sink is wired.
+   */
+  private emitTurnEvent(channel: string, event: TurnLifecycleEvent): void {
+    if (!this.onTurnEvent) return;
+    try {
+      this.onTurnEvent(channel, event);
+    } catch {
+      // A dead-stream / sink fault must not strand the queue.
+    }
   }
 
   /** The wake channel for a spec (its first channel, normalized). */
@@ -287,24 +328,33 @@ export class ProgrammaticAgentRegistry {
 
       let result;
       try {
-        result = await this.backend.deliver(handle.backendHandle, msg.content);
+        // Forward each interim event to the streaming-view sink (keyed by channel)
+        // as the turn runs — the "watch it work" live progress. The sink swallows
+        // its own throws (emitTurnEvent), so a dead live stream can't break the turn.
+        result = await this.backend.deliver(handle.backendHandle, msg.content, (e) =>
+          this.emitTurnEvent(channel, e),
+        );
       } catch (err) {
         // The backend contract is failure-as-VALUE, never a throw — but defend so a
-        // surprise throw can't kill the worker and strand the queue.
+        // surprise throw can't kill the worker and strand the queue. Resolve the live
+        // view to an error state (no stuck "working" spinner).
+        const reason = (err as Error).message;
         console.error(
           `parachute-channel: programmatic turn for channel "${channel}" threw ` +
-            `(should be a value): ${(err as Error).message}`,
+            `(should be a value): ${reason}`,
         );
+        this.emitTurnEvent(channel, { kind: "error", error: reason });
         continue;
       }
 
       if (!result.ok) {
         // Logged + dropped — no retry, no loop. The backend already persisted the
         // session id (a turn can fail after establishing a session), so the next
-        // message resumes the conversation.
+        // message resumes the conversation. Resolve the live view to an error state.
         console.warn(
           `parachute-channel: programmatic turn for channel "${channel}" failed: ${result.error}`,
         );
+        this.emitTurnEvent(channel, { kind: "error", error: result.error });
         continue;
       }
 
@@ -319,6 +369,11 @@ export class ProgrammaticAgentRegistry {
           );
         }
       }
+
+      // Resolve the live view: `done` carries the final reply text (empty when the
+      // turn produced none) so the UI finalizes the in-progress bubble — the durable
+      // note (written above) is what actually persists; this just ends the spinner.
+      this.emitTurnEvent(channel, { kind: "done", reply: result.reply ?? "" });
     }
   }
 }

--- a/src/backends/stream-json.test.ts
+++ b/src/backends/stream-json.test.ts
@@ -12,11 +12,31 @@
  *  - blank/garbage input → an empty parse, never a throw.
  */
 import { describe, test, expect } from "bun:test";
-import { parseStreamJson } from "./stream-json.ts";
+import { parseStreamJson, parseStreamJsonStream, type InterimTurnEvent } from "./stream-json.ts";
 
 /** Join NDJSON event objects into the line-delimited blob claude emits. */
 function ndjson(...events: unknown[]): string {
   return events.map((e) => JSON.stringify(e)).join("\n") + "\n";
+}
+
+/** A ReadableStream<Uint8Array> that emits the given byte chunks in order (then closes). */
+function streamOf(...chunks: string[]): ReadableStream<Uint8Array> {
+  const enc = new TextEncoder();
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const c of chunks) controller.enqueue(enc.encode(c));
+      controller.close();
+    },
+  });
+}
+
+/** Collect the interim events parseStreamJsonStream emits while parsing `chunks`. */
+async function collectInterim(
+  ...chunks: string[]
+): Promise<{ events: InterimTurnEvent[]; turn: Awaited<ReturnType<typeof parseStreamJsonStream>> }> {
+  const events: InterimTurnEvent[] = [];
+  const turn = await parseStreamJsonStream(streamOf(...chunks), (e) => events.push(e));
+  return { events, turn };
 }
 
 describe("parseStreamJson — success turn", () => {
@@ -155,5 +175,136 @@ describe("parseStreamJson — robustness", () => {
     expect(parseStreamJson("")).toEqual({});
     expect(parseStreamJson("   \n  \n")).toEqual({});
     expect(parseStreamJson("not json at all\nmore noise")).toEqual({});
+  });
+});
+
+describe("parseStreamJsonStream — interim events + final turn", () => {
+  test("emits init (session) + text chunks + tool_use, and returns the same final turn", async () => {
+    const blob = ndjson(
+      { type: "system", subtype: "init", session_id: "sess-1", apiKeySource: "none", mcp_servers: [] },
+      { type: "assistant", message: { content: [{ type: "text", text: "let me check" }] }, session_id: "sess-1" },
+      {
+        type: "assistant",
+        message: { content: [{ type: "tool_use", name: "Read", input: {} }] },
+        session_id: "sess-1",
+      },
+      { type: "assistant", message: { content: [{ type: "text", text: " — done." }] }, session_id: "sess-1" },
+      {
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        result: "let me check — done.",
+        session_id: "sess-1",
+        usage: { input_tokens: 9, output_tokens: 4 },
+        total_cost_usd: 0.0009,
+      },
+    );
+    const { events, turn } = await collectInterim(blob);
+
+    expect(events).toEqual([
+      { kind: "init", sessionId: "sess-1" },
+      { kind: "text", text: "let me check" },
+      { kind: "tool", tool: "Read" },
+      { kind: "text", text: " — done." },
+    ]);
+    // The FINAL turn is exactly what the blob parser would compute — durable path intact.
+    expect(turn).toEqual(parseStreamJson(blob));
+    expect(turn.reply).toBe("let me check — done.");
+    expect(turn.success).toBe(true);
+    expect(turn.sessionId).toBe("sess-1");
+  });
+
+  test("a SINGLE assistant event with multiple blocks emits each in order", async () => {
+    const blob = ndjson(
+      { type: "system", subtype: "init", session_id: "s" },
+      {
+        type: "assistant",
+        message: {
+          content: [
+            { type: "text", text: "first" },
+            { type: "tool_use", name: "Bash" },
+            { type: "text", text: "second" },
+          ],
+        },
+        session_id: "s",
+      },
+      { type: "result", subtype: "success", is_error: false, result: "ok", session_id: "s" },
+    );
+    const { events } = await collectInterim(blob);
+    expect(events).toEqual([
+      { kind: "init", sessionId: "s" },
+      { kind: "text", text: "first" },
+      { kind: "tool", tool: "Bash" },
+      { kind: "text", text: "second" },
+    ]);
+  });
+
+  test("chunk boundaries SPLIT mid-line still parse + emit correctly", async () => {
+    const blob = ndjson(
+      { type: "system", subtype: "init", session_id: "split-1" },
+      { type: "assistant", message: { content: [{ type: "text", text: "streamed" }] }, session_id: "split-1" },
+      { type: "result", subtype: "success", is_error: false, result: "streamed", session_id: "split-1" },
+    );
+    // Split the blob at an arbitrary mid-line byte offset into two chunks.
+    const cut = Math.floor(blob.length / 2);
+    const { events, turn } = await collectInterim(blob.slice(0, cut), blob.slice(cut));
+    expect(events).toEqual([
+      { kind: "init", sessionId: "split-1" },
+      { kind: "text", text: "streamed" },
+    ]);
+    expect(turn).toEqual(parseStreamJson(blob));
+  });
+
+  test("a final result line with NO trailing newline is still folded (pipe close)", async () => {
+    // The result line is emitted WITHOUT a terminating \n (the pipe closed) — it must
+    // still be parsed (folded once at end-of-stream).
+    const init = JSON.stringify({ type: "system", subtype: "init", session_id: "no-nl" }) + "\n";
+    const result = JSON.stringify({
+      type: "result",
+      subtype: "success",
+      is_error: false,
+      result: "tail reply",
+      session_id: "no-nl",
+    });
+    const { turn } = await collectInterim(init, result);
+    expect(turn.reply).toBe("tail reply");
+    expect(turn.success).toBe(true);
+  });
+
+  test("interim sink is NEVER called for the result event (final-only), and tolerates noise", async () => {
+    const blob =
+      "PreToolUse hook running...\n" +
+      ndjson({ type: "system", subtype: "init", session_id: "noise" }).trimEnd() +
+      "\n" +
+      ndjson({ type: "assistant", message: { content: [{ type: "text", text: "hi" }] }, session_id: "noise" }).trimEnd() +
+      "\n" +
+      JSON.stringify({ type: "result", subtype: "success", is_error: false, result: "hi", session_id: "noise" }) +
+      "\n";
+    const { events, turn } = await collectInterim(blob);
+    // init + the one text chunk only — the result event produces no interim event.
+    expect(events).toEqual([
+      { kind: "init", sessionId: "noise" },
+      { kind: "text", text: "hi" },
+    ]);
+    expect(turn.reply).toBe("hi");
+  });
+
+  test("a null stream yields an empty turn with no events (no stdout)", async () => {
+    const events: InterimTurnEvent[] = [];
+    const turn = await parseStreamJsonStream(null, (e) => events.push(e));
+    expect(turn).toEqual({});
+    expect(events).toHaveLength(0);
+  });
+
+  test("an error turn streams nothing-but-init then the final turn carries the failure", async () => {
+    const blob = ndjson(
+      { type: "system", subtype: "init", session_id: "err-1" },
+      { type: "result", subtype: "error_during_execution", is_error: true, result: "kaboom", session_id: "err-1" },
+    );
+    const { events, turn } = await collectInterim(blob);
+    expect(events).toEqual([{ kind: "init", sessionId: "err-1" }]);
+    expect(turn.success).toBe(false);
+    expect(turn.errorMessage).toBe("kaboom");
+    expect(turn.sessionId).toBe("err-1");
   });
 });

--- a/src/backends/stream-json.ts
+++ b/src/backends/stream-json.ts
@@ -27,6 +27,17 @@
  * `apiKeySource: "none"` on the init event is the SUBSCRIPTION-auth signal — the
  * turn ran on the operator's subscription, not a metered API key (design §1 / the
  * Billing caveat). We surface it so a caller / test can assert it.
+ *
+ * ── Two reading modes ───────────────────────────────────────────────────────────
+ * {@link parseStreamJson} folds a COMPLETE blob into the final {@link ParsedTurn}
+ * (used wherever the whole stdout is already in hand). {@link parseStreamJsonStream}
+ * reads a byte stream INCREMENTALLY, emitting {@link InterimTurnEvent}s — interim
+ * assistant text + which tool the agent is using — as each line arrives, and
+ * returns the same final {@link ParsedTurn} at the end. The streaming view (design
+ * 2026-06-16-channel-architecture-post-programmatic.md, build item #1) drives the
+ * "watch it work" chat UI off those interim events while the durable final-reply
+ * path is unchanged. Both modes share one per-line fold ({@link foldLine}), so the
+ * final-result semantics are identical whichever mode produced them.
  */
 
 /** A parsed `claude -p` stream-json turn. */
@@ -58,6 +69,25 @@ export interface ParsedTurn {
   errorMessage?: string;
 }
 
+/**
+ * An interim progress event surfaced WHILE a turn runs (the streaming view). The
+ * three kinds:
+ *  - `text`   — a chunk of the agent's assistant message (each assistant event's
+ *               text block; chunk-level, NOT token-level — design §1's "chunk-level
+ *               is fine"). The chat UI appends these into the live in-progress bubble.
+ *  - `tool`   — the agent invoked a tool; `tool` is its name (e.g. "Read", "Bash",
+ *               an MCP tool). The chat UI shows a "using <tool>" indicator.
+ *  - `init`   — the turn established a session; carries the `sessionId`. Lets the UI
+ *               start a fresh live bubble (and a consumer correlate by session id).
+ *
+ * Deliberately small + serializable so it maps 1:1 onto an SSE frame the chat (and,
+ * later, my-vault-ui) subscribes to.
+ */
+export type InterimTurnEvent =
+  | { kind: "init"; sessionId: string }
+  | { kind: "text"; text: string }
+  | { kind: "tool"; tool: string };
+
 interface SystemInitEvent {
   type: "system";
   subtype?: string;
@@ -73,10 +103,97 @@ interface ResultEvent {
   usage?: { input_tokens?: number; output_tokens?: number; [k: string]: unknown };
   total_cost_usd?: number;
 }
+/** One content block of an assistant message — text or a tool invocation. */
+interface AssistantContentBlock {
+  type?: string;
+  /** Present on a `{ type: "text" }` block — a chunk of the assistant's prose. */
+  text?: string;
+  /** Present on a `{ type: "tool_use" }` block — the invoked tool's name. */
+  name?: string;
+}
+interface AssistantEvent {
+  type: "assistant";
+  message?: { content?: AssistantContentBlock[] };
+  session_id?: string;
+}
 interface AnyEvent {
   type?: string;
   session_id?: string;
   [k: string]: unknown;
+}
+
+/**
+ * Fold ONE already-trimmed, non-empty NDJSON line into the running {@link ParsedTurn}
+ * and, when an `onInterim` sink is given, emit the interim events the line carries
+ * (assistant text chunks, tool_use names, the session-establishing init). Shared by
+ * the blob parser and the streaming parser so both have identical final-result
+ * semantics. Never throws: a non-`{` line or a JSON-parse failure (a truncated
+ * partial line, hook plain text, any noise) is silently ignored.
+ */
+function foldLine(line: string, turn: ParsedTurn, onInterim?: (e: InterimTurnEvent) => void): void {
+  // Fast reject: NDJSON events are objects. A non-`{` line (hook plain text, a
+  // partial line that got cut mid-token) can't be one — skip without a try/catch.
+  if (line[0] !== "{") return;
+
+  let obj: AnyEvent;
+  try {
+    obj = JSON.parse(line) as AnyEvent;
+  } catch {
+    // A partial/truncated line, or any non-JSON noise — tolerate it.
+    return;
+  }
+  if (!obj || typeof obj !== "object") return;
+
+  // Capture session_id from the FIRST event that has one (init precedes result),
+  // so a turn that errors after init still yields the id for a resume. The first
+  // sighting also drives the interim `init` event (a single per-turn signal the UI
+  // uses to open a fresh live bubble).
+  if (turn.sessionId === undefined && typeof obj.session_id === "string" && obj.session_id) {
+    turn.sessionId = obj.session_id;
+    onInterim?.({ kind: "init", sessionId: obj.session_id });
+  }
+
+  if (obj.type === "system" && (obj as SystemInitEvent).subtype === "init") {
+    const init = obj as SystemInitEvent;
+    if (typeof init.apiKeySource === "string") turn.apiKeySource = init.apiKeySource;
+    return;
+  }
+
+  // ASSISTANT events carry the interim progress: text chunks + tool_use blocks.
+  // These don't affect the final ParsedTurn (the authoritative reply is the result
+  // event's `result`), but they're what the live view renders. Only emitted when a
+  // sink is wired (the blob parser passes none, so this is a no-op there).
+  if (obj.type === "assistant" && onInterim) {
+    const blocks = (obj as AssistantEvent).message?.content;
+    if (Array.isArray(blocks)) {
+      for (const block of blocks) {
+        if (block.type === "text" && typeof block.text === "string" && block.text.length > 0) {
+          onInterim({ kind: "text", text: block.text });
+        } else if (block.type === "tool_use" && typeof block.name === "string" && block.name.length > 0) {
+          onInterim({ kind: "tool", tool: block.name });
+        }
+      }
+    }
+    return;
+  }
+
+  if (obj.type === "result") {
+    const r = obj as ResultEvent;
+    turn.subtype = typeof r.subtype === "string" ? r.subtype : undefined;
+    turn.isError = r.is_error === true;
+    turn.success = r.subtype === "success" && r.is_error !== true;
+    if (typeof r.result === "string") {
+      // `result` carries the reply on success; on some failures it carries the
+      // error message. Record it as both; the caller picks per success/isError.
+      turn.reply = r.result;
+      if (turn.isError) turn.errorMessage = r.result;
+    }
+    if (r.usage && typeof r.usage === "object") turn.usage = r.usage;
+    if (typeof r.total_cost_usd === "number") turn.totalCostUsd = r.total_cost_usd;
+    // Don't return early after a result so session_id capture stays robust if
+    // ordering ever surprises us — there's only one result event in practice.
+    return;
+  }
 }
 
 /**
@@ -87,53 +204,65 @@ interface AnyEvent {
  */
 export function parseStreamJson(stdout: string): ParsedTurn {
   const turn: ParsedTurn = {};
-
   for (const rawLine of stdout.split("\n")) {
     const line = rawLine.trim();
     if (!line) continue;
-    // Fast reject: NDJSON events are objects. A non-`{` line (hook plain text, a
-    // partial line that got cut mid-token) can't be one — skip without a try/catch.
-    if (line[0] !== "{") continue;
-
-    let obj: AnyEvent;
-    try {
-      obj = JSON.parse(line) as AnyEvent;
-    } catch {
-      // A partial/truncated final line, or any non-JSON noise — tolerate it.
-      continue;
-    }
-    if (!obj || typeof obj !== "object") continue;
-
-    // Capture session_id from the FIRST event that has one (init precedes result),
-    // so a turn that errors after init still yields the id for a resume.
-    if (turn.sessionId === undefined && typeof obj.session_id === "string" && obj.session_id) {
-      turn.sessionId = obj.session_id;
-    }
-
-    if (obj.type === "system" && (obj as SystemInitEvent).subtype === "init") {
-      const init = obj as SystemInitEvent;
-      if (typeof init.apiKeySource === "string") turn.apiKeySource = init.apiKeySource;
-      continue;
-    }
-
-    if (obj.type === "result") {
-      const r = obj as ResultEvent;
-      turn.subtype = typeof r.subtype === "string" ? r.subtype : undefined;
-      turn.isError = r.is_error === true;
-      turn.success = r.subtype === "success" && r.is_error !== true;
-      if (typeof r.result === "string") {
-        // `result` carries the reply on success; on some failures it carries the
-        // error message. Record it as both; the caller picks per success/isError.
-        turn.reply = r.result;
-        if (turn.isError) turn.errorMessage = r.result;
-      }
-      if (r.usage && typeof r.usage === "object") turn.usage = r.usage;
-      if (typeof r.total_cost_usd === "number") turn.totalCostUsd = r.total_cost_usd;
-      // Don't `break` — there's only one result event, but draining the rest is
-      // cheap and keeps session_id capture robust if ordering ever surprises us.
-      continue;
-    }
+    foldLine(line, turn);
   }
+  return turn;
+}
 
+/**
+ * Parse a stream-json byte stream INCREMENTALLY, emitting {@link InterimTurnEvent}s
+ * via `onInterim` as each complete line arrives, and resolving to the final
+ * {@link ParsedTurn} when the stream ends. This is the streaming-view path (design
+ * build item #1): the same final result `parseStreamJson` would compute from the
+ * whole blob, PLUS live progress.
+ *
+ * Mechanics: decode incrementally (a `TextDecoder` with `{ stream: true }` so a
+ * multi-byte char split across chunks doesn't corrupt), buffer until a newline,
+ * fold each complete line. The trailing partial line (no terminating newline — a
+ * chunk boundary mid-line, or a truncated final line) is folded ONCE at the end:
+ * `foldLine` tolerates a partial that isn't valid JSON, and a complete-but-
+ * unterminated final result line (the pipe closing without a trailing `\n`) is
+ * still parsed. A null stream (no stdout) yields an empty turn with no events.
+ *
+ * The `onInterim` callback must not throw (the daemon's sink swallows dead-stream
+ * errors); a throw here would abort the drain. Best-effort by contract: this is
+ * ADDITIVE live progress — the durable record is the final ParsedTurn the caller
+ * turns into the outbound note.
+ */
+export async function parseStreamJsonStream(
+  stream: ReadableStream<Uint8Array> | null,
+  onInterim: (e: InterimTurnEvent) => void,
+): Promise<ParsedTurn> {
+  const turn: ParsedTurn = {};
+  if (!stream) return turn;
+
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buf = "";
+  try {
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+      // Drain every COMPLETE line (terminated by \n). Keep the trailing remainder
+      // (a still-incomplete line) in `buf` for the next chunk.
+      let nl: number;
+      while ((nl = buf.indexOf("\n")) !== -1) {
+        const line = buf.slice(0, nl).trim();
+        buf = buf.slice(nl + 1);
+        if (line) foldLine(line, turn, onInterim);
+      }
+    }
+    // Flush any multi-byte tail the decoder is holding, then fold the final
+    // unterminated line (a result line the pipe closed without a trailing \n).
+    buf += decoder.decode();
+    const tail = buf.trim();
+    if (tail) foldLine(tail, turn, onInterim);
+  } finally {
+    reader.releaseLock();
+  }
   return turn;
 }

--- a/src/backends/types.ts
+++ b/src/backends/types.ts
@@ -44,6 +44,22 @@
  */
 
 import type { AgentSpec } from "../sandbox/types.ts";
+import type { InterimTurnEvent } from "./stream-json.ts";
+
+export type { InterimTurnEvent } from "./stream-json.ts";
+
+/**
+ * A sink for interim turn progress (the streaming view, design
+ * 2026-06-16-channel-architecture-post-programmatic.md build item #1). The backend
+ * calls this as a turn runs — assistant text chunks, which tool the agent is using,
+ * the session-establishing init — so the daemon can push live progress to the chat
+ * UI WHILE the turn is in flight. It is ADDITIVE: the durable record is still the
+ * final {@link DeliverResult} the backend returns. Optional on `deliver` — a backend
+ * that can't stream (or a caller that doesn't want live progress) omits it and the
+ * turn behaves exactly as before. MUST NOT throw (a throw would abort the drain);
+ * the daemon's implementation swallows dead-stream errors.
+ */
+export type InterimSink = (event: InterimTurnEvent) => void;
 
 /**
  * An opaque handle to a started agent, returned by {@link AgentBackend.start} and
@@ -140,8 +156,15 @@ export interface AgentBackend {
    * {@link DeliverResult} — a failure is a value (`{ ok: false, error }`), NEVER a
    * throw, so the caller always learns the outcome inline (the asymmetric-guarantee
    * fix). The daemon serializes deliveries per channel (one turn at a time).
+   *
+   * `onInterim` (optional) is the streaming-view sink: the backend calls it with
+   * interim progress (assistant text chunks + tool_use) AS the turn runs, so the
+   * daemon can render "watch it work" live in the chat UI. ADDITIVE — when omitted,
+   * the turn behaves exactly as before; the final {@link DeliverResult} is the
+   * durable record either way. (Only the programmatic backend streams today; an
+   * interactive retrofit may ignore it.)
    */
-  deliver(handle: AgentHandle, message: string): Promise<DeliverResult>;
+  deliver(handle: AgentHandle, message: string, onInterim?: InterimSink): Promise<DeliverResult>;
 
   /**
    * Tear the agent down. For the programmatic backend this clears the persisted

--- a/src/backlog-replay.test.ts
+++ b/src/backlog-replay.test.ts
@@ -494,3 +494,48 @@ describe("end-to-end deaf window", () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// turn-events SSE auth — a browser EventSource cannot send an Authorization
+// header, so the live-streaming SSE MUST authenticate via ?token=. Regression
+// guard for the allowQueryParam bug: the handler defaulted to header-only, which
+// 401'd every browser EventSource connection → the live view never opened.
+// ---------------------------------------------------------------------------
+
+describe("turn-events SSE authenticates via ?token= (browser EventSource has no Bearer)", () => {
+  test("GET /api/channels/<ch>/turn-events?token= with NO Authorization header → 200 text/event-stream", async () => {
+    const ds = new DeliveryState({ stateDir, defaultMark: "2026-01-01T00:00:00.000Z" });
+    const t = stubVault("eng", []);
+    const channels = vaultChannels("eng", t);
+    const handler = createFetchHandler(channels, new ClientRegistry(), { deliveryState: ds });
+    const srv = Bun.serve({ port: 0, hostname: "127.0.0.1", idleTimeout: 0, fetch: handler });
+    const base = `http://127.0.0.1:${srv.port}`;
+    try {
+      // NO `headers: auth` — only the query-param token, exactly as a browser
+      // EventSource sends it. Without allowQueryParam=true on the handler this 401s.
+      const res = await fetch(`${base}/api/channels/eng/turn-events?token=${RW_TOKEN}`);
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("text/event-stream");
+      const reader = res.body!.getReader();
+      const first = await reader.read();
+      expect(new TextDecoder().decode(first.value)).toContain(": connected");
+      await reader.cancel();
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("turn-events with neither Authorization header nor ?token= → 401", async () => {
+    const ds = new DeliveryState({ stateDir, defaultMark: "2026-01-01T00:00:00.000Z" });
+    const channels = vaultChannels("eng", stubVault("eng", []));
+    const handler = createFetchHandler(channels, new ClientRegistry(), { deliveryState: ds });
+    const srv = Bun.serve({ port: 0, hostname: "127.0.0.1", idleTimeout: 0, fetch: handler });
+    const base = `http://127.0.0.1:${srv.port}`;
+    try {
+      const res = await fetch(`${base}/api/channels/eng/turn-events`);
+      expect(res.status).toBe(401);
+    } finally {
+      srv.stop(true);
+    }
+  });
+});

--- a/src/daemon.test.ts
+++ b/src/daemon.test.ts
@@ -13,7 +13,7 @@
  * no-token reject is wired in front of the guarded handlers.
  */
 import { describe, test, expect, beforeAll, afterAll } from "bun:test";
-import { createFetchHandler, resolveStartCmd } from "./daemon.ts";
+import { createFetchHandler, resolveStartCmd, buildTurnEventSink } from "./daemon.ts";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -134,6 +134,14 @@ describe("bridge-facing endpoints require a bearer token (401 with none)", () =>
       body: JSON.stringify({ channel: "ui1", file_id: "f1" }),
     });
     expect(res.status).toBe(401);
+  });
+
+  test("GET /api/channels/<ch>/turn-events with no Authorization → 401 (channel:read gated)", async () => {
+    const res = await fetch(`${base}/api/channels/ui1/turn-events`);
+    expect(res.status).toBe(401);
+    expect(((await res.json()) as { error: string }).error).toBe("unauthorized");
+    // The SSE stream must NOT open on a 401 — the gate short-circuits to JSON.
+    expect(res.headers.get("content-type")).toContain("application/json");
   });
 
   test("an invalid bearer is also rejected (401, no JWKS needed for a non-JWT)", async () => {
@@ -608,5 +616,48 @@ describe("resolveStartCmd (hub-supervisor start command)", () => {
     // INSTALL_DIR at runtime is the repo root; src/.. is that root in this checkout.
     const repoRoot = join(import.meta.dir, "..");
     expect(resolveStartCmd(repoRoot)).toEqual(["parachute-channel"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Turn-event sink — the streaming-view fan-out (design build item #1).
+// ---------------------------------------------------------------------------
+
+describe("buildTurnEventSink (streaming-view fan-out)", () => {
+  test("routes a turn event to ONLY the channel's subscribers, as a 'turn' SSE frame", () => {
+    const turnEvents = new ClientRegistry();
+    const engFrames: string[] = [];
+    const opsFrames: string[] = [];
+    turnEvents.add("c-eng", { channel: "eng", enqueue: (p) => engFrames.push(p) });
+    turnEvents.add("c-ops", { channel: "ops", enqueue: (p) => opsFrames.push(p) });
+
+    const sink = buildTurnEventSink(turnEvents);
+    sink("eng", { kind: "text", text: "hi" });
+
+    // The eng subscriber got it; the ops subscriber did not (channel isolation).
+    expect(engFrames).toHaveLength(1);
+    expect(opsFrames).toHaveLength(0);
+    expect(engFrames[0]).toContain("event: turn");
+    expect(engFrames[0]).toContain(JSON.stringify({ kind: "text", text: "hi" }));
+  });
+
+  test("a 0-subscriber channel is a clean no-op (events drop; no throw)", () => {
+    const turnEvents = new ClientRegistry();
+    const sink = buildTurnEventSink(turnEvents);
+    expect(() => sink("ghost", { kind: "done", reply: "x" })).not.toThrow();
+  });
+
+  test("a dead (throwing) subscriber is dropped, not fatal", () => {
+    const turnEvents = new ClientRegistry();
+    turnEvents.add("dead", {
+      channel: "eng",
+      enqueue: () => {
+        throw new Error("stream closed");
+      },
+    });
+    const sink = buildTurnEventSink(turnEvents);
+    expect(() => sink("eng", { kind: "tool", tool: "Read" })).not.toThrow();
+    // routeToChannel drops the dead client; a follow-up emit finds no subscribers.
+    expect(turnEvents.countForChannel("eng")).toBe(0);
   });
 });

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -101,6 +101,7 @@ import {
 import {
   ProgrammaticAgentRegistry,
   type WriteOutbound,
+  type TurnEventSink,
 } from "./backends/registry.ts";
 import { AgentSessionState } from "./agent-session-state.ts";
 import { readPersistedSpec, interpretPersistedBackend, sessionWorkspace } from "./spawn-agent.ts";
@@ -512,6 +513,7 @@ export function buildWriteOutbound(channels: Map<string, Channel>): WriteOutboun
  */
 export function createDefaultProgrammaticRegistry(
   channels: Map<string, Channel>,
+  onTurnEvent?: TurnEventSink,
 ): ProgrammaticAgentRegistry {
   const stateDir = defaultStateDir();
   const sessionState = new AgentSessionState({ stateDir });
@@ -548,7 +550,36 @@ export function createDefaultProgrammaticRegistry(
   return new ProgrammaticAgentRegistry({
     backend,
     writeOutbound: buildWriteOutbound(channels),
+    ...(onTurnEvent ? { onTurnEvent } : {}),
   });
+}
+
+/**
+ * Build the {@link TurnEventSink} that pushes a programmatic turn's live progress
+ * (interim assistant text + tool_use, plus the registry's done/error lifecycle
+ * events) to the channel's turn-event SSE subscribers — the chat UI's "watch it
+ * work" view (design 2026-06-16 build item #1).
+ *
+ * Transport choice (documented in the PR): a DEDICATED per-channel SSE stream
+ * (`/api/channels/<ch>/turn-events`) over the existing {@link ClientRegistry},
+ * NOT the durable-message poll. Rationale — the chat already POLLs vault channels
+ * for their DURABLE transcript (the `#channel-message` notes, the record of truth);
+ * turn progress is EPHEMERAL and chunk-frequent, so polling would be coarse + would
+ * surface partial state as if durable. An SSE stream is the clean real-time fit and
+ * reuses the registry/`sseFrame` infra already in the daemon. The durable path is
+ * untouched: the final `result` still becomes the `#channel-message/outbound` note,
+ * and the live stream is purely additive progress that the UI finalizes against it.
+ *
+ * Keyed by channel; fans out to every subscriber on that channel. A 0-subscriber
+ * turn is a clean no-op (the events drop; the durable note still lands) — there is
+ * no high-water-mark / replay for live progress (it's ephemeral by design).
+ */
+export function buildTurnEventSink(turnEvents: ClientRegistry): TurnEventSink {
+  return (channel, event) => {
+    // routeToChannel swallows dead-stream enqueues (drops the client); a 0-subscriber
+    // channel returns 0 delivered — both are fine, progress is best-effort.
+    turnEvents.routeToChannel(channel, "turn", event);
+  };
 }
 
 /**
@@ -720,6 +751,19 @@ ${THEME_CSS}
   .msg.you a { color: #fff; }
   .files { margin-top: 4px; font-size: 0.8rem; opacity: .85; }
   .files .file-name { font-family: var(--font-mono); }
+  /* Live turn view ("watch it work"): an in-progress "them" bubble that streams the
+     agent's interim text + shows which tools it's using, finalized when the durable
+     reply note arrives. A subtle pulsing border marks it as still-working. */
+  .msg.live { border-style: dashed; animation: livePulse 1.4s ease-in-out infinite; }
+  @keyframes livePulse { 0%,100% { opacity: 1; } 50% { opacity: 0.6; } }
+  .msg .live-text { white-space: normal; }
+  .msg .live-tools { margin-top: 6px; display: flex; flex-wrap: wrap; gap: 4px; }
+  .msg .tool-chip {
+    font-family: var(--font-mono); font-size: 0.72rem; padding: 1px 7px; border-radius: 10px;
+    background: var(--bg-soft); color: var(--fg-muted); border: 1px solid var(--border);
+  }
+  .msg .live-working { margin-top: 6px; font-size: 0.75rem; color: var(--fg-muted); font-style: italic; }
+  .msg.live.errored { border-color: var(--warn); color: var(--warn); animation: none; }
   /* Permission bubble: Approve/Deny row + the follow-up note. */
   .perm-actions { display: flex; gap: 8px; margin-top: 8px; }
   .perm-note { margin-top: 8px; font-size: 0.78rem; color: var(--fg-muted); font-style: italic; }
@@ -788,6 +832,13 @@ ${SHELL_JS}
   var pollTimer = null;
   var seenIds = {}; // note id -> true, for the vault poll dedup
   var POLL_MS = 3500;
+  // Streaming turn view ("watch it work", design build item #1): a per-channel SSE
+  // (/api/channels/<ch>/turn-events) that streams a PROGRAMMATIC turn's interim
+  // assistant text + tool_use, finalized when the durable reply note arrives via the
+  // poll. turnEs is the EventSource; liveTurn holds the in-progress bubble's DOM
+  // refs while a turn runs.
+  var turnEs = null;
+  var liveTurn = null; // { el, textEl, toolsEl, toolNames:{}, statusEl } | null
   wireShell("chat");
 
   function transportFor(ch) { return channelTransports[ch] || ""; }
@@ -795,6 +846,13 @@ ${SHELL_JS}
 
   function stopPolling() {
     if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
+  }
+
+  // Tear down the live turn view (SSE + any in-progress bubble). Called on a channel
+  // switch / a reconnect so a stale stream + bubble can't leak across channels.
+  function stopTurnEvents() {
+    if (turnEs) { turnEs.close(); turnEs = null; }
+    clearLiveTurn();
   }
 
   // ----- Layer 2 auth -----------------------------------------------------
@@ -893,6 +951,103 @@ ${SHELL_JS}
     return true;
   }
 
+  // ----- Streaming turn view ("watch it work") ----------------------------
+  // Render a PROGRAMMATIC turn's live progress in an in-progress bubble: streaming
+  // assistant text + "using <tool>" chips, finalized to the durable outbound note
+  // (rendered by the poll) when the turn completes. The live bubble is EPHEMERAL —
+  // it's removed on 'done' (the durable note shows the real reply) or shown as an
+  // error on 'error', so the view never gets stuck "working".
+
+  // Tear down any in-progress live bubble (channel switch / fresh turn / cleanup).
+  function clearLiveTurn() {
+    if (liveTurn && liveTurn.el && liveTurn.el.parentNode) {
+      liveTurn.el.parentNode.removeChild(liveTurn.el);
+    }
+    liveTurn = null;
+  }
+
+  // Start a fresh in-progress bubble for a new turn (on the turn's 'init' event).
+  function startLiveTurn() {
+    clearLiveTurn();
+    var el = document.createElement("div");
+    el.className = "msg them live";
+    var textEl = document.createElement("div");
+    textEl.className = "live-text";
+    var toolsEl = document.createElement("div");
+    toolsEl.className = "live-tools";
+    var statusEl = document.createElement("div");
+    statusEl.className = "live-working";
+    statusEl.textContent = "working…";
+    el.appendChild(textEl);
+    el.appendChild(toolsEl);
+    el.appendChild(statusEl);
+    transcript.appendChild(el);
+    transcript.scrollTop = transcript.scrollHeight;
+    liveTurn = { el: el, textEl: textEl, toolsEl: toolsEl, toolNames: {}, statusEl: statusEl, text: "" };
+  }
+
+  // Append a chunk of streamed assistant text into the live bubble (render Markdown
+  // over the accumulated text so partial formatting still reads well).
+  function appendLiveText(chunk) {
+    if (!liveTurn) startLiveTurn();
+    liveTurn.text += chunk;
+    liveTurn.textEl.innerHTML = renderMarkdown(liveTurn.text);
+    transcript.scrollTop = transcript.scrollHeight;
+  }
+
+  // Show a "using <tool>" chip (deduped — one chip per distinct tool this turn).
+  function addLiveTool(tool) {
+    if (!liveTurn) startLiveTurn();
+    if (liveTurn.toolNames[tool]) return;
+    liveTurn.toolNames[tool] = true;
+    var chip = document.createElement("span");
+    chip.className = "tool-chip";
+    chip.textContent = "⚙ " + tool;
+    liveTurn.toolsEl.appendChild(chip);
+    transcript.scrollTop = transcript.scrollHeight;
+  }
+
+  // Handle one turn event from the SSE stream.
+  function onTurnEvent(d) {
+    if (!d || !d.kind) return;
+    if (d.kind === "init") { startLiveTurn(); return; }
+    if (d.kind === "text") { appendLiveText(d.text || ""); return; }
+    if (d.kind === "tool") { addLiveTool(d.tool || "tool"); return; }
+    if (d.kind === "done") {
+      // The turn finished. Drop the live bubble; the durable outbound note carries
+      // the real reply — poll once NOW so it appears immediately (not after up to a
+      // full POLL_MS). An empty reply leaves the chat clean (no note written).
+      clearLiveTurn();
+      pollVault(currentChannel());
+      return;
+    }
+    if (d.kind === "error") {
+      // The turn failed — resolve the live view to an error state (no stuck spinner).
+      if (!liveTurn) startLiveTurn();
+      liveTurn.el.className = "msg them live errored";
+      liveTurn.statusEl.textContent = "turn failed: " + (d.error || "unknown error");
+      liveTurn = null; // leave the errored bubble in place; stop treating it as live
+      return;
+    }
+  }
+
+  // Open the turn-event SSE for a vault channel. EPHEMERAL: a transient error just
+  // lets EventSource auto-reconnect; a 401 is handled by the poll's re-auth path, so
+  // we don't duplicate the refresh dance here (the live view is best-effort progress).
+  function connectTurnEvents(ch) {
+    if (turnEs) { turnEs.close(); turnEs = null; }
+    if (!ch || !isVault(ch)) return;
+    var url = MOUNT + "/api/channels/" + encodeURIComponent(ch) + "/turn-events";
+    if (window.__token) url += "?token=" + encodeURIComponent(window.__token);
+    turnEs = new EventSource(url);
+    turnEs.addEventListener("turn", function (e) {
+      // Ignore events that arrive after a channel switch (stale stream still closing).
+      if (ch !== currentChannel()) return;
+      try { onTurnEvent(JSON.parse(e.data)); } catch (_) {}
+    });
+    // No onerror handling beyond the browser's auto-reconnect — progress is additive.
+  }
+
   // Poll a vault channel's transcript: re-query, append only unseen ids. This is
   // how a session's replies + messages from other clients (Telegram, other
   // browsers) show up. Reconciles optimistic echoes too — an echo we already
@@ -922,8 +1077,12 @@ ${SHELL_JS}
   // start polling. Sets the composer live. authedFetch attaches the bearer.
   function connectVault(ch) {
     stopPolling();
+    stopTurnEvents();
     if (es) { es.close(); es = null; }
     seenIds = {};
+    // Open the live turn-event stream alongside the durable poll — watch programmatic
+    // turns work in real time; the poll renders the durable record when they finish.
+    connectTurnEvents(ch);
     setStatus("loading history…", "");
     authedFetch(MOUNT + "/api/channels/" + encodeURIComponent(ch) + "/messages").then(function (r) {
       if (ch !== currentChannel()) return;
@@ -1010,6 +1169,7 @@ ${SHELL_JS}
   function connect() {
     if (es) { es.close(); es = null; }
     stopPolling();
+    stopTurnEvents();
     var ch = currentChannel();
     if (!ch) { setStatus("no channel", ""); sendBtn.disabled = true; return; }
     updateSetup(ch);
@@ -1297,6 +1457,14 @@ export function createFetchHandler(
     agentOps?: AgentOps;
     deliveryState?: DeliveryState;
     programmatic?: ProgrammaticAgentRegistry;
+    /**
+     * The per-channel turn-event SSE registry (the streaming view, design build
+     * item #1). The `/api/channels/<ch>/turn-events` SSE route registers subscribers
+     * here; the programmatic registry's turn-event sink fans out to them. `main`
+     * passes the boot instance (the SAME one the lazily-defaulted programmatic
+     * registry pushes to); tests inject one to assert the live-progress fan-out.
+     */
+    turnEvents?: ClientRegistry;
   },
 ): (req: Request, server?: { upgrade: (req: Request, opts: { data: TerminalWsData }) => boolean }) => Promise<Response> {
   // Spawn/list/kill operations behind the web agents surface. Lazily defaulted to
@@ -1304,13 +1472,20 @@ export function createFetchHandler(
   // exercised without a hub, a sandbox, or a tmux server. Built once per handler.
   const agentOps: AgentOps = opts?.agentOps ?? createRealAgentOps();
 
+  // The per-channel turn-event SSE registry — subscribers of the live "watch it
+  // work" stream. Defaulted to a fresh instance so a plain createFetchHandler still
+  // serves the route; `main` shares its boot instance so the lazily-defaulted
+  // programmatic registry below pushes to the SAME subscribers the route registers.
+  const turnEvents: ClientRegistry = opts?.turnEvents ?? new ClientRegistry();
+
   // The programmatic-agent registry (design 2026-06-16) — inbound for a registered
   // channel routes to an on-demand `claude -p` turn instead of a push. `main`
   // constructs the real one (with the real backend + the outbound-write wiring);
   // tests inject a fake-backed instance. Defaulted lazily to the real registry so a
-  // plain `createFetchHandler(channels, registry)` still wires programmatic agents.
+  // plain `createFetchHandler(channels, registry)` still wires programmatic agents —
+  // and threads the turn-event sink so its turns stream to this handler's `turnEvents`.
   const programmatic: ProgrammaticAgentRegistry =
-    opts?.programmatic ?? createDefaultProgrammaticRegistry(channels);
+    opts?.programmatic ?? createDefaultProgrammaticRegistry(channels, buildTurnEventSink(turnEvents));
 
   // Per-channel delivery high-water-mark store (the no-silent-loss spine). The
   // daemon's `main` passes the boot-time instance; tests that don't care get a
@@ -2280,6 +2455,45 @@ export function createFetchHandler(
       return json({ ok: true });
     }
 
+    // Turn-event SSE — GET /api/channels/<ch>/turn-events (chat-facing; gated on
+    // `channel:read`, same scope as the transcript poll + /ui/events). The streaming
+    // view (design 2026-06-16 build item #1): the chat subscribes here to watch a
+    // PROGRAMMATIC turn work in real time — interim assistant text + tool_use, then a
+    // done/error lifecycle event. EPHEMERAL by design: no backlog/replay (the durable
+    // record is the `#channel-message/outbound` note the turn still writes). A channel
+    // with no programmatic agent simply never receives a `turn` frame (the stream
+    // stays open + idle). Open to any live channel — unknown channel still opens the
+    // stream (it just never emits), matching the low-stakes ephemeral contract.
+    // Externally `<hub>/channel/api/channels/<ch>/turn-events`.
+    {
+      const turnMatch = url.pathname.match(/^\/api\/channels\/([^/]+)\/turn-events$/);
+      if (req.method === "GET" && turnMatch) {
+        const denied = await requireScope(req, url, SCOPE_READ);
+        if (denied) return denied;
+        const channelName = decodeURIComponent(turnMatch[1]!);
+        const clientId = crypto.randomUUID();
+        const stream = new ReadableStream<string>({
+          start(controller) {
+            turnEvents.add(clientId, {
+              channel: channelName,
+              enqueue: (payload) => controller.enqueue(payload),
+            });
+            controller.enqueue(": connected\n\n");
+          },
+          cancel() {
+            turnEvents.remove(clientId);
+          },
+        });
+        return new Response(stream, {
+          headers: {
+            "content-type": "text/event-stream",
+            "cache-control": "no-cache",
+            connection: "keep-alive",
+          },
+        });
+      }
+    }
+
     // Transcript read — GET /api/channels/<ch>/messages (chat-facing; gated on
     // `channel:read`, same as /ui/events). The built-in chat polls this to render
     // a channel's durable history and pick up replies + messages from other
@@ -2540,13 +2754,21 @@ function main(): void {
     defaultMark: new Date().toISOString(),
   });
 
+  // The per-channel turn-event SSE registry (the streaming view, design build item
+  // #1), constructed ONCE at boot and shared by the fetch handler's
+  // `/api/channels/<ch>/turn-events` route (subscriber registration) and the
+  // programmatic registry's turn-event sink (live-progress fan-out) — so a turn's
+  // interim events reach the chat subscribers the route registered.
+  const turnEvents = new ClientRegistry();
+
   // The PROGRAMMATIC-agent registry (design 2026-06-16), constructed ONCE at boot
   // and shared by the fetch handler (the /api/agents + /health routes), the
   // transports' `contextFor` (inbound enqueue), and the boot re-register below — so
   // the SAME instance the routes operate on is the one inbound enqueues onto. Built
   // here (not lazily in createFetchHandler) precisely so the transports started
-  // below route inbound to it.
-  const programmatic = createDefaultProgrammaticRegistry(channels);
+  // below route inbound to it. Threaded with the turn-event sink so each turn streams
+  // its interim progress to `turnEvents` (the chat's live view).
+  const programmatic = createDefaultProgrammaticRegistry(channels, buildTurnEventSink(turnEvents));
 
   // The terminal WS handler set (pty↔socket relay + backpressure flow control,
   // src/terminal.ts). One handler object serves every terminal connection;
@@ -2554,7 +2776,7 @@ function main(): void {
   // upgrades into these via `server.upgrade(req, { data })`.
   const terminalWs = createTerminalWsHandlers();
 
-  const fetchHandler = createFetchHandler(channels, registry, { deliveryState, programmatic });
+  const fetchHandler = createFetchHandler(channels, registry, { deliveryState, programmatic, turnEvents });
   const server = Bun.serve<TerminalWsData, never>({
     port: PORT,
     hostname: "127.0.0.1",

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1036,6 +1036,9 @@ ${SHELL_JS}
   // we don't duplicate the refresh dance here (the live view is best-effort progress).
   function connectTurnEvents(ch) {
     if (turnEs) { turnEs.close(); turnEs = null; }
+    // Live turn streaming is for programmatic agents, which are always vault-transport
+    // channels today; gate the EventSource subscription on that. (The server-side SSE
+    // is transport-agnostic, so revisit if programmatic ever runs on a non-vault channel.)
     if (!ch || !isVault(ch)) return;
     var url = MOUNT + "/api/channels/" + encodeURIComponent(ch) + "/turn-events";
     if (window.__token) url += "?token=" + encodeURIComponent(window.__token);
@@ -2468,7 +2471,11 @@ export function createFetchHandler(
     {
       const turnMatch = url.pathname.match(/^\/api\/channels\/([^/]+)\/turn-events$/);
       if (req.method === "GET" && turnMatch) {
-        const denied = await requireScope(req, url, SCOPE_READ);
+        // allowQueryParam=true: this SSE is consumed by a browser EventSource, which
+        // cannot set an Authorization header — it authenticates via ?token=. Without
+        // this the live-streaming view 401s in the browser and never connects. (The
+        // stdio-bridge /events SSE uses a Bearer header, so it doesn't need this.)
+        const denied = await requireScope(req, url, SCOPE_READ, true);
         if (denied) return denied;
         const channelName = decodeURIComponent(turnMatch[1]!);
         const clientId = crypto.randomUUID();


### PR DESCRIPTION
## What

When you message a **programmatic** channel, watch the agent work in real time — its assistant text streaming in + which tools it's using — instead of only a delayed final reply. This reclaims the "watch it work" win programmatic-native (build item #1 of [`design/2026-06-16-channel-architecture-post-programmatic.md`](../blob/main/design/2026-06-16-channel-architecture-post-programmatic.md)).

## Emit mechanism

A new incremental NDJSON parser, `parseStreamJsonStream` (`src/backends/stream-json.ts`), reads the `claude -p` stdout stream **line-by-line**, emitting interim events (`init` / `text`-chunk / `tool_use`) via a callback as the turn runs — and returns the **same final `ParsedTurn`** the blob parser computes. Both modes share one per-line fold (`foldLine`), so final-result semantics are identical whichever produced them. Chunk-level text (not token-level), per the design.

- `ProgrammaticBackend.deliver` gains an optional `onInterim` sink — best-effort, throw-swallowed (a dead live stream can't abort the durable parse). stdout is now streamed incrementally while stderr drains in parallel.
- The `ProgrammaticAgentRegistry` worker forwards each interim event keyed by channel, and brackets **every** turn with a synthesized `done` / `error` lifecycle event so the live view never gets stuck "working" — empty reply, failed turn, and a backend throw all resolve cleanly.

## Push transport (and why)

A **dedicated per-channel SSE stream**: `GET /api/channels/<ch>/turn-events` (`channel:read`-gated, same as the transcript poll + `/ui/events`), over the existing `ClientRegistry`/`sseFrame` infra — **not** the durable-message poll.

Rationale: the chat already **polls** vault channels for their **durable** transcript (the `#channel-message` notes — the record of truth). Turn progress is **ephemeral** and chunk-frequent, so polling would be coarse and would surface partial state as if durable. SSE is the clean real-time fit and reuses infra already in the daemon. Ephemeral by design — **no** high-water-mark / backlog replay: a 0-subscriber turn drops its events; the durable note still lands.

## Where it renders

The daemon's **own** chat UI (`CHAT_UI_HTML` in `src/daemon.ts`): an in-progress dashed "them" bubble that streams assistant text + shows `⚙ <tool>` chips. It finalizes on `done` (drop the live bubble + poll once so the durable note appears immediately) or shows an error state on `error`. Vault channels open the turn-events `EventSource` alongside the existing durable poll; cleaned up on channel-switch / reconnect.

## Durable path preserved

The final `result` still becomes the `#channel-message/outbound` note (written **before** the `done` event), unchanged. Streaming is purely **additive** live progress — the note is the durable record. Error turns resolve the live view cleanly (no stuck "working" spinner).

## Scope

Programmatic backend only (interactive has its terminal). Per-channel serial turns already hold, so the live view shows one active turn per channel. Version stays `0.1.0`.

## my-vault-ui follow-up (deferred — no cross-repo work here)

The primary chat for vault-backed channels also renders in the separate **my-vault-ui** repo. Per the brief, scoped v1 to the channel daemon's own chat surface. The daemon-side streaming + a clean consumable `turn`-event SSE are in place; my-vault-ui can subscribe to `/api/channels/<ch>/turn-events` later to adopt the live view — no channel change needed.

## Self-review

Ran my own focused review (no separate reviewer dispatched, per the brief):
- **Ordering**: `writeOutbound` (await) runs before the `done` emit, so the durable note is in the vault when the browser polls on `done` — no flicker gap.
- **Safety**: the interim sink is throw-swallowed at both the backend (`safeInterim`) and registry (`emitTurnEvent`) layers; a dead SSE stream / sink fault can never strand the serial queue or break the durable turn. Verified by tests (throwing sink + backend throw both keep the durable write intact).
- **No-sink parity**: a turn with no `onInterim` runs identically to before (covered).
- **Byte-boundary robustness**: manually verified the streaming parser against 3-byte chunk splits (mid-line, mid-multibyte) — interim events stream in order, final turn byte-identical to the blob parser.
- **Auth**: turn-events route 401s with no token (covered); SSE doesn't open on a 401.
- **Embedded chat JS** validated as parseable (no template-literal backtick leaks).

## Tests + gates

- `bun test ./src`: **659 pass, 0 fail** (baseline 638 → +21 new).
- `bun run typecheck`: clean except the **2 pre-existing** TS2589 in `src/bridge.ts` (zero new).
- `bunx biome check .`: clean.
- Temp dirs only — no test touches the real `~/.parachute`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)