### PR TITLE
feat(channel): runner — scheduled agent turns (vault-native, narrow)

### DIFF
--- a/design/2026-06-17-runner-scheduled-agent-turns.md
+++ b/design/2026-06-17-runner-scheduled-agent-turns.md
@@ -8,27 +8,40 @@ A **scheduled job** is *an automated human*: "send message M to agent A on sched
 ## One mechanism (no new path)
 A fired job writes an **inbound note** exactly like a human typing in chat — same tags, same metadata, same durability. There is **no special-case turn path**: the note lands in the vault (durable, queryable, visible in the transcript), the channel's already-registered vault trigger fires, and the turn runs. The runner is indifferent to backend (programmatic/interactive) because it never touches the turn — it only authors notes.
 
-## Anatomy of a job
-Persisted in `~/.parachute/channel/jobs.json` (0600, read-modify-write — same pattern as `channels.json`/`credentials.json`; vault-native job storage is the blueprint's *later* phase):
+## Anatomy of a job — VAULT-NATIVE storage (Aaron's call 2026-06-17)
+A **job IS a vault note** — durable, queryable, and renderable by any surface — not a local `jobs.json`. This is the blueprint's "vault as the spine" realized in this phase, and it converges with the future `tag:job` idea. The job note lives in the **target channel's vault** (each vault-channel already carries `config.vault` / `config.vaultUrl` / `config.token` — the channel's existing `vault:<name>:write` token covers all job CRUD; the runner mints nothing).
+- **Parent tag** `#agent-job` (queryable; mirrors the `#channel-message` convention). This is a brand-new tag, so it's named for the module's new identity (Parachute Agent) from the start. (The `#channel-message → #agent-message` rename is a separate Phase-3 data migration — the *injected message* notes still use `#channel-message`.)
+- **content** = the message text to inject.
+- **metadata** (all string-typed in the vault): `{ channel, cron, tz?, enabled, createdAt, lastRunAt?, lastStatus? }`. **`nextRunAt` is computed IN MEMORY, never persisted.**
+- **path**: `Channels/<channel>/jobs/<jobId>` (slug id; deterministic so an upsert overwrites in place).
+
 ```jsonc
-{ "jobs": [ {
-  "id": "morning-standup", "channel": "uni-dev",
-  "message": "Run the morning weave…",
-  "schedule": { "cron": "53 7 * * *", "tz": "America/Los_Angeles" },
-  "enabled": true, "createdAt": "…", "lastRunAt": "…",
-  "lastStatus": "ok" | "error: …", "nextRunAt": "…"
-} ] }
+// the #agent-job note, as the vault stores it
+{ "content": "Run the morning weave…",
+  "path": "Channels/uni-dev/jobs/morning-standup",
+  "tags": ["#agent-job"],
+  "metadata": { "channel": "uni-dev", "cron": "53 7 * * *",
+                "tz": "America/Los_Angeles", "enabled": "true",
+                "createdAt": "…", "lastRunAt": "…", "lastStatus": "ok" } }
 ```
 - **`channel` must be a vault channel** (the inject path is "write an inbound note," which only a vault transport has). Telegram/http-ui are rejected with a clear error. The default agent is vault-backed.
 - **`schedule`** — a 5-field **cron** expression (`min hour dom mon dow`) plus optional IANA `tz` (default: daemon local tz). Small dependency-free evaluator (`src/cron.ts`): `*`, `*/n`, ranges (`a-b`), lists (`a,b,c`). No seconds, no macros in v1.
 
+### Vault REST endpoints (all with the channel's existing `vault:write` token)
+- **List:** `GET <vaultUrl>/vault/<vault>/api/notes?tag=%23agent-job&include_content=true&limit=<n>` → bare JSON array; **filter client-side by `metadata.channel`** (no `?metadata={channel:{eq}}` — FIELD_NOT_INDEXED risk; same index-free pattern `loadTranscript` uses).
+- **Create/replace:** `POST <vaultUrl>/vault/<vault>/api/notes` `{ content, path, tags:["#agent-job"], metadata }` (upsert by path).
+- **Update status on fire:** `PATCH <vaultUrl>/vault/<vault>/api/notes/<id>` with the changed metadata (lastRunAt, lastStatus).
+- **Delete:** `DELETE <vaultUrl>/vault/<vault>/api/notes/<id>`.
+
+These live on `VaultTransport` (it owns the URL + token + encoding), so `jobs.ts` is a thin storage-agnostic facade.
+
 ## Components
-1. **`src/jobs.ts`** — registry: `readJobsFile`/`upsertJob`/`removeJob` (mirrors `registry.ts`), plus `validateJob` (slug, known channel, vault-transport check, cron parse).
+1. **`src/jobs.ts`** — the `Job` model + `validateJob` (pure: slug, known channel, vault-transport check, cron parse) + `VaultJobStore` (`listAll`/`upsert`/`remove`/`patch`, same read-all/upsert/remove interface, now backed by `#agent-job` vault notes via the channel's `VaultTransport`).
 2. **`src/cron.ts`** — `parseCron(expr)` + `nextRunAfter(expr, tz, from)`. Pure, unit-tested.
-3. **`src/runner.ts`** — the scheduler. One `setInterval` tick (default 30s) checks each enabled job; if due, fire, set `lastRunAt`/`lastStatus`, recompute `nextRunAt`, persist. **Injectable clock + fire fn + tick scheduler** for deterministic tests. Catch-up = **fire-once-on-miss** (no stampede). Idempotent under overlap (skip a job already mid-fire).
+3. **`src/runner.ts`** — the scheduler. One `setInterval` tick (default 30s) **loads jobs from the vault store**, checks each enabled job; if due, fire, set `lastRunAt`/`lastStatus`, recompute `nextRunAt` (in memory), and PATCH the bookkeeping back. **Injectable clock + load fn + fire fn + persist fn + tick scheduler** for deterministic tests. `nextRunAt` is held in an in-memory per-job horizon map (never persisted). Catch-up = **fire-once-on-miss** (no stampede). Idempotent under overlap (skip a job already mid-fire).
 4. **Fire = inject inbound.** `VaultTransport.injectInbound({ content, sender })` — sibling of `reply()` writing `[#channel-message, #channel-message/inbound]`, `metadata: { channel, direction: "inbound", sender: "runner:<jobId>", ts }`, NO `channel_inbound_rendered_at`. Reuses the channel's existing `vault:<name>:write` token.
 5. **API** (`channel:admin`): `GET /api/jobs`; `POST /api/jobs {id,channel,message,schedule,enabled?}` (400 on bad cron / unknown / non-vault channel); `DELETE /api/jobs/:id`; `POST /api/jobs/:id/run` (fire now).
-6. **UI** — a **Schedules** panel: list (channel · cron · next-run · last-status), add form (agent picker → message → cron field + presets like "daily 8am"/"hourly"), enable/disable, delete, "Run now." Reuse `ui-kit` shell + the hub-minted `channel:admin` token bootstrap.
+6. **UI** — a sibling **Schedules** page (`/jobs`, nav entry): list (agent · cron · next-run · last-status), add form (agent picker → message → cron field + presets like "daily 8am"/"hourly"), enable/disable, delete, "Run now." Reuse `ui-kit` shell + the hub-minted `channel:admin` token bootstrap. (A dedicated page over an agents-page section: each surface stays single-purpose, matching the module's one-page-per-concern idiom, and avoids growing the already-large agents page.)
 
 ## Why correct + safe
 No new authority (uses the channel's existing write token, no hub round-trip). No loop risk (only writes inbound; trigger never matches outbound). Durable + visible (real vault note; high-water-mark/backlog-replay apply unchanged). Deterministic tests (clock/tick/fire injected; cron pure).
@@ -37,4 +50,4 @@ No new authority (uses the channel's existing write token, no hub round-trip). N
 Not `tag:job` event triggers; not script execution (an agent runs the script — the runner just sends "run the deploy script"); not multi-step weaves/DAGs; not telegram/http-ui targets.
 
 ## Later
-`tag:job` flavor; vault-native job storage; cron macros/seconds.
+`tag:job` event-trigger flavor; cron macros/seconds; declaring the `#agent-job` tag schema (indexed `channel`) for index-backed per-channel job queries at scale (today's list is index-free, mirroring the transcript read).

--- a/design/2026-06-17-runner-scheduled-agent-turns.md
+++ b/design/2026-06-17-runner-scheduled-agent-turns.md
@@ -1,0 +1,40 @@
+# Runner — scheduled agent turns (narrow, in-module)
+
+**Status:** built 2026-06-17. Phase 2 of the Parachute Agent consolidation (`2026-06-17-parachute-agent-blueprint.md` §Sequencing step 2). Builds on the programmatic backend (`2026-06-16-pluggable-agent-backend.md`) and the vault transport's inbound→turn→outbound mechanism.
+
+## The idea (start narrow)
+A **scheduled job** is *an automated human*: "send message M to agent A on schedule S." Per the blueprint, the runner is **in-module** and **the agent is always the unit of work** — the runner does not execute anything itself; it just *authors an inbound message on a schedule*, and the existing agent-turn machinery does the rest. Aaron's steer: **"Let's start runner narrow."** So Phase 2 is *scheduled messages*, nothing more. The `tag:job` event-trigger flavor is a deliberate future extension (§Later), not in this phase.
+
+## One mechanism (no new path)
+A fired job writes an **inbound note** exactly like a human typing in chat — same tags, same metadata, same durability. There is **no special-case turn path**: the note lands in the vault (durable, queryable, visible in the transcript), the channel's already-registered vault trigger fires, and the turn runs. The runner is indifferent to backend (programmatic/interactive) because it never touches the turn — it only authors notes.
+
+## Anatomy of a job
+Persisted in `~/.parachute/channel/jobs.json` (0600, read-modify-write — same pattern as `channels.json`/`credentials.json`; vault-native job storage is the blueprint's *later* phase):
+```jsonc
+{ "jobs": [ {
+  "id": "morning-standup", "channel": "uni-dev",
+  "message": "Run the morning weave…",
+  "schedule": { "cron": "53 7 * * *", "tz": "America/Los_Angeles" },
+  "enabled": true, "createdAt": "…", "lastRunAt": "…",
+  "lastStatus": "ok" | "error: …", "nextRunAt": "…"
+} ] }
+```
+- **`channel` must be a vault channel** (the inject path is "write an inbound note," which only a vault transport has). Telegram/http-ui are rejected with a clear error. The default agent is vault-backed.
+- **`schedule`** — a 5-field **cron** expression (`min hour dom mon dow`) plus optional IANA `tz` (default: daemon local tz). Small dependency-free evaluator (`src/cron.ts`): `*`, `*/n`, ranges (`a-b`), lists (`a,b,c`). No seconds, no macros in v1.
+
+## Components
+1. **`src/jobs.ts`** — registry: `readJobsFile`/`upsertJob`/`removeJob` (mirrors `registry.ts`), plus `validateJob` (slug, known channel, vault-transport check, cron parse).
+2. **`src/cron.ts`** — `parseCron(expr)` + `nextRunAfter(expr, tz, from)`. Pure, unit-tested.
+3. **`src/runner.ts`** — the scheduler. One `setInterval` tick (default 30s) checks each enabled job; if due, fire, set `lastRunAt`/`lastStatus`, recompute `nextRunAt`, persist. **Injectable clock + fire fn + tick scheduler** for deterministic tests. Catch-up = **fire-once-on-miss** (no stampede). Idempotent under overlap (skip a job already mid-fire).
+4. **Fire = inject inbound.** `VaultTransport.injectInbound({ content, sender })` — sibling of `reply()` writing `[#channel-message, #channel-message/inbound]`, `metadata: { channel, direction: "inbound", sender: "runner:<jobId>", ts }`, NO `channel_inbound_rendered_at`. Reuses the channel's existing `vault:<name>:write` token.
+5. **API** (`channel:admin`): `GET /api/jobs`; `POST /api/jobs {id,channel,message,schedule,enabled?}` (400 on bad cron / unknown / non-vault channel); `DELETE /api/jobs/:id`; `POST /api/jobs/:id/run` (fire now).
+6. **UI** — a **Schedules** panel: list (channel · cron · next-run · last-status), add form (agent picker → message → cron field + presets like "daily 8am"/"hourly"), enable/disable, delete, "Run now." Reuse `ui-kit` shell + the hub-minted `channel:admin` token bootstrap.
+
+## Why correct + safe
+No new authority (uses the channel's existing write token, no hub round-trip). No loop risk (only writes inbound; trigger never matches outbound). Durable + visible (real vault note; high-water-mark/backlog-replay apply unchanged). Deterministic tests (clock/tick/fire injected; cron pure).
+
+## Boundaries (NOT in Phase 2)
+Not `tag:job` event triggers; not script execution (an agent runs the script — the runner just sends "run the deploy script"); not multi-step weaves/DAGs; not telegram/http-ui targets.
+
+## Later
+`tag:job` flavor; vault-native job storage; cron macros/seconds.

--- a/src/cron.test.ts
+++ b/src/cron.test.ts
@@ -1,0 +1,249 @@
+import { describe, test, expect } from "bun:test";
+import { parseCron, nextRunAfter, CronParseError, type ParsedCron } from "./cron.ts";
+
+/** Helper: the wall-clock fields of an instant in a tz (for asserting matches). */
+function wall(date: Date, tz: string): { y: number; mo: number; d: number; h: number; mi: number; wd: number } {
+  const p = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    hour12: false,
+    weekday: "short",
+    year: "numeric",
+    month: "numeric",
+    day: "numeric",
+    hour: "numeric",
+    minute: "numeric",
+  }).formatToParts(date);
+  const g = (t: string) => p.find((x) => x.type === t)?.value ?? "";
+  const WD: Record<string, number> = { Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6 };
+  let h = parseInt(g("hour"), 10);
+  if (h === 24) h = 0;
+  return {
+    y: parseInt(g("year"), 10),
+    mo: parseInt(g("month"), 10),
+    d: parseInt(g("day"), 10),
+    h,
+    mi: parseInt(g("minute"), 10),
+    wd: WD[g("weekday")] ?? -1,
+  };
+}
+
+describe("parseCron — field parsing", () => {
+  test("a fully-wild expression matches every minute", () => {
+    const p = parseCron("* * * * *");
+    expect(p.minute.size).toBe(60);
+    expect(p.hour.size).toBe(24);
+    expect(p.dom.size).toBe(31);
+    expect(p.month.size).toBe(12);
+    expect(p.dow.size).toBe(7);
+    expect(p.domStar).toBe(true);
+    expect(p.dowStar).toBe(true);
+  });
+
+  test("concrete fields parse to single-value sets", () => {
+    const p = parseCron("53 7 * * *");
+    expect([...p.minute]).toEqual([53]);
+    expect([...p.hour]).toEqual([7]);
+    expect(p.domStar).toBe(true);
+    expect(p.dowStar).toBe(true);
+  });
+
+  test("step (*​/15) expands to the stepped set", () => {
+    const p = parseCron("*/15 * * * *");
+    expect([...p.minute].sort((a, b) => a - b)).toEqual([0, 15, 30, 45]);
+    // A stepped minute field is NOT a bare star — but minute has no union rule,
+    // so what matters is the value set. (domStar/dowStar only track dom/dow.)
+  });
+
+  test("ranges expand inclusively (1-5)", () => {
+    const p = parseCron("0 9 * * 1-5");
+    expect([...p.dow].sort((a, b) => a - b)).toEqual([1, 2, 3, 4, 5]);
+    expect(p.dowStar).toBe(false);
+  });
+
+  test("comma lists union their elements (0,30)", () => {
+    const p = parseCron("0,30 * * * *");
+    expect([...p.minute].sort((a, b) => a - b)).toEqual([0, 30]);
+  });
+
+  test("range + step (0-30/10)", () => {
+    const p = parseCron("0-30/10 * * * *");
+    expect([...p.minute].sort((a, b) => a - b)).toEqual([0, 10, 20, 30]);
+  });
+
+  test("bare number with step extends to field max (5/2 in hour)", () => {
+    const p = parseCron("0 5/2 * * *");
+    expect([...p.hour].sort((a, b) => a - b)).toEqual([5, 7, 9, 11, 13, 15, 17, 19, 21, 23]);
+  });
+});
+
+describe("parseCron — error cases", () => {
+  test("wrong field count throws", () => {
+    expect(() => parseCron("* * * *")).toThrow(CronParseError);
+    expect(() => parseCron("* * * * * *")).toThrow(/5 fields/);
+  });
+  test("out-of-range value throws (minute 60)", () => {
+    expect(() => parseCron("60 * * * *")).toThrow(/out of range/);
+  });
+  test("out-of-range hour throws (24)", () => {
+    expect(() => parseCron("0 24 * * *")).toThrow(/out of range/);
+  });
+  test("dow 7 is rejected in v1 (Sunday is 0 only)", () => {
+    expect(() => parseCron("0 0 * * 7")).toThrow(/out of range/);
+  });
+  test("non-numeric value throws", () => {
+    expect(() => parseCron("MON * * * *")).toThrow(CronParseError);
+  });
+  test("descending range throws", () => {
+    expect(() => parseCron("0 9-5 * * *")).toThrow(/descending/);
+  });
+  test("zero step throws", () => {
+    expect(() => parseCron("*/0 * * * *")).toThrow(/step/);
+  });
+  test("empty field throws", () => {
+    expect(() => parseCron("0 , * * *")).toThrow(CronParseError);
+  });
+});
+
+describe("nextRunAfter — strict advance + concrete schedules", () => {
+  const LA = "America/Los_Angeles";
+
+  test("'53 7 * * *' in LA returns 07:53 LA, strictly after `from`", () => {
+    // from = 2026-06-17 06:00 LA → next is 07:53 the SAME day.
+    const from = new Date("2026-06-17T13:00:00Z"); // 06:00 LA (PDT, UTC-7)
+    const next = nextRunAfter("53 7 * * *", LA, from)!;
+    expect(next).not.toBeNull();
+    const w = wall(next, LA);
+    expect(w.h).toBe(7);
+    expect(w.mi).toBe(53);
+    expect(w.d).toBe(17);
+    expect(next.getTime()).toBeGreaterThan(from.getTime());
+  });
+
+  test("'53 7 * * *' when already past today rolls to tomorrow", () => {
+    const from = new Date("2026-06-17T15:00:00Z"); // 08:00 LA, past 07:53
+    const next = nextRunAfter("53 7 * * *", LA, from)!;
+    const w = wall(next, LA);
+    expect(w.h).toBe(7);
+    expect(w.mi).toBe(53);
+    expect(w.d).toBe(18); // tomorrow
+  });
+
+  test("hourly '0 * * * *' returns the next top-of-hour", () => {
+    const from = new Date("2026-06-17T10:17:00Z");
+    const next = nextRunAfter("0 * * * *", "UTC", from)!;
+    expect(next.toISOString()).toBe("2026-06-17T11:00:00.000Z");
+  });
+
+  test("never returns `from` itself even when `from` is an exact match (no double-fire)", () => {
+    // from is exactly 11:00:00 UTC, which '0 * * * *' matches — must advance to 12:00.
+    const from = new Date("2026-06-17T11:00:00Z");
+    const next = nextRunAfter("0 * * * *", "UTC", from)!;
+    expect(next.toISOString()).toBe("2026-06-17T12:00:00.000Z");
+    expect(next.getTime()).toBeGreaterThan(from.getTime());
+  });
+
+  test("'*​/15 * * * *' steps to the next quarter-hour", () => {
+    const from = new Date("2026-06-17T10:07:30Z");
+    const next = nextRunAfter("*/15 * * * *", "UTC", from)!;
+    expect(next.toISOString()).toBe("2026-06-17T10:15:00.000Z");
+  });
+
+  test("'0 9 * * 1-5' (weekday 9am) skips the weekend", () => {
+    // 2026-06-19 is a Friday; from = Fri 10:00 UTC → next match is Mon 09:00.
+    const fri = new Date("2026-06-19T10:00:00Z");
+    expect(wall(fri, "UTC").wd).toBe(5); // Friday
+    const next = nextRunAfter("0 9 * * 1-5", "UTC", fri)!;
+    const w = wall(next, "UTC");
+    expect(w.wd).toBe(1); // Monday
+    expect(w.h).toBe(9);
+    expect(w.d).toBe(22); // 2026-06-22 is the Monday
+  });
+
+  test("end-of-month rollover ('0 0 1 * *' → first of next month)", () => {
+    const from = new Date("2026-01-31T12:00:00Z");
+    const next = nextRunAfter("0 0 1 * *", "UTC", from)!;
+    expect(next.toISOString()).toBe("2026-02-01T00:00:00.000Z");
+  });
+
+  test("end-of-year rollover ('0 0 1 1 *' → next Jan 1)", () => {
+    const from = new Date("2026-12-31T23:59:00Z");
+    const next = nextRunAfter("0 0 1 1 *", "UTC", from)!;
+    expect(next.toISOString()).toBe("2027-01-01T00:00:00.000Z");
+  });
+
+  test("leap day ('0 0 29 2 *' fires on Feb 29 2028, skips non-leap years)", () => {
+    // From mid-2026, the next Feb 29 is in 2028 (2026/2027 are not leap years).
+    const from = new Date("2026-06-01T00:00:00Z");
+    const next = nextRunAfter("0 0 29 2 *", "UTC", from)!;
+    const w = wall(next, "UTC");
+    expect(w.y).toBe(2028);
+    expect(w.mo).toBe(2);
+    expect(w.d).toBe(29);
+  });
+
+  test("dom AND dow both restricted → matches on EITHER (cron union rule)", () => {
+    // '0 0 13 * 5' = midnight on the 13th OR any Friday. From 2026-02-01:
+    // the first Friday (the 6th) comes before the 13th.
+    const from = new Date("2026-02-01T00:00:00Z");
+    const next = nextRunAfter("0 0 13 * 5", "UTC", from)!;
+    const w = wall(next, "UTC");
+    // 2026-02-06 is a Friday → that's the union hit before the 13th.
+    expect(w.d).toBe(6);
+    expect(w.wd).toBe(5);
+  });
+
+  test("a tz offset actually shifts the fire instant (UTC vs LA differ)", () => {
+    const from = new Date("2026-06-17T00:00:00Z");
+    const utc = nextRunAfter("0 12 * * *", "UTC", from)!;
+    const la = nextRunAfter("0 12 * * *", LA, from)!;
+    // 12:00 LA (PDT, UTC-7) is 19:00Z; 12:00 UTC is 12:00Z. They must differ by 7h.
+    expect(utc.toISOString()).toBe("2026-06-17T12:00:00.000Z");
+    expect(la.toISOString()).toBe("2026-06-17T19:00:00.000Z");
+  });
+
+  test("defaults: no tz uses local zone; no `from` uses now (returns a future instant)", () => {
+    const next = nextRunAfter("* * * * *");
+    expect(next).not.toBeNull();
+    expect(next!.getTime()).toBeGreaterThan(Date.now() - 1000);
+  });
+
+  test("an invalid IANA tz throws (not silently UTC)", () => {
+    expect(() => nextRunAfter("* * * * *", "Not/AZone", new Date())).toThrow();
+  });
+});
+
+describe("nextRunAfter — DST behavior (documented v1)", () => {
+  const LA = "America/Los_Angeles";
+
+  test("spring-forward: a 02:30 spec is SKIPPED on the gap day, fires next day", () => {
+    // 2026-03-08 is the US spring-forward (02:00 → 03:00 PST→PDT). 02:30 never
+    // occurs that day. from = 2026-03-08 00:00 LA.
+    const from = new Date("2026-03-08T08:00:00Z"); // 00:00 LA (PST, UTC-8)
+    const next = nextRunAfter("30 2 * * *", LA, from)!;
+    const w = wall(next, LA);
+    // The 02:30 wall time does not exist on the 8th → first match is the 9th.
+    expect(w.d).toBe(9);
+    expect(w.h).toBe(2);
+    expect(w.mi).toBe(30);
+  });
+
+  test("fall-back: a 01:30 spec yields a valid instant (both repeats are real instants)", () => {
+    // 2026-11-01 is the US fall-back (02:00 → 01:00 PDT→PST). 01:30 occurs twice.
+    // We only assert nextRunAfter returns a real matching instant (v1 fires on the
+    // first one it walks to); the dual-fire behavior is documented, not policed.
+    const from = new Date("2026-11-01T07:00:00Z"); // 00:00 LA (PDT, UTC-7)
+    const next = nextRunAfter("30 1 * * *", LA, from)!;
+    const w = wall(next, LA);
+    expect(w.d).toBe(1);
+    expect(w.h).toBe(1);
+    expect(w.mi).toBe(30);
+  });
+});
+
+describe("nextRunAfter — accepts a pre-parsed ParsedCron", () => {
+  test("reuses a ParsedCron without re-parsing", () => {
+    const parsed: ParsedCron = parseCron("0 0 * * *");
+    const next = nextRunAfter(parsed, "UTC", new Date("2026-06-17T12:00:00Z"))!;
+    expect(next.toISOString()).toBe("2026-06-18T00:00:00.000Z");
+  });
+});

--- a/src/cron.test.ts
+++ b/src/cron.test.ts
@@ -240,6 +240,99 @@ describe("nextRunAfter — DST behavior (documented v1)", () => {
   });
 });
 
+// ===========================================================================
+// REGRESSION GUARD — day-skip in a NEGATIVE-OFFSET timezone (the morning-miss bug).
+//
+// The day-skip fast path (taken whenever dom/dow restricts the date) used to jump
+// to UTC-midnight, which in America/Los_Angeles is ~17:00 of the wall-day; the
+// forward-only crawl then started in the EVENING and could never reach that
+// wall-day's MORNING. Result: morning weekday/sparse-dom jobs in PT were missed
+// (skipped to a later day) or never fired at all (returned null). These cases
+// FAIL on the old UTC-midnight code and PASS on the wall-midnight fix. They're
+// all in a negative-offset tz (where UTC-midnight ≠ wall-midnight) — the only
+// place the bug is visible — and they all exercise the day-skip (restricted dom
+// or dow), unlike the `*`-dom/dow cases above which never enter the skip path.
+// ===========================================================================
+describe("nextRunAfter — day-skip in a negative-offset tz (morning-miss regression)", () => {
+  const LA = "America/Los_Angeles";
+
+  test("'0 9 * * 1-5' from a Saturday → MONDAY 09:00 PT (not Tuesday — the morning isn't skipped)", () => {
+    // 2026-06-20 is a Saturday. The next weekday-9am is MONDAY the 22nd at 09:00 PT.
+    // The OLD code skipped Monday's morning (landed at Sun 17:00 wall after the
+    // UTC-midnight jump, crawled past Mon 09:00 having started Monday at 17:00…),
+    // returning TUESDAY. The fix returns Monday.
+    const sat = new Date("2026-06-20T18:00:00Z"); // ~11:00 Sat LA
+    expect(wall(sat, LA).wd).toBe(6); // Saturday
+    const next = nextRunAfter("0 9 * * 1-5", LA, sat)!;
+    expect(next).not.toBeNull();
+    const w = wall(next, LA);
+    expect(w.wd).toBe(1); // MONDAY (not 2/Tuesday)
+    expect(w.h).toBe(9);
+    expect(w.mi).toBe(0);
+    expect(w.d).toBe(22); // 2026-06-22 is the Monday
+  });
+
+  test("'0 6 1 * *' (sparse dom, morning) in PT → the 1st at 06:00 PT, NOT null", () => {
+    // The OLD code returned NULL here: every month's 1st has its morning stranded
+    // behind the UTC-midnight jump, so the sparse-dom search exhausted → null. The
+    // canonical "any sparse-dom morning job in PT never runs" failure.
+    const midMonth = new Date("2026-06-15T19:00:00Z"); // ~12:00 Jun 15 LA
+    const next = nextRunAfter("0 6 1 * *", LA, midMonth);
+    expect(next).not.toBeNull();
+    const w = wall(next!, LA);
+    expect(w.d).toBe(1);
+    expect(w.h).toBe(6);
+    expect(w.mi).toBe(0);
+    expect(w.mo).toBe(7); // the next 1st is July 1
+  });
+
+  test("'30 7 15 * *' (restricted-dom morning generic) in PT → the 15th at 07:30 PT", () => {
+    const from = new Date("2026-06-10T19:00:00Z"); // ~12:00 Jun 10 LA, before the 15th
+    const next = nextRunAfter("30 7 15 * *", LA, from);
+    expect(next).not.toBeNull();
+    const w = wall(next!, LA);
+    expect(w.d).toBe(15);
+    expect(w.h).toBe(7);
+    expect(w.mi).toBe(30);
+    expect(w.mo).toBe(6); // June 15
+  });
+
+  test("the canonical morning weave '53 7 * * 1-5' (weekday, restricted dow) fires Mon 07:53 PT", () => {
+    // dow restricted → day-skip path active (unlike the all-`*` '53 7 * * *' which
+    // works even on the buggy code). From a Sunday → Monday 07:53 PT.
+    const sun = new Date("2026-06-21T18:00:00Z"); // ~11:00 Sun LA
+    expect(wall(sun, LA).wd).toBe(0); // Sunday
+    const next = nextRunAfter("53 7 * * 1-5", LA, sun)!;
+    const w = wall(next, LA);
+    expect(w.wd).toBe(1); // Monday
+    expect(w.h).toBe(7);
+    expect(w.mi).toBe(53);
+  });
+
+  test("strictly-after still holds across a negative-offset day-skip", () => {
+    // from is exactly a matching morning instant; must advance to the NEXT match.
+    const at0900 = new Date("2026-06-22T16:00:00Z"); // 09:00 Mon LA (PDT) — matches '0 9 * * 1-5'
+    expect(wall(at0900, LA)).toMatchObject({ wd: 1, h: 9, mi: 0 });
+    const next = nextRunAfter("0 9 * * 1-5", LA, at0900)!;
+    expect(next.getTime()).toBeGreaterThan(at0900.getTime());
+    const w = wall(next, LA);
+    expect(w.wd).toBe(2); // the next weekday match is Tuesday 09:00
+    expect(w.h).toBe(9);
+  });
+
+  test("day-skip works in a POSITIVE-offset tz too (Tokyo, UTC+9) — morning not skipped", () => {
+    // Symmetric check: in a positive-offset zone UTC-midnight is ~09:00 wall, a
+    // different failure shape; assert the fix is correct here as well.
+    const TOKYO = "Asia/Tokyo";
+    const from = new Date("2026-06-14T03:00:00Z"); // 12:00 Jun 14 Tokyo
+    const next = nextRunAfter("0 6 15 * *", TOKYO, from)!;
+    const w = wall(next, TOKYO);
+    expect(w.d).toBe(15);
+    expect(w.h).toBe(6);
+    expect(w.mi).toBe(0);
+  });
+});
+
 describe("nextRunAfter — accepts a pre-parsed ParsedCron", () => {
   test("reuses a ParsedCron without re-parsing", () => {
     const parsed: ParsedCron = parseCron("0 0 * * *");

--- a/src/cron.ts
+++ b/src/cron.ts
@@ -1,0 +1,358 @@
+/**
+ * A tiny, dependency-free cron evaluator for the runner (design
+ * `2026-06-17-runner-scheduled-agent-turns.md`).
+ *
+ * Scope (v1, deliberately narrow):
+ *   - FIVE fields only: `minute hour day-of-month month day-of-week`.
+ *   - Each field supports `*`, `*​/n` (step), `a-b` (range), `a-b/n` (range+step),
+ *     and `a,b,c` (comma list, each element any of the above).
+ *   - NO seconds field, NO macros (`@daily`), NO names (`MON`, `JAN`) — numeric only.
+ *   - day-of-week: 0-6, Sunday = 0. (7 is NOT accepted as Sunday in v1 — keep the
+ *     accepted set tight and unambiguous.)
+ *
+ * Day-of-month / day-of-week semantics follow standard cron: if BOTH `dom` and
+ * `dow` are restricted (neither is `*`), a day matches when EITHER matches (the
+ * union). If only one is restricted, only that one constrains. This is the Vixie
+ * cron rule and the one operators expect from "0 9 * * 1-5".
+ *
+ * Timezone correctness — the #1 risk. `nextRunAfter` evaluates the cron fields
+ * against the WALL CLOCK in a given IANA timezone (default: the daemon's local
+ * tz). It does this by walking forward minute-by-minute from `from`, projecting
+ * each candidate instant into the target tz via `Intl.DateTimeFormat` (Bun ships
+ * full ICU), and testing the projected wall-clock fields against the cron sets.
+ * This is O(minutes-until-next-match); bounded by a hard cap (~366 days of
+ * minutes) so a pathological/never-matching spec returns null instead of looping
+ * forever. The minute-walk is simple and DST-honest: because we read the wall
+ * clock the OS/ICU reports for each real instant, a spring-forward gap simply has
+ * no matching instant (the wall time never occurs → that fire is skipped that
+ * day), and a fall-back repeat can match twice (both 01:30s exist as distinct
+ * instants → both fire). v1 accepts that behavior rather than inventing a policy;
+ * see the comment at `nextRunAfter`.
+ */
+
+/** A parsed cron expression: the allowed-value Sets per field, plus restriction flags. */
+export interface ParsedCron {
+  minute: Set<number>;
+  hour: Set<number>;
+  /** day-of-month (1-31). */
+  dom: Set<number>;
+  /** month (1-12). */
+  month: Set<number>;
+  /** day-of-week (0-6, Sun=0). */
+  dow: Set<number>;
+  /** Whether `dom` was `*` (unrestricted) — drives the dom/dow union rule. */
+  domStar: boolean;
+  /** Whether `dow` was `*` (unrestricted) — drives the dom/dow union rule. */
+  dowStar: boolean;
+}
+
+/** Inclusive numeric bounds for each of the five fields (v1: numeric only). */
+const FIELD_BOUNDS: ReadonlyArray<{ min: number; max: number; name: string }> = [
+  { min: 0, max: 59, name: "minute" },
+  { min: 0, max: 23, name: "hour" },
+  { min: 1, max: 31, name: "day-of-month" },
+  { min: 1, max: 12, name: "month" },
+  { min: 0, max: 6, name: "day-of-week" },
+];
+
+/** Thrown by `parseCron` on a malformed expression — callers map it to a 400. */
+export class CronParseError extends Error {}
+
+/**
+ * Parse ONE field token (between the spaces) into the set of allowed integers in
+ * `[min, max]`. Supports `*`, `*​/n`, `a`, `a-b`, `a-b/n`, and comma lists of any
+ * of those. Throws `CronParseError` on anything out of range or malformed.
+ */
+function parseField(token: string, min: number, max: number, fieldName: string): { set: Set<number>; star: boolean } {
+  const trimmed = token.trim();
+  if (trimmed.length === 0) {
+    throw new CronParseError(`cron ${fieldName}: empty field`);
+  }
+  const set = new Set<number>();
+  // A field is `*` only if EVERY comma-element is `*` / `*​/n` over the full range.
+  // We track whether the literal token was a bare `*` (no list, no step) for the
+  // dom/dow union rule — a stepped `*​/2` is a restriction, not "unrestricted".
+  const star = trimmed === "*";
+
+  for (const part of trimmed.split(",")) {
+    const elem = part.trim();
+    if (elem.length === 0) {
+      throw new CronParseError(`cron ${fieldName}: empty list element in "${token}"`);
+    }
+
+    // Split off an optional step (`/n`).
+    let rangePart = elem;
+    let step = 1;
+    const slash = elem.indexOf("/");
+    if (slash >= 0) {
+      rangePart = elem.slice(0, slash);
+      const stepStr = elem.slice(slash + 1);
+      if (!/^\d+$/.test(stepStr)) {
+        throw new CronParseError(`cron ${fieldName}: bad step "/${stepStr}" in "${token}"`);
+      }
+      step = parseInt(stepStr, 10);
+      if (step <= 0) {
+        throw new CronParseError(`cron ${fieldName}: step must be >= 1 in "${token}"`);
+      }
+    }
+
+    // Resolve the range the step applies over.
+    let lo: number;
+    let hi: number;
+    if (rangePart === "*") {
+      lo = min;
+      hi = max;
+    } else if (rangePart.includes("-")) {
+      const [aStr, bStr, ...rest] = rangePart.split("-");
+      if (rest.length > 0 || aStr === undefined || bStr === undefined) {
+        throw new CronParseError(`cron ${fieldName}: bad range "${rangePart}" in "${token}"`);
+      }
+      if (!/^\d+$/.test(aStr) || !/^\d+$/.test(bStr)) {
+        throw new CronParseError(`cron ${fieldName}: non-numeric range "${rangePart}" in "${token}"`);
+      }
+      lo = parseInt(aStr, 10);
+      hi = parseInt(bStr, 10);
+      if (lo > hi) {
+        throw new CronParseError(`cron ${fieldName}: descending range "${rangePart}" in "${token}"`);
+      }
+    } else {
+      // A single number, optionally with a step (`5/2` means 5,7,9,… to max — the
+      // step extends a bare number to the field max, matching common cron impls).
+      if (!/^\d+$/.test(rangePart)) {
+        throw new CronParseError(`cron ${fieldName}: non-numeric value "${rangePart}" in "${token}"`);
+      }
+      lo = parseInt(rangePart, 10);
+      hi = slash >= 0 ? max : lo;
+    }
+
+    if (lo < min || hi > max) {
+      throw new CronParseError(
+        `cron ${fieldName}: value out of range (${lo}-${hi}); allowed ${min}-${max}`,
+      );
+    }
+    for (let v = lo; v <= hi; v += step) set.add(v);
+  }
+
+  if (set.size === 0) {
+    throw new CronParseError(`cron ${fieldName}: no values matched in "${token}"`);
+  }
+  return { set, star };
+}
+
+/**
+ * Parse a 5-field cron expression into a {@link ParsedCron}. Throws
+ * `CronParseError` (message names the offending field) on anything malformed.
+ * Whitespace between fields is any run of spaces/tabs.
+ */
+export function parseCron(expr: string): ParsedCron {
+  if (typeof expr !== "string") {
+    throw new CronParseError("cron expression must be a string");
+  }
+  const fields = expr.trim().split(/\s+/);
+  if (fields.length !== 5) {
+    throw new CronParseError(
+      `cron expression must have exactly 5 fields (min hour dom mon dow); got ${fields.length}: "${expr}"`,
+    );
+  }
+  const minute = parseField(fields[0]!, FIELD_BOUNDS[0]!.min, FIELD_BOUNDS[0]!.max, "minute");
+  const hour = parseField(fields[1]!, FIELD_BOUNDS[1]!.min, FIELD_BOUNDS[1]!.max, "hour");
+  const dom = parseField(fields[2]!, FIELD_BOUNDS[2]!.min, FIELD_BOUNDS[2]!.max, "day-of-month");
+  const month = parseField(fields[3]!, FIELD_BOUNDS[3]!.min, FIELD_BOUNDS[3]!.max, "month");
+  const dow = parseField(fields[4]!, FIELD_BOUNDS[4]!.min, FIELD_BOUNDS[4]!.max, "day-of-week");
+  return {
+    minute: minute.set,
+    hour: hour.set,
+    dom: dom.set,
+    month: month.set,
+    dow: dow.set,
+    domStar: dom.star,
+    dowStar: dow.star,
+  };
+}
+
+/** The wall-clock fields of an instant projected into a given IANA timezone. */
+interface WallClock {
+  minute: number;
+  hour: number;
+  /** day-of-month (1-31). */
+  dom: number;
+  /** month (1-12). */
+  month: number;
+  /** day-of-week (0-6, Sun=0). */
+  dow: number;
+}
+
+const WEEKDAY_INDEX: Record<string, number> = {
+  Sun: 0,
+  Mon: 1,
+  Tue: 2,
+  Wed: 3,
+  Thu: 4,
+  Fri: 5,
+  Sat: 6,
+};
+
+/**
+ * Project a real instant (`Date`) into its wall-clock fields IN `tz` via
+ * `Intl.DateTimeFormat`. Throws if `tz` is not a valid IANA zone (the formatter
+ * throws a RangeError — we let it propagate so `nextRunAfter`'s caller surfaces
+ * "bad timezone" rather than silently using UTC).
+ */
+function wallClockInTz(date: Date, tz: string): WallClock {
+  // `en-US` with explicit numeric parts + `weekday: short` gives stable,
+  // locale-independent token shapes we can parse back to integers.
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    hour12: false,
+    weekday: "short",
+    year: "numeric",
+    month: "numeric",
+    day: "numeric",
+    hour: "numeric",
+    minute: "numeric",
+  }).formatToParts(date);
+
+  const get = (type: string): string => {
+    const p = parts.find((x) => x.type === type);
+    return p ? p.value : "";
+  };
+
+  // `hour12: false` can emit "24" for midnight in some ICU versions; normalize.
+  let hour = parseInt(get("hour"), 10);
+  if (hour === 24) hour = 0;
+
+  return {
+    minute: parseInt(get("minute"), 10),
+    hour,
+    dom: parseInt(get("day"), 10),
+    month: parseInt(get("month"), 10),
+    dow: WEEKDAY_INDEX[get("weekday")] ?? 0,
+  };
+}
+
+/** Does a wall clock satisfy the parsed cron? (applies the dom/dow union rule). */
+function matches(parsed: ParsedCron, wc: WallClock): boolean {
+  if (!parsed.minute.has(wc.minute)) return false;
+  if (!parsed.hour.has(wc.hour)) return false;
+  if (!parsed.month.has(wc.month)) return false;
+
+  // Standard cron dom/dow rule: if BOTH are restricted, match on EITHER (union).
+  // If only one is restricted, only that one constrains. If both are `*`, both
+  // pass trivially.
+  const domOk = parsed.dom.has(wc.dom);
+  const dowOk = parsed.dow.has(wc.dow);
+  if (!parsed.domStar && !parsed.dowStar) {
+    return domOk || dowOk;
+  }
+  if (!parsed.domStar) return domOk;
+  if (!parsed.dowStar) return dowOk;
+  return true; // both `*`
+}
+
+/** Does ONLY the date part (month + dom/dow union) match? Used for coarse day-skip. */
+function dateMatches(parsed: ParsedCron, wc: WallClock): boolean {
+  if (!parsed.month.has(wc.month)) return false;
+  const domOk = parsed.dom.has(wc.dom);
+  const dowOk = parsed.dow.has(wc.dow);
+  if (!parsed.domStar && !parsed.dowStar) return domOk || dowOk;
+  if (!parsed.domStar) return domOk;
+  if (!parsed.dowStar) return dowOk;
+  return true;
+}
+
+/**
+ * The hard cap for the forward search, expressed in DAYS. A sparse spec like
+ * "Feb 29" can legitimately be up to ~4 years out; cap at 5 years so it resolves
+ * while a truly never-matching spec (impossible with numeric-only fields, but
+ * cheap insurance) returns null instead of looping. Day-coarse skipping keeps the
+ * search O(days-until-match) + O(minutes-within-the-day), not O(total minutes).
+ */
+const MAX_LOOKAHEAD_DAYS = 5 * 366;
+
+/**
+ * Return the next instant STRICTLY AFTER `from` whose wall-clock-in-`tz` matches
+ * `expr`, or `null` if no match within ~5 years (effectively a never-firing spec).
+ *
+ * STRICTLY AFTER is load-bearing: the runner persists `nextRunAt` and re-derives
+ * forward from a fired instant, so returning `from` itself would double-fire on
+ * the same minute. We advance to the start of the NEXT minute first, then search
+ * forward at cron's one-minute resolution.
+ *
+ * Search strategy (so a sparse spec like Feb 29 doesn't take a million minute
+ * steps): a single FORWARD-ONLY minute cursor with a DAY-SKIP fast path. On each
+ * step we read the cursor's wall clock; if the cursor's wall DATE (month + dom/dow
+ * union) can't match, we skip the cursor forward to the next wall-midnight in one
+ * jump instead of crawling minute-by-minute through the dead day. On a date that
+ * DOES qualify, we walk its minutes testing the full predicate. So the cost is
+ * O(days-to-match) date-checks + O(minutes-in-the-few-matching-days) minute-checks.
+ *
+ * Forward-only is what keeps strictly-after honest: the cursor starts at the first
+ * minute AFTER `from` and never rewinds, so the first match it reaches is the
+ * earliest instant > `from`. (We deliberately do NOT rewind to wall-midnight on
+ * the matching day — that could surface a match earlier than `from`.)
+ *
+ * Timezone + DST: each candidate is a real instant; we read the wall clock the
+ * target tz reports for it. So a spring-forward gap (e.g. 02:00→03:00) has no
+ * matching instant for a 02:30 spec that day — it's simply skipped (the next
+ * day fires). A fall-back repeat (01:30 occurring twice) yields two distinct
+ * matching instants — both fire. v1 documents and accepts this rather than
+ * inventing skip/dedup policy; jobs are coarse ("daily 8am"), and the
+ * fire-once-on-miss catch-up in the runner bounds any practical surprise.
+ *
+ * The day-skip itself is DST-safe: to advance "to the next wall-midnight" we step
+ * the UTC day forward and zero the cursor's UTC clock, then minute-walk the small
+ * residual until the wall clock actually crosses into the next wall-date. Because
+ * the minute walk is the source of truth, no DST-offset arithmetic can desync it.
+ *
+ * `from` defaults to now; `tz` defaults to the daemon's local timezone (resolved
+ * from `Intl.DateTimeFormat().resolvedOptions().timeZone`).
+ */
+export function nextRunAfter(expr: string | ParsedCron, tz?: string, from: Date = new Date()): Date | null {
+  const parsed = typeof expr === "string" ? parseCron(expr) : expr;
+  const zone = tz ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+  // Validate the zone once (and fail loudly) by projecting `from`. An invalid IANA
+  // zone throws RangeError here, which propagates to the caller as a clear error.
+  wallClockInTz(from, zone);
+
+  // Start at the top of the NEXT minute after `from` (strictly-after + minute
+  // resolution: zero the seconds/ms and step one minute past `from`'s minute).
+  const cursor = new Date(from.getTime());
+  cursor.setUTCSeconds(0, 0);
+  cursor.setUTCMinutes(cursor.getUTCMinutes() + 1);
+
+  // Bound the search by DATE-CHECKS (one per distinct wall-day we touch), so a
+  // sparse "Feb 29" still resolves while a never-matching spec terminates. We
+  // count days touched, not minutes, since the day-skip collapses dead days.
+  let daysTouched = 0;
+  let lastSkipKey = "";
+
+  // Cap the total minute steps generously: matching days are few, and each gets a
+  // bounded (~25h) minute scan; a hard ceiling is belt-and-suspenders against an
+  // infinite loop. 5y of days × ~1500 min is the theoretical worst case, but the
+  // day-skip means we never get near it for real specs.
+  const MAX_MINUTE_STEPS = MAX_LOOKAHEAD_DAYS * 24 * 60;
+
+  for (let i = 0; i < MAX_MINUTE_STEPS; i++) {
+    const wc = wallClockInTz(cursor, zone);
+    if (dateMatches(parsed, wc)) {
+      if (matches(parsed, wc)) return new Date(cursor.getTime());
+      // Date qualifies but this minute/hour doesn't — crawl one minute.
+      cursor.setUTCMinutes(cursor.getUTCMinutes() + 1);
+      continue;
+    }
+    // Date does NOT qualify — DAY-SKIP: jump to the next wall-midnight. Each
+    // distinct dead wall-day counts once against the lookahead bound. We advance
+    // the UTC day and zero the UTC clock; the wall clock may not be exactly
+    // midnight (DST/offset), but it lands at the START of a fresh wall-day region
+    // and the loop re-evaluates from there.
+    const skipKey = `${wc.month}-${wc.dom}`;
+    if (skipKey !== lastSkipKey) {
+      lastSkipKey = skipKey;
+      if (++daysTouched > MAX_LOOKAHEAD_DAYS) return null;
+    }
+    cursor.setUTCDate(cursor.getUTCDate() + 1);
+    cursor.setUTCHours(0, 0, 0, 0);
+  }
+  return null;
+}

--- a/src/cron.ts
+++ b/src/cron.ts
@@ -299,10 +299,18 @@ const MAX_LOOKAHEAD_DAYS = 5 * 366;
  * inventing skip/dedup policy; jobs are coarse ("daily 8am"), and the
  * fire-once-on-miss catch-up in the runner bounds any practical surprise.
  *
- * The day-skip itself is DST-safe: to advance "to the next wall-midnight" we step
- * the UTC day forward and zero the cursor's UTC clock, then minute-walk the small
- * residual until the wall clock actually crosses into the next wall-date. Because
- * the minute walk is the source of truth, no DST-offset arithmetic can desync it.
+ * The day-skip advances to the next WALL-midnight (00:00 of the next wall-day IN
+ * `zone`), computed from the wall clock we already read — NOT to UTC-midnight. This
+ * is load-bearing in a negative-offset zone: UTC-midnight there is ~17:00 of the
+ * wall-day, so jumping to it would strand the forward-only cursor in the *evening*
+ * and the crawl could never reach that wall-day's MORNING (a `0 9 * * *` would be
+ * missed; a sparse-dom morning job would never fire). Instead we step the cursor by
+ * the minutes from this wall-instant to the next wall-midnight
+ * (`(23-hour)*60 + (60-minute)`), which lands at/just-before the next wall-day's
+ * 00:00. A DST transition can make the landing 23:00 or 01:00 of the wall-day — the
+ * main loop self-corrects with a few minute steps, and it never lands in the
+ * evening. The minute-walk remains the source of truth, so no offset arithmetic can
+ * desync it. (Each skip advances ≥1 minute, so the search always terminates.)
  *
  * `from` defaults to now; `tz` defaults to the daemon's local timezone (resolved
  * from `Intl.DateTimeFormat().resolvedOptions().timeZone`).
@@ -341,18 +349,32 @@ export function nextRunAfter(expr: string | ParsedCron, tz?: string, from: Date 
       cursor.setUTCMinutes(cursor.getUTCMinutes() + 1);
       continue;
     }
-    // Date does NOT qualify — DAY-SKIP: jump to the next wall-midnight. Each
-    // distinct dead wall-day counts once against the lookahead bound. We advance
-    // the UTC day and zero the UTC clock; the wall clock may not be exactly
-    // midnight (DST/offset), but it lands at the START of a fresh wall-day region
-    // and the loop re-evaluates from there.
+    // Date does NOT qualify — DAY-SKIP: jump to the next WALL-midnight (00:00 of
+    // the next wall-day IN `zone`), computed from the wall clock we already have.
+    // Each distinct dead wall-day counts once against the lookahead bound.
+    //
+    // CRITICAL: we must advance to the next *wall*-midnight, NOT UTC-midnight. In a
+    // negative-offset zone (e.g. America/Los_Angeles, UTC-7/8) UTC-midnight is
+    // ~17:00 of the wall-day — so zeroing the UTC clock would land the cursor in
+    // the *evening* of a wall-day and the forward-only crawl could never reach that
+    // wall-day's MORNING (a `0 9 * * *` would be missed every cycle; a sparse-dom
+    // morning job would exhaust the search → null). Stepping by the minutes from
+    // THIS wall-instant to the next wall-midnight lands the cursor AT/BEFORE the
+    // morning of the next wall-day, so the crawl reaches it.
+    //
+    // `mins` is the minutes remaining in this wall-day plus one (to roll into the
+    // next day's 00:00): (23 - hour)*60 covers the whole hours left, +(60 - minute)
+    // covers the rest of this minute's hour AND the +1 minute to cross midnight.
+    // A DST transition can make the landing 23:00 or 01:00 of the wall-day rather
+    // than exactly 00:00 — harmless: the main loop self-corrects with a few minute
+    // steps, and it never lands at the evening (17:00) the UTC bump produced.
     const skipKey = `${wc.month}-${wc.dom}`;
     if (skipKey !== lastSkipKey) {
       lastSkipKey = skipKey;
       if (++daysTouched > MAX_LOOKAHEAD_DAYS) return null;
     }
-    cursor.setUTCDate(cursor.getUTCDate() + 1);
-    cursor.setUTCHours(0, 0, 0, 0);
+    const mins = (23 - wc.hour) * 60 + (60 - wc.minute);
+    cursor.setUTCMinutes(cursor.getUTCMinutes() + mins);
   }
   return null;
 }

--- a/src/daemon-jobs-api.test.ts
+++ b/src/daemon-jobs-api.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Integration tests for the scheduled-jobs API (`/api/jobs*`) on the REAL daemon
+ * fetch handler (runner, design 2026-06-17). They cover:
+ *
+ *  - auth: all routes require `channel:admin` (no token → 401; channel:read → 403);
+ *  - GET    /api/jobs          → lists `#agent-job` notes across the vault channels;
+ *  - POST   /api/jobs          → 400 on bad cron / unknown / non-vault channel;
+ *                                200 + writes a #agent-job note on success;
+ *  - POST   /api/jobs/:id/run  → fires now (injects an inbound #channel-message note);
+ *  - DELETE /api/jobs/:id      → deletes the job note.
+ *
+ * The vault REST API is stubbed via `globalThis.fetch` (no live vault); the hub
+ * JWT validator is stubbed (sentinel tokens → fixed scopes) so the accept paths
+ * run without a live hub/JWKS. Mirrors daemon-config-api.test.ts's approach.
+ */
+import { describe, test, expect, mock, afterEach } from "bun:test";
+import { HubJwtError, looksLikeJwt } from "@openparachute/scope-guard";
+
+const ADMIN_TOKEN = "test-admin-token";
+const READ_TOKEN = "test-read-token";
+mock.module("./hub-jwt.ts", () => ({
+  CHANNEL_AUDIENCE: "channel",
+  async validateHubJwt(token: string) {
+    const base = { sub: "test", aud: "channel", jti: undefined, clientId: undefined, vaultScope: undefined };
+    if (token === ADMIN_TOKEN) return { ...base, scopes: ["channel:admin"] };
+    if (token === READ_TOKEN) return { ...base, scopes: ["channel:read"] };
+    throw new HubJwtError("issuer", "invalid token");
+  },
+  HubJwtError,
+  looksLikeJwt,
+  resetJwksCache() {},
+  resetRevocationCache() {},
+}));
+
+import { createFetchHandler } from "./daemon.ts";
+import { ClientRegistry } from "./routing.ts";
+import { VaultTransport } from "./transports/vault.ts";
+import type { Channel } from "./registry.ts";
+import type { TransportContext } from "./transport.ts";
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+const adminAuth = { authorization: "Bearer " + ADMIN_TOKEN } as const;
+const readAuth = { authorization: "Bearer " + READ_TOKEN } as const;
+
+/**
+ * A live channels map: one vault channel ("eng") + one telegram-shaped channel
+ * stub ("tg", non-vault) so the non-vault rejection path is exercised. The vault
+ * REST calls are routed through the `vaultFetch` stub the caller installs.
+ */
+function buildServer() {
+  const registry = new ClientRegistry();
+  const channels = new Map<string, Channel>();
+  const eng = new VaultTransport({ vault: "default", vaultUrl: "http://127.0.0.1:1940", token: "vtok" });
+  const ctx: TransportContext = { channel: "eng", emit() {}, emitPermissionVerdict() {} };
+  void eng.start(ctx);
+  channels.set("eng", { name: "eng", transport: eng, entry: { name: "eng", transport: "vault", config: { vault: "default" } } });
+
+  // A minimal non-vault transport stub for the "non-vault channel rejected" case.
+  const tgTransport = {
+    kind: "telegram",
+    async start() {},
+    async stop() {},
+    async reply() { return { sent: [] }; },
+  };
+  channels.set("tg", { name: "tg", transport: tgTransport as unknown as Channel["transport"], entry: { name: "tg", transport: "telegram" } });
+
+  const srv = Bun.serve({ port: 0, hostname: "127.0.0.1", idleTimeout: 0, fetch: createFetchHandler(channels, registry) });
+  return { srv, base: `http://127.0.0.1:${srv.port}`, channels };
+}
+
+/**
+ * Install a fetch stub that intercepts ONLY vault REST calls (port 1940 — the
+ * VaultTransport's `vaultUrl`) and records them + returns canned responses.
+ * Requests to ANY other URL — crucially the test client's own calls to the
+ * loopback test server — pass through to the real fetch, so overriding
+ * `globalThis.fetch` doesn't swallow the request under test.
+ */
+function stubVault(handler: (url: string, init: RequestInit) => Response) {
+  const calls: { url: string; init: RequestInit }[] = [];
+  globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+    const u = String(url);
+    if (u.includes(":1940/")) {
+      calls.push({ url: u, init: init ?? {} });
+      return handler(u, init ?? {});
+    }
+    return realFetch(url as Parameters<typeof fetch>[0], init);
+  }) as typeof fetch;
+  return calls;
+}
+
+describe("/api/jobs — auth", () => {
+  test("no token → 401", async () => {
+    const { srv, base } = buildServer();
+    try {
+      const res = await fetch(`${base}/api/jobs`);
+      expect(res.status).toBe(401);
+    } finally { srv.stop(true); }
+  });
+
+  test("channel:read (insufficient) → 403", async () => {
+    const { srv, base } = buildServer();
+    try {
+      const res = await fetch(`${base}/api/jobs`, { headers: readAuth });
+      expect(res.status).toBe(403);
+    } finally { srv.stop(true); }
+  });
+});
+
+describe("GET /api/jobs — list", () => {
+  test("lists #agent-job notes from the vault", async () => {
+    const { srv, base } = buildServer();
+    stubVault(() =>
+      new Response(
+        JSON.stringify([
+          { id: "Channels/eng/jobs/m", content: "go", metadata: { channel: "eng", cron: "0 9 * * *", enabled: "true", createdAt: "t0" } },
+        ]),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    try {
+      const res = await fetch(`${base}/api/jobs`, { headers: adminAuth });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.jobs).toHaveLength(1);
+      expect(body.jobs[0]).toMatchObject({ id: "Channels/eng/jobs/m", channel: "eng", message: "go" });
+    } finally { srv.stop(true); }
+  });
+});
+
+describe("POST /api/jobs — create + validation", () => {
+  test("bad cron → 400", async () => {
+    const { srv, base } = buildServer();
+    try {
+      const res = await fetch(`${base}/api/jobs`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ id: "x", channel: "eng", message: "m", schedule: { cron: "99 9 * * *" } }),
+      });
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toMatch(/cron/);
+    } finally { srv.stop(true); }
+  });
+
+  test("unknown channel → 400", async () => {
+    const { srv, base } = buildServer();
+    try {
+      const res = await fetch(`${base}/api/jobs`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ id: "x", channel: "ghost", message: "m", schedule: { cron: "0 9 * * *" } }),
+      });
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toMatch(/unknown channel/);
+    } finally { srv.stop(true); }
+  });
+
+  test("non-vault channel → 400", async () => {
+    const { srv, base } = buildServer();
+    try {
+      const res = await fetch(`${base}/api/jobs`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ id: "x", channel: "tg", message: "m", schedule: { cron: "0 9 * * *" } }),
+      });
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toMatch(/not a vault channel/);
+    } finally { srv.stop(true); }
+  });
+
+  test("valid → 200 + writes a #agent-job note", async () => {
+    const { srv, base } = buildServer();
+    const calls = stubVault((url, init) => {
+      // The job POST is to /api/notes; everything else (ensureSchema PUTs) is benign.
+      if (url.endsWith("/api/notes") && init.method === "POST") {
+        return new Response(JSON.stringify({ id: "Channels/eng/jobs/x" }), { status: 201, headers: { "content-type": "application/json" } });
+      }
+      return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
+    });
+    try {
+      const res = await fetch(`${base}/api/jobs`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ id: "x", channel: "eng", message: "  do it  ", schedule: { cron: "0 9 * * *", tz: "UTC" } }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.ok).toBe(true);
+      expect(body.job.id).toBe("x"); // the operator slug stays the id
+      expect(body.job.noteId).toBe("Channels/eng/jobs/x"); // vault note id for addressing
+      const post = calls.find((c) => c.url.endsWith("/api/notes") && c.init.method === "POST")!;
+      const sent = JSON.parse(String(post.init.body));
+      expect(sent.tags).toEqual(["#agent-job"]);
+      expect(sent.content).toBe("do it"); // trimmed
+      expect(sent.metadata.enabled).toBe("true");
+      expect(sent.metadata.jobId).toBe("x");
+    } finally { srv.stop(true); }
+  });
+});
+
+describe("POST /api/jobs/:id/run — fire now", () => {
+  test("injects an inbound #channel-message note + returns ok", async () => {
+    const { srv, base } = buildServer();
+    const calls = stubVault((url, init) => {
+      if (url.includes("/api/notes") && (init.method ?? "GET") === "GET") {
+        // The store's listAll → return the job to find.
+        return new Response(
+          JSON.stringify([{ id: "Channels/eng/jobs/x", content: "do it", metadata: { channel: "eng", cron: "0 9 * * *", enabled: "true", createdAt: "t0" } }]),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      // The inject POST (and any patch).
+      return new Response(JSON.stringify({ id: "inbound-1" }), { status: 201, headers: { "content-type": "application/json" } });
+    });
+    try {
+      // The "id" the route addresses is the vault NOTE id returned by the list.
+      const res = await fetch(`${base}/api/jobs/${encodeURIComponent("Channels/eng/jobs/x")}/run`, { method: "POST", headers: adminAuth });
+      expect(res.status).toBe(200);
+      expect((await res.json()).ok).toBe(true);
+      // The injected note is INBOUND with the existing #channel-message tags.
+      const inject = calls.find((c) => c.url.endsWith("/api/notes") && c.init.method === "POST")!;
+      const sent = JSON.parse(String(inject.init.body));
+      expect(sent.tags).toEqual(["#channel-message", "#channel-message/inbound"]);
+      expect(sent.metadata.sender).toBe("runner:Channels/eng/jobs/x");
+    } finally { srv.stop(true); }
+  });
+
+  test("unknown job id → 404", async () => {
+    const { srv, base } = buildServer();
+    stubVault(() => new Response(JSON.stringify([]), { status: 200, headers: { "content-type": "application/json" } }));
+    try {
+      const res = await fetch(`${base}/api/jobs/nope/run`, { method: "POST", headers: adminAuth });
+      expect(res.status).toBe(404);
+    } finally { srv.stop(true); }
+  });
+});
+
+describe("DELETE /api/jobs/:id", () => {
+  test("deletes the job note", async () => {
+    const { srv, base } = buildServer();
+    const calls = stubVault((url, init) => {
+      if (url.includes("/api/notes") && (init.method ?? "GET") === "GET") {
+        return new Response(
+          JSON.stringify([{ id: "Channels/eng/jobs/x", content: "go", metadata: { channel: "eng", cron: "0 9 * * *", enabled: "true" } }]),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response(null, { status: 204 });
+    });
+    try {
+      const res = await fetch(`${base}/api/jobs/Channels%2Feng%2Fjobs%2Fx`, { method: "DELETE", headers: adminAuth });
+      expect(res.status).toBe(200);
+      expect((await res.json()).removed).toBe(true);
+      expect(calls.some((c) => c.init.method === "DELETE")).toBe(true);
+    } finally { srv.stop(true); }
+  });
+
+  test("deleting an absent job is idempotent (removed:false)", async () => {
+    const { srv, base } = buildServer();
+    stubVault(() => new Response(JSON.stringify([]), { status: 200, headers: { "content-type": "application/json" } }));
+    try {
+      const res = await fetch(`${base}/api/jobs/gone`, { method: "DELETE", headers: adminAuth });
+      expect(res.status).toBe(200);
+      expect((await res.json()).removed).toBe(false);
+    } finally { srv.stop(true); }
+  });
+});

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -52,6 +52,9 @@ import {
   type ChannelEntry,
 } from "./registry.ts";
 import { VaultTransport, CHANNEL_VAULT_TRIGGER_TEMPLATE } from "./transports/vault.ts";
+import { VaultJobStore, validateJob, vaultTransportFor, type Job } from "./jobs.ts";
+import { Runner, realTickDriver } from "./runner.ts";
+import { JOBS_UI_HTML } from "./jobs-ui.ts";
 import {
   setDefaultClaudeCredential,
   setChannelClaudeCredential,
@@ -1472,6 +1475,20 @@ export function createFetchHandler(
      * registry pushes to); tests inject one to assert the live-progress fan-out.
      */
     turnEvents?: ClientRegistry;
+    /**
+     * The vault-native scheduled-job store (runner, design 2026-06-17). The
+     * `/api/jobs*` routes read/write through it. `main` passes the boot instance
+     * (shared with the runner); tests inject one (or let it default lazily) to
+     * exercise the routes against a fake-vault transport.
+     */
+    jobStore?: VaultJobStore;
+    /**
+     * The runner — used by `POST /api/jobs/:id/run` (fire now). `main` passes the
+     * boot instance; tests inject a fake. Optional: if absent, the run-now route
+     * fires inline via the job store + the channel's `injectInbound` (so the route
+     * still works in a plain createFetchHandler).
+     */
+    runner?: Runner;
   },
 ): (req: Request, server?: { upgrade: (req: Request, opts: { data: TerminalWsData }) => boolean }) => Promise<Response> {
   // Spawn/list/kill operations behind the web agents surface. Lazily defaulted to
@@ -1500,6 +1517,12 @@ export function createFetchHandler(
   // surprise-replays its whole transcript on connect. The MCP connect hook +
   // the SSE `/events` replay below both run `replayBacklog` against it.
   const deliveryState: DeliveryState = opts?.deliveryState ?? new DeliveryState();
+
+  // The vault-native scheduled-job store (runner, design 2026-06-17). Defaulted to
+  // a fresh store over the live channels so a plain createFetchHandler serves the
+  // /api/jobs routes; `main` shares its boot instance with the runner so the routes
+  // and the scheduler operate on the same vault.
+  const jobStore: VaultJobStore = opts?.jobStore ?? new VaultJobStore(channels);
 
   // Install the MCP connect hook: when an MCP session's GET push stream goes live
   // (mcp-http's handleMcp GET branch → fireConnectReplay — NOT at registration,
@@ -1623,6 +1646,17 @@ export function createFetchHandler(
     // every channel via the spawn form + the running-agents list).
     if (req.method === "GET" && url.pathname === "/agents") {
       return new Response(AGENTS_UI_HTML, {
+        headers: { "content-type": "text/html; charset=utf-8" },
+      });
+    }
+
+    // Schedules / runner page — `/jobs` (design 2026-06-17). The Schedules panel:
+    // list the scheduled jobs (channel · cron · next-run · last-status), add a job
+    // (agent picker → message → cron + presets), enable/disable, delete, "Run now."
+    // Loads OPEN (like /agents): it mints a hub-minted channel:admin token
+    // client-side; the `/api/jobs*` calls it makes are what `requireScope` gates.
+    if (req.method === "GET" && url.pathname === "/jobs") {
+      return new Response(JOBS_UI_HTML, {
         headers: { "content-type": "text/html; charset=utf-8" },
       });
     }
@@ -1821,6 +1855,116 @@ export function createFetchHandler(
         return json({ ok: true, name, removed: false }, 200);
       }
       return json({ ok: true, name, removed: true });
+    }
+
+    // ---------------------------------------------------------------------
+    // Scheduled-jobs API — the runner (design 2026-06-17). A job is "an
+    // automated human": send message M to a vault agent A on cron S. Storage is
+    // VAULT-NATIVE (`#agent-job` notes in the target channel's vault); these
+    // routes read/write through the shared `jobStore`. ALL gated on
+    // `channel:admin` (operator-only, like /api/channels). The runner does the
+    // injecting; these routes just CRUD the durable job notes (+ fire-now).
+    //
+    //   GET    /api/jobs          → list (across the live vault channels)
+    //   POST   /api/jobs          { id, channel, message, schedule, enabled? } → create
+    //   DELETE /api/jobs/:id      → delete the job note
+    //   POST   /api/jobs/:id/run  → fire now (inject the inbound message immediately)
+    //
+    // Externally hub strips `/channel`, so these are `<hub>/channel/api/jobs`.
+    // ---------------------------------------------------------------------
+    if (url.pathname === "/api/jobs" && (req.method === "GET" || req.method === "POST")) {
+      const denied = await requireScope(req, url, SCOPE_ADMIN);
+      if (denied) return denied;
+
+      if (req.method === "GET") {
+        // List across every live vault channel. A vault read failure surfaces as a
+        // 502 (not a silently-empty list that looks like "no jobs").
+        try {
+          const jobs = await jobStore.listAll();
+          return json({ jobs });
+        } catch (err) {
+          return json({ error: `failed to list jobs: ${(err as Error).message}` }, 502);
+        }
+      }
+
+      // POST — create/replace a job.
+      let body: { id?: unknown; channel?: unknown; message?: unknown; schedule?: unknown; enabled?: unknown };
+      try {
+        body = (await req.json()) as typeof body;
+      } catch {
+        return json({ error: "invalid JSON body" }, 400);
+      }
+      // Validate against the LIVE channels: known + vault-backed + parseable cron.
+      const validation = validateJob(body, (name) => {
+        if (!channels.has(name)) return null;
+        return channels.get(name)!.transport instanceof VaultTransport;
+      });
+      if (!validation.ok) return json({ error: validation.error }, 400);
+
+      const job: Job = {
+        id: body.id as string,
+        channel: body.channel as string,
+        message: (body.message as string).trim(),
+        schedule: body.schedule as Job["schedule"],
+        enabled: body.enabled === undefined ? true : Boolean(body.enabled),
+        createdAt: new Date().toISOString(),
+      };
+      try {
+        const saved = await jobStore.upsert(job);
+        return json({ ok: true, job: saved });
+      } catch (err) {
+        return json({ error: `failed to write job: ${(err as Error).message}` }, 502);
+      }
+    }
+
+    // POST /api/jobs/:id/run — fire now (inject the message immediately).
+    {
+      const runMatch = url.pathname.match(/^\/api\/jobs\/([^/]+)\/run$/);
+      if (runMatch && req.method === "POST") {
+        const denied = await requireScope(req, url, SCOPE_ADMIN);
+        if (denied) return denied;
+        const id = decodeURIComponent(runMatch[1]!);
+        try {
+          // Prefer the shared runner (records bookkeeping consistently with a
+          // scheduled fire). Fall back to an inline fire via the job store + the
+          // channel's injectInbound when no runner is wired (plain handler/tests).
+          if (opts?.runner) {
+            const status = await opts.runner.runNow(id);
+            return json({ ok: true, id, status });
+          }
+          const jobs = await jobStore.listAll();
+          const job = jobs.find((j) => j.id === id);
+          if (!job) return json({ error: `unknown job "${id}"` }, 404);
+          const transport = vaultTransportFor(channels, job.channel);
+          if (!transport) {
+            return json({ error: `job "${id}" targets a non-vault channel "${job.channel}"` }, 400);
+          }
+          await transport.injectInbound({ content: job.message, sender: `runner:${job.id}` });
+          return json({ ok: true, id, status: "ok" });
+        } catch (err) {
+          return json({ error: `failed to run job: ${(err as Error).message}` }, 502);
+        }
+      }
+    }
+
+    // DELETE /api/jobs/:id — remove the job note. We must resolve which channel's
+    // vault holds it; list once to find the job's channel, then delete there.
+    {
+      const jobDelMatch = url.pathname.match(/^\/api\/jobs\/([^/]+)$/);
+      if (jobDelMatch && req.method === "DELETE") {
+        const denied = await requireScope(req, url, SCOPE_ADMIN);
+        if (denied) return denied;
+        const id = decodeURIComponent(jobDelMatch[1]!);
+        try {
+          const jobs = await jobStore.listAll();
+          const job = jobs.find((j) => j.id === id);
+          if (!job || !job.noteId) return json({ ok: true, id, removed: false }, 200);
+          await jobStore.remove(job.noteId, job.channel);
+          return json({ ok: true, id, removed: true });
+        } catch (err) {
+          return json({ error: `failed to delete job: ${(err as Error).message}` }, 502);
+        }
+      }
     }
 
     // ---------------------------------------------------------------------
@@ -2787,7 +2931,40 @@ function main(): void {
   // upgrades into these via `server.upgrade(req, { data })`.
   const terminalWs = createTerminalWsHandlers();
 
-  const fetchHandler = createFetchHandler(channels, registry, { deliveryState, programmatic, turnEvents });
+  // The vault-native scheduled-job store + the runner (design 2026-06-17). The
+  // store reads/writes `#agent-job` notes in each vault channel's vault; the
+  // runner ticks every 30s, loading jobs from the store, firing due ones by
+  // injecting an inbound note onto the job's vault channel (the existing trigger →
+  // agent-turn → outbound flow does the rest). Shared with the fetch handler so
+  // the /api/jobs routes + the scheduler operate on the SAME store, and "Run now"
+  // goes through the runner's bookkeeping path.
+  const jobStore = new VaultJobStore(channels);
+  const runner = new Runner({
+    loadJobs: () => jobStore.listAll(),
+    // Fire = inject an inbound note onto the job's vault channel, exactly like a
+    // human typing in chat. Resolve the channel's vault transport at fire time so
+    // a job whose channel was deleted logs + records an error rather than throwing
+    // the tick. No new authority — uses the channel's existing vault write token.
+    fire: async (job) => {
+      const transport = vaultTransportFor(channels, job.channel);
+      if (!transport) {
+        throw new Error(`channel "${job.channel}" is not a live vault channel`);
+      }
+      await transport.injectInbound({ content: job.message, sender: `runner:${job.id}` });
+    },
+    // Persist bookkeeping (lastRunAt/lastStatus) back onto the job note (addressed
+    // by its vault note id). A job loaded from the store always carries `noteId`.
+    persistFire: async (job) => {
+      if (!job.noteId) return; // nothing to address (shouldn't happen for a loaded job).
+      await jobStore.patch(job.noteId, job.channel, {
+        lastRunAt: job.lastRunAt,
+        lastStatus: job.lastStatus,
+      });
+    },
+    driver: realTickDriver(),
+  });
+
+  const fetchHandler = createFetchHandler(channels, registry, { deliveryState, programmatic, turnEvents, jobStore, runner });
   const server = Bun.serve<TerminalWsData, never>({
     port: PORT,
     hostname: "127.0.0.1",
@@ -2888,8 +3065,17 @@ function main(): void {
   // a leaked/orphaned spec dir can't resurrect a phantom agent (channel#75).
   void reregisterProgrammaticAgents(programmatic, channels);
 
-  // Graceful shutdown — stop all transports.
+  // Start the runner's scheduled-job tick (design 2026-06-17). Tolerant of an
+  // empty/missing job set (no `#agent-job` notes → idle) and of a daemon with no
+  // vault channels (listAll queries nothing → idle). A job targeting a now-deleted
+  // channel sets lastStatus:error on fire rather than throwing the tick. The tick
+  // is `unref`'d so it never keeps the process alive on its own.
+  runner.start();
+  console.log(`parachute-channel: runner started (scheduled-job tick)`);
+
+  // Graceful shutdown — stop the runner + all transports.
   async function shutdown(): Promise<void> {
+    runner.stop();
     await Promise.allSettled([...channels.values()].map((c) => c.transport.stop()));
     server.stop();
     process.exit(0);

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -54,6 +54,7 @@ import {
 import { VaultTransport, CHANNEL_VAULT_TRIGGER_TEMPLATE } from "./transports/vault.ts";
 import { VaultJobStore, validateJob, vaultTransportFor, type Job } from "./jobs.ts";
 import { Runner, realTickDriver } from "./runner.ts";
+import { nextRunAfter } from "./cron.ts";
 import { JOBS_UI_HTML } from "./jobs-ui.ts";
 import {
   setDefaultClaudeCredential,
@@ -1881,7 +1882,22 @@ export function createFetchHandler(
         // 502 (not a silently-empty list that looks like "no jobs").
         try {
           const jobs = await jobStore.listAll();
-          return json({ jobs });
+          // `nextRunAt` is computed-in-memory (the stored note never carries it —
+          // see the Job docblock), so the persisted list lacks it and the UI's
+          // "Next run" column would always be "—". Derive it here for ENABLED jobs
+          // (a disabled job isn't scheduled → no next run). Per-job guard: a bad tz
+          // (a RangeError out of nextRunAfter) must not 502 the whole list.
+          const now = new Date();
+          const withNext = jobs.map((j) => {
+            if (!j.enabled) return j;
+            try {
+              const next = nextRunAfter(j.schedule.cron, j.schedule.tz, now);
+              return next ? { ...j, nextRunAt: next.toISOString() } : j;
+            } catch {
+              return j;
+            }
+          });
+          return json({ jobs: withNext });
         } catch (err) {
           return json({ error: `failed to list jobs: ${(err as Error).message}` }, 502);
         }

--- a/src/jobs-ui.test.ts
+++ b/src/jobs-ui.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tests for the Schedules page (src/jobs-ui.ts) — the runner's operator surface.
+ * The page is a self-contained HTML+JS string (same shape as agents-ui.ts), so
+ * these string-pin the served document: the create form, the list, the row
+ * actions, the cron presets, the API wiring, the vault-only picker, the shared
+ * shell, and the no-backtick-in-script-body invariant (so it can't break a host
+ * template literal if ever embedded).
+ */
+import { describe, test, expect } from "bun:test";
+import { JOBS_UI_HTML } from "./jobs-ui.ts";
+
+const html = JOBS_UI_HTML;
+
+describe("Schedules page — create form", () => {
+  test("has the agent picker, id, message, cron, and tz inputs", () => {
+    expect(html).toContain('id="f-channel"');
+    expect(html).toContain('id="f-id"');
+    expect(html).toContain('id="f-message"');
+    expect(html).toContain('id="f-cron"');
+    expect(html).toContain('id="f-tz"');
+    expect(html).toContain('id="create-btn"');
+  });
+
+  test("offers cron presets (daily 8am, hourly, …)", () => {
+    expect(html).toContain("daily 8am");
+    expect(html).toContain("hourly");
+    expect(html).toContain("weekdays 9am");
+    expect(html).toContain('id="cron-presets"');
+  });
+});
+
+describe("Schedules page — list + row actions", () => {
+  test("renders a jobs table container + per-row enable/run/delete", () => {
+    expect(html).toContain('id="jobs-table"');
+    expect(html).toContain("data-toggle");
+    expect(html).toContain("data-run");
+    expect(html).toContain("data-del");
+    expect(html).toContain("run now");
+    expect(html).toContain("delete");
+  });
+
+  test("shows the at-a-glance columns: agent, cron, next run, last status", () => {
+    expect(html).toContain("next run");
+    expect(html).toContain("last status");
+  });
+});
+
+describe("Schedules page — API wiring", () => {
+  test("targets the /api/jobs routes", () => {
+    expect(html).toContain('"/api/jobs"');
+    expect(html).toContain('"/api/jobs/" + encodeURIComponent(id) + "/run"');
+    expect(html).toContain('"/api/jobs/" + encodeURIComponent(id)');
+  });
+
+  test("filters the picker to VAULT channels only (jobs need a vault transport)", () => {
+    expect(html).toContain('c.transport === "vault"');
+    expect(html).toContain("/.parachute/config");
+  });
+
+  test("bootstraps the hub-minted token via the shared shell (fetchToken)", () => {
+    expect(html).toContain("fetchToken()");
+    expect(html).toContain('wireShell("schedules")');
+  });
+});
+
+describe("Schedules page — invariants", () => {
+  test("reuses the shared ui-kit shell (THEME_CSS + appShell nav)", () => {
+    // The shared nav marks the schedules tab active.
+    expect(html).toContain('data-view="schedules"');
+    expect(html).toContain("app-header");
+  });
+
+  test("the inline <script> body contains NO literal backtick (host-literal safe)", () => {
+    // Extract the <script>…</script> block and assert it's backtick-free, so the
+    // page can never break a surrounding template literal. (Backticks in the file
+    // are confined to the JSDoc + the two outer template delimiters.)
+    const start = html.indexOf("<script>");
+    const end = html.indexOf("</script>");
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    const scriptBody = html.slice(start, end);
+    expect(scriptBody.includes("`")).toBe(false); // U+0060 = backtick
+  });
+});

--- a/src/jobs-ui.ts
+++ b/src/jobs-ui.ts
@@ -250,7 +250,7 @@ ${SHELL_JS}
         "<td><code>" + esc(j.id) + "</code></td>" +
         "<td>" + esc(j.channel) + "</td>" +
         "<td><code>" + cron + "</code>" + (tz ? "<br><span class='muted-cell'>" + esc(tz) + "</span>" : "") + "</td>" +
-        "<td>" + fmtTime(j.nextRunAt) + "</td>" +
+        "<td>" + esc(fmtTime(j.nextRunAt)) + "</td>" +
         "<td>" + statusCell(j.lastStatus) + (j.lastRunAt ? "<br><span class='muted-cell'>" + esc(fmtTime(j.lastRunAt)) + "</span>" : "") + "</td>" +
         "<td class='actions'>" +
           "<button class='ghost' data-toggle='" + esc(j.id) + "'>" + (enabled ? "disable" : "enable") + "</button>" +

--- a/src/jobs-ui.ts
+++ b/src/jobs-ui.ts
@@ -1,0 +1,376 @@
+/**
+ * The Schedules page (`/channel/jobs`) — the runner's operator surface (design
+ * `2026-06-17-runner-scheduled-agent-turns.md` §Components.6).
+ *
+ * Why a SIBLING `/jobs` page (not a section on the agents page): the agents page is
+ * already the largest surface in the module and is squarely about *creating /
+ * watching agents*; scheduling is its own concern with its own list + form + state.
+ * A dedicated page keeps each surface single-purpose (matching the existing
+ * home/chat/agents/terminal/config one-page-per-concern idiom), slots cleanly into
+ * the shared nav, and avoids growing agents-ui.ts further. The picker reuses the
+ * SAME vault-channel list (`/.parachute/config`) the agents page reads, so an
+ * operator schedules an agent they already created.
+ *
+ * Idiom (matches agents-ui / admin-ui): the whole page is an HTML string with
+ * browser JS as a template-string `<script>`. It reuses `ui-kit`'s `THEME_CSS` +
+ * `appShell` + `SHELL_JS` (MOUNT derivation, nav wiring, `escapeHtml`,
+ * `setStatus`, `fetchToken`/`authedFetch` — the hub-minted `channel:admin` token
+ * bootstrap). All dynamic text is `esc()`'d before innerHTML. Emitted-JS newlines
+ * are written `\\n` so they survive into the page script.
+ *
+ * The page talks to the `/api/jobs*` routes (all `channel:admin`):
+ *   - GET    /api/jobs          → list
+ *   - POST   /api/jobs          → create
+ *   - DELETE /api/jobs/:id      → delete
+ *   - POST   /api/jobs/:id/run  → run now
+ * Enable/disable is a POST /api/jobs (upsert) with the toggled `enabled`.
+ */
+
+import { THEME_CSS, appShell, SHELL_JS } from "./ui-kit.ts";
+
+export const JOBS_UI_HTML = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="referrer" content="no-referrer" />
+<title>parachute-channel · schedules</title>
+<style>
+${THEME_CSS}
+  .app-header { position: sticky; top: 0; z-index: 5; }
+  body { padding-bottom: 48px; }
+  main { max-width: 940px; margin: 0 auto; padding: 20px; display: grid; gap: 20px; }
+  section {
+    background: var(--card); border: 1px solid var(--border); border-radius: 12px; padding: 16px 18px;
+    box-shadow: 0 1px 2px rgba(44,42,38,0.04), 0 8px 24px rgba(44,42,38,0.06);
+  }
+  section h2 { margin: 0 0 4px; font-size: 1.2rem; }
+  section p.hint { margin: 0 0 14px; color: var(--fg-muted); font-size: 0.85rem; }
+  label { display: block; font-size: 0.78rem; color: var(--fg-muted); margin: 0 0 4px; }
+  .row { display: flex; gap: 10px; align-items: flex-end; flex-wrap: wrap; }
+  .row > .grow { flex: 1 1 160px; }
+  .grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+  textarea, input[type=text], select { width: 100%; box-sizing: border-box; }
+  textarea { resize: vertical; min-height: 60px; }
+  .presets { display: flex; gap: 6px; flex-wrap: wrap; margin: 6px 0 0; }
+  .presets button { font-size: 0.78rem; padding: 3px 9px; }
+  .cron-line { font-family: var(--font-mono); font-size: 0.82rem; color: var(--fg-muted); margin-top: 6px; }
+  .cron-line.bad { color: var(--danger); }
+  button {
+    background: var(--card); color: var(--fg); border: 1px solid var(--border);
+    border-radius: 6px; padding: 8px 14px; font: inherit; cursor: pointer;
+  }
+  button:hover { border-color: var(--fg-dim); }
+  button:disabled { opacity: .4; cursor: default; }
+  button.primary { background: var(--accent); color: #06140f; border-color: var(--accent); font-weight: 600; }
+  button.primary:hover { background: var(--accent-hover); border-color: var(--accent-hover); }
+  button.danger { color: var(--danger); border-color: var(--border); background: transparent; }
+  button.danger:hover { border-color: var(--danger); background: var(--danger-soft); }
+  button.ghost { padding: 4px 9px; font-size: 12px; background: transparent; border-color: transparent; color: var(--fg-muted); }
+  button.ghost:hover { background: var(--bg-soft); color: var(--fg); }
+  table { width: 100%; border-collapse: collapse; font-size: 0.85rem; }
+  th, td { text-align: left; padding: 8px 10px; border-bottom: 1px solid var(--border); vertical-align: middle; }
+  th { color: var(--fg-muted); font-weight: 500; font-size: 0.78rem; }
+  td.actions { text-align: right; white-space: nowrap; }
+  td.actions button { margin-left: 6px; }
+  code { font-family: var(--font-mono); color: var(--fg); background: var(--bg-soft); padding: 1px 5px; border-radius: 4px; font-size: 0.8rem; }
+  .empty { color: var(--fg-muted); font-size: 0.85rem; padding: 8px 2px; }
+  .msg { margin-top: 12px; padding: 10px 12px; border-radius: 8px; font-size: 0.85rem; display: none; white-space: pre-wrap; border: 1px solid transparent; }
+  .msg.ok { display: block; background: var(--success-soft); color: var(--success); border-color: var(--success); }
+  .msg.err { display: block; background: var(--danger-soft); color: var(--danger); border-color: var(--danger); }
+  .laststatus.ok { color: var(--success); }
+  .laststatus.err { color: var(--danger); }
+  .muted-cell { color: var(--fg-dim); }
+</style>
+</head>
+<body>
+  ${appShell({ active: "schedules", tag: "schedules" })}
+
+  <main>
+    <!-- Create a schedule -->
+    <section id="create-section">
+      <h2>Schedule an agent</h2>
+      <p class="hint">A scheduled job is an automated human: send a message to an agent on a cron schedule. The runner writes the message as an inbound note; the agent runs its turn as if you typed it. Jobs target <strong>vault-backed agents</strong> only.</p>
+
+      <div class="grid2">
+        <div>
+          <label for="f-channel">Agent (vault channel)</label>
+          <select id="f-channel"></select>
+        </div>
+        <div>
+          <label for="f-id">Job id (slug)</label>
+          <input id="f-id" type="text" placeholder="morning-standup" />
+        </div>
+      </div>
+
+      <div class="field-row" style="margin-top:12px;">
+        <label for="f-message">Message to send</label>
+        <textarea id="f-message" placeholder="Run the morning weave…"></textarea>
+      </div>
+
+      <div class="grid2" style="margin-top:12px;">
+        <div>
+          <label for="f-cron">Cron (min hour dom mon dow)</label>
+          <input id="f-cron" type="text" placeholder="0 8 * * *" />
+          <div class="presets" id="cron-presets"></div>
+          <div class="cron-line" id="cron-preview"></div>
+        </div>
+        <div>
+          <label for="f-tz">Timezone (IANA, optional)</label>
+          <input id="f-tz" type="text" placeholder="America/Los_Angeles" />
+          <div class="cron-line" id="tz-default"></div>
+        </div>
+      </div>
+
+      <div class="row" style="margin-top:14px;">
+        <button id="create-btn" class="primary" type="button">Create schedule</button>
+      </div>
+      <div id="create-msg" class="msg"></div>
+    </section>
+
+    <!-- Existing schedules -->
+    <section>
+      <h2>Schedules</h2>
+      <p class="hint">Enable/disable, run now, or delete. <em>Next run</em> is computed from the cron + timezone.</p>
+      <div id="jobs-table"></div>
+      <div id="list-msg" class="msg"></div>
+    </section>
+  </main>
+
+<script>
+${SHELL_JS}
+(function () {
+  // MOUNT, setStatus, escapeHtml, fetchToken (caches on window.__token),
+  // authedFetch all come from SHELL_JS. Wire the shared nav for this view.
+  wireShell("schedules");
+  var esc = escapeHtml;
+  var vaultChannels = [];
+
+  // The default IANA timezone the daemon would use when a job omits tz — shown so
+  // the operator knows what "no tz" resolves to. Computed from the BROWSER here as
+  // a hint; the daemon evaluates against ITS local tz, but for an owner-operated
+  // single box they're the same. Labeled as a hint, not a guarantee.
+  var BROWSER_TZ = (function () {
+    try { return Intl.DateTimeFormat().resolvedOptions().timeZone; } catch (e) { return "UTC"; }
+  })();
+
+  var PRESETS = [
+    { label: "daily 8am", cron: "0 8 * * *" },
+    { label: "hourly", cron: "0 * * * *" },
+    { label: "every 15m", cron: "*/15 * * * *" },
+    { label: "weekdays 9am", cron: "0 9 * * 1-5" },
+    { label: "weekly Mon 8am", cron: "0 8 * * 1" }
+  ];
+
+  function showMsg(el, text, isErr) {
+    el.textContent = text; // textContent, not innerHTML — result strings aren't HTML.
+    el.className = "msg " + (isErr ? "err" : "ok");
+  }
+  function clearMsg(el) { el.textContent = ""; el.className = "msg"; }
+
+  // --- token + API (channel:admin Bearer; one 401 retry) ------------------
+  function api(path, opts, _retried) {
+    opts = opts || {};
+    var headers = Object.assign({}, opts.headers || {});
+    if (window.__token) headers["authorization"] = "Bearer " + window.__token;
+    if (opts.body && !headers["content-type"]) headers["content-type"] = "application/json";
+    return fetch(MOUNT + path, Object.assign({}, opts, { headers: headers })).then(function (r) {
+      if (r.status === 401 && !_retried) {
+        return fetchToken().then(function () { return api(path, opts, true); });
+      }
+      return r;
+    });
+  }
+  function apiJson(path, opts) {
+    return api(path, opts).then(function (r) {
+      return r.json().catch(function () { return {}; }).then(function (j) {
+        if (!r.ok) { var e = new Error((j && (j.message || j.error)) || ("HTTP " + r.status)); e.status = r.status; throw e; }
+        return j;
+      });
+    });
+  }
+
+  // --- vault-channel picker (from the OPEN /.parachute/config) -------------
+  function loadChannels() {
+    return fetch(MOUNT + "/.parachute/config").then(function (r) { return r.json(); }).then(function (cfg) {
+      vaultChannels = (cfg.channels || [])
+        .filter(function (c) { return c.transport === "vault"; })
+        .map(function (c) { return c.name; });
+      var sel = document.getElementById("f-channel");
+      if (!vaultChannels.length) {
+        sel.innerHTML = "<option value=''>(no vault agents — create one on the Agents page)</option>";
+        document.getElementById("create-btn").disabled = true;
+      } else {
+        sel.innerHTML = vaultChannels.map(function (c) {
+          return "<option value='" + esc(c) + "'>" + esc(c) + "</option>";
+        }).join("");
+        document.getElementById("create-btn").disabled = false;
+      }
+    }).catch(function () {
+      document.getElementById("f-channel").innerHTML = "<option value=''>(couldn't load agents)</option>";
+    });
+  }
+
+  // --- cron preview (a light client-side parse for feedback; the SERVER is the
+  //     source of truth — it 400s a bad cron on create) ---------------------
+  function describeCron(expr) {
+    var parts = String(expr || "").trim().split(/\\s+/);
+    if (parts.length !== 5) return { ok: false, text: "cron needs 5 fields: min hour dom mon dow" };
+    return { ok: true, text: "min=" + parts[0] + " hour=" + parts[1] + " dom=" + parts[2] + " mon=" + parts[3] + " dow=" + parts[4] };
+  }
+  function refreshCronPreview() {
+    var el = document.getElementById("cron-preview");
+    var d = describeCron(document.getElementById("f-cron").value);
+    el.textContent = d.text;
+    el.className = "cron-line" + (d.ok ? "" : " bad");
+  }
+
+  // --- list ---------------------------------------------------------------
+  function fmtTime(iso) {
+    if (!iso) return "—";
+    try { return new Date(iso).toLocaleString(); } catch (e) { return iso; }
+  }
+  function statusCell(s) {
+    if (!s) return "<span class='muted-cell'>—</span>";
+    var isErr = s.indexOf("error") === 0;
+    return "<span class='laststatus " + (isErr ? "err" : "ok") + "'>" + esc(s) + "</span>";
+  }
+
+  function renderJobs(jobs) {
+    var t = document.getElementById("jobs-table");
+    if (!jobs || !jobs.length) {
+      t.innerHTML = "<div class='empty'>No schedules yet. Create one above.</div>";
+      return;
+    }
+    var rows = jobs.map(function (j) {
+      var cron = esc(j.schedule && j.schedule.cron ? j.schedule.cron : "");
+      var tz = j.schedule && j.schedule.tz ? j.schedule.tz : "";
+      var enabled = j.enabled !== false;
+      return "<tr>" +
+        "<td><code>" + esc(j.id) + "</code></td>" +
+        "<td>" + esc(j.channel) + "</td>" +
+        "<td><code>" + cron + "</code>" + (tz ? "<br><span class='muted-cell'>" + esc(tz) + "</span>" : "") + "</td>" +
+        "<td>" + fmtTime(j.nextRunAt) + "</td>" +
+        "<td>" + statusCell(j.lastStatus) + (j.lastRunAt ? "<br><span class='muted-cell'>" + esc(fmtTime(j.lastRunAt)) + "</span>" : "") + "</td>" +
+        "<td class='actions'>" +
+          "<button class='ghost' data-toggle='" + esc(j.id) + "'>" + (enabled ? "disable" : "enable") + "</button>" +
+          "<button class='ghost' data-run='" + esc(j.id) + "'>run now</button>" +
+          "<button class='ghost danger' data-del='" + esc(j.id) + "'>delete</button>" +
+        "</td>" +
+      "</tr>";
+    }).join("");
+    t.innerHTML = "<table><thead><tr>" +
+      "<th>id</th><th>agent</th><th>cron</th><th>next run</th><th>last status</th><th></th>" +
+      "</tr></thead><tbody>" + rows + "</tbody></table>";
+
+    // Wire row actions. We keep a copy of the loaded jobs keyed by id for toggle.
+    var byId = {};
+    jobs.forEach(function (j) { byId[j.id] = j; });
+    t.querySelectorAll("[data-run]").forEach(function (b) {
+      b.addEventListener("click", function () { runNow(b.getAttribute("data-run")); });
+    });
+    t.querySelectorAll("[data-del]").forEach(function (b) {
+      b.addEventListener("click", function () { delJob(b.getAttribute("data-del")); });
+    });
+    t.querySelectorAll("[data-toggle]").forEach(function (b) {
+      b.addEventListener("click", function () { toggleJob(byId[b.getAttribute("data-toggle")]); });
+    });
+  }
+
+  function loadJobs() {
+    clearMsg(document.getElementById("list-msg"));
+    return apiJson("/api/jobs").then(function (j) {
+      renderJobs(j.jobs || []);
+      setStatus("ready", "live");
+    }).catch(function (err) {
+      document.getElementById("jobs-table").innerHTML = "";
+      showMsg(document.getElementById("list-msg"), "Couldn't load schedules: " + err.message, true);
+      setStatus("error", "err");
+    });
+  }
+
+  // --- create / toggle / run / delete -------------------------------------
+  function createJob() {
+    var msg = document.getElementById("create-msg");
+    clearMsg(msg);
+    var channel = document.getElementById("f-channel").value;
+    var id = document.getElementById("f-id").value.trim();
+    var message = document.getElementById("f-message").value;
+    var cron = document.getElementById("f-cron").value.trim();
+    var tz = document.getElementById("f-tz").value.trim();
+    if (!channel) { showMsg(msg, "Pick a vault agent first.", true); return; }
+    var schedule = { cron: cron };
+    if (tz) schedule.tz = tz;
+    var body = { id: id, channel: channel, message: message, schedule: schedule, enabled: true };
+    var btn = document.getElementById("create-btn");
+    btn.disabled = true;
+    apiJson("/api/jobs", { method: "POST", body: JSON.stringify(body) }).then(function () {
+      showMsg(msg, "Scheduled.", false);
+      document.getElementById("f-id").value = "";
+      document.getElementById("f-message").value = "";
+      return loadJobs();
+    }).catch(function (err) {
+      showMsg(msg, err.message, true);
+    }).then(function () { btn.disabled = false; });
+  }
+
+  function toggleJob(job) {
+    if (!job) return;
+    var body = {
+      id: job.id, channel: job.channel, message: job.message,
+      schedule: job.schedule, enabled: !(job.enabled !== false)
+    };
+    apiJson("/api/jobs", { method: "POST", body: JSON.stringify(body) })
+      .then(loadJobs)
+      .catch(function (err) { showMsg(document.getElementById("list-msg"), err.message, true); });
+  }
+
+  function runNow(id) {
+    showMsg(document.getElementById("list-msg"), "Running " + id + "…", false);
+    apiJson("/api/jobs/" + encodeURIComponent(id) + "/run", { method: "POST" }).then(function (r) {
+      showMsg(document.getElementById("list-msg"), "Ran " + id + " (" + (r.status || "ok") + ").", false);
+      return loadJobs();
+    }).catch(function (err) {
+      showMsg(document.getElementById("list-msg"), "Run failed: " + err.message, true);
+    });
+  }
+
+  function delJob(id) {
+    if (!window.confirm("Delete schedule '" + id + "'?")) return;
+    apiJson("/api/jobs/" + encodeURIComponent(id), { method: "DELETE" })
+      .then(loadJobs)
+      .catch(function (err) { showMsg(document.getElementById("list-msg"), err.message, true); });
+  }
+
+  // --- wire static UI -----------------------------------------------------
+  function renderPresets() {
+    var c = document.getElementById("cron-presets");
+    c.innerHTML = PRESETS.map(function (p, i) {
+      return "<button type='button' data-preset='" + i + "'>" + esc(p.label) + "</button>";
+    }).join("");
+    c.querySelectorAll("[data-preset]").forEach(function (b) {
+      b.addEventListener("click", function () {
+        document.getElementById("f-cron").value = PRESETS[+b.getAttribute("data-preset")].cron;
+        refreshCronPreview();
+      });
+    });
+  }
+
+  document.getElementById("create-btn").addEventListener("click", createJob);
+  document.getElementById("f-cron").addEventListener("input", refreshCronPreview);
+  document.getElementById("tz-default").textContent = "no tz → daemon local (" + BROWSER_TZ + ")";
+  renderPresets();
+  refreshCronPreview();
+
+  // Boot: mint the channel:admin token, then load the picker + the list. A failed
+  // token mint still lets the page render (it shows the load error in-place).
+  fetchToken().then(function () {
+    return Promise.all([loadChannels(), loadJobs()]);
+  }).catch(function () {
+    loadChannels();
+    showMsg(document.getElementById("list-msg"), "Not signed in to the hub — open this from the portal.", true);
+  });
+})();
+</script>
+</body>
+</html>`;

--- a/src/jobs.test.ts
+++ b/src/jobs.test.ts
@@ -1,0 +1,209 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import { validateJob, VaultJobStore, vaultTransportFor, type Job } from "./jobs.ts";
+import { VaultTransport } from "./transports/vault.ts";
+import type { Channel } from "./registry.ts";
+import { TelegramTransport } from "./transports/telegram.ts";
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+function makeJob(over: Partial<Job> = {}): Job {
+  return {
+    id: "morning",
+    channel: "uni-dev",
+    message: "Run the morning weave",
+    schedule: { cron: "53 7 * * *", tz: "America/Los_Angeles" },
+    enabled: true,
+    createdAt: "2026-06-17T00:00:00.000Z",
+    ...over,
+  };
+}
+
+describe("validateJob (pure)", () => {
+  const isVault = (name: string): boolean | null => {
+    if (name === "uni-dev") return true;
+    if (name === "tele") return false;
+    return null;
+  };
+
+  test("a well-formed vault job validates", () => {
+    expect(validateJob(makeJob(), isVault)).toEqual({ ok: true });
+  });
+  test("bad id (not a slug) rejected", () => {
+    const r = validateJob(makeJob({ id: "has spaces" }), isVault);
+    expect(r).toMatchObject({ ok: false });
+    expect((r as { error: string }).error).toMatch(/slug/);
+  });
+  test("empty message rejected", () => {
+    const r = validateJob(makeJob({ message: "   " }), isVault);
+    expect((r as { error: string }).error).toMatch(/message/);
+  });
+  test("bad cron rejected with a field-naming message", () => {
+    const r = validateJob(makeJob({ schedule: { cron: "99 7 * * *" } }), isVault);
+    expect((r as { error: string }).error).toMatch(/invalid schedule.cron/);
+  });
+  test("missing schedule.cron rejected", () => {
+    const r = validateJob({ id: "x", channel: "uni-dev", message: "m" }, isVault);
+    expect((r as { error: string }).error).toMatch(/schedule.cron/);
+  });
+  test("bad tz rejected", () => {
+    const r = validateJob(makeJob({ schedule: { cron: "0 0 * * *", tz: "Mars/Olympus" } }), isVault);
+    expect((r as { error: string }).error).toMatch(/timezone/);
+  });
+  test("unknown channel rejected", () => {
+    const r = validateJob(makeJob({ channel: "ghost" }), isVault);
+    expect((r as { error: string }).error).toMatch(/unknown channel/);
+  });
+  test("non-vault channel rejected (the inject path needs a vault transport)", () => {
+    const r = validateJob(makeJob({ channel: "tele" }), isVault);
+    expect((r as { error: string }).error).toMatch(/not a vault channel/);
+  });
+});
+
+/** Build a live channels map with one vault channel + (optionally) a telegram one. */
+function channelsWithVault(): { channels: Map<string, Channel>; vault: VaultTransport } {
+  const vault = new VaultTransport({
+    vault: "default",
+    vaultUrl: "http://127.0.0.1:1940",
+    token: "write-token",
+  });
+  const channels = new Map<string, Channel>();
+  channels.set("uni-dev", {
+    name: "uni-dev",
+    transport: vault,
+    entry: { name: "uni-dev", transport: "vault", config: { vault: "default", token: "write-token" } },
+  });
+  const tele = new TelegramTransport({ token: "tg", name: "tele" });
+  channels.set("tele", {
+    name: "tele",
+    transport: tele,
+    entry: { name: "tele", transport: "telegram", config: { token: "tg" } },
+  });
+  return { channels, vault };
+}
+
+describe("vaultTransportFor", () => {
+  test("resolves a vault channel to its transport; null for non-vault / unknown", () => {
+    const { channels, vault } = channelsWithVault();
+    expect(vaultTransportFor(channels, "uni-dev")).toBe(vault);
+    expect(vaultTransportFor(channels, "tele")).toBeNull();
+    expect(vaultTransportFor(channels, "ghost")).toBeNull();
+  });
+});
+
+describe("VaultJobStore — vault-native CRUD", () => {
+  test("listAll queries each unique vault once + maps job notes to Jobs", async () => {
+    const { channels } = channelsWithVault();
+    const urls: string[] = [];
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      urls.push(String(url));
+      return new Response(
+        JSON.stringify([
+          {
+            id: "note-1",
+            content: "Run the weave",
+            metadata: {
+              channel: "uni-dev",
+              cron: "53 7 * * *",
+              tz: "America/Los_Angeles",
+              enabled: "true",
+              createdAt: "2026-06-17T00:00:00Z",
+            },
+          },
+          {
+            id: "note-2",
+            content: "Hourly ping",
+            metadata: { channel: "uni-dev", cron: "0 * * * *", enabled: "false" },
+          },
+        ]),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    const store = new VaultJobStore(channels);
+    const jobs = await store.listAll();
+    // Only ONE vault transport in the map → queried exactly once (telegram is skipped).
+    expect(urls.filter((u) => u.includes("/api/notes")).length).toBe(1);
+    expect(urls[0]).toContain("tag=%23agent-job");
+    expect(jobs).toHaveLength(2);
+    expect(jobs[0]).toMatchObject({
+      id: "note-1",
+      channel: "uni-dev",
+      message: "Run the weave",
+      schedule: { cron: "53 7 * * *", tz: "America/Los_Angeles" },
+      enabled: true,
+    });
+    expect(jobs[1]!.enabled).toBe(false); // "false" string → disabled
+  });
+
+  test("upsert writes a #agent-job note via the target channel's vault", async () => {
+    const { channels } = channelsWithVault();
+    const calls: { url: string; init: RequestInit }[] = [];
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      calls.push({ url: String(url), init: init ?? {} });
+      return new Response(JSON.stringify({ id: "Channels/uni-dev/jobs/morning" }), {
+        status: 201,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const store = new VaultJobStore(channels);
+    const saved = await store.upsert(makeJob());
+    // `id` stays the operator slug; `noteId` is the vault note id for addressing.
+    expect(saved.id).toBe("morning");
+    expect(saved.noteId).toBe("Channels/uni-dev/jobs/morning");
+    expect(calls).toHaveLength(1);
+    const body = JSON.parse(String(calls[0]!.init.body));
+    expect(body.tags).toEqual(["#agent-job"]);
+    expect(body.path).toBe("Channels/uni-dev/jobs/morning");
+    expect(body.metadata.jobId).toBe("morning"); // slug persisted for stable display
+    expect(body.content).toBe("Run the morning weave");
+    expect(body.metadata).toMatchObject({
+      channel: "uni-dev",
+      cron: "53 7 * * *",
+      tz: "America/Los_Angeles",
+      enabled: "true",
+      createdAt: "2026-06-17T00:00:00.000Z",
+    });
+    // nextRunAt is NEVER persisted.
+    expect(body.metadata.nextRunAt).toBeUndefined();
+    const headers = calls[0]!.init.headers as Record<string, string>;
+    expect(headers.authorization).toBe("Bearer write-token");
+  });
+
+  test("upsert to a non-vault channel throws", async () => {
+    const { channels } = channelsWithVault();
+    const store = new VaultJobStore(channels);
+    await expect(store.upsert(makeJob({ channel: "tele" }))).rejects.toThrow(/not a live vault channel/);
+  });
+
+  test("remove DELETEs the note by id via the channel's vault", async () => {
+    const { channels } = channelsWithVault();
+    const calls: { url: string; method?: string }[] = [];
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      calls.push({ url: String(url), method: init?.method });
+      return new Response(null, { status: 204 });
+    }) as typeof fetch;
+    const store = new VaultJobStore(channels);
+    await store.remove("Channels/uni-dev/jobs/morning", "uni-dev");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.method).toBe("DELETE");
+    expect(calls[0]!.url).toContain("/api/notes/");
+  });
+
+  test("patch PATCHes bookkeeping metadata onto the note", async () => {
+    const { channels } = channelsWithVault();
+    const calls: { url: string; init: RequestInit }[] = [];
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      calls.push({ url: String(url), init: init ?? {} });
+      return new Response(null, { status: 200 });
+    }) as typeof fetch;
+    const store = new VaultJobStore(channels);
+    await store.patch("note-1", "uni-dev", { lastRunAt: "2026-06-17T11:00:00Z", lastStatus: "ok" });
+    expect(calls[0]!.init.method).toBe("PATCH");
+    const body = JSON.parse(String(calls[0]!.init.body));
+    expect(body.metadata).toEqual({ lastRunAt: "2026-06-17T11:00:00Z", lastStatus: "ok" });
+  });
+});

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -1,0 +1,262 @@
+/**
+ * Scheduled-job model + VAULT-NATIVE store for the runner (design
+ * `2026-06-17-runner-scheduled-agent-turns.md`).
+ *
+ * A scheduled job is "an automated human": send message M to agent (channel) A on
+ * schedule S. The runner does NOT execute anything — it authors an inbound
+ * `#channel-message/inbound` note on a schedule, and the existing vault trigger →
+ * agent-turn → outbound flow does the rest.
+ *
+ * STORAGE IS VAULT-NATIVE (Aaron's call, 2026-06-17): a job IS a `#agent-job`
+ * note in the TARGET channel's vault — durable, queryable, and renderable by any
+ * surface, converging with the blueprint's "vault as the spine" and the future
+ * `tag:job` idea. There is NO jobs.json. The vault note I/O lives on
+ * `VaultTransport` (it owns the vault URL + token + encoding); this module is the
+ * thin, storage-agnostic FACADE that keeps the same read-all / upsert / remove
+ * interface the runner + API call. Token handling is never duplicated here.
+ *
+ * `metadata` on the note is all string-typed (the vault stores metadata as
+ * strings): `{ channel, cron, tz?, enabled, createdAt, lastRunAt?, lastStatus? }`.
+ * `nextRunAt` is NOT persisted — the runner computes it in memory each tick.
+ *
+ * `validateJob` is the pure gate the API runs before writing: slug-shaped id, a
+ * known channel that's a VAULT transport, and a parseable cron.
+ */
+
+import { parseCron, CronParseError } from "./cron.ts";
+import { VaultTransport } from "./transports/vault.ts";
+import type { Channel } from "./registry.ts";
+
+/** A job's schedule: a 5-field cron expr + optional IANA tz (default daemon-local). */
+export interface JobSchedule {
+  /** 5-field cron: `min hour dom mon dow`. */
+  cron: string;
+  /** IANA timezone (e.g. "America/Los_Angeles"). Optional — default daemon-local. */
+  tz?: string;
+}
+
+/**
+ * One scheduled job. The in-memory shape the runner + API operate on; persisted as
+ * a `#agent-job` vault note (see the store below). `id` is the slug (also the
+ * `runner:<id>` sender provenance + the note path segment).
+ */
+export interface Job {
+  /** The operator-facing slug (typed on create; addresses the job in `/api/jobs/:id`). */
+  id: string;
+  /**
+   * The vault note id/path that addresses the persisted note for PATCH/DELETE.
+   * Absent on a freshly-created in-memory `Job` (set after `upsert` / on `listAll`).
+   * The runner + UI key off `id` (the slug); the store uses `noteId` for I/O.
+   */
+  noteId?: string;
+  /** The channel to inject into — MUST be a vault channel. */
+  channel: string;
+  /** The message text written as the inbound note content (= the job note's content). */
+  message: string;
+  /** When to fire. */
+  schedule: JobSchedule;
+  /** Whether the runner considers this job (default true on create). */
+  enabled: boolean;
+  /** ISO timestamp the job was created. */
+  createdAt: string;
+  /** ISO timestamp of the most recent fire (set by the runner; persisted via PATCH). */
+  lastRunAt?: string;
+  /** "ok" or "error: <detail>" from the most recent fire (persisted via PATCH). */
+  lastStatus?: string;
+  /** ISO timestamp of the next scheduled fire — COMPUTED IN MEMORY, never persisted. */
+  nextRunAt?: string;
+}
+
+/** A slug: alphanumeric, dash, underscore (same shape as channel names). */
+const SLUG_RE = /^[a-zA-Z0-9_-]+$/;
+
+/** The result of validating a candidate job. `ok:false` carries an operator-facing reason. */
+export type JobValidation = { ok: true } | { ok: false; error: string };
+
+/**
+ * Validate a candidate job before it's persisted. The API runs this and maps an
+ * `ok:false` to a 400. Pure (no vault I/O) — `isVaultChannel(name)` is injected:
+ *   - returns `true`  → known + vault,
+ *   - returns `false` → known but NOT vault,
+ *   - returns `null`  → unknown channel.
+ *
+ * Checks, in order: id slug → non-empty message → parseable cron → valid tz (if
+ * present) → channel known AND vault (the inject path is "write an inbound note,"
+ * which only a vault transport supports).
+ */
+export function validateJob(
+  candidate: {
+    id?: unknown;
+    channel?: unknown;
+    message?: unknown;
+    schedule?: unknown;
+    enabled?: unknown;
+  },
+  isVaultChannel: (name: string) => boolean | null,
+): JobValidation {
+  if (typeof candidate.id !== "string" || !SLUG_RE.test(candidate.id)) {
+    return { ok: false, error: "id must be a slug (alphanumeric, dash, underscore)" };
+  }
+  if (typeof candidate.message !== "string" || candidate.message.trim().length === 0) {
+    return { ok: false, error: "message must be a non-empty string" };
+  }
+  const sched = candidate.schedule as { cron?: unknown; tz?: unknown } | undefined;
+  if (!sched || typeof sched.cron !== "string" || sched.cron.trim().length === 0) {
+    return { ok: false, error: "schedule.cron must be a non-empty cron expression" };
+  }
+  try {
+    parseCron(sched.cron);
+  } catch (err) {
+    const msg = err instanceof CronParseError ? err.message : String(err);
+    return { ok: false, error: `invalid schedule.cron: ${msg}` };
+  }
+  if (sched.tz !== undefined) {
+    if (typeof sched.tz !== "string" || sched.tz.length === 0) {
+      return { ok: false, error: "schedule.tz must be a non-empty IANA timezone string" };
+    }
+    try {
+      // Construct a formatter to validate the zone — throws RangeError if invalid.
+      new Intl.DateTimeFormat("en-US", { timeZone: sched.tz });
+    } catch {
+      return { ok: false, error: `invalid schedule.tz: "${sched.tz}" is not a known IANA timezone` };
+    }
+  }
+  if (typeof candidate.channel !== "string" || candidate.channel.length === 0) {
+    return { ok: false, error: "channel must be a non-empty string" };
+  }
+  const vault = isVaultChannel(candidate.channel);
+  if (vault === null) {
+    return { ok: false, error: `unknown channel "${candidate.channel}"` };
+  }
+  if (vault === false) {
+    return {
+      ok: false,
+      error: `channel "${candidate.channel}" is not a vault channel — scheduled jobs require a vault-backed agent (the runner injects an inbound note)`,
+    };
+  }
+  return { ok: true };
+}
+
+/**
+ * Resolve a channel name to its live `VaultTransport`, or null if the channel is
+ * unknown or not vault-backed. Shared by the store + the runner's discovery so the
+ * "is this a vault channel?" check is one implementation.
+ */
+export function vaultTransportFor(
+  channels: Map<string, Channel>,
+  name: string,
+): VaultTransport | null {
+  const t = channels.get(name)?.transport;
+  return t instanceof VaultTransport ? t : null;
+}
+
+/**
+ * The vault-native job store. Same read-all / upsert / remove interface the file
+ * store had, now backed by `#agent-job` vault notes via the channel's
+ * `VaultTransport`. Each method resolves the target channel's vault transport (the
+ * channel carries the vault binding + write token) and delegates the I/O to it.
+ *
+ * `listAll` queries every UNIQUE vault among the live vault-channels once and maps
+ * each job note to a `Job`, routing by `metadata.channel`. A job note whose
+ * `channel` no longer names a live vault channel is still RETURNED (so the API/UI
+ * can show + let the operator delete a stale job), but the runner's discovery
+ * (which composes on top) skips firing it.
+ */
+export class VaultJobStore {
+  constructor(private readonly channels: Map<string, Channel>) {}
+
+  /**
+   * List all scheduled jobs across every vault the live channels point at. We
+   * query each DISTINCT vault transport once (dedup by vault URL + name), then map
+   * job notes to `Job`s. A note read from one vault may target ANY channel on that
+   * vault (routing is by `metadata.channel`), so we keep every well-formed job
+   * note. De-dup by job id across vaults isn't needed — ids are namespaced by the
+   * channel's vault in practice — but if two notes share an id we keep both (the
+   * runner routes each by its own `channel`).
+   */
+  async listAll(): Promise<Job[]> {
+    // Dedup the vault transports we query: many channels can share one vault.
+    const seen = new Set<VaultTransport>();
+    const transports: VaultTransport[] = [];
+    for (const ch of this.channels.values()) {
+      if (ch.transport instanceof VaultTransport && !seen.has(ch.transport)) {
+        seen.add(ch.transport);
+        transports.push(ch.transport);
+      }
+    }
+    const jobs: Job[] = [];
+    for (const t of transports) {
+      const notes = await t.listJobNotes();
+      for (const n of notes) {
+        jobs.push({
+          id: n.id, // the operator-facing slug (metadata.jobId)
+          noteId: n.noteId, // the vault note id/path — for PATCH/DELETE
+          channel: n.channel,
+          message: n.message,
+          schedule: { cron: n.cron, ...(n.tz ? { tz: n.tz } : {}) },
+          enabled: n.enabled,
+          createdAt: n.createdAt ?? "",
+          ...(n.lastRunAt ? { lastRunAt: n.lastRunAt } : {}),
+          ...(n.lastStatus ? { lastStatus: n.lastStatus } : {}),
+        });
+      }
+    }
+    return jobs;
+  }
+
+  /**
+   * Create or replace a job (by slug id) as a `#agent-job` note in its target
+   * channel's vault. Throws if the target channel isn't a live vault channel
+   * (the API validates this first, so it's a guard, not the primary check).
+   * Returns the persisted job with its `noteId` filled in (the `id` stays the slug).
+   */
+  async upsert(job: Job): Promise<Job> {
+    const t = vaultTransportFor(this.channels, job.channel);
+    if (!t) {
+      throw new Error(`cannot store job "${job.id}": channel "${job.channel}" is not a live vault channel`);
+    }
+    const { id: noteId } = await t.upsertJobNote({
+      id: job.id,
+      message: job.message,
+      channel: job.channel,
+      cron: job.schedule.cron,
+      ...(job.schedule.tz ? { tz: job.schedule.tz } : {}),
+      enabled: job.enabled,
+      createdAt: job.createdAt,
+      ...(job.lastRunAt ? { lastRunAt: job.lastRunAt } : {}),
+      ...(job.lastStatus ? { lastStatus: job.lastStatus } : {}),
+    });
+    return { ...job, noteId }; // id stays the slug; noteId addresses the persisted note.
+  }
+
+  /**
+   * Delete a job by its vault note id/path. The job lives in ITS channel's vault,
+   * so we need that channel to resolve the right transport. The API passes the
+   * job's `noteId` + channel (it has the job in hand from a prior list). Throws on
+   * a non-ok vault response.
+   */
+  async remove(noteId: string, channel: string): Promise<void> {
+    const t = vaultTransportFor(this.channels, channel);
+    if (!t) {
+      throw new Error(`cannot delete job in channel "${channel}": not a live vault channel`);
+    }
+    await t.deleteJobNote(noteId);
+  }
+
+  /**
+   * PATCH a job's bookkeeping (lastRunAt / lastStatus / enabled) onto its vault
+   * note. Used by the runner after a fire. Throws on a non-ok vault response (the
+   * runner swallows it — status persistence is best-effort).
+   */
+  async patch(
+    noteId: string,
+    channel: string,
+    fields: { lastRunAt?: string; lastStatus?: string; enabled?: boolean },
+  ): Promise<void> {
+    const t = vaultTransportFor(this.channels, channel);
+    if (!t) {
+      throw new Error(`cannot patch job in channel "${channel}": not a live vault channel`);
+    }
+    await t.patchJobNote(noteId, fields);
+  }
+}

--- a/src/runner.test.ts
+++ b/src/runner.test.ts
@@ -1,0 +1,349 @@
+import { describe, test, expect } from "bun:test";
+import { Runner, type TickDriver } from "./runner.ts";
+import type { Job } from "./jobs.ts";
+
+/** A controllable clock — tests step time by setting `current`. */
+function fakeClock(startIso: string) {
+  let current = new Date(startIso);
+  return {
+    now: () => new Date(current.getTime()),
+    set: (iso: string) => {
+      current = new Date(iso);
+    },
+  };
+}
+
+/** A manual tick driver — the test calls `runScheduled()` to fire the scheduled fn. */
+function manualDriver(): TickDriver & { runScheduled: () => void; scheduledMs: number } {
+  let fn: (() => void) | null = null;
+  let ms = 0;
+  return {
+    schedule(f, intervalMs) {
+      fn = f;
+      ms = intervalMs;
+      return { cancel: () => { fn = null; } };
+    },
+    runScheduled() {
+      if (fn) fn();
+    },
+    get scheduledMs() {
+      return ms;
+    },
+  };
+}
+
+function job(over: Partial<Job> = {}): Job {
+  return {
+    id: "j",
+    channel: "uni-dev",
+    message: "go",
+    schedule: { cron: "0 * * * *", tz: "UTC" }, // hourly, top of hour
+    enabled: true,
+    createdAt: "2026-06-17T00:00:00.000Z",
+    ...over,
+  };
+}
+
+const silent = { warn: () => {}, error: () => {} };
+
+/** A store stub: jobs the runner loads + a record of persisted bookkeeping. */
+function store(jobs: Job[]) {
+  const persisted: Array<{ id: string; lastStatus?: string; lastRunAt?: string }> = [];
+  return {
+    jobs,
+    persisted,
+    loadJobs: async () => jobs.map((j) => ({ ...j })), // fresh copies each tick (vault-like)
+    persistFire: async (j: Job) => {
+      persisted.push({ id: j.id, lastStatus: j.lastStatus, lastRunAt: j.lastRunAt });
+    },
+  };
+}
+
+describe("Runner.tick — horizon seeding + due detection", () => {
+  test("a job seen for the first time gets a future horizon and does NOT fire", async () => {
+    const clock = fakeClock("2026-06-17T10:30:00Z");
+    const fired: string[] = [];
+    const s = store([job()]);
+    const r = new Runner({
+      loadJobs: s.loadJobs,
+      fire: async (j) => { fired.push(j.id); },
+      persistFire: s.persistFire,
+      now: clock.now,
+      log: silent,
+    });
+    await r.tick();
+    expect(fired).toEqual([]); // seeded horizon is 11:00, not due at 10:30.
+  });
+
+  test("fires exactly when the horizon is due, once per slot", async () => {
+    const clock = fakeClock("2026-06-17T10:30:00Z");
+    const fired: string[] = [];
+    const s = store([job()]);
+    const r = new Runner({
+      loadJobs: s.loadJobs,
+      fire: async (j) => { fired.push(j.id); },
+      persistFire: s.persistFire,
+      now: clock.now,
+      log: silent,
+    });
+    await r.tick(); // seeds horizon 11:00
+    expect(fired).toEqual([]);
+
+    clock.set("2026-06-17T11:00:00Z");
+    await r.tick(); // due → fires
+    expect(fired).toEqual(["j"]);
+    expect(s.persisted.at(-1)).toMatchObject({ id: "j", lastStatus: "ok", lastRunAt: "2026-06-17T11:00:00.000Z" });
+
+    clock.set("2026-06-17T11:05:00Z");
+    await r.tick(); // next horizon is 12:00 → not due
+    expect(fired).toEqual(["j"]);
+  });
+
+  test("a disabled job never fires even when its horizon would be due", async () => {
+    const clock = fakeClock("2026-06-17T11:00:00Z");
+    const fired: string[] = [];
+    const s = store([job({ enabled: false })]);
+    const r = new Runner({
+      loadJobs: s.loadJobs,
+      fire: async (j) => { fired.push(j.id); },
+      persistFire: s.persistFire,
+      now: clock.now,
+      log: silent,
+    });
+    await r.tick();
+    clock.set("2026-06-17T12:00:00Z");
+    await r.tick();
+    expect(fired).toEqual([]);
+  });
+});
+
+describe("Runner.tick — fire-once-on-miss (no stampede)", () => {
+  test("a job whose horizon was seeded then time jumps far ahead fires ONCE", async () => {
+    const clock = fakeClock("2026-06-17T05:30:00Z");
+    let fireCount = 0;
+    const s = store([job()]);
+    const r = new Runner({
+      loadJobs: s.loadJobs,
+      fire: async () => { fireCount++; },
+      persistFire: s.persistFire,
+      now: clock.now,
+      log: silent,
+    });
+    await r.tick(); // seeds horizon 06:00
+    // Daemon "down" — next tick is at 11:30, well past 06:00 and several slots.
+    clock.set("2026-06-17T11:30:00Z");
+    await r.tick();
+    expect(fireCount).toBe(1); // exactly once despite 5+ missed slots
+    // Horizon recomputed forward from 11:30 → 12:00 (not 07:00).
+    expect(s.jobs[0]!.nextRunAt).toBeUndefined(); // store copy untouched; check via next tick
+    clock.set("2026-06-17T11:45:00Z");
+    await r.tick();
+    expect(fireCount).toBe(1); // still not due (next is 12:00)
+    clock.set("2026-06-17T12:00:00Z");
+    await r.tick();
+    expect(fireCount).toBe(2);
+  });
+});
+
+describe("Runner.tick — overlap guard (idempotent under slow fire)", () => {
+  test("a job mid-fire is skipped by an interleaving tick", async () => {
+    const clock = fakeClock("2026-06-17T11:00:00Z");
+    let resolveFire!: () => void;
+    let fireCount = 0;
+    const s = store([job()]);
+    const r = new Runner({
+      loadJobs: s.loadJobs,
+      fire: () => {
+        fireCount++;
+        return new Promise<void>((res) => { resolveFire = res; });
+      },
+      persistFire: s.persistFire,
+      now: clock.now,
+      log: silent,
+    });
+    await r.tick(); // seeds horizon 12:00 — but set clock so it's due:
+    clock.set("2026-06-17T12:00:00Z");
+
+    const t1 = r.tick(); // starts a fire that hasn't resolved
+    // Let the tick reach the fire (it awaits loadJobs first).
+    await new Promise((res) => setTimeout(res, 0));
+    expect(fireCount).toBe(1);
+
+    await r.tick(); // interleaving tick — job in-flight → skipped
+    expect(fireCount).toBe(1);
+
+    resolveFire();
+    await t1;
+  });
+});
+
+describe("Runner.tick — fire failure recorded, never thrown", () => {
+  test("a throwing fire records error status + advances the horizon", async () => {
+    const clock = fakeClock("2026-06-17T11:00:00Z");
+    const s = store([job()]);
+    const r = new Runner({
+      loadJobs: s.loadJobs,
+      fire: async () => { throw new Error("vault down"); },
+      persistFire: s.persistFire,
+      now: clock.now,
+      log: silent,
+    });
+    await r.tick(); // seed
+    clock.set("2026-06-17T12:00:00Z");
+    await r.tick(); // due → fire throws, recorded
+    expect(s.persisted.at(-1)).toMatchObject({ id: "j", lastStatus: "error: vault down" });
+  });
+
+  test("one bad job does not abort the pass for a good one", async () => {
+    const clock = fakeClock("2026-06-17T11:00:00Z");
+    const fired: string[] = [];
+    const s = store([job({ id: "bad" }), job({ id: "good" })]);
+    const r = new Runner({
+      loadJobs: s.loadJobs,
+      fire: async (j) => {
+        if (j.id === "bad") throw new Error("boom");
+        fired.push(j.id);
+      },
+      persistFire: s.persistFire,
+      now: clock.now,
+      log: silent,
+    });
+    await r.tick(); // seed both
+    clock.set("2026-06-17T12:00:00Z");
+    await r.tick(); // both due
+    expect(fired).toEqual(["good"]);
+    const byId = Object.fromEntries(s.persisted.map((p) => [p.id, p.lastStatus]));
+    expect(byId.bad).toMatch(/error/);
+    expect(byId.good).toBe("ok");
+  });
+});
+
+describe("Runner.tick — load failure is a no-op tick", () => {
+  test("a loadJobs rejection does not throw out of tick", async () => {
+    const r = new Runner({
+      loadJobs: async () => { throw new Error("vault unreachable"); },
+      fire: async () => {},
+      persistFire: async () => {},
+      log: silent,
+    });
+    await r.tick(); // must resolve, not reject
+    expect(true).toBe(true);
+  });
+});
+
+describe("Runner.tick — deleted jobs prune their horizon", () => {
+  test("a job removed from the store stops being tracked", async () => {
+    const clock = fakeClock("2026-06-17T10:30:00Z");
+    let current: Job[] = [job()];
+    const r = new Runner({
+      loadJobs: async () => current.map((j) => ({ ...j })),
+      fire: async () => {},
+      persistFire: async () => {},
+      now: clock.now,
+      log: silent,
+    });
+    await r.tick(); // seeds horizon for "j"
+    current = []; // job deleted from the vault
+    await r.tick(); // prunes — no throw, nothing to fire
+    expect(true).toBe(true);
+  });
+});
+
+describe("Runner.runNow — fire on demand", () => {
+  test("fires immediately regardless of schedule + persists bookkeeping", async () => {
+    const clock = fakeClock("2026-06-17T10:30:00Z");
+    const fired: string[] = [];
+    const s = store([job()]);
+    const r = new Runner({
+      loadJobs: s.loadJobs,
+      fire: async (j) => { fired.push(j.id); },
+      persistFire: s.persistFire,
+      now: clock.now,
+      log: silent,
+    });
+    const status = await r.runNow("j");
+    expect(status).toBe("ok");
+    expect(fired).toEqual(["j"]);
+    expect(s.persisted.at(-1)).toMatchObject({ id: "j", lastRunAt: "2026-06-17T10:30:00.000Z" });
+  });
+
+  test("runNow on an unknown id throws", async () => {
+    const r = new Runner({
+      loadJobs: async () => [],
+      fire: async () => {},
+      persistFire: async () => {},
+      log: silent,
+    });
+    await expect(r.runNow("nope")).rejects.toThrow(/no job/);
+  });
+
+  test("runNow records an error status without throwing on a fire failure", async () => {
+    const s = store([job()]);
+    const r = new Runner({
+      loadJobs: s.loadJobs,
+      fire: async () => { throw new Error("nope"); },
+      persistFire: s.persistFire,
+      log: silent,
+    });
+    const status = await r.runNow("j");
+    expect(status).toMatch(/error: nope/);
+  });
+});
+
+describe("Runner — driver wiring (start/stop)", () => {
+  test("start schedules the tick on the injected driver; stop cancels", async () => {
+    const clock = fakeClock("2026-06-17T12:00:00Z");
+    const driver = manualDriver();
+    const fired: string[] = [];
+    // Pre-seed via a horizon that's already due: a tick first seeds (future), so
+    // to observe a fire through the driver we drive twice with time advanced.
+    const s = store([job()]);
+    const r = new Runner({
+      loadJobs: s.loadJobs,
+      fire: async (j) => { fired.push(j.id); },
+      persistFire: s.persistFire,
+      now: clock.now,
+      driver,
+      intervalMs: 30_000,
+      log: silent,
+    });
+    r.start();
+    expect(driver.scheduledMs).toBe(30_000);
+
+    driver.runScheduled(); // tick 1 — seeds horizon 13:00
+    await new Promise((res) => setTimeout(res, 0));
+    expect(fired).toEqual([]);
+
+    clock.set("2026-06-17T13:00:00Z");
+    driver.runScheduled(); // tick 2 — due → fires
+    await new Promise((res) => setTimeout(res, 0));
+    expect(fired).toEqual(["j"]);
+
+    r.stop();
+    fired.length = 0;
+    clock.set("2026-06-17T14:00:00Z");
+    driver.runScheduled(); // cancelled — no-op
+    await new Promise((res) => setTimeout(res, 0));
+    expect(fired).toEqual([]);
+  });
+
+  test("start is idempotent (a second start does not double-schedule)", () => {
+    let scheduleCalls = 0;
+    const driver: TickDriver = {
+      schedule(_fn, _ms) {
+        scheduleCalls++;
+        return { cancel: () => {} };
+      },
+    };
+    const r = new Runner({
+      loadJobs: async () => [],
+      fire: async () => {},
+      persistFire: async () => {},
+      driver,
+      log: silent,
+    });
+    r.start();
+    r.start();
+    expect(scheduleCalls).toBe(1);
+  });
+});

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,0 +1,255 @@
+/**
+ * The runner — a scheduler that fires scheduled jobs (design
+ * `2026-06-17-runner-scheduled-agent-turns.md`).
+ *
+ * It does NOT execute anything. On each tick it loads the current jobs (from the
+ * VAULT-NATIVE store), asks each enabled job "are you due?" and, if so, FIRES it —
+ * where "fire" means "inject an inbound note onto the job's vault channel." The
+ * existing vault trigger → agent-turn → outbound flow does all the work. The
+ * runner is a clock that authors messages.
+ *
+ * Determinism is the design's hard requirement: the testable core takes an
+ * INJECTABLE clock (`now`), INJECTABLE load + fire + persist fns, and an
+ * INJECTABLE tick driver. The daemon's boot supplies the real ones (`Date`, the
+ * vault job store, the vault-inject fire, a `setInterval` tick); tests supply
+ * fakes and step time by hand. No real `setInterval`/`Date.now()` appears in
+ * `tick()` itself.
+ *
+ * Storage-agnostic: the runner never touches the vault directly. It calls:
+ *   - `loadJobs()`        → the current jobs (the store queries the vault),
+ *   - `fire(job)`         → inject the inbound note (the transport writes it),
+ *   - `persistFire(job)`  → write back lastRunAt/lastStatus (the store PATCHes).
+ *
+ * `nextRunAt` is COMPUTED IN MEMORY and NEVER persisted. The runner keeps a small
+ * per-job horizon map (keyed by id) across ticks so a job fires once per slot; a
+ * job seen for the first time gets a horizon computed from now (and won't fire
+ * until that horizon passes — so a freshly-created job never back-fires on its
+ * first tick).
+ *
+ * Catch-up policy = FIRE-ONCE-ON-MISS: if a job's horizon is already in the past
+ * on a tick (the daemon was down across one or more slots), the job fires ONCE and
+ * the horizon is recomputed forward from now — never replaying every missed slot.
+ *
+ * Idempotency under overlap: a job that's mid-fire (its async fire hasn't resolved)
+ * is SKIPPED on subsequent ticks, so a slow vault write can't be double-fired.
+ */
+
+import { nextRunAfter } from "./cron.ts";
+import type { Job } from "./jobs.ts";
+
+/** Load the current jobs (the vault-native store queries the vault). Async. */
+export type LoadJobsFn = () => Promise<Job[]>;
+
+/** Fire a job: inject its message as an inbound note onto its channel. Async. */
+export type FireFn = (job: Job) => Promise<void>;
+
+/** Persist a job's bookkeeping (lastRunAt/lastStatus) after a fire. Async. */
+export type PersistFireFn = (job: Job) => Promise<void>;
+
+/** A scheduler driver: schedule `fn` to run every `ms`, return a cancel handle. */
+export interface TickDriver {
+  schedule(fn: () => void, ms: number): { cancel: () => void };
+}
+
+export interface RunnerOptions {
+  /** Load the current jobs (queries the vault each tick). */
+  loadJobs: LoadJobsFn;
+  /** Fire a due job (inject the inbound note). */
+  fire: FireFn;
+  /** Persist a job's bookkeeping after a fire. */
+  persistFire: PersistFireFn;
+  /** Clock — injected for determinism. Default `() => new Date()`. */
+  now?: () => Date;
+  /** Tick driver — injected for determinism. Default a real-setInterval driver. */
+  driver?: TickDriver;
+  /** Tick interval (ms). Default 30s. */
+  intervalMs?: number;
+  /** Log sink (errors per job/tick never throw out). Default `console`. */
+  log?: { warn: (msg: string) => void; error: (msg: string) => void };
+}
+
+/** A real `setInterval`-backed tick driver (the daemon uses this; tests don't). */
+export function realTickDriver(): TickDriver {
+  return {
+    schedule(fn, ms) {
+      const t = setInterval(fn, ms);
+      // Don't keep the process alive solely for the runner tick.
+      if (typeof t === "object" && t && "unref" in t) (t as { unref: () => void }).unref();
+      return { cancel: () => clearInterval(t) };
+    },
+  };
+}
+
+const DEFAULT_INTERVAL_MS = 30_000;
+
+export class Runner {
+  private readonly loadJobs: LoadJobsFn;
+  private readonly fire: FireFn;
+  private readonly persistFire: PersistFireFn;
+  private readonly now: () => Date;
+  private readonly driver: TickDriver;
+  private readonly intervalMs: number;
+  private readonly log: { warn: (msg: string) => void; error: (msg: string) => void };
+
+  /**
+   * Per-job next-fire horizon (ISO), COMPUTED IN MEMORY and carried across ticks.
+   * Keyed by job id. Seeded the first time a job is seen; recomputed forward after
+   * each fire. Not persisted — the vault store doesn't carry nextRunAt.
+   */
+  private readonly horizons = new Map<string, string>();
+  /** Job ids currently mid-fire — skipped by an interleaving tick (overlap guard). */
+  private readonly inFlight = new Set<string>();
+  private handle: { cancel: () => void } | undefined;
+
+  constructor(opts: RunnerOptions) {
+    this.loadJobs = opts.loadJobs;
+    this.fire = opts.fire;
+    this.persistFire = opts.persistFire;
+    this.now = opts.now ?? (() => new Date());
+    this.driver = opts.driver ?? realTickDriver();
+    this.intervalMs = opts.intervalMs ?? DEFAULT_INTERVAL_MS;
+    this.log = opts.log ?? {
+      warn: (m) => console.warn(m),
+      error: (m) => console.error(m),
+    };
+  }
+
+  /**
+   * The stable per-job key for horizon + in-flight tracking. Prefer the vault
+   * `noteId` (globally unique across channels/vaults) so two jobs that share a
+   * SLUG in different channels don't collide; fall back to the slug `id` for an
+   * in-memory job that hasn't been persisted yet (tests).
+   */
+  private keyOf(job: Job): string {
+    return job.noteId ?? job.id;
+  }
+
+  /** Compute the next fire instant for a job after `from`, or null on a bad cron. */
+  private computeNext(job: Job, from: Date): Date | null {
+    try {
+      return nextRunAfter(job.schedule.cron, job.schedule.tz, from);
+    } catch (err) {
+      this.log.warn(`runner: job "${job.id}" has an unschedulable cron: ${(err as Error).message}`);
+      return null;
+    }
+  }
+
+  /** Start the periodic tick. Idempotent (a second start is a no-op). */
+  start(): void {
+    if (this.handle) return;
+    this.handle = this.driver.schedule(() => {
+      // A tick must never throw out (it'd kill the interval). `tick()` already
+      // guards; this is belt-and-suspenders for an unexpected throw.
+      void this.tick().catch((err) => this.log.error(`runner: tick failed: ${err}`));
+    }, this.intervalMs);
+  }
+
+  /** Stop the tick. Safe to call when not started. */
+  stop(): void {
+    this.handle?.cancel();
+    this.handle = undefined;
+  }
+
+  /**
+   * One scheduling pass. Loads the current jobs; for each enabled, not-in-flight
+   * job whose horizon is due (≤ now), fires it once and advances the horizon
+   * forward from now. A job seen for the first time gets a horizon computed (it
+   * won't fire this tick — it's in the future). Per-job failures are caught and
+   * recorded; one bad job never aborts the pass. A load failure is logged and the
+   * tick is a no-op (it retries next interval). Awaitable for deterministic tests.
+   */
+  async tick(): Promise<void> {
+    const at = this.now();
+    let jobs: Job[];
+    try {
+      jobs = await this.loadJobs();
+    } catch (err) {
+      this.log.error(`runner: loadJobs failed (skipping this tick): ${(err as Error).message}`);
+      return;
+    }
+
+    // Prune horizons for jobs that no longer exist (deleted), so the map can't grow.
+    const liveKeys = new Set(jobs.map((j) => this.keyOf(j)));
+    for (const key of [...this.horizons.keys()]) {
+      if (!liveKeys.has(key)) this.horizons.delete(key);
+    }
+
+    const fires: Array<Promise<void>> = [];
+    for (const job of jobs) {
+      if (!job.enabled) continue;
+      const key = this.keyOf(job);
+      if (this.inFlight.has(key)) continue; // overlap guard — already firing.
+
+      let horizon = this.horizons.get(key);
+      if (!horizon) {
+        // First time we've seen this job — seed a horizon from now. Future → not
+        // due this tick (a freshly-created job never back-fires on first sight).
+        const next = this.computeNext(job, at);
+        if (!next) continue; // unschedulable cron — skip (logged in computeNext).
+        horizon = next.toISOString();
+        this.horizons.set(key, horizon);
+        job.nextRunAt = horizon;
+        continue;
+      }
+
+      job.nextRunAt = horizon;
+      if (new Date(horizon).getTime() <= at.getTime()) {
+        fires.push(this.fireOne(job, at));
+      }
+    }
+    await Promise.allSettled(fires);
+  }
+
+  /**
+   * Fire one due job: mark in-flight, inject, record bookkeeping, recompute the
+   * horizon FORWARD FROM NOW (fire-once-on-miss — never replay missed slots),
+   * persist the bookkeeping. Never throws — a fire failure is recorded as
+   * `lastStatus: "error: …"` and still advances the horizon (so it retries the
+   * next slot rather than getting stuck).
+   */
+  private async fireOne(job: Job, at: Date): Promise<void> {
+    const key = this.keyOf(job);
+    this.inFlight.add(key);
+    try {
+      await this.fire(job);
+      job.lastStatus = "ok";
+    } catch (err) {
+      job.lastStatus = `error: ${(err as Error).message}`;
+      this.log.error(`runner: job "${job.id}" fire failed: ${(err as Error).message}`);
+    } finally {
+      job.lastRunAt = at.toISOString();
+      // Recompute the horizon from NOW (not the missed slot) — fire-once-on-miss.
+      const next = this.computeNext(job, at);
+      if (next) {
+        this.horizons.set(key, next.toISOString());
+        job.nextRunAt = next.toISOString();
+      } else {
+        this.horizons.delete(key);
+        job.nextRunAt = undefined;
+      }
+      this.inFlight.delete(key);
+      // Persist the bookkeeping (lastRunAt/lastStatus) — best-effort.
+      try {
+        await this.persistFire(job);
+      } catch (err) {
+        this.log.warn(`runner: persist bookkeeping for "${job.id}" failed (continuing): ${(err as Error).message}`);
+      }
+    }
+  }
+
+  /**
+   * Fire a single job immediately, on demand (the "Run now" API). Loads jobs to
+   * find it, bypasses the schedule + due check but honors the overlap guard and
+   * records bookkeeping exactly like a scheduled fire. Returns the resulting
+   * `lastStatus`. Throws only if the job is unknown; a fire failure is recorded
+   * and returned, not thrown.
+   */
+  async runNow(id: string): Promise<string> {
+    const jobs = await this.loadJobs();
+    const job = jobs.find((j) => j.id === id);
+    if (!job) throw new Error(`runner: no job with id "${id}"`);
+    if (this.inFlight.has(this.keyOf(job))) return job.lastStatus ?? "already running";
+    await this.fireOne(job, this.now());
+    return job.lastStatus ?? "ok";
+  }
+}

--- a/src/transports/vault.test.ts
+++ b/src/transports/vault.test.ts
@@ -520,3 +520,144 @@ describe("registry — vault", () => {
     ).toThrow(/token/);
   });
 });
+
+describe("VaultTransport — injectInbound (runner seam)", () => {
+  test("injectInbound writes an INBOUND note (both tags) with runner provenance", async () => {
+    const calls: { url: string; init: RequestInit }[] = [];
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      calls.push({ url: String(url), init: init ?? {} });
+      return new Response(JSON.stringify({ id: "inbound-1" }), {
+        status: 201,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+    const r = await t.injectInbound({ content: "Run the morning weave", sender: "runner:morning" });
+    expect(r.id).toBe("inbound-1");
+
+    const noteCalls = calls.filter((c) => c.url.endsWith("/api/notes"));
+    expect(noteCalls).toHaveLength(1);
+    const body = JSON.parse(String(noteCalls[0]!.init.body));
+    // Inbound: BOTH the parent + the inbound child (the trigger discriminator).
+    expect(body.tags).toEqual(["#channel-message", "#channel-message/inbound"]);
+    expect(body.content).toBe("Run the morning weave");
+    expect(body.metadata.direction).toBe("inbound");
+    expect(body.metadata.sender).toBe("runner:morning");
+    // NEVER stamps channel_inbound_rendered_at (so the trigger fires).
+    expect(body.metadata.channel_inbound_rendered_at).toBeUndefined();
+  });
+
+  test("injectInbound defaults sender to 'runner'", async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ id: "x" }), {
+        status: 201,
+        headers: { "content-type": "application/json" },
+      })) as unknown as typeof fetch;
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+    // No throw + returns the id; the default-sender path is exercised.
+    expect((await t.injectInbound({ content: "hi" })).id).toBe("x");
+  });
+});
+
+describe("VaultTransport — scheduled-job notes (vault-native store)", () => {
+  test("listJobNotes queries by #agent-job + maps metadata; skips malformed", async () => {
+    const urls: string[] = [];
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      urls.push(String(url));
+      return new Response(
+        JSON.stringify([
+          {
+            id: "note-uuid-1",
+            content: "the message",
+            metadata: { jobId: "morning", channel: "eng", cron: "0 9 * * *", tz: "UTC", enabled: "true", createdAt: "t0" },
+          },
+          // a note WITHOUT jobId metadata → slug falls back to the note id
+          {
+            id: "Channels/eng/jobs/legacy",
+            content: "legacy",
+            metadata: { channel: "eng", cron: "0 0 * * *", enabled: "false" },
+          },
+          // malformed (no cron) → skipped
+          { id: "job-bad", content: "x", metadata: { channel: "eng" } },
+        ]),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    const t = new VaultTransport(baseConfig());
+    const jobs = await t.listJobNotes();
+    expect(urls[0]).toContain("tag=%23agent-job");
+    expect(urls[0]).toContain("include_content=true");
+    expect(jobs).toHaveLength(2);
+    // id = the slug from metadata.jobId; noteId = the vault note id.
+    expect(jobs[0]).toMatchObject({ id: "morning", noteId: "note-uuid-1", channel: "eng", cron: "0 9 * * *", tz: "UTC", enabled: true });
+    // legacy note (no jobId) → id falls back to the note id.
+    expect(jobs[1]).toMatchObject({ id: "Channels/eng/jobs/legacy", noteId: "Channels/eng/jobs/legacy", enabled: false });
+  });
+
+  test("listJobNotes throws on a non-ok vault response", async () => {
+    globalThis.fetch = (async () => new Response("nope", { status: 502 })) as unknown as typeof fetch;
+    const t = new VaultTransport(baseConfig());
+    await expect(t.listJobNotes()).rejects.toThrow(/list jobs failed \(502\)/);
+  });
+
+  test("upsertJobNote POSTs a #agent-job note at the deterministic path", async () => {
+    const calls: { url: string; init: RequestInit }[] = [];
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      calls.push({ url: String(url), init: init ?? {} });
+      return new Response(JSON.stringify({ id: "Channels/eng/jobs/m" }), {
+        status: 201,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+    const t = new VaultTransport(baseConfig());
+    const r = await t.upsertJobNote({
+      id: "m",
+      message: "go",
+      channel: "eng",
+      cron: "0 9 * * *",
+      enabled: true,
+      createdAt: "t0",
+    });
+    expect(r.id).toBe("Channels/eng/jobs/m");
+    const body = JSON.parse(String(calls[0]!.init.body));
+    expect(body.path).toBe("Channels/eng/jobs/m");
+    expect(body.tags).toEqual(["#agent-job"]);
+    expect(body.metadata.enabled).toBe("true");
+    expect(body.metadata.jobId).toBe("m"); // slug persisted for stable display
+  });
+
+  test("patchJobNote sends a PATCH with only the changed metadata", async () => {
+    const calls: { url: string; init: RequestInit }[] = [];
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      calls.push({ url: String(url), init: init ?? {} });
+      return new Response(null, { status: 200 });
+    }) as typeof fetch;
+    const t = new VaultTransport(baseConfig());
+    await t.patchJobNote("job-1", { lastStatus: "ok", lastRunAt: "t1" });
+    expect(calls[0]!.init.method).toBe("PATCH");
+    expect(calls[0]!.url).toContain("/api/notes/job-1");
+    expect(JSON.parse(String(calls[0]!.init.body)).metadata).toEqual({ lastRunAt: "t1", lastStatus: "ok" });
+  });
+
+  test("deleteJobNote DELETEs by id", async () => {
+    const calls: { url: string; method?: string }[] = [];
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      calls.push({ url: String(url), method: init?.method });
+      return new Response(null, { status: 204 });
+    }) as typeof fetch;
+    const t = new VaultTransport(baseConfig());
+    await t.deleteJobNote("job-1");
+    expect(calls[0]!.method).toBe("DELETE");
+    expect(calls[0]!.url).toContain("/api/notes/job-1");
+  });
+
+  test("deleteJobNote throws on a non-ok vault response", async () => {
+    globalThis.fetch = (async () => new Response("no", { status: 404 })) as unknown as typeof fetch;
+    const t = new VaultTransport(baseConfig());
+    await expect(t.deleteJobNote("job-1")).rejects.toThrow(/delete job failed \(404\)/);
+  });
+});

--- a/src/transports/vault.ts
+++ b/src/transports/vault.ts
@@ -78,6 +78,57 @@ export interface InboundNote {
 }
 
 /**
+ * A scheduled-job note as read back from the vault (design
+ * `2026-06-17-runner-scheduled-agent-turns.md`). The runner's vault-native job
+ * store maps these to/from the `Job` type in `jobs.ts`. `content` is the message
+ * to inject; the schedule + bookkeeping live in `metadata` (all string-typed in
+ * the vault — `enabled` is "true"/"false"; `nextRunAt` is NEVER persisted, it's
+ * recomputed in memory by the runner). The note `id` (or path) addresses it for
+ * PATCH/DELETE.
+ */
+export interface JobNote {
+  /**
+   * The operator-facing job id — the SLUG the operator typed (carried in
+   * `metadata.jobId`). This is what the UI displays, what addresses the job in the
+   * `/api/jobs/:id` routes, and what stamps `runner:<jobId>` provenance. Falls back
+   * to `noteId` for a legacy note written without the metadata field.
+   */
+  id: string;
+  /** The vault note id/path — addresses the note for PATCH / DELETE I/O. */
+  noteId: string;
+  /** The message text to inject as the inbound note when this job fires. */
+  message: string;
+  /** Target channel (routes the job to its vault transport). */
+  channel: string;
+  /** 5-field cron expression. */
+  cron: string;
+  /** IANA timezone, if set. */
+  tz?: string;
+  /** Whether the runner considers this job. */
+  enabled: boolean;
+  /** ISO timestamp the job was created. */
+  createdAt?: string;
+  /** ISO timestamp of the most recent fire. */
+  lastRunAt?: string;
+  /** "ok" / "error: …" from the most recent fire. */
+  lastStatus?: string;
+}
+
+/** The metadata payload written for a job note (all string-typed, per the vault). */
+export interface JobNoteMetadata {
+  /** The operator-facing slug (so the displayed id survives the vault's note-id assignment). */
+  jobId: string;
+  channel: string;
+  cron: string;
+  tz?: string;
+  /** "true" | "false" — the vault stores metadata as strings. */
+  enabled: string;
+  createdAt: string;
+  lastRunAt?: string;
+  lastStatus?: string;
+}
+
+/**
  * One message in a channel transcript, as the built-in chat renders it. This is
  * the transport-neutral shape `loadTranscript` produces from the vault notes; the
  * daemon's `GET /api/channels/<ch>/messages` returns `{ messages: ChannelMessage[] }`.
@@ -110,6 +161,20 @@ const CHANNEL_MESSAGE_TAG = "#channel-message";
 const CHANNEL_MESSAGE_INBOUND_TAG = "#channel-message/inbound";
 /** Outbound child — replies carry this; the trigger's exact-match predicate excludes it. */
 const CHANNEL_MESSAGE_OUTBOUND_TAG = "#channel-message/outbound";
+/**
+ * Scheduled-job tag — the runner's vault-native job store (design
+ * `2026-06-17-runner-scheduled-agent-turns.md`). A job IS a vault note carrying
+ * this parent tag; queryable + durable + surface-renderable, exactly like
+ * `#channel-message`. This is a BRAND-NEW tag, so it's named for the module's new
+ * identity ("Parachute Agent") from the start — `#agent-job` — rather than the
+ * legacy `#channel-` prefix. (The separate `#channel-message → #agent-message`
+ * rename is a Phase-3 data migration; the INJECTED message notes still use the
+ * existing `#channel-message` tags. Only this never-before-written job tag adopts
+ * the new name now.)
+ */
+const AGENT_JOB_TAG = "#agent-job";
+/** Default path prefix under which job notes are written: `Channels/<ch>/jobs/<id>`. */
+const JOB_PATH_PREFIX = "Channels";
 
 /**
  * The tag schema this module manages in any vault it's connected to.
@@ -531,6 +596,187 @@ export class VaultTransport implements Transport {
       // Non-JSON / empty body — keep the proposed id.
     }
     return { id: noteId };
+  }
+
+  /**
+   * Inject an inbound message AUTHORED BY THE RUNNER (a scheduled job firing) —
+   * design `2026-06-17-runner-scheduled-agent-turns.md`. This is the runner's
+   * ONLY seam into the transport: a scheduled job is "an automated human," so
+   * firing it = writing an inbound note exactly like a human typing in chat. The
+   * existing vault trigger → agent-turn → outbound flow does the rest; the runner
+   * never touches the turn.
+   *
+   * Mechanically this is `writeInbound` with runner provenance: BOTH the parent
+   * `#channel-message` (queryable) and the inbound child `#channel-message/inbound`
+   * (the trigger discriminator that wakes the session), `direction: "inbound"`,
+   * and `sender` defaulting to a `runner:<jobId>` marker so the transcript shows
+   * who authored it. We deliberately do NOT stamp `channel_inbound_rendered_at`
+   * (so the trigger fires), and we do NOT `ctx.emit` (the trigger is the single
+   * wake path — emitting too would double-wake). Reuses the channel's existing
+   * `vault:<name>:write` token — the runner mints nothing and adds no authority.
+   *
+   * Returns the created note id (for logging / the "run now" response). Kept a
+   * thin wrapper over `writeInbound` so the inbound write path has ONE
+   * implementation; only the default sender differs.
+   */
+  async injectInbound(opts: { content: string; sender?: string }): Promise<{ id: string }> {
+    return this.writeInbound(opts.content, opts.sender ?? "runner");
+  }
+
+  // -------------------------------------------------------------------------
+  // Scheduled-job notes — the runner's VAULT-NATIVE job store (design
+  // 2026-06-17). A job IS a `#agent-job` note in THIS channel's vault. These
+  // methods own the vault I/O (URL + token + encoding) so jobs.ts stays a thin,
+  // storage-agnostic facade — token handling lives in ONE place (the transport),
+  // mirroring loadTranscript / writeInbound. The channel's existing
+  // `vault:<name>:write` token covers all of GET/POST/PATCH/DELETE — no new mint.
+  // -------------------------------------------------------------------------
+
+  /**
+   * List the scheduled-job notes in THIS channel's vault. Queries by the parent
+   * `#agent-job` tag (URLSearchParams encodes `#`→`%23`) and returns ALL job
+   * notes in the vault — the CALLER filters by `metadata.channel` (same index-free
+   * pattern as loadTranscript; we don't assume a `channel` index exists). Throws
+   * on a non-ok vault response so the API surfaces a clear error rather than a
+   * silently-empty list.
+   */
+  async listJobNotes(opts?: { limit?: number }): Promise<JobNote[]> {
+    const limit = opts?.limit ?? 500;
+    const params = new URLSearchParams();
+    params.set("tag", AGENT_JOB_TAG); // → %23agent-job
+    params.set("include_content", "true");
+    params.set("limit", String(limit));
+    const url = `${this.vaultUrl}/vault/${this.vault}/api/notes?${params.toString()}`;
+    const res = await fetch(url, { headers: { authorization: `Bearer ${this.token}` } });
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "");
+      throw new Error(`vault transport: list jobs failed (${res.status}) ${detail}`.trim());
+    }
+    let notes: Array<{ id?: string; content?: string; metadata?: Record<string, unknown> }>;
+    try {
+      const parsed = (await res.json()) as unknown;
+      notes = Array.isArray(parsed)
+        ? (parsed as typeof notes)
+        : ((parsed as { notes?: typeof notes })?.notes ?? []);
+    } catch (err) {
+      throw new Error(`vault transport: list jobs — bad JSON from vault: ${(err as Error).message}`);
+    }
+    const jobs: JobNote[] = [];
+    for (const note of notes) {
+      if (typeof note.id !== "string" || !note.id) continue;
+      const m = note.metadata ?? {};
+      const channel = typeof m.channel === "string" ? m.channel : "";
+      const cron = typeof m.cron === "string" ? m.cron : "";
+      if (!channel || !cron) continue; // not a well-formed job note; skip.
+      // The operator-facing id is the slug in `metadata.jobId`; fall back to the
+      // note id for a note written before that field existed.
+      const slug = typeof m.jobId === "string" && m.jobId ? m.jobId : note.id;
+      const job: JobNote = {
+        id: slug,
+        noteId: note.id,
+        message: typeof note.content === "string" ? note.content : "",
+        channel,
+        cron,
+        // The vault stores metadata as strings; "false" (and only "false") disables.
+        enabled: String(m.enabled) !== "false",
+      };
+      if (typeof m.tz === "string" && m.tz) job.tz = m.tz;
+      if (typeof m.createdAt === "string") job.createdAt = m.createdAt;
+      if (typeof m.lastRunAt === "string") job.lastRunAt = m.lastRunAt;
+      if (typeof m.lastStatus === "string") job.lastStatus = m.lastStatus;
+      jobs.push(job);
+    }
+    return jobs;
+  }
+
+  /**
+   * Create OR replace a job note at a deterministic path (`Channels/<ch>/jobs/<id>`)
+   * so an upsert by the same job id overwrites in place. The vault upserts by path
+   * on POST. Returns the created/updated note id. `nextRunAt` is NEVER written
+   * (recomputed in memory by the runner).
+   */
+  async upsertJobNote(job: {
+    id: string;
+    message: string;
+    channel: string;
+    cron: string;
+    tz?: string;
+    enabled: boolean;
+    createdAt: string;
+    lastRunAt?: string;
+    lastStatus?: string;
+  }): Promise<{ id: string }> {
+    const safeId = job.id.replace(/[^a-zA-Z0-9_-]/g, "-");
+    const safeChannel = job.channel.replace(/[^a-zA-Z0-9_-]/g, "-");
+    const path = `${JOB_PATH_PREFIX}/${safeChannel}/jobs/${safeId}`;
+    const metadata: JobNoteMetadata = {
+      jobId: job.id, // the operator-facing slug, so it survives the vault's note-id assignment.
+      channel: job.channel,
+      cron: job.cron,
+      enabled: job.enabled ? "true" : "false",
+      createdAt: job.createdAt,
+    };
+    if (job.tz) metadata.tz = job.tz;
+    if (job.lastRunAt) metadata.lastRunAt = job.lastRunAt;
+    if (job.lastStatus) metadata.lastStatus = job.lastStatus;
+
+    const res = await fetch(`${this.vaultUrl}/vault/${this.vault}/api/notes`, {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${this.token}` },
+      body: JSON.stringify({ content: job.message, path, tags: [AGENT_JOB_TAG], metadata }),
+    });
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "");
+      throw new Error(`vault transport: write job failed (${res.status}) ${detail}`.trim());
+    }
+    let noteId = path;
+    try {
+      const created = (await res.json()) as { id?: string; note?: { id?: string } };
+      noteId = created?.id ?? created?.note?.id ?? path;
+    } catch {
+      // Non-JSON / empty body — keep the path as the addressable id.
+    }
+    return { id: noteId };
+  }
+
+  /**
+   * PATCH a job note's bookkeeping metadata (lastRunAt / lastStatus) after a fire,
+   * by note id. We send ONLY the changed metadata fields; the vault merges them.
+   * Best-effort on the runner's side (a failed status-write is logged, not fatal),
+   * so this throws and the caller decides — the runner swallows it.
+   */
+  async patchJobNote(
+    id: string,
+    fields: { lastRunAt?: string; lastStatus?: string; enabled?: boolean },
+  ): Promise<void> {
+    const metadata: Record<string, string> = {};
+    if (fields.lastRunAt !== undefined) metadata.lastRunAt = fields.lastRunAt;
+    if (fields.lastStatus !== undefined) metadata.lastStatus = fields.lastStatus;
+    if (fields.enabled !== undefined) metadata.enabled = fields.enabled ? "true" : "false";
+    const res = await fetch(
+      `${this.vaultUrl}/vault/${this.vault}/api/notes/${encodeURIComponent(id)}`,
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json", authorization: `Bearer ${this.token}` },
+        body: JSON.stringify({ metadata }),
+      },
+    );
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "");
+      throw new Error(`vault transport: patch job failed (${res.status}) ${detail}`.trim());
+    }
+  }
+
+  /** Delete a job note by id. Throws on a non-ok vault response. */
+  async deleteJobNote(id: string): Promise<void> {
+    const res = await fetch(
+      `${this.vaultUrl}/vault/${this.vault}/api/notes/${encodeURIComponent(id)}`,
+      { method: "DELETE", headers: { authorization: `Bearer ${this.token}` } },
+    );
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "");
+      throw new Error(`vault transport: delete job failed (${res.status}) ${detail}`.trim());
+    }
   }
 
   // -------------------------------------------------------------------------

--- a/src/transports/vault.ts
+++ b/src/transports/vault.ts
@@ -216,6 +216,10 @@ export const CHANNEL_VAULT_TAG_SCHEMA: ReadonlyArray<{
     parent_names: [CHANNEL_MESSAGE_TAG],
     description: "Session→human reply.",
   },
+  {
+    name: AGENT_JOB_TAG,
+    description: "A scheduled job — the runner injects this note's message on its cron schedule.",
+  },
 ];
 
 /**

--- a/src/ui-kit.test.ts
+++ b/src/ui-kit.test.ts
@@ -39,8 +39,15 @@ describe("appShell", () => {
     expect(appShell({ active: "terminal" })).not.toContain("app-controls");
   });
 
-  test("nav covers exactly home/chat/agents/terminal/config, Home first", () => {
-    expect(NAV_VIEWS.map((v) => v.view)).toEqual(["home", "chat", "agents", "terminal", "config"]);
+  test("nav covers exactly home/chat/agents/schedules/terminal/config, Home first", () => {
+    expect(NAV_VIEWS.map((v) => v.view)).toEqual([
+      "home",
+      "chat",
+      "agents",
+      "schedules",
+      "terminal",
+      "config",
+    ]);
   });
 });
 

--- a/src/ui-kit.ts
+++ b/src/ui-kit.ts
@@ -59,6 +59,7 @@ export const NAV_VIEWS = [
   { view: "home", label: "Home", path: "/home" },
   { view: "chat", label: "Chat", path: "/ui" },
   { view: "agents", label: "Agents", path: "/agents" },
+  { view: "schedules", label: "Schedules", path: "/jobs" },
   { view: "terminal", label: "Terminal", path: "/terminal" },
   { view: "config", label: "Config", path: "/admin" },
 ] as const;
@@ -263,8 +264,8 @@ export function appShell(opts: { active: ShellView; controls?: string; status?: 
  */
 export const SHELL_JS = `
   // Public mount prefix: "" on loopback, "/channel" behind the hub proxy.
-  var MOUNT = window.location.pathname.replace(/\\/(home|ui|admin|agents|terminal)(\\/[^?]*)?\\/?$/, "");
-  var NAV_MAP = { home: "/home", chat: "/ui", agents: "/agents", terminal: "/terminal", config: "/admin" };
+  var MOUNT = window.location.pathname.replace(/\\/(home|ui|admin|agents|jobs|terminal)(\\/[^?]*)?\\/?$/, "");
+  var NAV_MAP = { home: "/home", chat: "/ui", agents: "/agents", schedules: "/jobs", terminal: "/terminal", config: "/admin" };
   function wireShell(active) {
     var links = document.querySelectorAll(".app-nav a[data-view]");
     for (var i = 0; i < links.length; i++) {


### PR DESCRIPTION
## Runner — Phase 2 of the Parachute Agent consolidation

A **scheduled job is an automated human**: send message M to a vault agent A on cron S. The runner **executes nothing itself** — it authors an inbound `#channel-message/inbound` note on a schedule, and the existing **vault trigger → agent-turn → outbound** flow does the rest. No new turn path, no new authority (reuses the channel's existing `vault:<name>:write` token; the runner mints nothing).

Design: [`design/2026-06-17-runner-scheduled-agent-turns.md`](../blob/ag-agent-phase2-runner/design/2026-06-17-runner-scheduled-agent-turns.md). Blueprint §Sequencing step 2.

### Storage is vault-native
A job **IS an `#agent-job` note** in the target channel's vault — durable, queryable, surface-renderable. No `jobs.json`. The brand-new job tag adopts the module's new identity (`#agent-job`); the **injected message notes keep the existing `#channel-message` tags** (the `#channel-message → #agent-message` rename is a separate Phase-3 data migration, not here).

### What's in it
- **`src/cron.ts`** — dependency-free 5-field cron (`* */n a-b a,b a-b/n`) + **tz-aware `nextRunAfter`** via `Intl.DateTimeFormat` wall-clock evaluation. Day-skip search so a sparse spec (e.g. `Feb 29`) resolves without crawling a million minutes; **strictly-after** so a fired slot never double-fires; documented DST v1 behavior. Pure + unit-tested.
- **`src/jobs.ts`** — `Job` model + pure `validateJob` + `VaultJobStore` (`listAll`/`upsert`/`remove`/`patch` over `#agent-job` notes; **index-free client-side channel filter**, same pattern as `loadTranscript`).
- **`src/runner.ts`** — the scheduler. **Injectable clock + loadJobs + fire + persistFire + tick driver** (deterministic tests; no real `setInterval`/`Date.now` in the core). In-memory horizon map (`nextRunAt` never persisted), **fire-once-on-miss** catch-up, **overlap guard**.
- **`VaultTransport.injectInbound`** — the runner's only transport seam (sibling of `reply()`, writes the inbound message tags) + the `#agent-job` note CRUD.
- **API** (`channel:admin`): `GET`/`POST /api/jobs`, `DELETE /api/jobs/:id`, `POST /api/jobs/:id/run`.
- **`src/jobs-ui.ts`** — a sibling **Schedules** page (`/jobs`, nav entry): list (agent · cron · next-run · last-status), add form (vault-agent picker → message → cron + presets), enable/disable, run-now, delete. Reuses the `ui-kit` shell + hub-minted token bootstrap.
- Daemon boots the runner (30s `unref`'d tick); shutdown stops it.

**UI placement decision:** a **sibling `/jobs` page**, not a section on the agents page — each surface stays single-purpose (matching the one-page-per-concern idiom), it slots cleanly into the nav, and it avoids growing the already-large agents page. Noted in the design doc.

**Job ids:** the operator **slug** stays the user-facing id (carried in `metadata.jobId` + the `runner:<jobId>` sender); the vault **note id** addresses CRUD (`Job.noteId`).

### Gates (literal)
- `bun test ./src` → **788 pass, 0 fail** (baseline on main: 701 → +87 new tests).
- `bun run typecheck` → only the **2 pre-existing `src/bridge.ts` TS2589** errors remain (untouched, per brief); zero new type errors.
- **No version bump.**
- Boot-smoke verified: runner starts, `/jobs` serves, `/api/jobs` is `401` without auth, Schedules nav renders.

### For the reviewer to scrutinize
- **cron/tz correctness** (`src/cron.ts`) — the day-skip search + strictly-after invariant + the documented DST v1 behavior (spring-forward gap skipped; fall-back repeat may fire twice). Concrete cases in `src/cron.test.ts` (LA 07:53, hourly, `*/15`, weekday 9am, end-of-month/year, leap day, tz-offset shift, DST).
- **The inject seam** — `injectInbound` writes `#channel-message` + `#channel-message/inbound` exactly like `reply()` (inbound, no `channel_inbound_rendered_at`), so the existing trigger fires and there is no loop risk (it only ever writes inbound).
- **Scheduler determinism** — the runner's core is clock/load/fire/persist/tick-injected; verify the fire-once-on-miss + overlap-guard tests in `src/runner.test.ts`.
- **Vault-native CRUD** — `src/transports/vault.test.ts` (job note list/upsert/patch/delete) + `src/daemon-jobs-api.test.ts` (the routes end-to-end, auth-gated, against a stubbed vault).

🤖 Generated with [Claude Code](https://claude.com/claude-code)