### PR TITLE
feat(channel): unified create-agent flow + programmatic terminal/UI cleanup

### DIFF
--- a/src/admin-ui.test.ts
+++ b/src/admin-ui.test.ts
@@ -138,20 +138,30 @@ describe("unified transport select drives fields + submit path", () => {
     expect(html).toContain('el("f-telegram-token").value');
     expect(html).toContain("config = { token: tgToken }");
     expect(html).toContain('setFieldError("f-telegram-token"');
-    // The POST body carries config when present.
-    expect(html).toContain("if (config) postBody.config = config;");
+    // The daemon-transport submit goes through the SHARED provisioning client
+    // (ChannelProvision.provisionDaemonChannel — src/provision-channel.ts), which
+    // attaches config when present. The page hands it the assembled config.
+    expect(html).toContain("ChannelProvision.provisionDaemonChannel");
+    // provisionDaemonChannel builds the POST body (name + transport + optional
+    // config) internally; the shared client carries config only when given.
+    expect(html).toContain("if (opts.config) postBody.config = opts.config;");
     expect(html).toContain('method: "POST"');
   });
 
   test("the http-ui transport posts just name + transport (no config)", () => {
     const html = renderAdminPage("");
-    // The base POST body is name + transport; config is only attached for telegram.
-    expect(html).toContain("var postBody = { name: name, transport: transport };");
+    // The shared provisioning client's base POST body is name + transport; config
+    // is only attached when the caller supplies it (telegram). http-ui passes no
+    // config, so the body stays name + transport.
+    expect(html).toContain("var postBody = { name: opts.name, transport: opts.transport };");
   });
 
   test("loads the vault list from the hub's public discovery doc (same-origin)", () => {
     const html = renderAdminPage("");
+    // loadVaults delegates the fetch to the shared ChannelProvision.listVaults,
+    // which reads the hub's public discovery doc.
     expect(html).toContain("function loadVaults");
+    expect(html).toContain("ChannelProvision.listVaults");
     expect(html).toContain("/.well-known/parachute.json");
   });
 
@@ -167,6 +177,22 @@ describe("unified transport select drives fields + submit path", () => {
     // The vault submit handler distinguishes 401 (not signed in to the hub) from
     // other failures with a specific, actionable banner.
     expect(html).toContain("Not signed in to the hub");
+  });
+
+  test("reveals the Terminal nav if an interactive agent exists (no stranding)", () => {
+    const html = renderAdminPage("");
+    // The config page hides the standalone Terminal entry by default (Phase-1 nav
+    // cleanup) but doesn't list agents — so it calls the shared reveal helper to
+    // avoid stranding an operator who has a live interactive session.
+    expect(html).toContain("revealTerminalNavIfInteractive()");
+  });
+
+  test("preserves the 400-vs-other add-channel banner distinction", () => {
+    const html = renderAdminPage("");
+    // Even after routing through the shared provisioning client, a request
+    // rejection (400) keeps its distinct copy from an infrastructure failure.
+    expect(html).toContain("Could not add channel");
+    expect(html).toContain("Add failed");
   });
 });
 

--- a/src/admin-ui.ts
+++ b/src/admin-ui.ts
@@ -66,6 +66,7 @@
  */
 
 import { THEME_CSS, appShell, SHELL_JS } from "./ui-kit.ts";
+import { PROVISION_JS } from "./provision-channel.ts";
 
 const PALETTE = {
   bg: "#faf8f4",
@@ -258,7 +259,7 @@ export function renderAdminPage(mount = ""): string {
       }
     })();
   </script>
-  <script>${SHELL_JS}${PAGE_SCRIPT}</script>
+  <script>${SHELL_JS}${PROVISION_JS}${PAGE_SCRIPT}</script>
 </body>
 </html>`;
 }
@@ -650,7 +651,7 @@ const PAGE_SCRIPT = String.raw`
       var spawn = document.createElement("a");
       spawn.className = "btn btn-sm btn-ghost";
       spawn.href = MOUNT + "/agents?channel=" + encodeURIComponent(c.name);
-      spawn.textContent = "Spawn agent";
+      spawn.textContent = "Create agent";
       actions.appendChild(spawn);
       var chat = document.createElement("a");
       chat.className = "btn btn-sm btn-ghost";
@@ -751,40 +752,37 @@ const PAGE_SCRIPT = String.raw`
     btn.disabled = true;
     var prev = btn.textContent;
     btn.textContent = "Adding...";
-    var postBody = { name: name, transport: transport };
-    if (config) postBody.config = config;
-    fetch(API_URL, {
-      method: "POST",
-      headers: authHeaders({ "content-type": "application/json" }),
-      body: JSON.stringify(postBody),
+    // Provision via the SHARED provisioning client (ChannelProvision). It POSTs
+    // <mount>/api/channels (channel:admin Bearer) and resolves a structured result;
+    // never rejects. Same code the create-agent flow runs for telegram/http-ui.
+    ChannelProvision.provisionDaemonChannel({
+      apiUrl: API_URL, token: window.__token, name: name, transport: transport, config: config,
     }).then(function (res) {
-      return res.json().catch(function () { return {}; }).then(function (payload) {
-        if (res.status === 401 || res.status === 403) { noAuthBanner(); return; }
+      if (res.auth) { noAuthBanner(); return; }
+      if (!res.ok) {
+        // Preserve the request-rejection (400) vs infrastructure-failure wording —
+        // provisionDaemonChannel carries the status so we keep the distinction.
         if (res.status === 400) {
-          setBanner("error", "<strong>Could not add channel.</strong> " + escapeHtml((payload && payload.error) || "invalid request"));
-          return;
-        }
-        if (!res.ok) {
-          setBanner("error", "<strong>Add failed.</strong> " + escapeHtml((payload && payload.error) || ("HTTP " + res.status)));
-          return;
-        }
-        // 200 may still carry restart_needed: true (persisted, hot-add failed).
-        if (payload && payload.restart_needed) {
-          setBanner(
-            "warn",
-            "<strong>Saved &mdash; restart needed.</strong> Channel <code>" + escapeHtml(name) +
-              "</code> was written to disk but didn't start live: " + escapeHtml(payload.error || "") +
-              " Run <code>parachute restart channel</code>."
-          );
+          setBanner("error", "<strong>Could not add channel.</strong> " + escapeHtml(res.error || "invalid request"));
         } else {
-          setBanner("success", "<strong>Channel added.</strong> <code>" + escapeHtml(name) + "</code> (" + escapeHtml(transport) + ") is live.");
+          setBanner("error", "<strong>Add failed.</strong> " + escapeHtml(res.error || ("HTTP " + (res.status || "?"))));
         }
-        el("f-name").value = "";
-        if (el("f-telegram-token")) el("f-telegram-token").value = "";
-        loadChannels();
-      });
-    }).catch(function (err) {
-      setBanner("error", "<strong>Network error.</strong> " + escapeHtml(err && err.message ? err.message : String(err)));
+        return;
+      }
+      // A successful add may still carry restart_needed (persisted, hot-add failed).
+      if (res.restart_needed) {
+        setBanner(
+          "warn",
+          "<strong>Saved &mdash; restart needed.</strong> Channel <code>" + escapeHtml(name) +
+            "</code> was written to disk but didn't start live: " + escapeHtml(res.error || "") +
+            " Run <code>parachute restart channel</code>."
+        );
+      } else {
+        setBanner("success", "<strong>Channel added.</strong> <code>" + escapeHtml(name) + "</code> (" + escapeHtml(transport) + ") is live.");
+      }
+      el("f-name").value = "";
+      if (el("f-telegram-token")) el("f-telegram-token").value = "";
+      loadChannels();
     }).then(function () {
       btn.disabled = false;
       btn.textContent = prev;
@@ -1056,16 +1054,27 @@ const PAGE_SCRIPT = String.raw`
   // transport is selected); a no-vaults / load-error state disables the add
   // button only WHILE vault is the selected transport (see applyTransportUI).
   window.__vaultsAvailable = false;
+  // Populate the vault dropdown via the shared provisioning client
+  // (ChannelProvision.listVaults — the hub's PUBLIC discovery doc). The fetch is
+  // shared with the create-agent flow so the two surfaces read vaults identically;
+  // the admin page keeps its own DOM rendering + __vaultsAvailable gate.
   function loadVaults() {
-    return fetch(window.location.origin + "/.well-known/parachute.json", {
-      headers: { accept: "application/json" },
-      credentials: "include",
-    })
-      .then(function (r) { return r.ok ? r.json() : null; })
-      .then(function (doc) {
+    return ChannelProvision.listVaults({ origin: window.location.origin })
+      .then(function (res) {
         var sel = el("f-vault");
-        var vaults = (doc && Array.isArray(doc.vaults)) ? doc.vaults : [];
+        var vaults = (res && res.ok && Array.isArray(res.vaults)) ? res.vaults : [];
         sel.innerHTML = "";
+        if (!res || !res.ok) {
+          var optErr = document.createElement("option");
+          optErr.value = "";
+          optErr.disabled = true;
+          optErr.selected = true;
+          optErr.textContent = "Could not load vaults";
+          sel.appendChild(optErr);
+          window.__vaultsAvailable = false;
+          applyTransportUI();
+          return;
+        }
         if (!vaults.length) {
           var opt = document.createElement("option");
           opt.value = "";
@@ -1079,26 +1088,14 @@ const PAGE_SCRIPT = String.raw`
           applyTransportUI();
           return;
         }
-        vaults.forEach(function (v, i) {
+        vaults.forEach(function (name, i) {
           var opt = document.createElement("option");
-          opt.value = v.name;
-          opt.textContent = v.name;
+          opt.value = name;
+          opt.textContent = name;
           if (i === 0) opt.selected = true;
           sel.appendChild(opt);
         });
         window.__vaultsAvailable = true;
-        applyTransportUI();
-      })
-      .catch(function () {
-        var sel = el("f-vault");
-        sel.innerHTML = "";
-        var opt = document.createElement("option");
-        opt.value = "";
-        opt.disabled = true;
-        opt.selected = true;
-        opt.textContent = "Could not load vaults";
-        sel.appendChild(opt);
-        window.__vaultsAvailable = false;
         applyTransportUI();
       });
   }
@@ -1147,34 +1144,16 @@ const PAGE_SCRIPT = String.raw`
     btn.disabled = true;
     var prev = btn.textContent;
     btn.textContent = "Linking...";
-    // POST to the HUB's general Connections engine. The page is same-origin
-    // under the /channel proxy, so the operator's hub session cookie flows with
-    // credentials:"include" -- the click IS the approval. We label provenance
-    // requestedBy:"channel" so the hub's Connections view shows it as
-    // module-initiated. The body is the canonical vault-backed-channel shape:
-    // vault.note.created (filtered to the inbound tag) -> channel.message.deliver.
-    var body = {
-      requestedBy: "channel",
-      source: {
-        module: "vault",
-        vault: vault,
-        event: "note.created",
-        filter: {
-          tags: ["#channel-message/inbound"],
-          has_metadata: ["channel"],
-          missing_metadata: ["channel_inbound_rendered_at"]
-        }
-      },
-      sink: { module: "channel", action: "message.deliver", params: { channel: name } }
-    };
-    fetch(window.location.origin + "/admin/connections", {
-      method: "POST",
-      credentials: "include",
-      headers: { "content-type": "application/json", accept: "application/json" },
-      body: JSON.stringify(body)
-    }).then(function (res) {
-      return res.json().catch(function () { return {}; }).then(function (payload) {
-        if (res.status === 401) {
+    // Provision via the SHARED provisioning client (ChannelProvision —
+    // src/provision-channel.ts). It POSTs the canonical vault-backed-channel body
+    // (vault.note.created filtered to the inbound tag -> channel.message.deliver)
+    // to the HUB's Connections engine with the operator's hub session cookie
+    // (credentials:"include" -- the click IS the approval). Same code the
+    // create-agent flow runs, so the two surfaces register identical triggers.
+    // Resolves a structured result; never rejects -- the page owns the banners.
+    ChannelProvision.provisionVaultChannel({ origin: window.location.origin, name: name, vault: vault })
+      .then(function (res) {
+        if (res.auth) {
           setBanner(
             "warn",
             "<strong>Not signed in to the hub.</strong> Linking a vault uses your hub admin session. " +
@@ -1183,33 +1162,30 @@ const PAGE_SCRIPT = String.raw`
           );
           return;
         }
-        if (res.status === 403) {
+        if (res.forbidden) {
           setBanner(
             "error",
             "<strong>Not permitted.</strong> Only the hub admin can link a vault. " +
-              escapeHtml((payload && payload.error_description) || "")
+              escapeHtml(res.error || "")
           );
           return;
         }
         if (!res.ok) {
           setBanner(
             "error",
-            "<strong>Link failed.</strong> " +
-              escapeHtml((payload && (payload.error_description || payload.error)) || ("HTTP " + res.status))
+            "<strong>Link failed.</strong> " + escapeHtml(res.error || ("HTTP " + (res.status || "?")))
           );
           return;
         }
         setBanner("success", "<strong>Vault linked.</strong> Channel <code>" + escapeHtml(name) + "</code> is backed by vault <code>" + escapeHtml(vault) + "</code>.");
-        renderConnectResult(payload && payload.connection, payload && payload.connect);
+        renderConnectResult(res.connection, res.connect);
         el("f-name").value = "";
         loadChannels();
+      })
+      .then(function () {
+        btn.disabled = false;
+        btn.textContent = prev;
       });
-    }).catch(function (err) {
-      setBanner("error", "<strong>Network error.</strong> " + escapeHtml(err && err.message ? err.message : String(err)));
-    }).then(function () {
-      btn.disabled = false;
-      btn.textContent = prev;
-    });
   }
 
   document.addEventListener("DOMContentLoaded", function () {
@@ -1223,7 +1199,13 @@ const PAGE_SCRIPT = String.raw`
     // list. A token failure still proceeds to loadChannels -- which surfaces the
     // no-auth banner on the resulting 401, so the operator sees one clear notice.
     // The vault dropdown loads in parallel (public discovery doc, no token).
-    ensureToken().then(loadChannels);
+    ensureToken().then(function () {
+      loadChannels();
+      // Reveal the Terminal nav entry if a live interactive agent exists (the config
+      // page doesn't list agents, so without this it would strand a user with a live
+      // interactive session). Best-effort; default-hidden on failure.
+      revealTerminalNavIfInteractive();
+    });
     loadVaults();
   });
 `;

--- a/src/agents-ui.test.ts
+++ b/src/agents-ui.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for the unified create-agent page (src/agents-ui.ts) — Parachute Agent
+ * Phase-1 consolidation. The page is a self-contained HTML+JS string (the same
+ * shape as admin-ui.ts), so these string-pin the served document's shape: the
+ * minimal default flow, the Advanced disclosure, the client-side-orchestration
+ * decision (reuse the shared ChannelProvision, no server-side vault minting), the
+ * channel-reuse idempotency, the unified-form payload shaping (the SAME /api/agents
+ * body), and the terminal-link gating (terminal links only for interactive agents).
+ *
+ * These mirror admin-ui.test.ts's discipline — assert the served strings, no DOM.
+ */
+import { describe, test, expect } from "bun:test";
+import { AGENTS_UI_HTML } from "./agents-ui.ts";
+
+const html = AGENTS_UI_HTML;
+
+describe("create-agent page — the unified primary surface", () => {
+  test("leads with the Create an agent section + button", () => {
+    expect(html).toContain('id="create-section"');
+    expect(html).toContain("Create an agent");
+    expect(html).toContain('id="create-go"');
+    // The minimal default: name + vault + optional system prompt.
+    expect(html).toContain('id="agent-name"');
+    expect(html).toContain('id="agent-vault"');
+    expect(html).toContain('id="agent-system-prompt"');
+  });
+
+  test("vault is the default transport (the new-channel transport leads with vault selected)", () => {
+    expect(html).toContain('id="agent-transport"');
+    expect(html).toContain('<option value="vault" selected>');
+  });
+
+  test("Advanced reveals existing-channel, transports, backend, isolation, mounts", () => {
+    expect(html).toContain('id="advanced"');
+    expect(html).toContain('id="use-existing"');
+    expect(html).toContain('id="existing-channel"');
+    expect(html).toContain('id="agent-backend"');
+    expect(html).toContain('value="telegram"');
+    expect(html).toContain('value="http-ui"');
+    expect(html).toContain('id="fs-mode"');
+    expect(html).toContain('id="net-mode"');
+    expect(html).toContain('id="agent-workspace"');
+    expect(html).toContain('id="mounts-rows"');
+    // System-prompt mode (append/replace) lives under Advanced.
+    expect(html).toContain('<option value="append" selected>Append (default)</option>');
+    expect(html).toContain('<option value="replace">Replace</option>');
+  });
+
+  test("backend defaults to programmatic; interactive is selectable but not default", () => {
+    expect(html).toMatch(/<option value="programmatic" selected>/);
+    expect(html).not.toMatch(/<option value="interactive" selected>/);
+    expect(html).toContain('<option value="interactive">');
+  });
+});
+
+describe("client-side orchestration (the load-bearing decision)", () => {
+  test("reuses the shared ChannelProvision client — no server-side vault minting", () => {
+    expect(html).toContain("window.ChannelProvision");
+    expect(html).toContain("Provision.provisionVaultChannel");
+    expect(html).toContain("Provision.provisionDaemonChannel");
+    expect(html).toContain("Provision.channelExists");
+    expect(html).toContain("Provision.listVaults");
+    // The vault path goes to the HUB (cookie-gated), not a daemon vault-mint.
+    expect(html).toContain("window.location.origin");
+  });
+
+  test("the agent spawn posts the SAME /api/agents body (no new API fields)", () => {
+    expect(html).toContain('apiJson("/api/agents", { method: "POST"');
+    // collectSpec assembles the canonical fields buildSpecFromBody already accepts.
+    expect(html).toContain("function collectSpec");
+    expect(html).toContain("spec.backend =");
+    expect(html).toContain("spec.systemPrompt = sysPrompt");
+    expect(html).toContain("spec.workspace = workspace");
+  });
+});
+
+describe("channel-reuse idempotency", () => {
+  test("checks for an existing channel and REUSES it (no double-provision)", () => {
+    // ensureChannel first asks channelExists; an existing channel resolves reused.
+    expect(html).toContain("function ensureChannel");
+    expect(html).toContain("Provision.channelExists");
+    expect(html).toContain("chk.exists");
+    expect(html).toContain("reused: true");
+  });
+
+  test("an existing-channel selection skips provisioning entirely", () => {
+    // useExisting === "existing" → channelStep resolves ok without provisioning.
+    expect(html).toContain('useExistingEl.value === "existing"');
+    expect(html).toContain("Promise.resolve({ ok: true, reused: true })");
+  });
+
+  test("a post-provision spawn failure surfaces a clear error (channel may remain)", () => {
+    expect(html).toContain("the agent spawn failed");
+    expect(html).toContain("may remain");
+  });
+});
+
+describe("unified-form payload shaping", () => {
+  test("resolveWakeChannel: existing mode uses the picker; new mode uses the name", () => {
+    expect(html).toContain("function resolveWakeChannel");
+    expect(html).toContain("return ch;"); // existing → the picked channel
+    expect(html).toContain("return name;"); // new → the agent name
+  });
+
+  test("the wake channel is the first channels[] entry; extras append", () => {
+    expect(html).toContain("var channels = [{ name: wake,");
+    expect(html).toContain("channels.push({ name: n,");
+  });
+
+  test("optional fields are omitted when blank (filesystem/network/workspace/prompt)", () => {
+    expect(html).toContain('if (fsMode.value === "full") spec.filesystem = "full";');
+    expect(html).toContain('if (netMode.value === "restricted")');
+    expect(html).toContain("if (workspace) spec.workspace = workspace;");
+    expect(html).toContain("if (sysPrompt) {");
+  });
+});
+
+describe("terminal-link gating (Phase-1 cleanup)", () => {
+  test("the per-agent terminal link is shown ONLY for interactive agents", () => {
+    // The running-agents list gates the terminal link behind !prog (interactive).
+    expect(html).toContain("if (!prog) {");
+    expect(html).toContain("terminal ↗");
+  });
+
+  test("reveals the Terminal nav entry only when an interactive agent exists", () => {
+    expect(html).toContain("setTerminalNavVisible(agents.some(function (a) { return a.backend !== \"programmatic\"; }))");
+  });
+
+  test("the /terminal helper + route are preserved (capability not deleted)", () => {
+    expect(html).toContain("function terminalUrl");
+    expect(html).toContain("/terminal?agent=");
+  });
+
+  test("an interactive launch surfaces its sandbox posture (mcp/filesystem/network)", () => {
+    // Security-relevant: the operator must be able to verify an interactive agent's
+    // isolation matches what they selected. These lines render on an interactive
+    // (non-programmatic, non-alreadyRunning) launch result.
+    expect(html).toContain("MCP servers: ");
+    expect(html).toContain('"filesystem: "');
+    expect(html).toContain('"network: "');
+    // Programmatic auto-navigates to chat; interactive does NOT (the posture lines +
+    // Terminal-attach affordance stay on screen).
+    expect(html).toContain("if (prog) {");
+    expect(html).toContain("window.location.href = chatUrl(wake)");
+  });
+});
+
+describe("vocabulary + safety", () => {
+  test("uses Create vocabulary (the unified create-agent flow), not Spawn", () => {
+    expect(html).toContain("Create agent");
+    expect(html).not.toContain("Spawn an agent");
+  });
+
+  test("the page still loads OPEN and mints a channel:admin Bearer", () => {
+    expect(html).toContain("fetchToken()");
+    expect(html).toContain("channel:admin token");
+  });
+});

--- a/src/agents-ui.ts
+++ b/src/agents-ui.ts
@@ -1,12 +1,35 @@
 /**
- * Static HTML for `/channel/agents` — the in-page agent management surface
- * (design `design/2026-06-14-sandboxed-agent-sessions.md` §4/§5; the web spawn
- * flow Aaron asked for: "this needs to work through the web interface since
- * that's really the default way of operating").
+ * Static HTML for `/channel/agents` — the PRIMARY "Agents" surface: the unified
+ * **create-an-agent** flow (Phase-1 consolidation,
+ * `design/2026-06-17-parachute-agent-blueprint.md` §Sequencing step 1).
  *
- * Self-contained document (HTML + inline CSS + inline JS, no build step — the
- * same shape as `terminal-ui.ts` and `daemon.ts`'s chat UI). It drives the
- * daemon's `channel:admin`-gated JSON API:
+ * The blueprint collapses today's TWO steps — create-channel (the Config page),
+ * then spawn-agent-on-it (this page) — into ONE form: you "configure an agent,
+ * then talk to it" (agent ≡ channel, 1:1). The default UX is minimal:
+ *
+ *     Agent name → Vault (auto-selected if exactly one) → optional System prompt → Create
+ *
+ * One submit (a) provisions the (vault) channel of that name if it doesn't already
+ * exist, then (b) spawns a PROGRAMMATIC agent on it, then (c) lands the operator in
+ * chat (`/ui?channel=<name>`). Vault is the default transport; programmatic is the
+ * default backend.
+ *
+ * CLIENT-SIDE ORCHESTRATION (the load-bearing decision): the channel half reuses
+ * the EXISTING provisioning paths via the shared `PROVISION_JS`
+ * (`src/provision-channel.ts`) — the SAME hub-mediated `/admin/connections` vault
+ * flow + `/api/channels` telegram/http-ui flow the Config page runs. The channel
+ * daemon does NOT mint vault tokens (it lacks hub authority); the hub does, exactly
+ * as on the Config page. No new `/api/agents` fields — the form posts the same body
+ * `buildSpecFromBody` already accepts.
+ *
+ * Advanced disclosure reveals the dynamic cases: use an EXISTING channel (skip
+ * provisioning), transport telegram / http-ui (with config), the interactive
+ * backend, system-prompt mode, extra channels, vault tags/access, filesystem,
+ * network, egress, working directory, mounts.
+ *
+ * Self-contained document (HTML + inline CSS + inline JS, no build step — the same
+ * shape as `terminal-ui.ts` / `home-ui.ts` / `daemon.ts`'s chat UI). It drives the
+ * daemon's `channel:admin`-gated JSON API + the hub Connections engine:
  *
  *   - GET    /api/credentials/claude   → credential status (default set? overrides?)
  *   - POST   /api/credentials/claude[/:channel]  → set default / per-channel token
@@ -18,21 +41,27 @@
  *   - POST   /api/agents               → spawn a sandboxed agent from a spec
  *   - POST   /api/agents/:name/restart → per-session restart (re-source env + reconnect)
  *   - DELETE /api/agents/:name         → kill a session
- *   - GET    /api/vaults               → installed vault instances (the picker)
- *   - GET    /.parachute/config        → channel list (the picker)
+ *   - GET    /api/vaults               → installed vault instances (advanced vault binding)
+ *   - GET    /api/channels             → existing channels (the Advanced "use existing" picker + idempotency)
+ *   - POST   <origin>/admin/connections → hub-mediated vault-channel provisioning
+ *   - GET    <origin>/.well-known/parachute.json → installed vaults (the default Vault picker)
+ *   - GET    /.parachute/config        → channel list
  *   - GET    /health                   → live per-channel connection status (mcp_sessions)
  *
- * UX: the DEFAULT flow is one-agent-one-channel — pick a channel, the agent name
- * auto-fills from it, click Spawn. Everything else (extra channels, vault binding,
- * network mode, mounts) lives under "Advanced" for the dynamic cases.
- *
  * Auth: loads OPEN (like /ui, /admin, /terminal), then fetches a hub-minted
- * `channel:admin` Bearer from `<origin>/admin/channel-token` and attaches it to
- * every /api call. Token hygiene: the pasted Claude token is POSTed once and never
- * read back; the spawn result shows scopes but never minted token values.
+ * `channel:admin` Bearer from `<origin>/admin/channel-token` and attaches it to the
+ * daemon `/api` calls; the vault provisioning path uses the operator's hub SESSION
+ * COOKIE (credentials:"include"), not this token. Token hygiene: the pasted Claude
+ * token is POSTed once and never read back; the spawn result shows scopes but never
+ * minted token values.
+ *
+ * Vocabulary: an AGENT is the configured, vault-backed Claude actor; a CHANNEL is
+ * the messaging pipe it wakes on. In the default vault flow they are 1:1 (the agent
+ * IS its channel) — the blueprint's "agent ≡ channel".
  */
 
 import { THEME_CSS, appShell, SHELL_JS } from "./ui-kit.ts";
+import { PROVISION_JS } from "./provision-channel.ts";
 
 export const AGENTS_UI_HTML = `<!doctype html>
 <html lang="en">
@@ -73,6 +102,8 @@ ${THEME_CSS}
   button.danger:hover { border-color: var(--danger); background: var(--danger-soft); }
   button.ghost { padding: 4px 9px; font-size: 12px; background: transparent; border-color: transparent; color: var(--fg-muted); }
   button.ghost:hover { background: var(--bg-soft); color: var(--fg); }
+  /* The primary Create button — a touch larger than the page's default button. */
+  button.create { padding: 10px 22px; font-size: 0.95rem; }
   .pill.detached { color: var(--fg-dim); }
   table { width: 100%; border-collapse: collapse; font-size: 0.85rem; }
   th, td { text-align: left; padding: 8px 10px; border-bottom: 1px solid var(--border); vertical-align: middle; }
@@ -83,6 +114,8 @@ ${THEME_CSS}
   details summary { cursor: pointer; color: var(--fg-muted); font-size: 0.85rem; user-select: none; }
   details[open] summary { color: var(--fg); margin-bottom: 12px; }
   .sub { display: grid; gap: 12px; }
+  .sub-group { border: 1px solid var(--border-light); border-radius: 8px; padding: 12px 14px; display: grid; gap: 12px; }
+  .sub-group > .sub-title { font-size: 0.82rem; font-weight: 600; color: var(--fg); margin: 0; }
   .extra-channels { display: grid; gap: 8px; }
   .extra-channels .crow, .mounts-rows .mrow { display: flex; gap: 8px; align-items: center; }
   .extra-channels .crow select.ch-name { flex: 1 1 auto; }
@@ -105,17 +138,220 @@ ${THEME_CSS}
   /* Connection-status pill on the running-agents list (mcp_sessions from /health). */
   .pill.connected { color: var(--success); }
   .pill.idle-conn { color: var(--fg-dim); }
+  .field-row { margin-top: 12px; }
+  .field-row textarea {
+    width: 100%; box-sizing: border-box; font: inherit; padding: 8px 10px;
+    border: 1px solid var(--border); border-radius: 6px; background: var(--card);
+    color: var(--fg); resize: vertical;
+  }
 </style>
 </head>
 <body>
   ${appShell({ active: "agents", tag: "agents" })}
 
   <main>
+    <!-- Create an agent (the unified flow — primary surface) -->
+    <section id="create-section">
+      <h2>Create an agent</h2>
+      <p class="hint">Configure an agent, then talk to it. The default is one agent on its own
+        vault-backed channel running the reliable <strong>Programmatic</strong> backend — name it,
+        pick a vault, add an optional role, and Create. We provision the channel (if needed) and the
+        agent in one step, then drop you into its chat. Open <strong>Advanced</strong> for an existing
+        channel, Telegram / HTTP-UI transports, the interactive backend, extra channels, vault scope,
+        filesystem, network, working directory, or mounts.</p>
+
+      <div class="grid2">
+        <div>
+          <label for="agent-name">Agent name</label>
+          <input type="text" id="agent-name" placeholder="e.g. release-bot" autocomplete="off" />
+        </div>
+        <div>
+          <label for="agent-vault">Vault <span class="muted">(the channel's backing store)</span></label>
+          <select id="agent-vault"><option value="">(loading vaults…)</option></select>
+        </div>
+      </div>
+
+      <div class="field-row">
+        <label for="agent-system-prompt">System prompt <span class="muted">(optional — the agent's role)</span></label>
+        <textarea id="agent-system-prompt" rows="3" placeholder="e.g. You are the release assistant. Keep replies terse and action-oriented."></textarea>
+      </div>
+
+      <details id="advanced">
+        <summary>Advanced — existing channel, transport, backend, isolation, mounts</summary>
+        <div class="sub">
+          <!-- Existing channel vs. provision a new one -->
+          <div class="sub-group">
+            <p class="sub-title">Channel</p>
+            <div>
+              <label for="use-existing">Channel source</label>
+              <select id="use-existing">
+                <option value="new" selected>Create a new channel named after the agent (default)</option>
+                <option value="existing">Use an existing channel</option>
+              </select>
+            </div>
+            <div id="existing-wrap" style="display:none;">
+              <label for="existing-channel">Existing channel <span class="muted">(the wake channel)</span></label>
+              <select id="existing-channel"></select>
+              <div class="muted" style="font-size:12px; margin-top:6px;">
+                The agent wakes on this channel; no new channel is provisioned.
+              </div>
+            </div>
+            <div id="new-transport-wrap">
+              <div class="grid2">
+                <div>
+                  <label for="agent-transport">Transport <span class="muted">(of the new channel)</span></label>
+                  <select id="agent-transport">
+                    <option value="vault" selected>Vault — durable, queryable (default)</option>
+                    <option value="telegram">Telegram — a bot with its own token</option>
+                    <option value="http-ui">HTTP-UI — built-in chat (testing / backup)</option>
+                  </select>
+                </div>
+                <div>
+                  <label for="agent-access">Channel access</label>
+                  <select id="agent-access">
+                    <option value="write" selected>read+write</option>
+                    <option value="read">read only</option>
+                  </select>
+                </div>
+              </div>
+              <div id="telegram-token-wrap" style="display:none; margin-top:8px;">
+                <label for="agent-telegram-token">Telegram bot token <span class="muted">(required)</span></label>
+                <input type="password" id="agent-telegram-token" placeholder="123456:ABC-…" autocomplete="off" />
+                <div class="muted" style="font-size:12px; margin-top:6px;">
+                  Each Telegram channel carries its own per-channel bot token (no daemon-global fallback).
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Backend -->
+          <div class="sub-group">
+            <p class="sub-title">Backend</p>
+            <div>
+              <label for="agent-backend">Backend</label>
+              <select id="agent-backend">
+                <option value="programmatic" selected>Programmatic — clean per-message turns, reliable (recommended)</option>
+                <option value="interactive">Interactive — watch / drive a live tmux session (advanced)</option>
+              </select>
+              <div id="backend-note" class="muted" style="font-size:12px; margin-top:8px;"></div>
+            </div>
+          </div>
+
+          <!-- System-prompt mode -->
+          <div class="sub-group">
+            <p class="sub-title">System prompt mode</p>
+            <div class="row" style="align-items:center;">
+              <div>
+                <label for="agent-prompt-mode" style="display:inline; margin-right:6px;">Mode</label>
+                <select id="agent-prompt-mode">
+                  <option value="append" selected>Append (default)</option>
+                  <option value="replace">Replace</option>
+                </select>
+              </div>
+              <span class="muted" style="font-size:12px;">Append keeps Claude Code's capable base and adds your role; Replace gives full control.</span>
+            </div>
+          </div>
+
+          <!-- Extra channels -->
+          <div class="sub-group">
+            <p class="sub-title">Additional channels <span class="muted" style="font-weight:400;">(beyond the wake channel)</span></p>
+            <div id="extra-channels" class="extra-channels"></div>
+            <button id="add-channel" class="ghost" type="button" style="justify-self:start;">+ channel</button>
+          </div>
+
+          <!-- Vault binding (extra: tags / access for the agent's vault scope) -->
+          <div class="sub-group">
+            <p class="sub-title">Vault binding <span class="muted" style="font-weight:400;">(the agent's vault read/write scope)</span></p>
+            <div class="grid3">
+              <div>
+                <label for="vault-name">Vault</label>
+                <select id="vault-name"><option value="">(channel's vault)</option></select>
+              </div>
+              <div>
+                <label for="vault-access">Vault access</label>
+                <select id="vault-access">
+                  <option value="read">read</option>
+                  <option value="write" selected>write</option>
+                  <option value="admin">admin</option>
+                </select>
+              </div>
+              <div>
+                <label for="vault-tags">Tag scope (optional)</label>
+                <input type="text" id="vault-tags" placeholder="#channel-message, …" autocomplete="off" />
+              </div>
+            </div>
+            <div class="muted" style="font-size:12px;">
+              Leave the Vault blank to grant the agent the same vault that backs its channel. Set it to
+              scope the agent's vault access explicitly.
+            </div>
+          </div>
+
+          <!-- Isolation -->
+          <div class="sub-group">
+            <p class="sub-title">Isolation</p>
+            <div>
+              <label for="fs-mode">Filesystem</label>
+              <select id="fs-mode">
+                <option value="workspace" selected>Sandboxed to its workspace (default) — can't read your files or secrets</option>
+                <option value="full">Full read access — can read your whole disk (use with care)</option>
+              </select>
+              <div id="fs-warn" class="muted" style="display:none; font-size:12px; margin-top:8px;">
+                Default: the agent reads only its own workspace + mounts + the claude runtime. Your home
+                tree (including <code>~/.parachute/operator.token</code>, SSH keys, other projects) is
+                unreadable. Writes are always confined to the workspace. Switch to Full read only when an
+                agent genuinely needs to see across your disk and you trust it not to leak.
+              </div>
+            </div>
+
+            <div>
+              <label for="net-mode">Network</label>
+              <select id="net-mode">
+                <option value="open" selected>Open — full internet (default)</option>
+                <option value="restricted">Restricted — Anthropic + hub/vault + listed hosts only (untrusted input)</option>
+              </select>
+              <div id="egress-wrap" style="display:none; margin-top:8px;">
+                <label for="egress">Additional allowed hosts (comma-separated)</label>
+                <input type="text" id="egress" placeholder="registry.npmjs.org, github.com" autocomplete="off" />
+              </div>
+              <div id="net-note" class="muted" style="display:none; font-size:12px; margin-top:8px;">
+                Open is safe as the default because the workspace filesystem sandbox already keeps your
+                secrets unreadable — open network can't exfiltrate what the agent can't see. Choose
+                Restricted to also bound where an agent fed untrusted input can reach.
+              </div>
+            </div>
+
+            <div>
+              <label for="agent-workspace">Working directory <span class="muted">(optional — absolute host path)</span></label>
+              <input type="text" id="agent-workspace" placeholder="/Users/you/Code/my-repo" autocomplete="off" />
+              <div class="muted" style="font-size:12px; margin-top:8px;">
+                The directory the agent works in (its cwd, read-write). Leave blank and it works in its own
+                private session dir. Set a real repo path to have it work there — that dir can be shared with
+                other agents, runner jobs, or scripts. Its private config &amp; tokens (<code>.mcp.json</code>)
+                always stay in the per-agent session dir, never written here.
+              </div>
+            </div>
+
+            <div>
+              <label>Filesystem mounts</label>
+              <div id="mounts-rows" class="mounts-rows"></div>
+              <button id="add-mount" class="ghost" type="button" style="justify-self:start;">+ mount</button>
+            </div>
+          </div>
+        </div>
+      </details>
+
+      <div class="row" style="margin-top:16px;">
+        <button id="create-go" class="primary create" type="button">Create agent</button>
+        <span class="muted" id="create-note" style="font-size:12px;"></span>
+      </div>
+      <div id="create-msg" class="msg"></div>
+    </section>
+
     <!-- Claude credential -->
     <section id="cred-section">
       <h2>Claude credential</h2>
-      <p class="hint">A launched session runs on a Claude subscription token from
-        <code>claude setup-token</code> — injected per session, never your CLI login.
+      <p class="hint">A launched agent runs on a Claude subscription token from
+        <code>claude setup-token</code> — injected per agent, never your CLI login.
         Set a default once; override per channel if needed.</p>
       <div class="row">
         <span>Default credential: <span id="cred-default" class="pill off">checking…</span></span>
@@ -146,14 +382,14 @@ ${THEME_CSS}
     <!-- Per-channel env / credentials (GH_TOKEN, CLOUDFLARE_API_TOKEN, …) -->
     <section id="env-section">
       <h2>Channel env / credentials</h2>
-      <p class="hint">Scope a channel's spawned agent extra secrets &mdash; a
+      <p class="hint">Scope a channel's agent extra secrets &mdash; a
         <code>GH_TOKEN</code>, <code>CLOUDFLARE_API_TOKEN</code>, etc. These are injected
-        into the session's shell (its <code>gh</code>/<code>git</code>/build tooling) &mdash;
+        into the agent's shell (its <code>gh</code>/<code>git</code>/build tooling) &mdash;
         Claude's own login is never touched. Set a default for every channel, or override per
-        channel. After setting one, hit <strong>Restart / reconnect</strong> on a running session
+        channel. After setting one, hit <strong>Restart / reconnect</strong> on a running agent
         to apply it.</p>
       <div id="env-list" class="scopes"></div>
-      <details open>
+      <details>
         <summary>Set an env var</summary>
         <div class="sub">
           <div class="grid3">
@@ -179,156 +415,6 @@ ${THEME_CSS}
       <div id="env-msg" class="msg"></div>
     </section>
 
-    <!-- Spawn -->
-    <section id="spawn-section">
-      <h2>Spawn an agent</h2>
-      <p class="hint">Launches a sandboxed Claude agent wired to a channel. The default backend is
-        Programmatic (reliable per-message turns); the live-terminal Interactive backend is under
-        Advanced. The common case is one agent per channel — pick a channel and spawn. Open the
-        lower Advanced section for extra channels, a vault, network, or mounts.</p>
-
-      <div class="grid3">
-        <div>
-          <label for="spawn-channel">Channel <span class="muted">(wake)</span></label>
-          <select id="spawn-channel"></select>
-        </div>
-        <div>
-          <label for="spawn-access">Access</label>
-          <select id="spawn-access">
-            <option value="write" selected>read+write</option>
-            <option value="read">read only</option>
-          </select>
-        </div>
-        <div>
-          <label for="spawn-name">Agent name</label>
-          <input type="text" id="spawn-name" placeholder="(defaults to channel)" autocomplete="off" />
-        </div>
-      </div>
-
-      <div style="margin-top:12px;">
-        <label for="spawn-backend">Backend</label>
-        <select id="spawn-backend">
-          <option value="programmatic" selected>Programmatic — clean per-message turns, reliable (recommended)</option>
-          <option value="interactive">Interactive — watch / drive a live tmux session (advanced)</option>
-        </select>
-        <div id="backend-note" class="muted" style="font-size:12px; margin-top:8px;"></div>
-        <details id="backend-advanced" style="margin-top:10px;">
-          <summary>Advanced — interactive (live terminal) backend</summary>
-          <div class="sub">
-            <p class="muted" style="font-size:12px; margin:0;">
-              Interactive runs a live Claude Code in a terminal you can attach to —
-              currently less stable (the deaf-on-restart / reconnect class). Use
-              Programmatic unless you specifically want to watch / drive a live session.
-              Selecting it below switches the backend to interactive.
-            </p>
-            <div class="row" style="margin-top:8px;">
-              <button id="backend-use-interactive" class="ghost" type="button">Use interactive backend</button>
-              <span class="muted" id="backend-current" style="font-size:12px;"></span>
-            </div>
-          </div>
-        </details>
-      </div>
-
-      <div style="margin-top:12px;">
-        <label for="spawn-system-prompt">System prompt <span class="muted">(optional — the channel's role)</span></label>
-        <textarea id="spawn-system-prompt" rows="3" placeholder="e.g. You are the eng channel's release assistant. Keep replies terse and action-oriented." style="width:100%; box-sizing:border-box; font:inherit; padding:8px 10px; border:1px solid var(--border); border-radius:6px; background:var(--card); color:var(--fg); resize:vertical;"></textarea>
-        <div class="row" style="margin-top:8px; align-items:center;">
-          <div>
-            <label for="spawn-prompt-mode" style="display:inline; margin-right:6px;">Mode</label>
-            <select id="spawn-prompt-mode">
-              <option value="append" selected>Append (default)</option>
-              <option value="replace">Replace</option>
-            </select>
-          </div>
-          <span class="muted" style="font-size:12px;">Append keeps Claude Code's capable base and adds your channel's role; Replace gives full control.</span>
-        </div>
-      </div>
-
-      <details id="advanced">
-        <summary>Advanced — extra channels, vault, network, mounts</summary>
-        <div class="sub">
-          <div>
-            <label>Additional channels <span class="muted">(beyond the wake channel above)</span></label>
-            <div id="extra-channels" class="extra-channels"></div>
-            <button id="add-channel" class="ghost" type="button" style="margin-top:8px;">+ channel</button>
-          </div>
-
-          <div class="grid3">
-            <div>
-              <label for="vault-name">Vault</label>
-              <select id="vault-name"><option value="">(no vault)</option></select>
-            </div>
-            <div>
-              <label for="vault-access">Vault access</label>
-              <select id="vault-access">
-                <option value="read">read</option>
-                <option value="write">write</option>
-                <option value="admin">admin</option>
-              </select>
-            </div>
-            <div>
-              <label for="vault-tags">Tag scope (optional)</label>
-              <input type="text" id="vault-tags" placeholder="#channel-message, …" autocomplete="off" />
-            </div>
-          </div>
-
-          <div>
-            <label for="fs-mode">Filesystem</label>
-            <select id="fs-mode">
-              <option value="workspace" selected>Sandboxed to its workspace (default) — can't read your files or secrets</option>
-              <option value="full">Full read access — can read your whole disk (use with care)</option>
-            </select>
-            <div id="fs-warn" class="muted" style="display:none; font-size:12px; margin-top:8px;">
-              Default: the agent reads only its own workspace + mounts + the claude runtime. Your home
-              tree (including <code>~/.parachute/operator.token</code>, SSH keys, other projects) is
-              unreadable. Writes are always confined to the workspace. Switch to Full read only when an
-              agent genuinely needs to see across your disk and you trust it not to leak.
-            </div>
-          </div>
-
-          <div>
-            <label for="net-mode">Network</label>
-            <select id="net-mode">
-              <option value="open" selected>Open — full internet (default)</option>
-              <option value="restricted">Restricted — Anthropic + hub/vault + listed hosts only (untrusted input)</option>
-            </select>
-            <div id="egress-wrap" style="display:none; margin-top:8px;">
-              <label for="egress">Additional allowed hosts (comma-separated)</label>
-              <input type="text" id="egress" placeholder="registry.npmjs.org, github.com" autocomplete="off" />
-            </div>
-            <div id="net-note" class="muted" style="display:none; font-size:12px; margin-top:8px;">
-              Open is safe as the default because the workspace filesystem sandbox already keeps your
-              secrets unreadable — open network can't exfiltrate what the agent can't see. Choose
-              Restricted to also bound where an agent fed untrusted input can reach.
-            </div>
-          </div>
-
-          <div>
-            <label for="spawn-workspace">Working directory <span class="muted">(optional — absolute host path)</span></label>
-            <input type="text" id="spawn-workspace" placeholder="/Users/you/Code/my-repo" autocomplete="off" />
-            <div class="muted" style="font-size:12px; margin-top:8px;">
-              The directory the agent works in (its cwd, read-write). Leave blank and it works in its own
-              private session dir. Set a real repo path to have it work there — that dir can be shared with
-              other agents, runner jobs, or scripts. Its private config &amp; tokens (<code>.mcp.json</code>)
-              always stay in the per-agent session dir, never written here.
-            </div>
-          </div>
-
-          <div>
-            <label>Filesystem mounts</label>
-            <div id="mounts-rows" class="mounts-rows"></div>
-            <button id="add-mount" class="ghost" type="button" style="margin-top:8px;">+ mount</button>
-          </div>
-        </div>
-      </details>
-
-      <div class="row" style="margin-top:16px;">
-        <button id="spawn-go" class="primary" type="button">Spawn agent</button>
-        <span class="muted" id="spawn-note" style="font-size:12px;"></span>
-      </div>
-      <div id="spawn-msg" class="msg"></div>
-    </section>
-
     <!-- Running agents -->
     <section id="agents-section">
       <div class="row" style="margin-bottom:10px;">
@@ -342,10 +428,13 @@ ${THEME_CSS}
 
 <script>
 ${SHELL_JS}
+${PROVISION_JS}
 (function () {
   // MOUNT, setStatus, escapeHtml, fetchToken (caches on window.__token),
-  // authedFetch all come from SHELL_JS. Wire the shared nav for the agents view.
+  // authedFetch all come from SHELL_JS. ChannelProvision (the shared
+  // provisioning client) comes from PROVISION_JS. Wire the shared nav.
   wireShell("agents");
+  var Provision = window.ChannelProvision;
   var knownChannels = [];
 
   // esc is the page-local name for the shared escapeHtml (used widely below).
@@ -401,17 +490,17 @@ ${SHELL_JS}
           btn.addEventListener("click", function () { removeCred(btn.getAttribute("data-cred-rm")); });
         });
       } else { ov.innerHTML = ""; }
-      updateSpawnNote(j.defaultSet, j.channels || []);
+      updateCreateNote(j.defaultSet, j.channels || []);
       return j;
     }).catch(function (err) {
       document.getElementById("cred-default").textContent = "unknown (" + err.message + ")";
     });
   }
 
-  function updateSpawnNote(defaultSet, overrides) {
-    var note = document.getElementById("spawn-note");
+  function updateCreateNote(defaultSet, overrides) {
+    var note = document.getElementById("create-note");
     if (!defaultSet && (!overrides || !overrides.length)) {
-      note.textContent = "⚠ no Claude credential set — set one above before spawning.";
+      note.textContent = "⚠ no Claude credential set — set one below before creating.";
       note.style.color = "var(--warn)";
     } else { note.textContent = ""; }
   }
@@ -493,7 +582,7 @@ ${SHELL_JS}
       document.getElementById("env-name").value = "";
       document.getElementById("env-value").value = "";
       showMsg(msg, "Saved " + name + (channel ? (" for channel " + channel) : " (default)") +
-        ". Restart a session to apply it.", false);
+        ". Restart an agent to apply it.", false);
       loadEnv();
     }).catch(function (err) { showMsg(msg, "Failed: " + err.message, true); });
   });
@@ -508,21 +597,37 @@ ${SHELL_JS}
     }).catch(function (err) { showMsg(msg, "Failed: " + err.message, true); });
   }
 
-  // --- spawn form ---------------------------------------------------------
+  // --- create-agent form: dynamic UI --------------------------------------
   function channelOptions(selected) {
     return knownChannels.map(function (c) {
       return "<option value='" + esc(c) + "'" + (c === selected ? " selected" : "") + ">" + esc(c) + "</option>";
     }).join("");
   }
 
-  // Auto-fill the name from the chosen wake channel until the operator edits it.
-  var nameEdited = false;
-  var nameEl = document.getElementById("spawn-name");
-  var chanEl = document.getElementById("spawn-channel");
-  nameEl.addEventListener("input", function () { nameEdited = true; });
-  chanEl.addEventListener("change", function () {
-    if (!nameEdited) nameEl.value = chanEl.value;
-  });
+  var nameEl = document.getElementById("agent-name");
+  var useExistingEl = document.getElementById("use-existing");
+  var existingChannelEl = document.getElementById("existing-channel");
+  var transportEl = document.getElementById("agent-transport");
+
+  // Channel source toggle: "new" provisions a channel named after the agent;
+  // "existing" reuses one from the list (skips provisioning).
+  function syncChannelSource() {
+    var existing = useExistingEl.value === "existing";
+    document.getElementById("existing-wrap").style.display = existing ? "" : "none";
+    document.getElementById("new-transport-wrap").style.display = existing ? "none" : "";
+  }
+  useExistingEl.addEventListener("change", syncChannelSource);
+  syncChannelSource();
+
+  // Transport toggle (new-channel path): reveal the Telegram bot-token field only
+  // for telegram. vault + http-ui need no extra field here (vault picks the vault
+  // up top; http-ui is self-contained).
+  function syncTransport() {
+    document.getElementById("telegram-token-wrap").style.display =
+      transportEl.value === "telegram" ? "" : "none";
+  }
+  transportEl.addEventListener("change", syncTransport);
+  syncTransport();
 
   function extraChannelRow() {
     var div = document.createElement("div");
@@ -568,44 +673,41 @@ ${SHELL_JS}
   netMode.addEventListener("change", syncNetMode);
   syncNetMode(); // default is open → show the note, hide the hosts field
 
-  // Backend toggle. PROGRAMMATIC is the default + recommended path (reliable — no
-  // deaf-on-restart / reconnect class). INTERACTIVE (the original tmux session you
-  // watch/drive via terminal attach) is the buggier opt-in, gated behind the
-  // "Advanced — interactive" disclosure; it stays fully selectable once expanded.
-  // The note updates on change; the advanced button switches to interactive.
-  var backendMode = document.getElementById("spawn-backend");
+  // Backend toggle (under Advanced). PROGRAMMATIC is the default + recommended path
+  // (reliable — no deaf-on-restart / reconnect class). INTERACTIVE (the original
+  // tmux session you watch/drive via terminal attach) is the buggier opt-in.
+  var backendMode = document.getElementById("agent-backend");
   function syncBackendMode() {
     var note = document.getElementById("backend-note");
-    var cur = document.getElementById("backend-current");
     if (backendMode.value === "programmatic") {
       note.textContent = "Programmatic (default): no live terminal. Each message runs one on-demand claude -p turn " +
         "(resumes the prior conversation) and its reply is posted back to the channel. No idle session to go " +
-        "deaf, no reconnect — reliable, ideal for fire-and-forget 'do a task, report back'. The Terminal link won't apply.";
-      if (cur) cur.textContent = "Current: programmatic.";
+        "deaf, no reconnect — reliable, ideal for fire-and-forget 'do a task, report back'.";
     } else {
       note.textContent = "Interactive (advanced): an idle Claude Code session in a tmux pane you can attach to (Terminal ↗). " +
         "Messages inject into the live session; you watch it work — but it's currently less stable (deaf-on-restart / " +
         "reconnect class). Use Programmatic unless you specifically want a live session.";
-      if (cur) cur.textContent = "Current: interactive (advanced).";
     }
   }
   backendMode.addEventListener("change", syncBackendMode);
-  // The Advanced disclosure's button switches the selector to interactive (and
-  // updates the note) — interactive stays fully selectable, just opt-in.
-  var useInteractiveBtn = document.getElementById("backend-use-interactive");
-  if (useInteractiveBtn) {
-    useInteractiveBtn.addEventListener("click", function () {
-      backendMode.value = "interactive";
-      syncBackendMode();
-    });
-  }
   syncBackendMode(); // default is programmatic
 
-  function collectSpec() {
-    var wake = chanEl.value;
-    if (!wake) throw new Error("pick a channel");
-    var name = nameEl.value.trim() || wake;
-    var channels = [{ name: wake, access: document.getElementById("spawn-access").value }];
+  // --- create-agent form: spec shaping ------------------------------------
+  // Resolve the wake channel: in "existing" mode it's the picked channel; in
+  // "new" mode it's the agent name (the channel is provisioned under that name).
+  function resolveWakeChannel(name) {
+    if (useExistingEl.value === "existing") {
+      var ch = existingChannelEl.value;
+      if (!ch) throw new Error("pick an existing channel (Advanced → Channel)");
+      return ch;
+    }
+    return name;
+  }
+
+  // Build the /api/agents spec — the SAME body buildSpecFromBody() accepts (no new
+  // fields). Throws Error on a validation miss. wake is the resolved wake channel.
+  function collectSpec(name, wake) {
+    var channels = [{ name: wake, access: document.getElementById("agent-access").value }];
     document.querySelectorAll("#extra-channels .crow").forEach(function (row) {
       var n = row.querySelector(".ch-name").value;
       if (!n) return;
@@ -629,10 +731,9 @@ ${SHELL_JS}
     }
     // defaults (omitted): filesystem "workspace" (scoped reads) + network "open".
 
-    // Working directory (the working-directory axis). Only send when non-blank —
-    // the server treats a blank value as unset (the agent works in its private
-    // session dir). An absolute path is required server-side; we send as-is.
-    var workspace = document.getElementById("spawn-workspace").value.trim();
+    // Working directory. Only send when non-blank — the server treats a blank value
+    // as unset (the agent works in its private session dir).
+    var workspace = document.getElementById("agent-workspace").value.trim();
     if (workspace) spec.workspace = workspace;
 
     var mounts = [];
@@ -643,80 +744,192 @@ ${SHELL_JS}
       mounts.push({ hostPath: host, mountPath: mount, mode: row.querySelector(".mt-mode").value });
     });
     if (mounts.length) spec.mounts = mounts;
-    // Backend selector — programmatic is the default; send the selected backend
-    // EXPLICITLY. Programmatic could be omitted (it's now the server default for a
-    // new request), but interactive MUST be passed explicitly to opt out of that
-    // default, so send the value either way for clarity.
+
+    // Backend — programmatic is the default; send the selected backend EXPLICITLY.
     spec.backend = backendMode.value === "interactive" ? "interactive" : "programmatic";
-    // System prompt (the channel's role). Only send when non-blank — the server
-    // treats a blank prompt as unset (CC's default, untouched). The mode rides
-    // along so append (default) vs replace is the operator's choice.
-    var sysPrompt = document.getElementById("spawn-system-prompt").value.trim();
+
+    // System prompt (the agent's role). Only send when non-blank.
+    var sysPrompt = document.getElementById("agent-system-prompt").value.trim();
     if (sysPrompt) {
       spec.systemPrompt = sysPrompt;
-      spec.systemPromptMode = document.getElementById("spawn-prompt-mode").value === "replace" ? "replace" : "append";
+      spec.systemPromptMode = document.getElementById("agent-prompt-mode").value === "replace" ? "replace" : "append";
     }
     return spec;
   }
 
-  document.getElementById("spawn-go").addEventListener("click", function () {
-    var msg = document.getElementById("spawn-msg");
-    clearMsg(msg);
-    var spec;
-    try { spec = collectSpec(); } catch (e) { showMsg(msg, e.message, true); return; }
-    var btn = document.getElementById("spawn-go");
-    btn.disabled = true; btn.textContent = "Spawning…";
-    apiJson("/api/agents", { method: "POST", body: JSON.stringify(spec) }).then(function (r) {
-      var lines = [];
-      if (r.backend === "programmatic") {
-        // Programmatic spawn returns { name, channel, backend, workspace, alreadyRunning }.
-        lines.push((r.alreadyRunning ? "Re-registered" : "Registered") + " programmatic agent " + r.name + ".");
-        lines.push("channel: " + r.channel);
-        lines.push("workspace: " + r.workspace);
-        lines.push("No tmux session — inbound messages run on-demand claude -p turns; replies post back to the channel.");
-      } else if (r.alreadyRunning) {
-        lines.push("Session " + r.session + " is already running (no-op).");
-      } else {
-        lines.push("Launched " + r.session + ".");
-        lines.push("workspace: " + r.workspace);
-        if (r.tokens && r.tokens.length) {
-          lines.push("scopes:");
-          r.tokens.forEach(function (t) { lines.push("  " + t.resource + " → " + t.scope); });
+  // --- create-agent form: orchestration -----------------------------------
+  // ONE submit: (1) provision the channel if it doesn't already exist (reusing the
+  // shared ChannelProvision client — the SAME hub-mediated vault flow + daemon
+  // telegram/http-ui flow the Config page runs), then (2) POST /api/agents to spawn
+  // the agent on it, then (3) land in chat. Idempotent: an existing channel is
+  // REUSED (no error, no double-provision). A spawn failure after provisioning
+  // surfaces a clear error — the channel may remain (acceptable; retry or manage on
+  // Config).
+  function setCreating(on) {
+    var btn = document.getElementById("create-go");
+    btn.disabled = on;
+    btn.textContent = on ? "Creating…" : "Create agent";
+  }
+
+  // Provision the wake channel for a NEW-channel create. Returns a Promise resolving
+  // { ok:true } when the channel exists (created now or already present), else
+  // { ok:false, message }. Uses ChannelProvision throughout.
+  function ensureChannel(name, transport) {
+    // First, idempotency: does a channel with this name already exist? If so, REUSE
+    // it regardless of transport (don't double-provision, don't error).
+    return Provision.channelExists({ apiUrl: MOUNT + "/api/channels", token: window.__token, name: name })
+      .then(function (chk) {
+        if (chk.ok && chk.exists) {
+          return { ok: true, reused: true, transport: chk.transport };
         }
-        if (r.mcpServers && r.mcpServers.length) lines.push("MCP servers: " + r.mcpServers.join(", "));
-        lines.push("filesystem: " + (r.filesystem || "workspace") +
-          (r.filesystem === "full" ? " (reads whole disk)" : " (sandboxed to workspace)"));
-        lines.push("network: " + (r.network || "open") +
-          (r.network === "restricted" ? " (egress: " + ((r.egress || []).join(", ") || "base only") + ")" : " (full internet)"));
+        // If the existence check itself failed with auth (the channel:admin list
+        // 401/403'd), we can't know whether the channel already exists — so for the
+        // DAEMON transports we must NOT blindly re-POST (that could 409 a duplicate
+        // or overwrite an existing channel's config). Surface the auth error and let
+        // the operator sign in + retry; the idempotent reuse path needs a readable
+        // list. The VAULT path is exempt: it uses the hub session cookie (not this
+        // token), so a list 401 doesn't predict a hub-cookie failure — fall through
+        // and let provisionVaultChannel report its own auth state.
+        if (chk.auth && transport !== "vault") {
+          return { ok: false, message: "not signed in — the page needs a channel:admin token to check/create the channel (open it through the hub portal, signed in)." };
+        }
+        // Provision per transport:
+        if (transport === "vault") {
+          var vault = document.getElementById("agent-vault").value;
+          if (!vault) return { ok: false, message: "pick a vault for the new channel" };
+          return Provision.provisionVaultChannel({ origin: window.location.origin, name: name, vault: vault })
+            .then(function (res) {
+              if (res.ok) return { ok: true, connect: res.connect, connection: res.connection };
+              if (res.auth) return { ok: false, message: "not signed in to the hub — open this page through the hub portal (signed in) to provision a vault channel." };
+              if (res.forbidden) return { ok: false, message: "not permitted to link a vault: " + (res.error || "") };
+              return { ok: false, message: "vault channel provisioning failed: " + (res.error || "unknown error") };
+            });
+        }
+        if (transport === "telegram") {
+          var tgToken = document.getElementById("agent-telegram-token").value.trim();
+          if (!tgToken) return { ok: false, message: "a Telegram channel needs its own bot token (Advanced → Channel)" };
+          return Provision.provisionDaemonChannel({ apiUrl: MOUNT + "/api/channels", token: window.__token, name: name, transport: "telegram", config: { token: tgToken } })
+            .then(daemonProvisionResult);
+        }
+        // http-ui
+        return Provision.provisionDaemonChannel({ apiUrl: MOUNT + "/api/channels", token: window.__token, name: name, transport: "http-ui" })
+          .then(daemonProvisionResult);
+      });
+  }
+  function daemonProvisionResult(res) {
+    if (res.ok) return { ok: true, restart_needed: res.restart_needed, restart_error: res.error };
+    if (res.auth) return { ok: false, message: "not signed in — the page needs a channel:admin token (open it through the hub portal, signed in)." };
+    return { ok: false, message: "channel provisioning failed: " + (res.error || "unknown error") };
+  }
+
+  function createAgent() {
+    var msg = document.getElementById("create-msg");
+    clearMsg(msg);
+    var name = nameEl.value.trim();
+    if (!name) { showMsg(msg, "Enter an agent name.", true); return; }
+    if (!/^[A-Za-z0-9_-]+$/.test(name)) {
+      showMsg(msg, "Agent name: letters, numbers, dash, underscore only.", true);
+      return;
+    }
+
+    var existing = useExistingEl.value === "existing";
+    var transport = transportEl.value;
+    var wake;
+    var spec;
+    try {
+      wake = resolveWakeChannel(name);
+      spec = collectSpec(name, wake);
+    } catch (e) { showMsg(msg, e.message, true); return; }
+
+    setCreating(true);
+
+    // Step 1 — channel. Existing-channel mode skips provisioning entirely.
+    var channelStep = existing
+      ? Promise.resolve({ ok: true, reused: true })
+      : ensureChannel(wake, transport);
+
+    channelStep.then(function (chRes) {
+      if (!chRes.ok) {
+        showMsg(msg, chRes.message || "could not provision the channel.", true);
+        setCreating(false);
+        return;
       }
-      showMsg(msg, lines.join("\\n"), false);
-      loadAgents();
+      // Step 2 — spawn the agent (the SAME /api/agents body as before). On a
+      // post-provision spawn failure, surface a clear error (the channel may
+      // remain; that's acceptable — retry or manage it on Config).
+      return apiJson("/api/agents", { method: "POST", body: JSON.stringify(spec) }).then(function (r) {
+        var lines = [];
+        var prog = r.backend === "programmatic";
+        // On REUSE, name the existing channel's transport — it may differ from the
+        // one selected (the operator picked vault but a same-named telegram channel
+        // already existed). Reuse is intended (don't double-provision), but the
+        // transport divergence must be VISIBLE so it isn't a silent surprise.
+        var verb = chRes.reused
+          ? ("Reused existing channel" + (chRes.transport ? " (transport: " + chRes.transport + ")" : ""))
+          : "Provisioned channel";
+        lines.push(verb + " " + wake + (chRes.restart_needed ? " (restart needed: " + (chRes.restart_error || "") + ")" : "") + ".");
+        if (prog) {
+          lines.push((r.alreadyRunning ? "Re-registered" : "Created") + " programmatic agent " + r.name + ".");
+          lines.push("workspace: " + r.workspace);
+          lines.push("Opening chat…");
+        } else if (r.alreadyRunning) {
+          lines.push("Agent " + (r.session || r.name) + " is already running (no-op).");
+        } else {
+          // Interactive launch — surface the agent's SANDBOX POSTURE so the operator
+          // can verify the isolation matches what they selected (security-relevant).
+          lines.push("Launched " + (r.session || r.name) + " (interactive).");
+          lines.push("workspace: " + r.workspace);
+          if (r.tokens && r.tokens.length) {
+            lines.push("scopes:");
+            r.tokens.forEach(function (t) { lines.push("  " + t.resource + " → " + t.scope); });
+          }
+          if (r.mcpServers && r.mcpServers.length) lines.push("MCP servers: " + r.mcpServers.join(", "));
+          lines.push("filesystem: " + (r.filesystem || "workspace") +
+            (r.filesystem === "full" ? " (reads whole disk)" : " (sandboxed to workspace)"));
+          lines.push("network: " + (r.network || "open") +
+            (r.network === "restricted" ? " (egress: " + ((r.egress || []).join(", ") || "base only") + ")" : " (full internet)"));
+          lines.push("Open the agent's chat or attach via Terminal ↗ (Running agents, below).");
+        }
+        showMsg(msg, lines.join("\\n"), false);
+        loadAgents();
+        if (prog) {
+          // Step 3 (programmatic only) — land the operator in the agent's chat. A
+          // short beat so the success banner is visible, then navigate. INTERACTIVE
+          // agents are NOT auto-navigated: the sandbox-posture lines above + the
+          // Terminal-attach affordance stay on screen for the operator to verify.
+          setTimeout(function () { window.location.href = chatUrl(wake); }, 900);
+        } else {
+          setCreating(false);
+        }
+      }).catch(function (err) {
+        showMsg(msg,
+          "Channel is ready, but the agent spawn failed: " + err.message +
+          (existing ? "" : "\\nThe channel \\"" + wake + "\\" may remain — retry, or manage it on Config."),
+          true);
+        loadAgents();
+        setCreating(false);
+      });
     }).catch(function (err) {
-      showMsg(msg, "Spawn failed: " + err.message, true);
-    }).then(function () {
-      btn.disabled = false; btn.textContent = "Spawn agent";
+      showMsg(msg, "Create failed: " + (err && err.message ? err.message : String(err)), true);
+      setCreating(false);
     });
-  });
+  }
+  document.getElementById("create-go").addEventListener("click", createAgent);
 
   // --- running agents list ------------------------------------------------
   // The terminal attaches to an AGENT (its tmux session), so the link carries the
   // agent name as ?agent= (the terminal page also accepts the legacy ?channel=).
+  // Surfaced only for INTERACTIVE agents (programmatic has no tmux to attach).
   function terminalUrl(agent) { return MOUNT + "/terminal?agent=" + encodeURIComponent(agent); }
   // /api/agents returns { name, session, attached } — it does NOT carry the
-  // agent's wake channel(s). The default is one-agent-one-channel (the spawn form
-  // auto-names the agent after its wake channel), so the Chat link uses the agent
-  // name as the channel (?channel=<name>). When an agent was custom-named off its
-  // channel, the chat page still loads on its picker — no fabricated data.
+  // agent's wake channel(s). The default is one-agent-one-channel (the agent name
+  // IS its wake channel), so the Chat link uses the agent name as the channel.
   function chatUrl(channel) { return MOUNT + "/ui?channel=" + encodeURIComponent(channel); }
   // /health is OPEN (no token) and carries per-channel { mcp_sessions, clients }.
-  // The default is one-agent-one-channel (the agent name IS its wake channel), so we
-  // key live connection status by the agent name. An agent custom-named off its
-  // channel shows "—" (no fabricated data), which is honest.
   function fetchHealth() {
     return fetch(MOUNT + "/health").then(function (r) { return r.ok ? r.json() : null; }).catch(function () { return null; });
   }
   function connectionCell(h) {
-    // h is the channel's /health row ({ mcp_sessions, clients }) or undefined.
     if (!h) return "<span class='pill idle-conn' title='no matching channel in /health'>—</span>";
     var sessions = (typeof h.mcp_sessions === "number") ? h.mcp_sessions : 0;
     var clients = (typeof h.clients === "number") ? h.clients : 0;
@@ -736,8 +949,12 @@ ${SHELL_JS}
       }
       var host = document.getElementById("agents-table");
       var agents = j.agents || [];
+      // Reveal the Terminal nav link only when an INTERACTIVE agent exists (it's
+      // the only backend with a live terminal to attach). Programmatic-only → the
+      // standalone Terminal entry stays hidden (Phase-1 nav cleanup).
+      setTerminalNavVisible(agents.some(function (a) { return a.backend !== "programmatic"; }));
       if (!agents.length) {
-        host.innerHTML = "<div class='empty'>No agent sessions running. Spawn one above.</div>";
+        host.innerHTML = "<div class='empty'>No agents running. Create one above.</div>";
         return;
       }
       var rows = agents.map(function (a) {
@@ -756,9 +973,9 @@ ${SHELL_JS}
         var connCell = prog
           ? "<span class='pill connected'>● " + esc(a.status || "idle") + "</span>"
           : connectionCell(liveByChannel[a.name]);
-        // Actions: programmatic has no terminal to attach (no tmux). "restart" maps
-        // to a conversation reset server-side. Chat link still applies (the channel
-        // transcript shows its replies).
+        // Actions: programmatic has no terminal to attach (no tmux) — the terminal
+        // link is surfaced ONLY for interactive agents (Phase-1 cleanup). Chat link
+        // always applies (the channel transcript shows its replies).
         var actions = "<a href='" + esc(chatUrl(a.name)) + "'>chat →</a>";
         if (!prog) {
           actions += "<a href='" + esc(terminalUrl(a.name)) + "' target='_blank' rel='noopener'>terminal ↗</a>";
@@ -802,7 +1019,7 @@ ${SHELL_JS}
   function killAgent(name) {
     // name is a server-enforced slug (alphanumeric/dash/underscore, agents.ts), so
     // it carries no HTML/JS-special chars in the confirm string; encodeURI'd anyway.
-    if (!confirm("Kill agent " + name + "? This ends its tmux session.")) return;
+    if (!confirm("Kill agent " + name + "? This ends its session.")) return;
     apiJson("/api/agents/" + encodeURIComponent(name), { method: "DELETE" }).then(function () {
       loadAgents();
     }).catch(function (err) { alert("Kill failed: " + err.message); });
@@ -818,7 +1035,7 @@ ${SHELL_JS}
     var orig = btn ? btn.textContent : "";
     if (btn) { btn.disabled = true; btn.textContent = "restarting…"; }
     apiJson("/api/agents/" + encodeURIComponent(name) + "/restart", { method: "POST" }).then(function (r) {
-      var msg = document.getElementById("spawn-msg");
+      var msg = document.getElementById("create-msg");
       clearMsg(msg);
       showMsg(msg, "Restarted " + (r.session || (name + "-agent")) + " — env re-sourced, session reconnected.", false);
       loadAgents();
@@ -831,9 +1048,9 @@ ${SHELL_JS}
   document.getElementById("refresh").addEventListener("click", function () { loadAgents(); });
 
   // --- pickers: channels + vaults -----------------------------------------
-  // A ?channel=<name> query param (from a "Spawn agent" link on another surface)
-  // pre-selects that channel + auto-fills the agent name, so the form lands
-  // ready-to-go. Only honored when the channel actually exists in the list.
+  // A ?channel=<name> query param (from a "Create agent" link on another surface)
+  // pre-fills the agent name AND switches Advanced → Channel to that existing
+  // channel, so the form lands ready-to-go. Only honored when the channel exists.
   function requestedChannel() {
     try { return new URL(window.location.href).searchParams.get("channel") || ""; }
     catch (_e) { return ""; }
@@ -841,52 +1058,75 @@ ${SHELL_JS}
   function loadChannels() {
     return fetch(MOUNT + "/.parachute/config").then(function (r) { return r.json(); }).then(function (cfg) {
       knownChannels = (cfg.channels || []).map(function (c) { return c.name; });
+      // Populate the Advanced "existing channel" picker.
       if (!knownChannels.length) {
-        // No channels configured: don't dead-end. Show a CTA to Config in the
-        // picker AND surface it on the spawn form (a channel is required first).
-        chanEl.innerHTML = "<option value=''>(no channels — add one in Config)</option>";
-        showMsg(document.getElementById("spawn-msg"),
-          "No channels configured yet — configure a channel first, then spawn an agent on it.", true);
-        var sm = document.getElementById("spawn-msg");
-        // Append a real link (showMsg uses textContent; add the link after it).
-        var a = document.createElement("a");
-        a.href = MOUNT + "/admin";
-        a.textContent = " Configure a channel first →";
-        a.style.display = "inline-block";
-        a.style.marginTop = "6px";
-        sm.appendChild(document.createElement("br"));
-        sm.appendChild(a);
-        return;
+        existingChannelEl.innerHTML = "<option value=''>(no channels yet)</option>";
+      } else {
+        existingChannelEl.innerHTML = channelOptions(knownChannels[0]);
       }
+      // If arrived with ?channel=<name> for an EXISTING channel, pre-fill the name +
+      // switch to the existing-channel path (the deep-link from Config/Home/Chat).
       var want = requestedChannel();
-      var pre = (want && knownChannels.indexOf(want) >= 0) ? want : knownChannels[0];
-      chanEl.innerHTML = channelOptions(pre);
-      if (!nameEdited) nameEl.value = pre;
+      if (want && knownChannels.indexOf(want) >= 0) {
+        if (!nameEl.value) nameEl.value = want;
+        useExistingEl.value = "existing";
+        existingChannelEl.value = want;
+        syncChannelSource();
+      }
     }).catch(function () {
-      chanEl.innerHTML = "<option value=''>(channel list failed)</option>";
+      existingChannelEl.innerHTML = "<option value=''>(channel list failed)</option>";
     });
   }
-  function loadVaults() {
+  // The DEFAULT Vault picker (the primary create flow) reads the hub's PUBLIC
+  // discovery doc via ChannelProvision.listVaults. Per the blueprint: auto-select
+  // when exactly one vault exists (no real choice — it's pre-chosen); with several,
+  // the first is the default but the operator picks. Either way the FIRST option is
+  // selected (a <select> defaults to its first option regardless); the explicit
+  // selected attribute on index 0 just makes that intent visible in the markup.
+  function loadDefaultVaults() {
+    return Provision.listVaults({ origin: window.location.origin }).then(function (res) {
+      var sel = document.getElementById("agent-vault");
+      var vaults = (res && res.ok && res.vaults) ? res.vaults : [];
+      if (!vaults.length) {
+        sel.innerHTML = "<option value=''>(no vaults — create one in the hub portal)</option>";
+        return;
+      }
+      sel.innerHTML = vaults.map(function (v, i) {
+        return "<option value='" + esc(v) + "'" + (i === 0 ? " selected" : "") + ">" + esc(v) + "</option>";
+      }).join("");
+    }).catch(function () {
+      document.getElementById("agent-vault").innerHTML = "<option value=''>(could not load vaults)</option>";
+    });
+  }
+  // The Advanced vault-BINDING picker (the agent's own vault scope) reads the
+  // daemon's installed-vaults endpoint (channel:admin). Distinct from the channel's
+  // backing vault — this is the vault the agent itself reads/writes.
+  function loadBindingVaults() {
     return apiJson("/api/vaults").then(function (j) {
       var vaults = j.vaults || [];
       var sel = document.getElementById("vault-name");
-      sel.innerHTML = "<option value=''>(no vault)</option>" +
+      sel.innerHTML = "<option value=''>(channel's vault)</option>" +
         vaults.map(function (v) { return "<option value='" + esc(v) + "'>" + esc(v) + "</option>"; }).join("");
-    }).catch(function () { /* leave the (no vault) default */ });
+    }).catch(function () { /* leave the (channel's vault) default */ });
   }
 
   // --- boot ---------------------------------------------------------------
   setStatus("authenticating…");
   fetchToken().then(function () {
     setStatus("● ready", "live");
-    return Promise.all([loadChannels(), loadVaults(), loadCreds(), loadEnv(), loadAgents()]);
+    return Promise.all([loadChannels(), loadDefaultVaults(), loadBindingVaults(), loadCreds(), loadEnv(), loadAgents()]);
   }).then(function () {
     setInterval(loadAgents, 5000);
   }).catch(function (err) {
     setStatus("not authenticated", "err");
-    showMsg(document.getElementById("spawn-msg"),
+    // Even unauthenticated, the public vault picker + channel list can load (the
+    // vault provisioning path uses the hub cookie). Surface the auth note but still
+    // populate what we can so the form isn't a dead-end.
+    loadChannels();
+    loadDefaultVaults();
+    showMsg(document.getElementById("create-msg"),
       "Open this page through the hub portal, signed in as the operator. " +
-      "The agents surface needs a channel:admin token (" + err.message + ").", true);
+      "Creating an agent needs a channel:admin token (" + err.message + ").", true);
   });
 })();
 </script>

--- a/src/agents.test.ts
+++ b/src/agents.test.ts
@@ -604,7 +604,7 @@ function buildServer(agentOps?: Partial<AgentOps>) {
   return { srv, base: `http://127.0.0.1:${srv.port}` };
 }
 
-describe("GET /agents — the management page (loads open)", () => {
+describe("GET /agents — the unified create-agent page (loads open)", () => {
   test("returns the HTML page with no token", async () => {
     const { srv, base } = buildServer();
     try {
@@ -613,16 +613,39 @@ describe("GET /agents — the management page (loads open)", () => {
       expect(res.headers.get("content-type")).toContain("text/html");
       const html = await res.text();
       expect(html).toContain("parachute-channel");
-      expect(html).toContain("Spawn an agent");
+      // Phase-1 consolidation: the page leads with the unified "Create an agent"
+      // flow (fuses create-channel + spawn-agent).
+      expect(html).toContain("Create an agent");
+      expect(html).toContain('id="create-section"');
+      expect(html).toContain('id="create-go"');
     } finally {
       srv.stop(true);
     }
   });
 
-  // UI gating (design 2026-06-16 + Aaron's gating decision): the backend selector
-  // DEFAULTS to programmatic; interactive is moved behind an "Advanced" disclosure
-  // (a collapsed <details>) but stays fully selectable.
-  test("spawn form defaults the backend selector to programmatic + gates interactive under Advanced", async () => {
+  // The unified flow's MINIMAL default: Agent name → Vault → optional System prompt
+  // → Create. Vault is the default transport; the vault picker leads the form.
+  test("minimal default flow: name + vault + optional system prompt", async () => {
+    const { srv, base } = buildServer();
+    try {
+      const html = await (await fetch(`${base}/agents`)).text();
+      expect(html).toContain('id="agent-name"');
+      expect(html).toContain('id="agent-vault"');
+      expect(html).toContain('id="agent-system-prompt"');
+      expect(html).toContain("System prompt");
+      // The Append(default)/Replace mode control lives under Advanced.
+      expect(html).toContain('<option value="append" selected>Append (default)</option>');
+      expect(html).toContain('<option value="replace">Replace</option>');
+      expect(html).toContain("Append keeps Claude Code's capable base");
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  // Backend gating (design 2026-06-16 + Aaron's gating decision): programmatic is
+  // the DEFAULT; the interactive backend is gated under the Advanced disclosure but
+  // stays fully selectable.
+  test("backend defaults to programmatic; interactive lives under Advanced", async () => {
     const { srv, base } = buildServer();
     try {
       const html = await (await fetch(`${base}/agents`)).text();
@@ -630,28 +653,49 @@ describe("GET /agents — the management page (loads open)", () => {
       expect(html).toMatch(/<option value="programmatic" selected>/);
       expect(html).not.toMatch(/<option value="interactive" selected>/);
       expect(html).toContain('<option value="interactive">');
-      // Interactive lives behind an Advanced disclosure (a <details>) with the caveat.
-      expect(html).toContain('<details id="backend-advanced"');
-      expect(html).toContain("Advanced — interactive");
+      // The Advanced disclosure carries the backend selector + the dynamic cases.
+      expect(html).toContain('id="advanced"');
+      expect(html).toContain('id="agent-backend"');
       expect(html).toContain("less stable");
-      expect(html).toContain("Use Programmatic unless you specifically want");
     } finally {
       srv.stop(true);
     }
   });
 
-  // Per-channel system prompt (design 2026-06-16-channel-system-prompt.md): the
-  // spawn form carries a System prompt textarea + an Append (default)/Replace mode
-  // control with the one-line hint.
-  test("spawn form has a System prompt textarea + Append(default)/Replace mode control", async () => {
+  // The Advanced disclosure reveals the dynamic cases: an EXISTING channel, the
+  // telegram/http-ui transports, extra channels, isolation, mounts.
+  test("Advanced reveals existing-channel + transport + isolation", async () => {
     const { srv, base } = buildServer();
     try {
       const html = await (await fetch(`${base}/agents`)).text();
-      expect(html).toContain('id="spawn-system-prompt"');
-      expect(html).toContain("System prompt");
-      expect(html).toContain('<option value="append" selected>Append (default)</option>');
-      expect(html).toContain('<option value="replace">Replace</option>');
-      expect(html).toContain("Append keeps Claude Code's capable base");
+      expect(html).toContain('id="use-existing"');
+      expect(html).toContain('id="existing-channel"');
+      expect(html).toContain('id="agent-transport"');
+      // Vault is the default-selected transport for a NEW channel.
+      expect(html).toContain('<option value="vault" selected>');
+      expect(html).toContain('value="telegram"');
+      expect(html).toContain('value="http-ui"');
+      expect(html).toContain('id="fs-mode"');
+      expect(html).toContain('id="net-mode"');
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  // CLIENT-SIDE ORCHESTRATION: the create flow reuses the shared provisioning
+  // client (ChannelProvision) — the hub-mediated vault flow + daemon telegram/
+  // http-ui flow — then POSTs /api/agents. No server-side vault-token minting.
+  test("uses the shared ChannelProvision client (no new /api/agents fields)", async () => {
+    const { srv, base } = buildServer();
+    try {
+      const html = await (await fetch(`${base}/agents`)).text();
+      // The shared provisioning namespace is present + used by the create flow.
+      expect(html).toContain("window.ChannelProvision");
+      expect(html).toContain("Provision.provisionVaultChannel");
+      expect(html).toContain("Provision.provisionDaemonChannel");
+      expect(html).toContain("Provision.channelExists");
+      // The agent spawn still POSTs /api/agents (same body shape).
+      expect(html).toContain('apiJson("/api/agents", { method: "POST"');
     } finally {
       srv.stop(true);
     }

--- a/src/daemon.test.ts
+++ b/src/daemon.test.ts
@@ -182,6 +182,14 @@ describe("UI-facing + discovery endpoints stay open (no token, 200)", () => {
     expect(res.headers.get("content-type")).toContain("text/html");
   });
 
+  test("GET /ui reveals the Terminal nav if an interactive agent exists (no stranding)", async () => {
+    // Phase-1 terminal-nav cleanup hides the standalone Terminal entry by default;
+    // the chat page doesn't list agents, so it must call the shared reveal helper or
+    // it would strand an operator with a live interactive session.
+    const body = await (await fetch(`${base}/ui`)).text();
+    expect(body).toContain("revealTerminalNavIfInteractive()");
+  });
+
   test("GET /home → 200 (html) — the overview landing (uiUrl points here)", async () => {
     const res = await fetch(`${base}/home`);
     expect(res.status).toBe(200);

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -840,6 +840,10 @@ ${SHELL_JS}
   var turnEs = null;
   var liveTurn = null; // { el, textEl, toolsEl, toolNames:{}, statusEl } | null
   wireShell("chat");
+  // Reveal the Terminal nav entry if a live interactive agent exists (the chat page
+  // doesn't otherwise list agents, so without this it would strand a user who wants
+  // to attach to their live session). Best-effort; default-hidden on failure.
+  revealTerminalNavIfInteractive();
 
   function transportFor(ch) { return channelTransports[ch] || ""; }
   function isVault(ch) { return transportFor(ch) === "vault"; }

--- a/src/home-ui.ts
+++ b/src/home-ui.ts
@@ -78,7 +78,12 @@ ${THEME_CSS}
   <main class="page">
     <div class="page-head">
       <h1>Home</h1>
-      <p class="subtitle">Your channels and the agents running on them.</p>
+      <p class="subtitle">Configure an agent, then talk to it. Below: your agents and the channels they run on.</p>
+    </div>
+
+    <div class="quick-actions" style="margin: 0 0 1.5rem;">
+      <a id="qa-create" class="btn btn-primary" href="#">Create an agent</a>
+      <a id="qa-chat-top" class="btn" href="#">Open chat</a>
     </div>
 
     <div class="overview-grid">
@@ -103,14 +108,14 @@ ${THEME_CSS}
         <div id="agents-list" class="ov-list">
           <div class="ov-empty">Loading agents…</div>
         </div>
-        <p class="card-foot"><a id="agents-spawn" href="#">Spawn an agent →</a></p>
+        <p class="card-foot"><a id="agents-spawn" href="#">Create an agent →</a></p>
       </section>
     </div>
 
     <div class="quick-actions">
-      <a id="qa-spawn" class="btn btn-primary" href="#">Spawn agent</a>
+      <a id="qa-create-2" class="btn btn-primary" href="#">Create an agent</a>
       <a id="qa-chat" class="btn" href="#">Open chat</a>
-      <a id="qa-config" class="btn" href="#">Configure</a>
+      <a id="qa-config" class="btn" href="#">Manage channels</a>
       <span class="spacer"></span>
       <button id="refresh" class="btn btn-sm" type="button">Refresh</button>
     </div>
@@ -129,11 +134,15 @@ ${SHELL_JS}
   var agentsList = document.getElementById("agents-list");
   var agentsCount = document.getElementById("agents-count");
 
-  // Static cross-surface links (resolved under the runtime mount prefix).
+  // Static cross-surface links (resolved under the runtime mount prefix). The
+  // landing leads with "Create an agent" (→ /agents, the unified create flow);
+  // channel management stays reachable as a secondary "Manage channels" link.
   function wireLinks() {
     document.getElementById("channels-config").href = MOUNT + "/admin";
     document.getElementById("agents-spawn").href = MOUNT + "/agents";
-    document.getElementById("qa-spawn").href = MOUNT + "/agents";
+    document.getElementById("qa-create").href = MOUNT + "/agents";
+    document.getElementById("qa-create-2").href = MOUNT + "/agents";
+    document.getElementById("qa-chat-top").href = MOUNT + "/ui";
     document.getElementById("qa-chat").href = MOUNT + "/ui";
     document.getElementById("qa-config").href = MOUNT + "/admin";
   }
@@ -175,7 +184,7 @@ ${SHELL_JS}
             "<span class='spacer'></span>" +
             clients +
             "<span class='links'>" +
-              "<a href='" + esc(spawnUrl(c.name)) + "'>spawn →</a>" +
+              "<a href='" + esc(spawnUrl(c.name)) + "'>create agent →</a>" +
               "<a href='" + esc(chatUrl(c.name)) + "'>chat →</a>" +
             "</span>" +
           "</div>";
@@ -194,21 +203,31 @@ ${SHELL_JS}
       .then(function (j) {
         var agents = j.agents || [];
         agentsCount.textContent = agents.length ? String(agents.length) : "";
+        // Reveal the Terminal nav entry only when an INTERACTIVE agent exists — it's
+        // the only backend with a live terminal to attach (Phase-1 nav cleanup).
+        setTerminalNavVisible(agents.some(function (a) { return a.backend !== "programmatic"; }));
         if (!agents.length) {
           agentsList.innerHTML = "<div class='ov-empty'>No agents running — " +
-            "<a href='" + MOUNT + "/agents'>Spawn one →</a></div>";
+            "<a href='" + MOUNT + "/agents'>Create one →</a></div>";
           return;
         }
         agentsList.innerHTML = agents.map(function (a) {
-          var state = a.attached
-            ? "<span class='pill attached'>attached</span>"
-            : "<span class='pill'>running</span>";
+          // Programmatic agents have no tmux session — show their turn status, not
+          // an "attached" pill, and drop the dead terminal link. Interactive agents
+          // keep the terminal link (a live session you can attach to).
+          var prog = a.backend === "programmatic";
+          var state = prog
+            ? "<span class='pill'>" + esc(a.status || "idle") + "</span>"
+            : (a.attached ? "<span class='pill attached'>attached</span>" : "<span class='pill'>running</span>");
+          var termLink = prog
+            ? ""
+            : "<a href='" + esc(terminalUrl(a.name)) + "'>terminal →</a>";
           return "<div class='ov-row'>" +
             "<span class='name'>" + esc(a.name) + "</span>" +
             state +
             "<span class='spacer'></span>" +
             "<span class='links'>" +
-              "<a href='" + esc(terminalUrl(a.name)) + "'>terminal →</a>" +
+              termLink +
               "<a href='" + esc(chatUrl(a.name)) + "'>chat →</a>" +
             "</span>" +
           "</div>";

--- a/src/provision-channel.test.ts
+++ b/src/provision-channel.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Tests for the shared channel-provisioning client (src/provision-channel.ts) —
+ * the module the Config page and the unified create-agent flow BOTH use so they
+ * can't drift on how they provision channels.
+ *
+ * Two halves:
+ *   1. `vaultConnectionBody()` — the pure, canonical hub-Connections request body
+ *      for a vault-backed channel (the trigger filter is the loop-avoidance
+ *      contract). Asserted directly.
+ *   2. `PROVISION_JS` — the browser-side client injected into the pages. We assert
+ *      its string contract (backtick-free so it interpolates safely; exposes the
+ *      `window.ChannelProvision` namespace), then EVALUATE it against a stubbed
+ *      window + fetch to exercise each function's real behavior (the same code the
+ *      pages run in the browser).
+ */
+import { describe, test, expect } from "bun:test";
+import { vaultConnectionBody, PROVISION_JS } from "./provision-channel.ts";
+
+describe("vaultConnectionBody (the canonical vault-backed-channel connection)", () => {
+  test("builds vault.note.created (inbound tag) → channel.message.deliver", () => {
+    const body = vaultConnectionBody("eng", "default");
+    expect(body.requestedBy).toBe("channel");
+    expect(body.source.module).toBe("vault");
+    expect(body.source.vault).toBe("default");
+    expect(body.source.event).toBe("note.created");
+    // The inbound-tag filter is the loop-avoidance contract (CLAUDE.md "Vault
+    // integration"): fire on the inbound CHILD tag only; require channel metadata;
+    // skip already-rendered notes.
+    expect(body.source.filter.tags).toEqual(["#channel-message/inbound"]);
+    expect(body.source.filter.has_metadata).toEqual(["channel"]);
+    expect(body.source.filter.missing_metadata).toEqual(["channel_inbound_rendered_at"]);
+    expect(body.sink.module).toBe("channel");
+    expect(body.sink.action).toBe("message.deliver");
+    expect(body.sink.params.channel).toBe("eng");
+  });
+
+  test("the channel name rides as the sink param (the route key)", () => {
+    expect(vaultConnectionBody("release-bot", "v").sink.params.channel).toBe("release-bot");
+  });
+});
+
+describe("PROVISION_JS string contract", () => {
+  test("is backtick-free — safe to interpolate into a host template literal", () => {
+    expect(PROVISION_JS.includes("`")).toBe(false);
+  });
+
+  test("exposes the window.ChannelProvision namespace with the four client fns", () => {
+    expect(PROVISION_JS).toContain("window.ChannelProvision");
+    for (const fn of ["channelExists", "provisionVaultChannel", "provisionDaemonChannel", "listVaults"]) {
+      expect(PROVISION_JS).toContain(fn + ":");
+    }
+  });
+});
+
+// Evaluate PROVISION_JS against a stubbed window + fetch, exactly as the browser
+// would, and hand back the live ChannelProvision namespace so we can exercise the
+// real functions. `fetchImpl` is the per-test fetch stub; `origin` seeds
+// window.location.origin (used by the vault + discovery calls).
+function loadProvision(fetchImpl: typeof fetch, origin = "https://hub.example") {
+  const win: Record<string, unknown> = { location: { origin } };
+  const factory = new Function(
+    "window",
+    "fetch",
+    PROVISION_JS + "\nreturn window.ChannelProvision;",
+  ) as (w: unknown, f: unknown) => {
+    channelExists: (o: Record<string, unknown>) => Promise<Record<string, unknown>>;
+    provisionVaultChannel: (o: Record<string, unknown>) => Promise<Record<string, unknown>>;
+    provisionDaemonChannel: (o: Record<string, unknown>) => Promise<Record<string, unknown>>;
+    listVaults: (o: Record<string, unknown>) => Promise<Record<string, unknown>>;
+    vaultConnectionBody: (name: string, vault: string) => Record<string, unknown>;
+  };
+  return factory(win, fetchImpl);
+}
+
+// A minimal Response-shaped object the eval'd client reads (status, ok, json()).
+function resp(status: number, jsonBody: unknown): Response {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    json: () => Promise.resolve(jsonBody),
+  } as unknown as Response;
+}
+
+describe("ChannelProvision.channelExists (idempotency check)", () => {
+  test("reports an existing channel by name (the reuse signal)", async () => {
+    const P = loadProvision((() =>
+      Promise.resolve(resp(200, { channels: [{ name: "eng", transport: "vault" }] }))) as unknown as typeof fetch);
+    const out = await P.channelExists({ apiUrl: "/api/channels", token: "t", name: "eng" });
+    expect(out.ok).toBe(true);
+    expect(out.exists).toBe(true);
+    expect(out.transport).toBe("vault");
+  });
+
+  test("reports absence when no channel matches the name", async () => {
+    const P = loadProvision((() =>
+      Promise.resolve(resp(200, { channels: [{ name: "other", transport: "http-ui" }] }))) as unknown as typeof fetch);
+    const out = await P.channelExists({ apiUrl: "/api/channels", token: "t", name: "eng" });
+    expect(out.ok).toBe(true);
+    expect(out.exists).toBe(false);
+  });
+
+  test("a 401/403 list surfaces { ok:false, auth:true } (never throws)", async () => {
+    const P = loadProvision((() => Promise.resolve(resp(401, {}))) as unknown as typeof fetch);
+    const out = await P.channelExists({ apiUrl: "/api/channels", name: "eng" });
+    expect(out.ok).toBe(false);
+    expect(out.auth).toBe(true);
+  });
+});
+
+describe("ChannelProvision.provisionVaultChannel (hub-mediated)", () => {
+  test("POSTs the canonical body to <origin>/admin/connections with the cookie", async () => {
+    let seenUrl = "";
+    let seenInit: RequestInit | undefined;
+    const P = loadProvision(((url: string, init: RequestInit) => {
+      seenUrl = url;
+      seenInit = init;
+      return Promise.resolve(resp(200, { connection: { id: "c1" }, connect: { mcpAdd: "x" } }));
+    }) as unknown as typeof fetch);
+    const out = await P.provisionVaultChannel({ origin: "https://hub.example", name: "eng", vault: "default" });
+    expect(seenUrl).toBe("https://hub.example/admin/connections");
+    expect(seenInit?.method).toBe("POST");
+    expect((seenInit as RequestInit & { credentials?: string }).credentials).toBe("include");
+    const sentBody = JSON.parse(String(seenInit?.body));
+    // The browser-side body MATCHES the server-side vaultConnectionBody — the whole
+    // point of sharing the helper (no drift between surfaces).
+    expect(sentBody).toEqual(vaultConnectionBody("eng", "default"));
+    expect(out.ok).toBe(true);
+    expect((out.connection as { id: string }).id).toBe("c1");
+  });
+
+  test("401 → { auth:true }; 403 → { forbidden:true }; other → { error }", async () => {
+    const auth = await loadProvision((() => Promise.resolve(resp(401, {}))) as unknown as typeof fetch)
+      .provisionVaultChannel({ origin: "o", name: "n", vault: "v" });
+    expect(auth.ok).toBe(false);
+    expect(auth.auth).toBe(true);
+
+    const forbidden = await loadProvision((() =>
+      Promise.resolve(resp(403, { error_description: "nope" }))) as unknown as typeof fetch)
+      .provisionVaultChannel({ origin: "o", name: "n", vault: "v" });
+    expect(forbidden.ok).toBe(false);
+    expect(forbidden.forbidden).toBe(true);
+    expect(forbidden.error).toBe("nope");
+
+    const err = await loadProvision((() =>
+      Promise.resolve(resp(500, { error: "boom" }))) as unknown as typeof fetch)
+      .provisionVaultChannel({ origin: "o", name: "n", vault: "v" });
+    expect(err.ok).toBe(false);
+    expect(err.error).toBe("boom");
+  });
+});
+
+describe("ChannelProvision.provisionDaemonChannel (telegram / http-ui)", () => {
+  test("POSTs { name, transport, config } to the daemon with the Bearer", async () => {
+    let seenInit: RequestInit | undefined;
+    const P = loadProvision(((_url: string, init: RequestInit) => {
+      seenInit = init;
+      return Promise.resolve(resp(200, {}));
+    }) as unknown as typeof fetch);
+    const out = await P.provisionDaemonChannel({
+      apiUrl: "/api/channels", token: "tok", name: "tg", transport: "telegram", config: { token: "bot" },
+    });
+    const headers = seenInit?.headers as Record<string, string>;
+    expect(headers["authorization"]).toBe("Bearer tok");
+    const sent = JSON.parse(String(seenInit?.body));
+    expect(sent).toEqual({ name: "tg", transport: "telegram", config: { token: "bot" } });
+    expect(out.ok).toBe(true);
+  });
+
+  test("omits config for http-ui (just name + transport)", async () => {
+    let seenInit: RequestInit | undefined;
+    const P = loadProvision(((_url: string, init: RequestInit) => {
+      seenInit = init;
+      return Promise.resolve(resp(200, {}));
+    }) as unknown as typeof fetch);
+    await P.provisionDaemonChannel({ apiUrl: "/api/channels", token: "t", name: "web", transport: "http-ui" });
+    const sent = JSON.parse(String(seenInit?.body));
+    expect(sent).toEqual({ name: "web", transport: "http-ui" });
+  });
+
+  test("carries restart_needed through on a 200 (persisted, hot-add failed)", async () => {
+    const P = loadProvision((() =>
+      Promise.resolve(resp(200, { restart_needed: true, error: "port busy" }))) as unknown as typeof fetch);
+    const out = await P.provisionDaemonChannel({ apiUrl: "/api/channels", name: "x", transport: "http-ui" });
+    expect(out.ok).toBe(true);
+    expect(out.restart_needed).toBe(true);
+  });
+
+  test("401/403 → { ok:false, auth:true } (never throws)", async () => {
+    const out = await loadProvision((() => Promise.resolve(resp(403, {}))) as unknown as typeof fetch)
+      .provisionDaemonChannel({ apiUrl: "/api/channels", name: "x", transport: "http-ui" });
+    expect(out.ok).toBe(false);
+    expect(out.auth).toBe(true);
+  });
+});
+
+describe("ChannelProvision.listVaults (hub public discovery)", () => {
+  test("maps the discovery doc's vaults to names", async () => {
+    const P = loadProvision((() =>
+      Promise.resolve(resp(200, { vaults: [{ name: "default" }, { name: "team" }] }))) as unknown as typeof fetch);
+    const out = await P.listVaults({ origin: "https://hub.example" });
+    expect(out.ok).toBe(true);
+    expect(out.vaults).toEqual(["default", "team"]);
+  });
+
+  test("a failed discovery fetch resolves { ok:false } (never throws)", async () => {
+    const out = await loadProvision((() => Promise.resolve(resp(404, {}))) as unknown as typeof fetch)
+      .listVaults({ origin: "o" });
+    expect(out.ok).toBe(false);
+  });
+});
+
+// The browser-side vaultConnectionBody (inside PROVISION_JS) MUST agree with the
+// server-side export — otherwise the two pages would register divergent triggers.
+describe("browser/server vaultConnectionBody parity", () => {
+  test("the eval'd browser body equals the exported server body", () => {
+    const P = loadProvision((() => Promise.resolve(resp(200, {}))) as unknown as typeof fetch);
+    expect(P.vaultConnectionBody("eng", "default")).toEqual(vaultConnectionBody("eng", "default"));
+  });
+});

--- a/src/provision-channel.ts
+++ b/src/provision-channel.ts
@@ -1,0 +1,218 @@
+/**
+ * Shared channel-PROVISIONING client logic, factored out of `admin-ui.ts` so the
+ * Config page and the unified "create an agent" flow (`agents-ui.ts`) run the
+ * SAME provisioning paths and can't drift apart.
+ *
+ * Why this module exists: the create-agent flow (Phase-1 consolidation,
+ * `design/2026-06-17-parachute-agent-blueprint.md` §Sequencing step 1) fuses the
+ * two old steps — create-channel, then spawn-agent-on-it — into one form. The
+ * channel half MUST reuse the existing, carefully-built provisioning paths:
+ *
+ *   - VAULT (the default/primary transport) — a HUB-MEDIATED flow. The page POSTs
+ *     to `<hub-origin>/admin/connections` (cookie-gated, `credentials:"include"`).
+ *     The HUB mints the `vault:default:write` token, registers the inbound vault
+ *     trigger, fills vaultUrl / notePathPrefix, and persists the channel. The
+ *     channel daemon does NOT and CANNOT mint vault tokens — so the client
+ *     orchestrates against the hub, exactly as the Config page does.
+ *   - TELEGRAM / HTTP-UI — a plain `POST <mount>/api/channels` to the channel
+ *     daemon (channel:admin Bearer), `{ name, transport, config? }`.
+ *
+ * These functions are pure browser JS exposed as a STRING (`PROVISION_JS`) so the
+ * pages interpolate it into their inline `<script>` exactly like `SHELL_JS`. The
+ * string is asserted backtick-free (a `bun:test` guards it), so it never breaks a
+ * host template literal. Every function is promise-shaped and NEVER rejects — it
+ * resolves a structured result `{ ok, ... }` so the calling page renders one clear
+ * banner per outcome (auth, error, restart_needed, success).
+ *
+ * Exposed on the page as a namespace object `window.ChannelProvision` with:
+ *   - channelExists({ apiUrl, token, name })       → Promise<{ ok, exists, transport, channel, auth, error }>
+ *   - provisionVaultChannel({ origin, name, vault }) → Promise<{ ok, connection, connect, auth, forbidden, status, error }>
+ *   - provisionDaemonChannel({ apiUrl, token, name, transport, config }) → Promise<{ ok, restart_needed, auth, status, error }>
+ *   - listVaults({ origin })                        → Promise<{ ok, vaults, error }>
+ *
+ * The connection-body shape (vault.note.created → channel.message.deliver) is the
+ * single canonical definition — both pages get it from `vaultConnectionBody(name,
+ * vault)` here, so the trigger filter can never diverge between the two surfaces.
+ */
+
+/**
+ * The canonical hub-Connections request body for a vault-backed channel. Shared so
+ * the Config page and the create-agent flow register byte-identical triggers (the
+ * inbound-tag filter is the loop-avoidance contract; see CLAUDE.md "Vault
+ * integration"). Pure data — also re-derived inside `PROVISION_JS` for the browser.
+ */
+export function vaultConnectionBody(name: string, vault: string): {
+  requestedBy: string;
+  source: {
+    module: string;
+    vault: string;
+    event: string;
+    filter: { tags: string[]; has_metadata: string[]; missing_metadata: string[] };
+  };
+  sink: { module: string; action: string; params: { channel: string } };
+} {
+  return {
+    requestedBy: "channel",
+    source: {
+      module: "vault",
+      vault,
+      event: "note.created",
+      filter: {
+        tags: ["#channel-message/inbound"],
+        has_metadata: ["channel"],
+        missing_metadata: ["channel_inbound_rendered_at"],
+      },
+    },
+    sink: { module: "channel", action: "message.deliver", params: { channel: name } },
+  };
+}
+
+/**
+ * The browser-side provisioning client, injected into a page's `<script>` as
+ * `${PROVISION_JS}` (its content is inserted at runtime, so its own contents —
+ * which contain no backtick — never collide with the host page's template
+ * literal). Defines `window.ChannelProvision`.
+ *
+ * NOTE: keep this backtick-free (the `provision-channel.test.ts` asserts it). Use
+ * string concatenation, never template literals.
+ */
+export const PROVISION_JS = `
+  (function () {
+    "use strict";
+
+    // GET <mount>/api/channels (channel:admin Bearer) and report whether a channel
+    // with this name already exists — the idempotency check both the Config page
+    // and the create-agent flow use to REUSE an existing channel instead of
+    // double-provisioning. Resolves { ok:true, exists, transport, channel } on a
+    // successful list; { ok:false, auth:true } on 401/403; { ok:false, error } on
+    // anything else. Never rejects.
+    function channelExists(opts) {
+      opts = opts || {};
+      var headers = { accept: "application/json" };
+      if (opts.token) headers.authorization = "Bearer " + opts.token;
+      return fetch(opts.apiUrl, { headers: headers }).then(function (res) {
+        if (res.status === 401 || res.status === 403) return { ok: false, auth: true };
+        if (!res.ok) return { ok: false, error: "HTTP " + res.status };
+        return res.json().catch(function () { return {}; }).then(function (data) {
+          var channels = (data && Array.isArray(data.channels)) ? data.channels : [];
+          var match = null;
+          for (var i = 0; i < channels.length; i++) {
+            if (channels[i] && channels[i].name === opts.name) { match = channels[i]; break; }
+          }
+          return {
+            ok: true,
+            exists: !!match,
+            transport: match ? match.transport : null,
+            channel: match,
+          };
+        });
+      }).catch(function (err) {
+        return { ok: false, error: "network error: " + (err && err.message ? err.message : String(err)) };
+      });
+    }
+
+    // The canonical hub-Connections body for a vault-backed channel — re-derived
+    // here so the browser doesn't depend on a server import. MUST stay in sync with
+    // vaultConnectionBody() above (the test asserts the shapes agree).
+    function vaultConnectionBody(name, vault) {
+      return {
+        requestedBy: "channel",
+        source: {
+          module: "vault",
+          vault: vault,
+          event: "note.created",
+          filter: {
+            tags: ["#channel-message/inbound"],
+            has_metadata: ["channel"],
+            missing_metadata: ["channel_inbound_rendered_at"]
+          }
+        },
+        sink: { module: "channel", action: "message.deliver", params: { channel: name } }
+      };
+    }
+
+    // VAULT provisioning — the HUB-MEDIATED path. POST <origin>/admin/connections
+    // with the operator's hub SESSION COOKIE (credentials:"include"); the click IS
+    // the approval. The hub mints the cross-module tokens + registers the vault
+    // trigger and returns { connection, connect }. The channel daemon is NOT
+    // involved (it can't mint vault tokens). Resolves a structured result; never
+    // rejects. requestedBy:"channel" labels provenance in the hub Connections view.
+    function provisionVaultChannel(opts) {
+      opts = opts || {};
+      var body = vaultConnectionBody(opts.name, opts.vault);
+      return fetch(opts.origin + "/admin/connections", {
+        method: "POST",
+        credentials: "include",
+        headers: { "content-type": "application/json", accept: "application/json" },
+        body: JSON.stringify(body)
+      }).then(function (res) {
+        return res.json().catch(function () { return {}; }).then(function (payload) {
+          if (res.status === 401) return { ok: false, auth: true, status: 401 };
+          if (res.status === 403) {
+            return { ok: false, forbidden: true, status: 403, error: (payload && payload.error_description) || "" };
+          }
+          if (!res.ok) {
+            return { ok: false, status: res.status, error: (payload && (payload.error_description || payload.error)) || ("HTTP " + res.status) };
+          }
+          return { ok: true, connection: payload && payload.connection, connect: payload && payload.connect };
+        });
+      }).catch(function (err) {
+        return { ok: false, error: "network error: " + (err && err.message ? err.message : String(err)) };
+      });
+    }
+
+    // TELEGRAM / HTTP-UI provisioning — the plain daemon path. POST
+    // <mount>/api/channels (channel:admin Bearer), { name, transport, config? }.
+    // A 200 may still carry restart_needed:true (persisted, hot-add failed).
+    // Resolves a structured result; never rejects.
+    function provisionDaemonChannel(opts) {
+      opts = opts || {};
+      var headers = { "content-type": "application/json", accept: "application/json" };
+      if (opts.token) headers.authorization = "Bearer " + opts.token;
+      var postBody = { name: opts.name, transport: opts.transport };
+      if (opts.config) postBody.config = opts.config;
+      return fetch(opts.apiUrl, {
+        method: "POST",
+        headers: headers,
+        body: JSON.stringify(postBody)
+      }).then(function (res) {
+        return res.json().catch(function () { return {}; }).then(function (payload) {
+          if (res.status === 401 || res.status === 403) return { ok: false, auth: true, status: res.status };
+          if (!res.ok) {
+            return { ok: false, status: res.status, error: (payload && payload.error) || ("HTTP " + res.status) };
+          }
+          return { ok: true, restart_needed: !!(payload && payload.restart_needed), error: payload && payload.error };
+        });
+      }).catch(function (err) {
+        return { ok: false, error: "network error: " + (err && err.message ? err.message : String(err)) };
+      });
+    }
+
+    // List installed vaults from the hub's PUBLIC discovery doc
+    // (<origin>/.well-known/parachute.json). No token needed — it's public. Resolves
+    // { ok:true, vaults:[names] } or { ok:false, error }; never rejects.
+    function listVaults(opts) {
+      opts = opts || {};
+      return fetch(opts.origin + "/.well-known/parachute.json", {
+        headers: { accept: "application/json" },
+        credentials: "include"
+      }).then(function (r) {
+        if (!r.ok) return { ok: false, error: "HTTP " + r.status };
+        return r.json().catch(function () { return null; }).then(function (doc) {
+          var vaults = (doc && Array.isArray(doc.vaults)) ? doc.vaults.map(function (v) { return v.name; }) : [];
+          return { ok: true, vaults: vaults };
+        });
+      }).catch(function (err) {
+        return { ok: false, error: "network error: " + (err && err.message ? err.message : String(err)) };
+      });
+    }
+
+    window.ChannelProvision = {
+      channelExists: channelExists,
+      vaultConnectionBody: vaultConnectionBody,
+      provisionVaultChannel: provisionVaultChannel,
+      provisionDaemonChannel: provisionDaemonChannel,
+      listVaults: listVaults
+    };
+  })();
+`;

--- a/src/ui-kit.test.ts
+++ b/src/ui-kit.test.ts
@@ -65,12 +65,22 @@ describe("THEME_CSS", () => {
 
 describe("SHELL_JS", () => {
   test("provides MOUNT derivation, nav wiring, token fetch, and helpers", () => {
-    for (const sym of ["var MOUNT", "function wireShell", "function escapeHtml", "function setStatus", "function fetchToken", "function authedFetch"]) {
+    for (const sym of ["var MOUNT", "function wireShell", "function escapeHtml", "function setStatus", "function fetchToken", "function authedFetch", "function setTerminalNavVisible"]) {
       expect(SHELL_JS).toContain(sym);
     }
     // It hits the hub channel-token endpoint with the operator cookie.
     expect(SHELL_JS).toContain("/admin/channel-token");
     expect(SHELL_JS).toContain('credentials: "include"');
+  });
+
+  // Terminal-nav cleanup (Parachute Agent Phase 1): wireShell hides the standalone
+  // Terminal nav entry by default (programmatic backend has no terminal); pages
+  // reveal it via setTerminalNavVisible when an interactive agent exists. The
+  // Terminal page itself (active === "terminal") shows it.
+  test("wireShell gates the Terminal nav link via setTerminalNavVisible", () => {
+    expect(SHELL_JS).toContain('a[data-view="terminal"]');
+    // wireShell defaults the terminal entry to its own-page-only visibility.
+    expect(SHELL_JS).toContain('setTerminalNavVisible(active === "terminal")');
   });
   test("is safe to interpolate — no naked backtick that could break a host literal", () => {
     expect(SHELL_JS.includes("`")).toBe(false);

--- a/src/ui-kit.ts
+++ b/src/ui-kit.ts
@@ -273,6 +273,38 @@ export const SHELL_JS = `
       if (v === active) links[i].classList.add("active");
       else links[i].classList.remove("active");
     }
+    // Terminal-nav cleanup (Parachute Agent Phase 1): programmatic is the default
+    // backend, which has no live terminal — so the standalone Terminal nav entry is
+    // HIDDEN by default. It's only meaningful when an INTERACTIVE agent exists.
+    // Pages that know the interactive-agent count call setTerminalNavVisible(true)
+    // to reveal it; the Terminal page itself reveals it (you're already on it). The
+    // /terminal ROUTE + page stay fully functional regardless — only the nav chrome
+    // is gated, never the capability.
+    setTerminalNavVisible(active === "terminal");
+  }
+  // Show/hide the standalone Terminal nav link. Default hidden (see wireShell);
+  // a page reveals it once it learns an interactive agent is running. Idempotent.
+  function setTerminalNavVisible(show) {
+    var link = document.querySelector('.app-nav a[data-view="terminal"]');
+    if (link) link.style.display = show ? "" : "none";
+  }
+  // Reveal the Terminal nav entry IFF ≥1 interactive agent is running. Pages that
+  // don't otherwise list agents (chat, config) call this on boot so they don't
+  // STRAND an operator who has a live interactive session: GET /api/agents
+  // (channel:admin via authedFetch) and reveal when any agent's backend isn't
+  // programmatic. Best-effort + never throws — a failed/401 fetch leaves the
+  // default-hidden state (the /terminal route still works regardless). The agents
+  // + home pages drive the link directly from their own list and don't need this.
+  function revealTerminalNavIfInteractive() {
+    return authedFetch(MOUNT + "/api/agents")
+      .then(function (r) { return r && r.ok ? r.json() : null; })
+      .then(function (j) {
+        var agents = (j && j.agents) || [];
+        if (agents.some(function (a) { return a.backend !== "programmatic"; })) {
+          setTerminalNavVisible(true);
+        }
+      })
+      .catch(function () { /* leave default-hidden */ });
   }
   function escapeHtml(s) {
     return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#39;");


### PR DESCRIPTION
## What

**Parachute Agent Phase-1 consolidation** ([blueprint](design/2026-06-17-parachute-agent-blueprint.md) §Sequencing step 1): collapse today's **two** steps — create-channel (the Config page) then spawn-agent-on-it (the Agents page) — into **one** "create an agent" flow. You configure an agent, then talk to it (agent ≡ channel, 1:1).

## The unified create-agent surface (`/agents`, now the primary surface)

- **Minimal default UX:** Agent name → **Vault** (auto-selected if exactly one available, else a picker) → optional **System prompt** → **Create**. One submit (a) provisions the vault channel if it doesn't already exist, (b) spawns a **programmatic** agent on it, (c) lands the operator in chat (`/ui?channel=<name>`). Vault is the default transport; programmatic is the default backend.
- **Advanced** discloses the dynamic cases (all preserved from the old spawn form): **use an existing channel** (skip provisioning), **transport** telegram / http-ui (with config), the **interactive** backend, system-prompt mode, extra channels, vault scope (access/tags), filesystem, network, egress, working directory, mounts.
- **Idempotent / safe:** an existing channel of the same name is **reused** (no error, no double-provision); the reused channel's transport is named in the result so a transport divergence is visible. A post-provision spawn failure surfaces a clear error (the channel may remain — acceptable, retry or manage on Config).

## Client-side orchestration (the load-bearing decision)

The channel half **reuses the existing provisioning paths** via a new shared browser-JS client `src/provision-channel.ts` (`PROVISION_JS` + `vaultConnectionBody`):

- **vault** (default) → the **hub-mediated** `POST <hub-origin>/admin/connections` (cookie-gated; the **hub** mints `vault:default:write` + registers the inbound trigger).
- **telegram / http-ui** → `POST <mount>/api/channels` (channel:admin Bearer).

The channel daemon does **not** and **cannot** mint vault tokens — nothing here changes that, and the hub repo is untouched. **No new `/api/agents` fields**: the form posts the **same body** `buildSpecFromBody` already accepts. `admin-ui.ts` is refactored onto the same shared client, so the two surfaces register byte-identical triggers and can't drift.

## Terminal / UI cleanup

Programmatic is the default backend and has no live terminal, so:
- The standalone **Terminal nav entry is hidden by default**; it's revealed only when an interactive agent exists. The agents + home pages drive it from their agent list; chat + config call the shared `revealTerminalNavIfInteractive()` so they don't strand an operator who has a live interactive session. The Terminal page itself always shows its own tab.
- Per-agent **terminal links render only for interactive agents** (home-ui + agents-ui).
- The `/terminal` **route + page stay fully functional** — only the nav chrome is gated, never the capability.

Nav/landing leads with **"Create an agent"**; channel management stays reachable as **"Manage channels"** (`/admin`). Interactive launches surface their **sandbox posture** (MCP servers / filesystem / network-egress) and are **not** auto-navigated, so the operator can verify isolation; programmatic auto-opens chat.

## Backward-compatibility (verified preserved)

- `/admin` page + `POST/GET/DELETE /api/channels` — unchanged and functional.
- `POST/GET/DELETE/restart /api/agents` request/response shapes — unchanged (same `collectSpec` body via `buildSpecFromBody`).

## Tests + gates

- **New:** `src/provision-channel.test.ts` (the shared client behavior + browser/server `vaultConnectionBody` parity, evaluated against a stubbed fetch) and `src/agents-ui.test.ts` (payload shaping, channel-reuse idempotency, terminal-link gating, sandbox-posture rendering).
- **Updated:** admin-ui / agents / ui-kit / daemon tests for the consolidation.
- `bun test ./src` → **701 pass / 0 fail** across 37 files.
- `bun run typecheck` → clean except **2 pre-existing `TS2589` errors in `src/bridge.ts`** (untouched by this diff; present on `main`).
- **No version bump** (RC bump+tag is a later ship call).

## For the reviewer to scrutinize

- **The vault provisioning seam** — confirm we only orchestrate the existing hub `/admin/connections` flow client-side and never mint vault tokens daemon-side. `vaultConnectionBody` is the single canonical trigger-filter definition shared by both surfaces (parity asserted in `provision-channel.test.ts`).
- **Backward-compat of `/api/channels` + `/api/agents`** — the refactor of `admin-ui.ts` onto the shared client preserved the 401/403 distinction, `restart_needed`, the 400-vs-other banner, and the connect-lines rendering (all re-verified + test-pinned).
- **Terminal-nav stranding fix** — chat (`daemon.ts`) and config (`admin-ui.ts`) now call `revealTerminalNavIfInteractive()`; the `/terminal` route is intentionally kept fully functional.
- **`PROVISION_JS` is asserted backtick-free** (it interpolates into two host template literals) — guarded by a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)