### PR TITLE
fix(agent): idle with zero channels instead of exiting

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -2906,12 +2906,17 @@ function main(): void {
   }
 
   if (channels.size === 0) {
-    console.error(
-      `parachute-agent: no channels configured.\n` +
-        `  Add ${join(STATE_DIR, "channels.json")} (or use the admin UI at /agent/admin)\n` +
-        `  to define a channel. Telegram channels carry a per-channel bot token in config.`,
+    // Zero channels is a valid STARTING state, not a fatal error. The daemon must
+    // stay up and serve its HTTP surface so an operator can create the first agent
+    // (the /agent/admin + create-agent UI POST to this very daemon — exiting here is
+    // a chicken-and-egg: you couldn't define the first channel), and so future
+    // vault-defined agents can appear into a running module. Channels added live
+    // (via the API/UI, or hot-added) are picked up immediately. So: warn + idle.
+    console.warn(
+      `parachute-agent: no channels configured yet — starting idle.\n` +
+        `  Create an agent via the admin UI at /agent/admin (or add ${join(STATE_DIR, "channels.json")}).\n` +
+        `  The daemon stays up; channels added live are picked up immediately.`,
     );
-    process.exit(1);
   }
 
   const registry = new ClientRegistry();


### PR DESCRIPTION
The daemon `process.exit(1)`'d when `channels.size === 0`. That's a chicken-and-egg for the create-agent flow and a blocker for the clean-slate / vault-native direction: you can't define the first channel via the admin UI / create-agent POST if the daemon won't stay up with zero channels, and a freshly-wiped or freshly-installed module crash-loops under the supervisor (`supervisor: crashed`) instead of idling ready.

**Fix:** zero channels is a valid starting state — warn + start the HTTP surface so channels/agents can be created live (and future vault-defined `#agent/*` agents can appear into a running module).

**Verified:** daemon stays up with zero channels (`/health` → `{"status":"ok","channels":[]}`); live-added channels picked up as before. Found during the channel→agent cutover (a clean wipe left zero channels → the old code crash-looped).

Gates: `bun test ./src` → 821 pass / 0 fail; typecheck clean except the 2 pre-existing `src/bridge.ts` TS2589. No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)