### PR TITLE
Phase 4a — vault-native agent definitions (an agent IS a #agent/definition note)

### DIFF
--- a/.parachute/module.json
+++ b/.parachute/module.json
@@ -42,7 +42,7 @@
         "module": "vault",
         "event": "note.created",
         "filter": {
-          "tags": ["#agent-message/inbound"],
+          "tags": ["#agent/message/inbound"],
           "has_metadata": ["channel"],
           "missing_metadata": ["channel_inbound_rendered_at"]
         }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,38 +155,50 @@ set headers). On a 401/SSE-error it re-fetches once and retries. `/ui`, `/health
 `/.parachute/config[/schema]` stay OPEN — the page must load to bootstrap its token fetch, and the
 config listing is non-sensitive.
 
-## Vault integration (Stage 2) — channels backed by `#agent-message` notes
+## Vault integration (Stage 2) — channels backed by `#agent/message` notes
 
 A `vault` transport backs a channel with notes in a Parachute vault, so messages
 are durable, queryable, and a vault surface can render them. Multiple channels per
 vault: the note's `channel` metadata routes it.
 
+**The `#agent/*` namespace is module-owned** (design
+`design/2026-06-17-vault-native-agents.md`). Every vault object this module manages
+hangs off the `#agent` prefix: `#agent/definition` (a vault-native agent def — body
+is the system prompt, metadata is the config), `#agent/message{,/inbound,/outbound}`
+(a conversation turn), `#agent/job` (a scheduled trigger). The tag schema declares
+`parent_names` so a human `tag:#agent` query rolls up to everything the module owns.
+The module always queries the EXACT leaf tag (never relies on prefix magic), and
+keeps the "tag both queryable parent + directional child literally" floor so loop
+avoidance + transcript listing work with zero per-vault schema dependency. DUAL-READ
+recognizes the prior flat `#agent-message*` and legacy `#channel-message*` tags on
+READ (pre-namespace history) but only ever WRITES the namespaced tags.
+
 **Note shape** — TWO tags per note, carried literally (two orthogonal axes):
-- the parent `#agent-message` — the QUERYABLE membership tag. A UI lists a channel's
-  whole transcript (both directions) with one `tag: "#agent-message"` + `metadata.channel`
+- the parent `#agent/message` — the QUERYABLE membership tag. A UI lists a channel's
+  whole transcript (both directions) with one `tag: "#agent/message"` + `metadata.channel`
   query, because the parent is literally on every note.
-- a directional child — the trigger DISCRIMINATOR: `#agent-message/inbound` (human→session)
-  or `#agent-message/outbound` (session reply).
+- a directional child — the trigger DISCRIMINATOR: `#agent/message/inbound` (human→session)
+  or `#agent/message/outbound` (session reply).
 
 **The slash is a namespace, NOT query inheritance.** In a Parachute vault a slash in a tag
-NAME is a namespace convention only — `query-notes { tag: "#agent-message" }` matches
+NAME is a namespace convention only — `query-notes { tag: "#agent/message" }` matches
 descendants by the `tags.parent_names` graph (declared via `update-tag`), NOT by name-prefix.
-A note tagged ONLY `#agent-message/inbound` is INVISIBLE to a `tag: "#agent-message"`
+A note tagged ONLY `#agent/message/inbound` is INVISIBLE to a `tag: "#agent/message"`
 query unless that inheritance was separately declared — so we tag BOTH the parent and the
 child and don't depend on per-vault schema setup.
 
 Content = the message text; metadata: `{ channel, direction: "inbound"|"outbound", sender,
 in_reply_to (outbound), ts }`. Loop avoidance lives in the TAG, not metadata: the trigger
 fires on the inbound child tag only (exact match), which an outbound note never carries, so a
-reply never wakes its own session. **Inbound notes MUST carry BOTH `#agent-message` (parent,
-makes it queryable) AND `#agent-message/inbound` (child, fires the trigger), with the channel
-name in `metadata.channel`.** Outbound notes carry `#agent-message` + `#agent-message/outbound`.
+reply never wakes its own session. **Inbound notes MUST carry BOTH `#agent/message` (parent,
+makes it queryable) AND `#agent/message/inbound` (child, fires the trigger), with the channel
+name in `metadata.channel`.** Outbound notes carry `#agent/message` + `#agent/message/outbound`.
 
-**Flow.** INBOUND (human→session): a new `#agent-message` + `#agent-message/inbound` note →
+**Flow.** INBOUND (human→session): a new `#agent/message` + `#agent/message/inbound` note →
 a vault **trigger** POSTs a webhook → the agent daemon's `POST /api/vault/inbound` → routes by
 `note.metadata.channel` → `ctx.emit` wakes the session (fans to SSE bridges + HTTP-MCP sessions
-alike). OUTBOUND (session→human): the session's `reply` writes a `#agent-message` +
-`#agent-message/outbound` note via the vault REST API (`POST <vaultUrl>/vault/<vault>/api/notes`,
+alike). OUTBOUND (session→human): the session's `reply` writes a `#agent/message` +
+`#agent/message/outbound` note via the vault REST API (`POST <vaultUrl>/vault/<vault>/api/notes`,
 Bearer `vault:<name>:write`).
 
 **channels.json** (the channel side):
@@ -197,20 +209,20 @@ Bearer `vault:<name>:write`).
 ```
 
 **Vault side** (operator config — activates the inbound trigger):
-1. (Optional, for indexed queries) declare the `#agent-message` tag schema with
+1. (Optional, for indexed queries) declare the `#agent/message` tag schema with
    indexed `channel`/`direction`/`sender` fields (`update-tag`).
 2. Add a trigger to the vault's `config.yaml` that fires on new inbound notes and
    webhooks the agent daemon. Loop avoidance is by tag: the vault predicate does
-   EXACT tag membership, so firing on the inbound CHILD tag (`#agent-message/inbound`)
-   never matches an outbound (reply) note — which carries `#agent-message/outbound`,
+   EXACT tag membership, so firing on the inbound CHILD tag (`#agent/message/inbound`)
+   never matches an outbound (reply) note — which carries `#agent/message/outbound`,
    not the inbound child — so no `missing_metadata` clause is needed. (Both directions
-   also carry the parent `#agent-message`, but the trigger keys on the child only.)
+   also carry the parent `#agent/message`, but the trigger keys on the child only.)
    ```yaml
    triggers:
      - name: channel_inbound
        events: ["created"]
        when:
-         tags: ["#agent-message/inbound"]
+         tags: ["#agent/message/inbound"]
          has_metadata: ["channel"]
          missing_metadata: ["channel_inbound_rendered_at"]
        action:
@@ -219,7 +231,7 @@ Bearer `vault:<name>:write`).
    ```
    The shared secret rides in the URL — vault doesn't sign webhooks yet; a hub-JWT
    auth block on the trigger is a follow-up. The daemon defends in depth too:
-   `ingestInbound` drops any note tagged `#agent-message/outbound`, so a reply can
+   `ingestInbound` drops any note tagged `#agent/message/outbound`, so a reply can
    never wake its own session.
 
 ## Environment variables

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ sessions from the browser**.
 ## What you get
 
 - **Talk to a session over any transport.** A channel is bound to one transport:
-  - `vault` — messages are durable [`#agent-message`](#vault-backed-channels)
+  - `vault` — messages are durable [`#agent/message`](#vault-backed-channels)
     notes in a Parachute vault, so the conversation is queryable and renders in any
     vault surface (this is the recommended transport).
   - `telegram` — a Telegram bot, one per channel.
@@ -123,9 +123,9 @@ Reachable at `<hub-origin>/agent/`:
 ## Vault-backed channels
 
 A `vault` channel stores every message as a note carrying **two tags**: the parent
-`#agent-message` (queryable membership — list a channel's whole transcript with
-one `tag: "#agent-message"` + `metadata.channel` query) and a directional child
-`#agent-message/inbound` (human→session) or `#agent-message/outbound`
+`#agent/message` (queryable membership — list a channel's whole transcript with
+one `tag: "#agent/message"` + `metadata.channel` query) and a directional child
+`#agent/message/inbound` (human→session) or `#agent/message/outbound`
 (session→human). Inbound notes wake the session via a vault trigger; replies are
 written as outbound notes. Because the conversation lives in the vault, it's
 durable, queryable, and renders in any vault surface — the built-in chat and a

--- a/src/admin-ui.test.ts
+++ b/src/admin-ui.test.ts
@@ -123,7 +123,7 @@ describe("unified transport select drives fields + submit path", () => {
     expect(html).toContain('requestedBy: "agent"');
     // The canonical source/sink: vault.note.created (inbound tag) → agent.message.deliver.
     expect(html).toContain('event: "note.created"');
-    expect(html).toContain("#agent-message/inbound");
+    expect(html).toContain("#agent/message/inbound");
     expect(html).toContain('action: "message.deliver"');
     // The chosen channel name (the shared #f-name input) rides as the sink param.
     expect(html).toContain("params: { channel: name }");
@@ -494,7 +494,7 @@ describe("module.json — modular-UI (P4) declaration", () => {
     expect(tmpl?.requestedBy).toBe("agent");
     expect(tmpl?.source?.module).toBe("vault");
     expect(tmpl?.source?.event).toBe("note.created");
-    expect(tmpl?.source?.filter?.tags).toContain("#agent-message/inbound");
+    expect(tmpl?.source?.filter?.tags).toContain("#agent/message/inbound");
     expect(tmpl?.sink?.module).toBe("agent");
     expect(tmpl?.sink?.action).toBe("message.deliver");
     // It's PARAMETERIZED — the operator picks the vault + names the channel.

--- a/src/admin-ui.ts
+++ b/src/admin-ui.ts
@@ -547,7 +547,7 @@ const PAGE_SCRIPT = String.raw`
     if (hint) {
       if (transport === "vault") {
         hint.innerHTML =
-          "Inbound messages become <code>#agent-message</code> notes; a session replies by writing notes. " +
+          "Inbound messages become <code>#agent/message</code> notes; a session replies by writing notes. " +
           "Clicking <strong>Add channel</strong> is your approval &mdash; the hub mints the cross-module tokens " +
           "and registers the vault trigger.";
       } else if (transport === "telegram") {

--- a/src/agent-defs.test.ts
+++ b/src/agent-defs.test.ts
@@ -1,0 +1,466 @@
+/**
+ * Unit tests for vault-native agent definitions (design
+ * 2026-06-17-vault-native-agents, Phase 4a).
+ *
+ * Three layers, all deterministic — `fetch` is stubbed (restored in afterEach, NO
+ * global mock.module leak) and the registry's side-effects are INJECTED so the
+ * lifecycle is exercised without a daemon, a vault, a sandbox, or tmux:
+ *   - parseAgentDef: note (body + metadata) → AgentSpec, defaults + validation;
+ *   - DefVaultClient: the def query encoding + the status PATCH;
+ *   - AgentDefRegistry: instantiate / reload (update + delete) / deregister, with a
+ *     recorder for ensureChannel / setupAndRegister / deregister / removeChannel.
+ */
+
+import { describe, test, expect, afterEach } from "bun:test";
+import {
+  parseAgentDef,
+  resolveDefStatus,
+  DefVaultClient,
+  AgentDefRegistry,
+  AgentDefParseError,
+  type DefVaultBinding,
+  type InstantiateDeps,
+} from "./agent-defs.ts";
+import type { AgentSpec } from "./sandbox/types.ts";
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+// ---------------------------------------------------------------------------
+// parseAgentDef — note → AgentSpec
+// ---------------------------------------------------------------------------
+
+describe("parseAgentDef", () => {
+  test("maps body → systemPrompt, metadata → spec; defaults backend=programmatic, own-vault binding", () => {
+    const def = parseAgentDef(
+      {
+        id: "Agents/uni-dev",
+        content: "You are uni-dev, the development agent for the Parachute project.",
+        metadata: { name: "uni-dev" },
+      },
+      { vault: "default" },
+    );
+    expect(def.noteId).toBe("Agents/uni-dev");
+    expect(def.name).toBe("uni-dev");
+    const spec = def.spec;
+    expect(spec.name).toBe("uni-dev");
+    // Wake channel = the agent name (agent ≡ channel).
+    expect(spec.channels).toEqual(["uni-dev"]);
+    expect(spec.backend).toBe("programmatic");
+    // Own-vault binding (4a): the def-vault, write-scoped.
+    expect(spec.vault).toEqual({ name: "default", access: "write" });
+    // The note BODY is the system prompt.
+    expect(spec.systemPrompt).toBe(
+      "You are uni-dev, the development agent for the Parachute project.",
+    );
+    // No declared connections → resolves enabled.
+    expect(def.declaredConnections).toEqual([]);
+    expect(resolveDefStatus(def)).toEqual({ status: "enabled" });
+  });
+
+  test("parses the full config knobs (backend, mode, workspace, filesystem, network, egress)", () => {
+    const def = parseAgentDef(
+      {
+        id: "n1",
+        content: "role prose",
+        metadata: {
+          name: "builder",
+          backend: "programmatic",
+          systemPromptMode: "replace",
+          workspace: "/Users/me/code/proj",
+          filesystem: "full",
+          network: "restricted",
+          egress: "api.github.com, registry.npmjs.org",
+        },
+      },
+      { vault: "default" },
+    );
+    const spec = def.spec;
+    expect(spec.systemPromptMode).toBe("replace");
+    expect(spec.workspace).toBe("/Users/me/code/proj");
+    expect(spec.filesystem).toBe("full");
+    expect(spec.network).toBe("restricted");
+    expect(spec.egress).toEqual(["api.github.com", "registry.npmjs.org"]);
+  });
+
+  test("a blank body → no systemPrompt (CC default untouched), no mode flag", () => {
+    const def = parseAgentDef(
+      { id: "n1", content: "   \n  ", metadata: { name: "a", systemPromptMode: "replace" } },
+      { vault: "default" },
+    );
+    expect("systemPrompt" in def.spec).toBe(false);
+    expect("systemPromptMode" in def.spec).toBe(false);
+  });
+
+  test("parses `uses` connections (NOT granted in 4a) → status pending listing them", () => {
+    const def = parseAgentDef(
+      {
+        id: "n1",
+        content: "role",
+        metadata: { name: "researcher", uses: "github, vault:research:read" },
+      },
+      { vault: "default" },
+    );
+    expect(def.declaredConnections).toEqual(["github", "vault:research:read"]);
+    expect(resolveDefStatus(def)).toEqual({
+      status: "pending",
+      pending: ["github", "vault:research:read"],
+    });
+  });
+
+  test("parses an array-valued `uses` field too", () => {
+    const def = parseAgentDef(
+      { id: "n1", content: "role", metadata: { name: "x", uses: ["github", "cloudflare"] } },
+      { vault: "default" },
+    );
+    expect(def.declaredConnections).toEqual(["github", "cloudflare"]);
+  });
+
+  test("parses JSON-array mounts; ignores malformed entries", () => {
+    const def = parseAgentDef(
+      {
+        id: "n1",
+        content: "role",
+        metadata: {
+          name: "x",
+          mounts: JSON.stringify([
+            { hostPath: "/data", mountPath: "/data", mode: "ro" },
+            { hostPath: "relative", mountPath: "/x", mode: "ro" }, // dropped (not absolute)
+            { hostPath: "/y", mountPath: "/y", mode: "bogus" }, // dropped (bad mode)
+          ]),
+        },
+      },
+      { vault: "default" },
+    );
+    expect(def.spec.mounts).toEqual([{ hostPath: "/data", mountPath: "/data", mode: "ro" }]);
+  });
+
+  test("rejects a note with no metadata.name", () => {
+    expect(() => parseAgentDef({ id: "n1", content: "x", metadata: {} }, { vault: "default" })).toThrow(
+      AgentDefParseError,
+    );
+  });
+
+  test("rejects a non-slug name", () => {
+    expect(() =>
+      parseAgentDef({ id: "n1", content: "x", metadata: { name: "has spaces" } }, { vault: "default" }),
+    ).toThrow(/slug/);
+  });
+
+  test("rejects a bad backend / filesystem / network value", () => {
+    expect(() =>
+      parseAgentDef({ id: "n", content: "x", metadata: { name: "a", backend: "weird" } }, { vault: "v" }),
+    ).toThrow(/backend/);
+    expect(() =>
+      parseAgentDef({ id: "n", content: "x", metadata: { name: "a", filesystem: "weird" } }, { vault: "v" }),
+    ).toThrow(/filesystem/);
+    expect(() =>
+      parseAgentDef({ id: "n", content: "x", metadata: { name: "a", network: "weird" } }, { vault: "v" }),
+    ).toThrow(/network/);
+  });
+
+  test("rejects a relative workspace path", () => {
+    expect(() =>
+      parseAgentDef({ id: "n", content: "x", metadata: { name: "a", workspace: "rel/path" } }, { vault: "v" }),
+    ).toThrow(/absolute/);
+  });
+
+  test("does NOT read any secret field off the note (only references)", () => {
+    // A note that tries to smuggle a token must NOT end up on the spec.
+    const def = parseAgentDef(
+      { id: "n", content: "x", metadata: { name: "a", token: "sekret", CLAUDE_CODE_OAUTH_TOKEN: "sekret2" } },
+      { vault: "v" },
+    );
+    expect(JSON.stringify(def.spec)).not.toContain("sekret");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DefVaultClient — the def query + the status PATCH
+// ---------------------------------------------------------------------------
+
+const binding: DefVaultBinding = {
+  vault: "default",
+  vaultUrl: "http://127.0.0.1:1940",
+  token: "write-token",
+};
+
+describe("DefVaultClient", () => {
+  test("listDefNotes queries by the EXACT #agent/definition tag (encoded) with Bearer", async () => {
+    const urls: string[] = [];
+    let auth = "";
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      urls.push(String(url));
+      auth = (init?.headers as Record<string, string> | undefined)?.authorization ?? "";
+      return new Response(
+        JSON.stringify([
+          { id: "Agents/uni-dev", content: "role A", metadata: { name: "uni-dev" } },
+          { id: "Agents/researcher", content: "role B", metadata: { name: "researcher" } },
+          { id: "", content: "no id", metadata: { name: "skip" } }, // dropped (no id)
+        ]),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    const client = new DefVaultClient(binding);
+    const notes = await client.listDefNotes();
+    expect(urls).toHaveLength(1);
+    // `#agent/definition` → `%23agent%2Fdefinition` (both `#` and `/` encoded).
+    expect(urls[0]).toContain("tag=%23agent%2Fdefinition");
+    expect(urls[0]).toContain("include_content=true");
+    expect(auth).toBe("Bearer write-token");
+    expect(notes.map((n) => n.id)).toEqual(["Agents/uni-dev", "Agents/researcher"]);
+  });
+
+  test("listDefNotes throws on a non-ok vault response", async () => {
+    globalThis.fetch = (async () => new Response("nope", { status: 500 })) as unknown as typeof fetch;
+    const client = new DefVaultClient(binding);
+    await expect(client.listDefNotes()).rejects.toThrow(/list defs failed \(500\)/);
+  });
+
+  test("patchStatus PATCHes status + clears pending when enabled", async () => {
+    const calls: { url: string; init: RequestInit }[] = [];
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      calls.push({ url: String(url), init: init ?? {} });
+      return new Response(null, { status: 200 });
+    }) as typeof fetch;
+    const client = new DefVaultClient(binding);
+    await client.patchStatus("Agents/uni-dev", "enabled");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.init.method).toBe("PATCH");
+    expect(calls[0]!.url).toContain("/api/notes/");
+    const body = JSON.parse(String(calls[0]!.init.body));
+    expect(body.metadata.status).toBe("enabled");
+    // Always sets pending (empty here) so a prior list doesn't go stale.
+    expect(body.metadata.pending).toBe("");
+  });
+
+  test("patchStatus writes the pending list joined when pending", async () => {
+    let captured: Record<string, string> = {};
+    globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+      captured = JSON.parse(String(init?.body)).metadata;
+      return new Response(null, { status: 200 });
+    }) as typeof fetch;
+    const client = new DefVaultClient(binding);
+    await client.patchStatus("n", "pending", ["github", "vault:research:read"]);
+    expect(captured.status).toBe("pending");
+    expect(captured.pending).toBe("github, vault:research:read");
+  });
+
+  test("getNote returns null on 404", async () => {
+    globalThis.fetch = (async () => new Response("no", { status: 404 })) as unknown as typeof fetch;
+    const client = new DefVaultClient(binding);
+    expect(await client.getNote("gone")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AgentDefRegistry — reactive lifecycle (instantiate / reload / deregister)
+// ---------------------------------------------------------------------------
+
+/** A recorder for the injected instantiate side-effects. */
+function recorderDeps() {
+  const calls = {
+    ensured: [] as string[],
+    registered: [] as AgentSpec[],
+    deregistered: [] as string[],
+    removed: [] as string[],
+  };
+  const deps: InstantiateDeps = {
+    ensureChannel: async (name) => {
+      calls.ensured.push(name);
+    },
+    setupAndRegister: async (spec) => {
+      calls.registered.push(spec);
+    },
+    deregister: async (name) => {
+      calls.deregistered.push(name);
+      return true;
+    },
+    removeChannel: async (name) => {
+      calls.removed.push(name);
+      return true;
+    },
+  };
+  return { deps, calls };
+}
+
+/** A fetch that serves a def list + records PATCHes, keyed by query. */
+function vaultFetch(opts: {
+  defs?: Array<{ id: string; content?: string; metadata?: Record<string, unknown> }>;
+  byId?: Record<string, { id: string; content?: string; metadata?: Record<string, unknown> } | null>;
+  patches?: Array<{ id: string; status?: string; pending?: string }>;
+}): typeof fetch {
+  return (async (url: string | URL | Request, init?: RequestInit) => {
+    const u = String(url);
+    const method = init?.method ?? "GET";
+    if (method === "PATCH") {
+      const id = decodeURIComponent(u.split("/api/notes/")[1]!);
+      const meta = JSON.parse(String(init?.body)).metadata as Record<string, string>;
+      opts.patches?.push({ id, status: meta.status, pending: meta.pending });
+      return new Response(null, { status: 200 });
+    }
+    if (u.includes("/api/notes?") && u.includes("tag=%23agent%2Fdefinition")) {
+      return new Response(JSON.stringify(opts.defs ?? []), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    // GET one note by id (reload path).
+    const m = u.match(/\/api\/notes\/([^?]+)/);
+    if (m) {
+      const id = decodeURIComponent(m[1]!);
+      const note = opts.byId?.[id] ?? null;
+      if (!note) return new Response("no", { status: 404 });
+      return new Response(JSON.stringify(note), { status: 200 });
+    }
+    return new Response("[]", { status: 200 });
+  }) as typeof fetch;
+}
+
+describe("AgentDefRegistry — lifecycle", () => {
+  test("loadAll instantiates each def: ensureChannel + setupAndRegister + status stamp", async () => {
+    const { deps, calls } = recorderDeps();
+    const patches: Array<{ id: string; status?: string; pending?: string }> = [];
+    const fetchFn = vaultFetch({
+      defs: [
+        { id: "Agents/uni-dev", content: "role A", metadata: { name: "uni-dev" } },
+        { id: "Agents/researcher", content: "role B", metadata: { name: "researcher", uses: "github" } },
+      ],
+      patches,
+    });
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn });
+    const n = await reg.loadAll();
+    expect(n).toBe(2);
+    expect(calls.ensured).toEqual(["uni-dev", "researcher"]);
+    expect(calls.registered.map((s) => s.name)).toEqual(["uni-dev", "researcher"]);
+    // Both agents bind their own vault, write-scoped (own-vault, 4a).
+    expect(calls.registered[0]!.vault).toEqual({ name: "default", access: "write" });
+    expect(calls.registered[0]!.backend).toBe("programmatic");
+    // Status stamped: uni-dev enabled (no connections), researcher pending (declares github).
+    const uni = patches.find((p) => p.id === "Agents/uni-dev")!;
+    const res = patches.find((p) => p.id === "Agents/researcher")!;
+    expect(uni.status).toBe("enabled");
+    expect(uni.pending).toBe("");
+    expect(res.status).toBe("pending");
+    expect(res.pending).toBe("github");
+    // The live set reflects both.
+    expect(reg.list().map((d) => d.name).sort()).toEqual(["researcher", "uni-dev"]);
+  });
+
+  test("a malformed def is skipped (status error) and does NOT abort the others", async () => {
+    const { deps, calls } = recorderDeps();
+    const patches: Array<{ id: string; status?: string; pending?: string }> = [];
+    const fetchFn = vaultFetch({
+      defs: [
+        { id: "bad", content: "x", metadata: {} }, // no name → parse error
+        { id: "Agents/ok", content: "role", metadata: { name: "ok" } },
+      ],
+      patches,
+    });
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn });
+    const n = await reg.loadAll();
+    expect(n).toBe(1); // only the good one
+    expect(calls.registered.map((s) => s.name)).toEqual(["ok"]);
+    expect(patches.find((p) => p.id === "bad")!.status).toBe("error");
+  });
+
+  test("an instantiate failure stamps error and does not record a live def", async () => {
+    const { deps } = recorderDeps();
+    // Make registration fail (e.g. missing Claude credential at setup).
+    deps.setupAndRegister = async () => {
+      throw new Error("CredentialNotConfigured: set the Claude credential");
+    };
+    const patches: Array<{ id: string; status?: string }> = [];
+    const fetchFn = vaultFetch({
+      defs: [{ id: "Agents/x", content: "role", metadata: { name: "x" } }],
+      patches,
+    });
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn });
+    const n = await reg.loadAll();
+    expect(n).toBe(0);
+    expect(reg.list()).toHaveLength(0);
+    expect(patches.find((p) => p.id === "Agents/x")!.status).toBe("error");
+  });
+
+  test("reload(updated) re-instantiates the changed def (idempotent replace)", async () => {
+    const { deps, calls } = recorderDeps();
+    const fetchFn = vaultFetch({
+      byId: { "Agents/uni-dev": { id: "Agents/uni-dev", content: "NEW role", metadata: { name: "uni-dev" } } },
+    });
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn });
+    const result = await reg.reload("default", "Agents/uni-dev", "updated");
+    expect(result).toBe("instantiated");
+    expect(calls.registered).toHaveLength(1);
+    expect(calls.registered[0]!.systemPrompt).toBe("NEW role");
+    expect(reg.list().map((d) => d.name)).toEqual(["uni-dev"]);
+  });
+
+  test("reload(deleted) deregisters + removes the channel without a fetch", async () => {
+    const { deps, calls } = recorderDeps();
+    // Seed a live def first via loadAll, then delete it.
+    const fetchFn = vaultFetch({
+      defs: [{ id: "Agents/uni-dev", content: "role", metadata: { name: "uni-dev" } }],
+    });
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn });
+    await reg.loadAll();
+    expect(reg.list()).toHaveLength(1);
+
+    const result = await reg.reload("default", "Agents/uni-dev", "deleted");
+    expect(result).toBe("deregistered");
+    expect(calls.deregistered).toEqual(["uni-dev"]);
+    expect(calls.removed).toEqual(["uni-dev"]);
+    expect(reg.list()).toHaveLength(0);
+  });
+
+  test("reload of a note that re-reads as gone (no event) deregisters", async () => {
+    const { deps, calls } = recorderDeps();
+    const fetchFn = vaultFetch({
+      defs: [{ id: "Agents/uni-dev", content: "role", metadata: { name: "uni-dev" } }],
+      byId: { "Agents/uni-dev": null }, // a later GET says it's gone
+    });
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn });
+    await reg.loadAll();
+    const result = await reg.reload("default", "Agents/uni-dev"); // no event → fetch → 404
+    expect(result).toBe("deregistered");
+    expect(calls.deregistered).toEqual(["uni-dev"]);
+  });
+
+  test("reload for an unknown def-vault is a safe skip", async () => {
+    const { deps } = recorderDeps();
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn: vaultFetch({}) });
+    expect(await reg.reload("ghost-vault", "n")).toBe("skipped");
+  });
+
+  test("a def-vault list failure does not sink the others (best-effort per vault)", async () => {
+    const { deps, calls } = recorderDeps();
+    const b2: DefVaultBinding = { vault: "research", vaultUrl: "http://127.0.0.1:1940", token: "t2" };
+    // vault `default` 500s its list; `research` serves one def.
+    const fetchFn = (async (url: string | URL | Request) => {
+      const u = String(url);
+      if (u.includes("/vault/default/")) return new Response("boom", { status: 500 });
+      if (u.includes("/vault/research/") && u.includes("tag=%23agent%2Fdefinition")) {
+        return new Response(JSON.stringify([{ id: "r1", content: "role", metadata: { name: "r" } }]), {
+          status: 200,
+        });
+      }
+      return new Response(null, { status: 200 }); // PATCHes etc.
+    }) as typeof fetch;
+    const reg = new AgentDefRegistry(deps, { bindings: [binding, b2], fetchFn });
+    const n = await reg.loadAll();
+    expect(n).toBe(1);
+    expect(calls.registered.map((s) => s.name)).toEqual(["r"]);
+  });
+
+  test("soleVaultName resolves the single binding (the reload-webhook default)", () => {
+    const { deps } = recorderDeps();
+    const reg = new AgentDefRegistry(deps, { bindings: [binding] });
+    expect(reg.soleVaultName()).toBe("default");
+    expect(reg.vaultCount).toBe(1);
+    reg.addVault({ vault: "research", token: "t" });
+    expect(reg.soleVaultName()).toBeUndefined();
+    expect(reg.vaultCount).toBe(2);
+  });
+});

--- a/src/agent-defs.test.ts
+++ b/src/agent-defs.test.ts
@@ -161,6 +161,12 @@ describe("parseAgentDef", () => {
     ).toThrow(/network/);
   });
 
+  test("rejects backend:interactive for 4a (not yet wired for vault defs)", () => {
+    expect(() =>
+      parseAgentDef({ id: "n", content: "x", metadata: { name: "a", backend: "interactive" } }, { vault: "v" }),
+    ).toThrow(/interactive/);
+  });
+
   test("rejects a relative workspace path", () => {
     expect(() =>
       parseAgentDef({ id: "n", content: "x", metadata: { name: "a", workspace: "rel/path" } }, { vault: "v" }),

--- a/src/agent-defs.ts
+++ b/src/agent-defs.ts
@@ -175,13 +175,24 @@ export function parseAgentDef(note: {
   }
 
   // Backend — default programmatic (the reliable primary path; interactive is the
-  // gated opt-in, selectable but not the default for a vault def).
+  // gated opt-in, selectable but not the default for a vault def). 4a: the
+  // vault-native instantiate path is programmatic-only — `interactive` is NOT yet
+  // wired for vault defs (it forces a tmux spawn the def path doesn't drive). So we
+  // REJECT it here with a clear message (→ status:error on the note) rather than
+  // silently demoting to programmatic. Supporting interactive for vault defs is a
+  // later increment.
   let backend: AgentBackendKind = "programmatic";
   const rawBackend = metaStr(meta.backend);
   if (rawBackend !== undefined) {
-    if (rawBackend !== "programmatic" && rawBackend !== "interactive") {
+    if (rawBackend === "interactive") {
       throw new AgentDefParseError(
-        `#agent/definition note ${noteId}: backend must be "programmatic" or "interactive"`,
+        `#agent/definition note ${noteId}: the "interactive" backend is not yet supported for ` +
+          `vault-native defs — use "programmatic" (the default).`,
+      );
+    }
+    if (rawBackend !== "programmatic") {
+      throw new AgentDefParseError(
+        `#agent/definition note ${noteId}: backend must be "programmatic"`,
       );
     }
     backend = rawBackend;

--- a/src/agent-defs.ts
+++ b/src/agent-defs.ts
@@ -1,0 +1,660 @@
+/**
+ * Vault-native agent definitions — an agent IS a `#agent/definition` note
+ * (design `2026-06-17-vault-native-agents.md`, Phase 4a).
+ *
+ * Instead of a `channels.json` entry + a `sessions/<name>/spec.json`, a
+ * vault-native agent is a single vault note: the note BODY is the system prompt,
+ * the note METADATA is the config. The module reads `#agent/definition` notes from
+ * a configured DEF-VAULT and, for each one, instantiates a live agent — a vault
+ * channel (so inbound/outbound notes flow) + a registered programmatic agent (so an
+ * inbound turn runs `claude -p`). Reactively: a note created/updated/deleted →
+ * reload that one agent.
+ *
+ * REUSE (the design's "near-stateless executor" point — this module is small
+ * because it stands on the existing machinery):
+ *   - {@link AgentSpec} (sandbox/types.ts) stays the canonical in-memory shape; only
+ *     its SOURCE moves from `spec.json` to a note. {@link parseAgentDef} is "note →
+ *     AgentSpec".
+ *   - `addChannelLive` (daemon.ts) brings up the vault channel — the SAME call the
+ *     create-agent flow + boot use; injected here as {@link InstantiateDeps.ensureChannel}.
+ *   - `setupProgrammaticSpawn` (agents.ts) persists `spec.json` (so the existing boot
+ *     re-register + the per-turn deliver find the workspace) and `programmatic.register`
+ *     registers the agent — injected as {@link InstantiateDeps.setupAndRegister}.
+ *   - The def-vault's `vault:<name>:write` token (minted by the daemon the SAME way a
+ *     channel/job token is — `mint-token.ts`) drives BOTH the def query and the status
+ *     stamp; the vault REST encoding mirrors `VaultTransport`.
+ *
+ * SCOPE (4a only — OWN-VAULT). An agent defined in vault X is scoped to vault X: its
+ * conversation + jobs live there, and its minted vault token is for X. There is NO
+ * cross-vault / MCP / external-service connector, NO approval flow — that is 4b.
+ * A def MAY declare a `uses: […]` / connections field; we PARSE + SURFACE it (so the
+ * status note lists what it wants) but do NOT grant it. Secrets NEVER live in a note;
+ * the Claude OAuth token + any service creds stay in the local store and are injected
+ * at run time by the programmatic backend, exactly as today.
+ *
+ * STATUS (queryable liveness — the design's "lives in the field so an MCP side knows"):
+ * after resolving a def, the registry PATCHes the note's metadata `status`. In 4a
+ * (own-vault only) a successfully-instantiated agent is `enabled`; a def that declares
+ * external connections is `pending` (listing them) since 4b hasn't granted them yet —
+ * it still runs own-vault, the declared connections are simply absent until approved.
+ */
+
+import {
+  type AgentSpec,
+  type AgentBackendKind,
+  type SystemPromptMode,
+  type AgentMount,
+} from "./sandbox/types.ts";
+import { AGENT_DEFINITION_TAG } from "./transports/vault.ts";
+
+const DEFAULT_DEF_VAULT_URL = "http://127.0.0.1:1940";
+
+/** A slug: alphanumeric, dash, underscore — the agent name + wake-channel key. */
+const NAME_SLUG_RE = /^[a-zA-Z0-9_-]+$/;
+
+/**
+ * A def-vault the module reads `#agent/definition` notes from. The architecture is
+ * a LIST (default: one — the local `default` vault) so opening up multi-vault later
+ * is appending, not a refactor (design "Decided: multi-vault"). The token grants
+ * vault read (query defs) + write (stamp status + the agents' message/job notes),
+ * scoped to THIS vault only — an agent defined here reaches only this vault (4a).
+ */
+export interface DefVaultBinding {
+  /** Vault name (the `<vault>` path segment in the REST URL). */
+  vault: string;
+  /** REST base origin. Default `http://127.0.0.1:1940`. */
+  vaultUrl?: string;
+  /** A `vault:<name>:write` hub JWT (read + write), presented as Bearer. */
+  token: string;
+}
+
+/** The resolved status of a def after instantiation (stamped onto the note). */
+export type AgentDefStatus = "enabled" | "pending" | "error";
+
+/**
+ * The parse of one `#agent/definition` note: the canonical {@link AgentSpec} the
+ * registry instantiates, plus the note bookkeeping (its id for PATCH, the declared
+ * connections to surface, and any parse error).
+ */
+export interface ParsedAgentDef {
+  /** The vault note id/path — addresses the note for the status PATCH. */
+  noteId: string;
+  /** The agent name (= the wake channel + the spec name). */
+  name: string;
+  /** The canonical in-memory spec, ready for `programmatic.register`. */
+  spec: AgentSpec;
+  /**
+   * Declared cross-vault / MCP / external-service connections beyond the def-vault
+   * (the `uses:` field). PARSED + surfaced in 4a; granting is 4b. Empty = own-vault
+   * only → `enabled`.
+   */
+  declaredConnections: string[];
+}
+
+/** A failed parse — the note isn't a well-formed agent def. */
+export class AgentDefParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AgentDefParseError";
+  }
+}
+
+/**
+ * Coerce a vault metadata value (the vault stores metadata as strings, but a note
+ * authored in another client may carry a real array/number) to a trimmed string.
+ */
+function metaStr(v: unknown): string | undefined {
+  if (typeof v === "string") {
+    const t = v.trim();
+    return t.length > 0 ? t : undefined;
+  }
+  if (typeof v === "number" || typeof v === "boolean") return String(v);
+  return undefined;
+}
+
+/**
+ * Parse a comma/space-separated list field OR a real array → a clean string[].
+ * Used for `egress` and `uses` (a note authored as YAML front-matter may carry
+ * either; a vault that stringifies arrays gives us the comma form).
+ */
+function metaList(v: unknown): string[] {
+  let parts: string[] = [];
+  if (Array.isArray(v)) {
+    parts = v.map((x) => (typeof x === "string" ? x : String(x)));
+  } else if (typeof v === "string") {
+    parts = v.split(/[,\s]+/);
+  }
+  return parts.map((s) => s.trim()).filter((s) => s.length > 0);
+}
+
+/**
+ * Parse one `#agent/definition` note into a {@link ParsedAgentDef}. PURE — no I/O.
+ *
+ * Mapping (the design's "note shape"):
+ *   - note BODY (`content`)  → `spec.systemPrompt` (the agent's role, in prose).
+ *   - `metadata.name`        → `spec.name` (REQUIRED, slug) = the wake channel.
+ *   - `metadata.backend`     → `spec.backend` (default `programmatic`).
+ *   - `metadata.systemPromptMode` → `spec.systemPromptMode` (default `append`).
+ *   - `metadata.workspace`   → `spec.workspace` (optional absolute host cwd).
+ *   - `metadata.filesystem`  → `spec.filesystem` (`workspace` | `full`).
+ *   - `metadata.network`     → `spec.network` (`open` | `restricted`).
+ *   - `metadata.egress`      → `spec.egress` (host list, for `restricted`).
+ *   - the def-vault binding   → `spec.vault` (own-vault, `write`) — passed in, since
+ *     the note never names which vault it lives in (it's defined BY being in it).
+ *   - `metadata.uses`        → `declaredConnections` (PARSED, NOT granted — 4b).
+ *
+ * `spec.channels` is `[name]` — the wake channel IS the agent name (the design's
+ * "agent ≡ channel" collapse). Throws {@link AgentDefParseError} on a missing/bad
+ * name (the registry skips that note + stamps `error`, rather than instantiating a
+ * malformed agent).
+ *
+ * SECRETS: a def declares creds BY REFERENCE only (`uses:`). We deliberately do NOT
+ * read any token/secret field off the note — secrets stay local. `credentialRef`
+ * stays the local Claude-credential selector (defaults to the wake channel) and is
+ * never sourced from the note.
+ */
+export function parseAgentDef(note: {
+  id?: string;
+  content?: string;
+  metadata?: Record<string, unknown>;
+}, binding: { vault: string }): ParsedAgentDef {
+  const noteId = typeof note.id === "string" ? note.id : "";
+  if (!noteId) {
+    throw new AgentDefParseError("#agent/definition note has no id");
+  }
+  const meta = note.metadata ?? {};
+
+  const name = metaStr(meta.name);
+  if (!name) {
+    throw new AgentDefParseError(`#agent/definition note ${noteId} has no metadata.name`);
+  }
+  if (!NAME_SLUG_RE.test(name)) {
+    throw new AgentDefParseError(
+      `#agent/definition note ${noteId}: name "${name}" must be a slug (alphanumeric, dash, underscore)`,
+    );
+  }
+
+  // Backend — default programmatic (the reliable primary path; interactive is the
+  // gated opt-in, selectable but not the default for a vault def).
+  let backend: AgentBackendKind = "programmatic";
+  const rawBackend = metaStr(meta.backend);
+  if (rawBackend !== undefined) {
+    if (rawBackend !== "programmatic" && rawBackend !== "interactive") {
+      throw new AgentDefParseError(
+        `#agent/definition note ${noteId}: backend must be "programmatic" or "interactive"`,
+      );
+    }
+    backend = rawBackend;
+  }
+
+  const spec: AgentSpec = {
+    name,
+    channels: [name], // wake channel = the agent name (agent ≡ channel)
+    backend,
+    // Own-vault binding (4a): the def-vault, write-scoped. NOT sourced from the note
+    // — it's the vault the note LIVES in (passed in by the caller).
+    vault: { name: binding.vault, access: "write" },
+  };
+
+  // The note body IS the system prompt. A blank body → no system prompt (CC's
+  // default, untouched) rather than an empty `--append-system-prompt-file`.
+  const body = typeof note.content === "string" ? note.content.trim() : "";
+  if (body.length > 0) {
+    spec.systemPrompt = note.content!; // keep the untrimmed body (whitespace may matter in prose)
+    const mode = metaStr(meta.systemPromptMode);
+    if (mode !== undefined) {
+      if (mode !== "append" && mode !== "replace") {
+        throw new AgentDefParseError(
+          `#agent/definition note ${noteId}: systemPromptMode must be "append" or "replace"`,
+        );
+      }
+      spec.systemPromptMode = mode as SystemPromptMode;
+    }
+  }
+
+  // Working directory (optional absolute host cwd). We do NOT statSync here (parse is
+  // pure + may run on a box where the dir is mounted differently); the spawn path's
+  // own checks apply when the turn runs.
+  const workspace = metaStr(meta.workspace);
+  if (workspace !== undefined) {
+    if (!workspace.startsWith("/")) {
+      throw new AgentDefParseError(
+        `#agent/definition note ${noteId}: workspace must be an absolute path (start with "/")`,
+      );
+    }
+    spec.workspace = workspace;
+  }
+
+  // Filesystem read scope.
+  const filesystem = metaStr(meta.filesystem);
+  if (filesystem !== undefined) {
+    if (filesystem !== "workspace" && filesystem !== "full") {
+      throw new AgentDefParseError(
+        `#agent/definition note ${noteId}: filesystem must be "workspace" or "full"`,
+      );
+    }
+    spec.filesystem = filesystem;
+  }
+
+  // Network egress mode + (under restricted) the additional host allowlist.
+  const network = metaStr(meta.network);
+  if (network !== undefined) {
+    if (network !== "open" && network !== "restricted") {
+      throw new AgentDefParseError(
+        `#agent/definition note ${noteId}: network must be "open" or "restricted"`,
+      );
+    }
+    spec.network = network;
+  }
+  const egress = metaList(meta.egress);
+  if (egress.length > 0) spec.egress = egress;
+
+  // Filesystem mounts — JSON-encoded array in metadata (the note can't carry a
+  // structured array natively in a string vault), parsed defensively. Optional; a
+  // malformed value is ignored (not fatal — mounts are an advanced knob).
+  const mounts = parseMounts(meta.mounts);
+  if (mounts.length > 0) spec.mounts = mounts;
+
+  // Declared connections beyond the def-vault (the `uses:` field). PARSED + surfaced;
+  // granting is 4b. Never a secret — these are NAMES (`github`, `vault:research:read`).
+  const declaredConnections = metaList(meta.uses);
+
+  return { noteId, name, spec, declaredConnections };
+}
+
+/** Parse a metadata `mounts` value (JSON array string or real array) → AgentMount[]. */
+function parseMounts(v: unknown): AgentMount[] {
+  let arr: unknown;
+  if (typeof v === "string") {
+    const t = v.trim();
+    if (t.length === 0) return [];
+    try {
+      arr = JSON.parse(t);
+    } catch {
+      return [];
+    }
+  } else {
+    arr = v;
+  }
+  if (!Array.isArray(arr)) return [];
+  const out: AgentMount[] = [];
+  for (const raw of arr) {
+    if (!raw || typeof raw !== "object") continue;
+    const m = raw as Record<string, unknown>;
+    if (typeof m.hostPath !== "string" || !m.hostPath.startsWith("/")) continue;
+    if (typeof m.mountPath !== "string" || !m.mountPath.startsWith("/")) continue;
+    if (m.mode !== "ro" && m.mode !== "rw") continue;
+    const mount: AgentMount = { hostPath: m.hostPath, mountPath: m.mountPath, mode: m.mode };
+    if (typeof m.shared === "string" && m.shared.length > 0) mount.shared = m.shared;
+    out.push(mount);
+  }
+  return out;
+}
+
+/**
+ * Resolve the status a parsed def gets in 4a. Own-vault only → `enabled`; a def that
+ * declares external connections → `pending` (listing them) since 4b hasn't granted
+ * them. The agent still runs own-vault either way; this is the queryable signal.
+ */
+export function resolveDefStatus(def: ParsedAgentDef): {
+  status: AgentDefStatus;
+  pending?: string[];
+} {
+  if (def.declaredConnections.length > 0) {
+    return { status: "pending", pending: def.declaredConnections };
+  }
+  return { status: "enabled" };
+}
+
+/**
+ * A thin vault client for ONE def-vault — the def-query + the status-PATCH. Mirrors
+ * `VaultTransport`'s REST encoding (the `#` + `/` in a tag → `%23`/`%2F`; the note
+ * PATCH route is `PATCH /vault/<vault>/api/notes/<id>`). `fetchFn` is injectable so
+ * tests drive it with a recorder, deterministic, no global mock leak.
+ */
+export class DefVaultClient {
+  private readonly vault: string;
+  private readonly vaultUrl: string;
+  private readonly token: string;
+  private readonly fetchFn: typeof fetch;
+
+  constructor(binding: DefVaultBinding, fetchFn?: typeof fetch) {
+    if (!binding.vault) throw new Error("DefVaultClient: binding.vault is required");
+    if (!binding.token) throw new Error("DefVaultClient: binding.token is required");
+    this.vault = binding.vault;
+    this.vaultUrl = (binding.vaultUrl ?? DEFAULT_DEF_VAULT_URL).replace(/\/$/, "");
+    this.token = binding.token;
+    this.fetchFn = fetchFn ?? fetch;
+  }
+
+  /** The def-vault name (for routing reload events to the right client). */
+  get vaultName(): string {
+    return this.vault;
+  }
+
+  /**
+   * List the `#agent/definition` notes in this vault. INDEX-FREE: queries by the
+   * exact tag (the leaf — we never rely on namespace prefix expansion) with
+   * `include_content=true` (we need the body = the system prompt). Throws on a
+   * non-ok vault response so the caller surfaces a clear error rather than a
+   * silently-empty agent set.
+   */
+  async listDefNotes(opts?: { limit?: number }): Promise<
+    Array<{ id: string; content?: string; metadata?: Record<string, unknown> }>
+  > {
+    const limit = opts?.limit ?? 500;
+    const params = new URLSearchParams();
+    params.set("tag", AGENT_DEFINITION_TAG); // URLSearchParams encodes `#`→`%23`, `/`→`%2F`
+    params.set("include_content", "true");
+    params.set("limit", String(limit));
+    const url = `${this.vaultUrl}/vault/${this.vault}/api/notes?${params.toString()}`;
+    const res = await this.fetchFn(url, { headers: { authorization: `Bearer ${this.token}` } });
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "");
+      throw new Error(`def-vault "${this.vault}": list defs failed (${res.status}) ${detail}`.trim());
+    }
+    let parsed: unknown;
+    try {
+      parsed = await res.json();
+    } catch (err) {
+      throw new Error(`def-vault "${this.vault}": list defs — bad JSON: ${(err as Error).message}`);
+    }
+    type RawNote = { id?: string; content?: string; metadata?: Record<string, unknown> };
+    const notes: RawNote[] = Array.isArray(parsed)
+      ? (parsed as RawNote[])
+      : ((parsed as { notes?: RawNote[] })?.notes ?? []);
+    const out: Array<{ id: string; content?: string; metadata?: Record<string, unknown> }> = [];
+    for (const n of notes) {
+      if (typeof n.id === "string" && n.id) {
+        out.push({ id: n.id, content: n.content, metadata: n.metadata });
+      }
+    }
+    return out;
+  }
+
+  /** Fetch ONE note by id (for a created/updated reload). Null on 404/miss. */
+  async getNote(
+    id: string,
+  ): Promise<{ id: string; content?: string; metadata?: Record<string, unknown> } | null> {
+    const url = `${this.vaultUrl}/vault/${this.vault}/api/notes/${encodeURIComponent(id)}?include_content=true`;
+    const res = await this.fetchFn(url, { headers: { authorization: `Bearer ${this.token}` } });
+    if (res.status === 404) return null;
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "");
+      throw new Error(`def-vault "${this.vault}": get note ${id} failed (${res.status}) ${detail}`.trim());
+    }
+    let parsed: unknown;
+    try {
+      parsed = await res.json();
+    } catch (err) {
+      throw new Error(`def-vault "${this.vault}": get note ${id} — bad JSON: ${(err as Error).message}`);
+    }
+    const n = (parsed ?? {}) as { id?: string; note?: { id?: string; content?: string; metadata?: Record<string, unknown> }; content?: string; metadata?: Record<string, unknown> };
+    const note = n.note ?? n;
+    if (typeof note.id !== "string" || !note.id) return null;
+    return { id: note.id, content: note.content, metadata: note.metadata };
+  }
+
+  /**
+   * Stamp the resolved status onto the def note's metadata. PATCH merges the changed
+   * fields (the vault merges metadata). `pending` is written as a comma-joined string
+   * when present (the vault stores metadata as strings) and CLEARED (empty string)
+   * otherwise, so a flip enabled→pending→enabled doesn't leave a stale list. Throws
+   * on a non-ok response; the caller logs + continues (status is best-effort — a
+   * failed stamp must not prevent the agent from running).
+   */
+  async patchStatus(
+    noteId: string,
+    status: AgentDefStatus,
+    pending?: string[],
+  ): Promise<void> {
+    const metadata: Record<string, string> = { status };
+    // Always set `pending` (to the list, or empty) so it never goes stale across flips.
+    metadata.pending = pending && pending.length > 0 ? pending.join(", ") : "";
+    const url = `${this.vaultUrl}/vault/${this.vault}/api/notes/${encodeURIComponent(noteId)}`;
+    const res = await this.fetchFn(url, {
+      method: "PATCH",
+      headers: { "content-type": "application/json", authorization: `Bearer ${this.token}` },
+      body: JSON.stringify({ metadata }),
+    });
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "");
+      throw new Error(`def-vault "${this.vault}": patch status ${noteId} failed (${res.status}) ${detail}`.trim());
+    }
+  }
+}
+
+/**
+ * The side-effects the registry needs to bring a def to life, injected so the
+ * registry is unit-testable WITHOUT a daemon, a vault, a sandbox, or tmux.
+ *
+ *   - {@link ensureChannel} — bring up (or replace) the vault channel for the agent's
+ *     wake channel. The daemon wires this to `addChannelLive` with a vault
+ *     `ChannelEntry` built from the def-vault binding (the SAME path create-agent +
+ *     boot use). Awaited so the transport is live before we register the agent.
+ *   - {@link setupAndRegister} — persist `spec.json` (so the existing boot
+ *     re-register + per-turn deliver find the workspace) + register the programmatic
+ *     agent. The daemon wires this to `setupProgrammaticSpawn` + `programmatic.register`.
+ *   - {@link deregister} — tear an agent down by name (drop its programmatic
+ *     registration). The daemon wires this to `programmatic.deregister`.
+ *   - {@link removeChannel} — stop + drop the wake channel (on delete). The daemon
+ *     wires this to `removeChannelLive`.
+ */
+export interface InstantiateDeps {
+  /** Bring up the vault channel for `name`, bound to `binding`. */
+  ensureChannel(name: string, binding: DefVaultBinding): Promise<void>;
+  /** Persist spec.json + register the programmatic agent for `spec`. */
+  setupAndRegister(spec: AgentSpec): Promise<void>;
+  /** Deregister the programmatic agent `name`. Returns whether one was registered. */
+  deregister(name: string): Promise<boolean>;
+  /** Stop + remove the wake channel `name`. Returns whether one existed. */
+  removeChannel(name: string): Promise<boolean>;
+}
+
+/** The live record of an instantiated def (so a reload/delete can address it). */
+interface LiveDef {
+  /** The def-vault this agent belongs to. */
+  vault: string;
+  /** The note id (the reload/delete key within a vault). */
+  noteId: string;
+  /** The agent name (= wake channel) — for channel/registry teardown. */
+  name: string;
+  /** The resolved status (for /health + observability). */
+  status: AgentDefStatus;
+}
+
+/**
+ * The vault-native agent-def registry — reads `#agent/definition` notes from the
+ * configured def-vaults and keeps the live agent set in sync with them.
+ *
+ * Lifecycle (the design's reactive model):
+ *   - {@link loadAll} (boot) — for each def-vault, list its defs + instantiate each.
+ *   - {@link reload} (trigger / poll) — re-read ONE note: created/updated →
+ *     re-instantiate; deleted (note gone) → deregister. Per-note granularity via the
+ *     `vault + noteId → LiveDef` map.
+ *   - {@link deregisterAllForVault} — drop a whole vault's agents (config change).
+ *
+ * Idempotent: re-instantiating the same name swaps the registration in place
+ * (`programmatic.register` + `addChannelLive` both replace-by-name), so an update is
+ * a clean re-instantiate, not a duplicate. A name collision ACROSS def-vaults (two
+ * vaults both defining `uni-dev`) is resolved last-writer-wins on the shared wake
+ * channel; we log it (the operator owns their vaults — 4a is own-box).
+ */
+export class AgentDefRegistry {
+  /** def-vault name → its client. */
+  private readonly clients = new Map<string, DefVaultClient>();
+  /** def-vault name → its binding (for `ensureChannel`). */
+  private readonly bindings = new Map<string, DefVaultBinding>();
+  /** `${vault} ${noteId}` → the live record. */
+  private readonly live = new Map<string, LiveDef>();
+  private readonly deps: InstantiateDeps;
+
+  constructor(deps: InstantiateDeps, opts?: { bindings?: DefVaultBinding[]; fetchFn?: typeof fetch }) {
+    this.deps = deps;
+    for (const b of opts?.bindings ?? []) {
+      this.addVault(b, opts?.fetchFn);
+    }
+  }
+
+  /** Register a def-vault binding (additive — multi-vault is appending). */
+  addVault(binding: DefVaultBinding, fetchFn?: typeof fetch): void {
+    this.clients.set(binding.vault, new DefVaultClient(binding, fetchFn));
+    this.bindings.set(binding.vault, binding);
+  }
+
+  /** The number of def-vaults bound (for /health + tests). */
+  get vaultCount(): number {
+    return this.clients.size;
+  }
+
+  /** The sole bound def-vault's name, or undefined when not exactly one. Lets the
+   *  reload webhook default `vault` when the install is single-vault (the common case). */
+  soleVaultName(): string | undefined {
+    if (this.clients.size !== 1) return undefined;
+    return [...this.clients.keys()][0];
+  }
+
+  /** The live instantiated defs (for /health + the agents list + tests). */
+  list(): ReadonlyArray<{ vault: string; noteId: string; name: string; status: AgentDefStatus }> {
+    return [...this.live.values()].map((d) => ({ ...d }));
+  }
+
+  private keyOf(vault: string, noteId: string): string {
+    return `${vault} ${noteId}`;
+  }
+
+  /**
+   * Read all defs from every bound def-vault + instantiate each. Best-effort per
+   * vault AND per note: a single vault's list failure (or one note's parse/instantiate
+   * failure) is logged and never aborts the others, so one bad def can't sink the set.
+   * Returns the count successfully instantiated.
+   */
+  async loadAll(): Promise<number> {
+    let count = 0;
+    for (const [vault, client] of this.clients) {
+      let notes: Awaited<ReturnType<DefVaultClient["listDefNotes"]>>;
+      try {
+        notes = await client.listDefNotes();
+      } catch (err) {
+        console.error(`agent-defs: listing defs from vault "${vault}" failed (continuing): ${(err as Error).message}`);
+        continue;
+      }
+      for (const note of notes) {
+        if (await this.instantiate(vault, note)) count++;
+      }
+    }
+    return count;
+  }
+
+  /**
+   * Reload ONE def by note id (the reactive path — a vault trigger / poll says this
+   * note changed). Re-reads the note from its vault: present → (re)instantiate;
+   * absent (deleted) → deregister. `event` is a hint from the trigger
+   * (`created`/`updated`/`deleted`); we still re-read so a stale/racing event
+   * resolves to ground truth (a "created" that was since deleted tears down, not up).
+   *
+   * Returns the resulting state so the webhook can ack meaningfully.
+   */
+  async reload(
+    vault: string,
+    noteId: string,
+    event?: "created" | "updated" | "deleted",
+  ): Promise<"instantiated" | "deregistered" | "skipped"> {
+    const client = this.clients.get(vault);
+    if (!client) {
+      console.warn(`agent-defs: reload for unknown def-vault "${vault}" — ignoring.`);
+      return "skipped";
+    }
+    // A delete event: the note is gone — tear down without a fetch (the GET would 404
+    // anyway; skipping it is faster + avoids a confusing 404 log).
+    if (event === "deleted") {
+      await this.deregisterByNote(vault, noteId);
+      return "deregistered";
+    }
+    let note: Awaited<ReturnType<DefVaultClient["getNote"]>>;
+    try {
+      note = await client.getNote(noteId);
+    } catch (err) {
+      console.error(`agent-defs: reload fetch of ${noteId} from "${vault}" failed: ${(err as Error).message}`);
+      return "skipped";
+    }
+    if (!note) {
+      // Re-read says it's gone (deleted, or no longer carries the def tag we can see).
+      await this.deregisterByNote(vault, noteId);
+      return "deregistered";
+    }
+    return (await this.instantiate(vault, note)) ? "instantiated" : "skipped";
+  }
+
+  /**
+   * Instantiate (or re-instantiate) one def note: parse → bring up the channel →
+   * persist+register the agent → stamp status. Returns true on success. A parse
+   * failure stamps `error` (so the note surfaces the problem) and returns false; an
+   * instantiate failure is logged + returns false (the prior registration, if any,
+   * is left intact — we don't tear down a working agent on a transient failure).
+   */
+  private async instantiate(
+    vault: string,
+    note: { id: string; content?: string; metadata?: Record<string, unknown> },
+  ): Promise<boolean> {
+    const binding = this.bindings.get(vault);
+    const client = this.clients.get(vault);
+    if (!binding || !client) return false;
+
+    let def: ParsedAgentDef;
+    try {
+      def = parseAgentDef(note, { vault });
+    } catch (err) {
+      console.error(`agent-defs: skipping malformed def ${note.id} in "${vault}": ${(err as Error).message}`);
+      // Best-effort: surface the problem on the note itself.
+      await client.patchStatus(note.id, "error").catch(() => {});
+      return false;
+    }
+
+    try {
+      await this.deps.ensureChannel(def.name, binding);
+      await this.deps.setupAndRegister(def.spec);
+    } catch (err) {
+      console.error(`agent-defs: instantiating "${def.name}" (${note.id} in "${vault}") failed: ${(err as Error).message}`);
+      await client.patchStatus(note.id, "error").catch(() => {});
+      return false;
+    }
+
+    const { status, pending } = resolveDefStatus(def);
+    this.live.set(this.keyOf(vault, note.id), { vault, noteId: note.id, name: def.name, status });
+    // Stamp status — best-effort: a failed stamp doesn't unmake the running agent.
+    try {
+      await client.patchStatus(note.id, status, pending);
+    } catch (err) {
+      console.warn(`agent-defs: status stamp for "${def.name}" failed (continuing): ${(err as Error).message}`);
+    }
+    console.log(`agent-defs: instantiated "${def.name}" from ${note.id} in "${vault}" (status=${status}).`);
+    return true;
+  }
+
+  /** Tear down the agent for a given (vault, noteId): deregister + drop its channel. */
+  private async deregisterByNote(vault: string, noteId: string): Promise<void> {
+    const key = this.keyOf(vault, noteId);
+    const rec = this.live.get(key);
+    if (!rec) return; // never instantiated (a delete for a note we don't track) — no-op.
+    this.live.delete(key);
+    try {
+      await this.deps.deregister(rec.name);
+    } catch (err) {
+      console.error(`agent-defs: deregistering "${rec.name}" failed (continuing): ${(err as Error).message}`);
+    }
+    try {
+      await this.deps.removeChannel(rec.name);
+    } catch (err) {
+      console.error(`agent-defs: removing channel "${rec.name}" failed (continuing): ${(err as Error).message}`);
+    }
+    console.log(`agent-defs: deregistered "${rec.name}" (${noteId} in "${vault}").`);
+  }
+
+  /** Tear down every agent from a def-vault (e.g. the vault binding is removed). */
+  async deregisterAllForVault(vault: string): Promise<void> {
+    for (const rec of [...this.live.values()]) {
+      if (rec.vault === vault) await this.deregisterByNote(vault, rec.noteId);
+    }
+  }
+}

--- a/src/agent-defs.ts
+++ b/src/agent-defs.ts
@@ -485,7 +485,7 @@ export class AgentDefRegistry {
   private readonly clients = new Map<string, DefVaultClient>();
   /** def-vault name → its binding (for `ensureChannel`). */
   private readonly bindings = new Map<string, DefVaultBinding>();
-  /** `${vault} ${noteId}` → the live record. */
+  /** `${vault}\u0000${noteId}` → the live record. */
   private readonly live = new Map<string, LiveDef>();
   private readonly deps: InstantiateDeps;
 
@@ -520,7 +520,7 @@ export class AgentDefRegistry {
   }
 
   private keyOf(vault: string, noteId: string): string {
-    return `${vault} ${noteId}`;
+    return `${vault}\u0000${noteId}`;
   }
 
   /**

--- a/src/agents-ui.ts
+++ b/src/agents-ui.ts
@@ -277,7 +277,7 @@ ${THEME_CSS}
               </div>
               <div>
                 <label for="vault-tags">Tag scope (optional)</label>
-                <input type="text" id="vault-tags" placeholder="#agent-message/inbound, …" autocomplete="off" />
+                <input type="text" id="vault-tags" placeholder="#agent/message/inbound, …" autocomplete="off" />
               </div>
             </div>
             <div class="muted" style="font-size:12px;">

--- a/src/agents.test.ts
+++ b/src/agents.test.ts
@@ -180,12 +180,12 @@ describe("buildSpecFromBody", () => {
     const spec = buildSpecFromBody({
       name: "weaver",
       channels: [{ name: "weave", access: "read" }, { name: "out" }],
-      vault: { name: "default", access: "read", tags: ["#agent-message", " "] },
+      vault: { name: "default", access: "read", tags: ["#agent/message", " "] },
       egress: ["registry.npmjs.org", "  "],
       mounts: [{ hostPath: "/data", mountPath: "/data", mode: "ro", shared: "corpus" }],
     });
     expect(spec.channels).toEqual([{ name: "weave", access: "read" }, { name: "out" }]);
-    expect(spec.vault).toEqual({ name: "default", access: "read", tags: ["#agent-message"] });
+    expect(spec.vault).toEqual({ name: "default", access: "read", tags: ["#agent/message"] });
     expect(spec.egress).toEqual(["registry.npmjs.org"]); // blank trimmed out
     expect(spec.mounts).toEqual([{ hostPath: "/data", mountPath: "/data", mode: "ro", shared: "corpus" }]);
   });

--- a/src/backends/programmatic.test.ts
+++ b/src/backends/programmatic.test.ts
@@ -171,7 +171,7 @@ function specWithVault(name = "eng"): AgentSpec {
   return {
     name,
     channels: [name],
-    vault: { name: "default", access: "read", tags: ["#agent-message"] },
+    vault: { name: "default", access: "read", tags: ["#agent/message"] },
   };
 }
 
@@ -183,7 +183,7 @@ function specWithSystemPrompt(
   return {
     name,
     channels: [name],
-    vault: { name: "default", access: "read", tags: ["#agent-message"] },
+    vault: { name: "default", access: "read", tags: ["#agent/message"] },
     systemPrompt: prompt,
     ...(mode ? { systemPromptMode: mode } : {}),
   };
@@ -524,7 +524,7 @@ function specWithWorkspace(workspace: string, name = "eng"): AgentSpec {
   return {
     name,
     channels: [name],
-    vault: { name: "default", access: "read", tags: ["#agent-message"] },
+    vault: { name: "default", access: "read", tags: ["#agent/message"] },
     workspace,
   };
 }
@@ -562,7 +562,7 @@ describe("ProgrammaticBackend.deliver — workspace seam: cwd = workspace, secre
       const spec: AgentSpec = {
         name: "eng",
         channels: ["eng"],
-        vault: { name: "default", access: "read", tags: ["#agent-message"] },
+        vault: { name: "default", access: "read", tags: ["#agent/message"] },
         workspace: workspaceDir,
         systemPrompt: "Work in the repo.",
       };

--- a/src/backends/programmatic.ts
+++ b/src/backends/programmatic.ts
@@ -27,7 +27,7 @@
  * ── What's deliberately ABSENT vs the interactive spawn ─────────────────────────
  *   - NO channel MCP entry. The daemon mediates messaging in this backend: it
  *     hands the agent the inbound text as the `-p` prompt, and turns the returned
- *     reply into an outbound `#agent-message/outbound` note itself (the wiring
+ *     reply into an outbound `#agent/message/outbound` note itself (the wiring
  *     follow-up). The agent's `.mcp.json` carries the VAULT MCP only — so the agent
  *     has memory + tools, but inbound/outbound is the daemon's job, not the agent's.
  *   - NO `--dangerously-load-development-channels`, NO consent-gate auto-confirm.

--- a/src/backends/registry.ts
+++ b/src/backends/registry.ts
@@ -8,7 +8,7 @@
  * session_id) and a per-channel serial worker. An inbound message for a registered
  * channel is ENQUEUED here; the worker drains the queue ONE turn at a time, FIFO,
  * running a single `claude -p --resume <sid>` turn per message and posting the
- * reply back as an outbound `#agent-message/outbound` note.
+ * reply back as an outbound `#agent/message/outbound` note.
  *
  * ── The serial-queue contract (HARD requirement — reviewer contract) ─────────────
  * Each agent processes turns ONE AT A TIME, FIFO. There is NEVER two concurrent
@@ -27,8 +27,8 @@
  * On `ok: false` the error is logged and the turn is DROPPED (no infinite loop, no
  * retry — a failed turn's session id is already persisted by the backend, so the
  * next message resumes the conversation). The outbound write goes through `reply()`,
- * which tags the note `#agent-message/outbound` — the vault inbound trigger keys on
- * `#agent-message/inbound` only, so writing the reply CANNOT re-trigger the inbound
+ * which tags the note `#agent/message/outbound` — the vault inbound trigger keys on
+ * `#agent/message/inbound` only, so writing the reply CANNOT re-trigger the inbound
  * webhook (no loop).
  */
 
@@ -63,7 +63,7 @@ export type TurnLifecycleEvent =
 /**
  * Write an outbound reply for a channel — the seam the registry posts a turn's
  * reply through. The daemon wires this to the channel transport's `reply()` (a
- * VaultTransport writes a `#agent-message/outbound` note). `inReplyTo` threads the
+ * VaultTransport writes a `#agent/message/outbound` note). `inReplyTo` threads the
  * reply to the inbound note id when one is known. Returns nothing; a write failure
  * is the implementation's to surface (the registry logs whatever it throws).
  */

--- a/src/backends/types.ts
+++ b/src/backends/types.ts
@@ -17,10 +17,10 @@
  *     reconnect, no backlog to replay, no TUI gate to answer. `deliver` is a direct
  *     turn into a fresh `claude -p` invocation that resumes the channel's prior
  *     conversation (`--resume <session_id>`). The daemon turns the returned reply
- *     into an outbound `#agent-message/outbound` note (the wiring follow-up).
+ *     into an outbound `#agent/message/outbound` note (the wiring follow-up).
  *
  * Everything ABOVE this seam is backend-agnostic: the vault message transport
- * (`#agent-message/{inbound,outbound}`), the chat UI, the sandbox/isolation
+ * (`#agent/message/{inbound,outbound}`), the chat UI, the sandbox/isolation
  * envelope, and the per-channel env/credential injection. Only the
  * "drive-the-agent" layer differs.
  *
@@ -103,7 +103,7 @@ export interface DeliverUsage {
 /**
  * The result of delivering one message — a discriminated union so a failure is
  * always observable inline (never a silent drop). On success the daemon turns
- * `reply` into an outbound `#agent-message/outbound` note (the wiring follow-up).
+ * `reply` into an outbound `#agent/message/outbound` note (the wiring follow-up).
  */
 export type DeliverResult =
   | {

--- a/src/backlog-replay.test.ts
+++ b/src/backlog-replay.test.ts
@@ -274,7 +274,7 @@ describe("emit advances the mark only on real delivery (via /api/vault/inbound)"
         method: "POST",
         headers: { ...auth, "content-type": "application/json" },
         body: JSON.stringify({
-          note: { id: "note-0", content: "deaf", tags: ["#agent-message/inbound"], metadata: { channel: "eng", ts: ts0, direction: "inbound" } },
+          note: { id: "note-0", content: "deaf", tags: ["#agent/message/inbound"], metadata: { channel: "eng", ts: ts0, direction: "inbound" } },
         }),
       });
       expect(r0.status).toBe(200);
@@ -293,7 +293,7 @@ describe("emit advances the mark only on real delivery (via /api/vault/inbound)"
         method: "POST",
         headers: { ...auth, "content-type": "application/json" },
         body: JSON.stringify({
-          note: { id: "note-1", content: "heard", tags: ["#agent-message/inbound"], metadata: { channel: "eng", ts: ts1, direction: "inbound" } },
+          note: { id: "note-1", content: "heard", tags: ["#agent/message/inbound"], metadata: { channel: "eng", ts: ts1, direction: "inbound" } },
         }),
       });
       expect(r1.status).toBe(200);
@@ -462,7 +462,7 @@ describe("end-to-end deaf window", () => {
         method: "POST",
         headers: { ...auth, "content-type": "application/json" },
         body: JSON.stringify({
-          note: { id: "note-deaf", content: "are you there?", tags: ["#agent-message/inbound"], metadata: { channel: "eng", ts: missedTs, sender: "aaron", direction: "inbound" } },
+          note: { id: "note-deaf", content: "are you there?", tags: ["#agent/message/inbound"], metadata: { channel: "eng", ts: missedTs, sender: "aaron", direction: "inbound" } },
         }),
       });
       expect(wh.status).toBe(200);

--- a/src/daemon-agent-def-api.test.ts
+++ b/src/daemon-agent-def-api.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Daemon route test for the vault-native agent-def RELOAD webhook
+ * (POST /api/vault/agent-def, design 2026-06-17-vault-native-agents Phase 4a).
+ *
+ * Auth mirrors /api/vault/inbound: hub JWT, scope agent:send, uniform-401. The
+ * AgentDefRegistry is injected with a recorder for its `reload`, so we assert the
+ * route's dispatch (auth → parse → route to vault → reload) without a real vault.
+ * Uses the same sentinel-token `mock.module("./hub-jwt.ts")` harness as the other
+ * daemon route tests (file-scoped).
+ */
+import { describe, test, expect, mock } from "bun:test";
+
+const SEND_TOKEN = "test-send-token"; // agent:send
+import { HubJwtError, looksLikeJwt } from "@openparachute/scope-guard";
+mock.module("./hub-jwt.ts", () => ({
+  AGENT_AUDIENCE: "agent",
+  CHANNEL_AUDIENCE: "channel",
+  async validateHubJwt(token: string) {
+    const base = { sub: "test", aud: "agent", jti: undefined, clientId: undefined, vaultScope: undefined };
+    if (token === SEND_TOKEN) return { ...base, scopes: ["agent:read", "agent:send"] };
+    throw new HubJwtError("issuer", "invalid token");
+  },
+  HubJwtError,
+  looksLikeJwt,
+  resetJwksCache() {},
+  resetRevocationCache() {},
+}));
+
+import { createFetchHandler } from "./daemon.ts";
+import { ClientRegistry } from "./routing.ts";
+import { AgentDefRegistry, type InstantiateDeps } from "./agent-defs.ts";
+import type { Channel } from "./registry.ts";
+
+/** A registry whose `reload` is recorded; one bound def-vault by default. */
+function recordingRegistry(opts?: { vaults?: string[] }) {
+  const reloads: Array<{ vault: string; noteId: string; event?: string }> = [];
+  const noopDeps: InstantiateDeps = {
+    ensureChannel: async () => {},
+    setupAndRegister: async () => {},
+    deregister: async () => true,
+    removeChannel: async () => true,
+  };
+  const reg = new AgentDefRegistry(noopDeps, {
+    bindings: (opts?.vaults ?? ["default"]).map((v) => ({ vault: v, token: "t" })),
+  });
+  // Override reload to record (avoid any vault I/O).
+  reg.reload = (async (vault: string, noteId: string, event?: "created" | "updated" | "deleted") => {
+    reloads.push({ vault, noteId, event });
+    return "instantiated";
+  }) as typeof reg.reload;
+  return { reg, reloads };
+}
+
+function serverWith(channels: Map<string, Channel>, agentDefs?: AgentDefRegistry) {
+  const registry = new ClientRegistry();
+  const srv = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    idleTimeout: 0,
+    fetch: createFetchHandler(channels, registry, agentDefs ? { agentDefs } : undefined),
+  });
+  return { srv, base: `http://127.0.0.1:${srv.port}` };
+}
+
+const emptyChannels = () => new Map<string, Channel>();
+const auth = { authorization: `Bearer ${SEND_TOKEN}`, "content-type": "application/json" };
+
+describe("POST /api/vault/agent-def", () => {
+  test("no Authorization → 401", async () => {
+    const { reg } = recordingRegistry();
+    const { srv, base } = serverWith(emptyChannels(), reg);
+    const res = await fetch(`${base}/api/vault/agent-def`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ note: { id: "n" } }),
+    });
+    expect(res.status).toBe(401);
+    srv.stop();
+  });
+
+  test("authed reload routes to the registry with vault + noteId + event (single-vault default)", async () => {
+    const { reg, reloads } = recordingRegistry();
+    const { srv, base } = serverWith(emptyChannels(), reg);
+    const res = await fetch(`${base}/api/vault/agent-def`, {
+      method: "POST",
+      headers: auth,
+      body: JSON.stringify({ event: "updated", note: { id: "Agents/uni-dev" } }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; reloaded: string };
+    expect(body.ok).toBe(true);
+    expect(body.reloaded).toBe("instantiated");
+    // vault defaulted to the sole bound def-vault.
+    expect(reloads).toEqual([{ vault: "default", noteId: "Agents/uni-dev", event: "updated" }]);
+    srv.stop();
+  });
+
+  test("explicit body.vault is honored", async () => {
+    const { reg, reloads } = recordingRegistry({ vaults: ["default", "research"] });
+    const { srv, base } = serverWith(emptyChannels(), reg);
+    const res = await fetch(`${base}/api/vault/agent-def`, {
+      method: "POST",
+      headers: auth,
+      body: JSON.stringify({ event: "deleted", vault: "research", note: { id: "Agents/r" } }),
+    });
+    expect(res.status).toBe(200);
+    expect(reloads).toEqual([{ vault: "research", noteId: "Agents/r", event: "deleted" }]);
+    srv.stop();
+  });
+
+  test("multiple def-vaults + no explicit vault → 400 (ambiguous)", async () => {
+    const { reg, reloads } = recordingRegistry({ vaults: ["default", "research"] });
+    const { srv, base } = serverWith(emptyChannels(), reg);
+    const res = await fetch(`${base}/api/vault/agent-def`, {
+      method: "POST",
+      headers: auth,
+      body: JSON.stringify({ note: { id: "n" } }),
+    });
+    expect(res.status).toBe(400);
+    expect(reloads).toHaveLength(0);
+    srv.stop();
+  });
+
+  test("missing note.id → 400", async () => {
+    const { reg } = recordingRegistry();
+    const { srv, base } = serverWith(emptyChannels(), reg);
+    const res = await fetch(`${base}/api/vault/agent-def`, {
+      method: "POST",
+      headers: auth,
+      body: JSON.stringify({ event: "created" }),
+    });
+    expect(res.status).toBe(400);
+    srv.stop();
+  });
+
+  test("no agentDefs configured → clean no-op ack (200, reloaded: skipped)", async () => {
+    const { srv, base } = serverWith(emptyChannels()); // no registry
+    const res = await fetch(`${base}/api/vault/agent-def`, {
+      method: "POST",
+      headers: auth,
+      body: JSON.stringify({ note: { id: "n" } }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; reloaded: string };
+    expect(body.reloaded).toBe("skipped");
+    srv.stop();
+  });
+});

--- a/src/daemon-config-api.test.ts
+++ b/src/daemon-config-api.test.ts
@@ -130,7 +130,7 @@ function inboundBody(noteId: string, channel = "eng") {
       id: noteId,
       path: `channel/${channel}/${noteId}`,
       content: "wake up session",
-      tags: ["#agent-message", "#agent-message/inbound"],
+      tags: ["#agent/message", "#agent/message/inbound"],
       metadata: { channel, direction: "inbound", sender: "aaron" },
     },
   });
@@ -594,9 +594,9 @@ describe("C — AGENT_VAULT_TRIGGER_TEMPLATE exposed via /.parachute/config", ()
       // Sanity on the shape the hub depends on (placeholders + webhook path).
       // The trigger NAME stays `channel_inbound_<channel>` — `channel` is the
       // domain routing key, not the module identity. The TAG moved to
-      // #agent-message and the webhook moved to the /agent mount.
+      // #agent/message and the webhook moved to the /agent mount.
       expect(body.triggerTemplate.name).toBe("channel_inbound_<channel>");
-      expect(body.triggerTemplate.when.tags).toEqual(["#agent-message/inbound"]);
+      expect(body.triggerTemplate.when.tags).toEqual(["#agent/message/inbound"]);
       expect(body.triggerTemplate.action.webhook).toBe("<hub-origin>/agent/api/vault/inbound");
     } finally {
       srv.stop(true);

--- a/src/daemon-jobs-api.test.ts
+++ b/src/daemon-jobs-api.test.ts
@@ -3,10 +3,10 @@
  * fetch handler (runner, design 2026-06-17). They cover:
  *
  *  - auth: all routes require `agent:admin` (no token → 401; agent:read → 403);
- *  - GET    /api/jobs          → lists `#agent-job` notes across the vault channels;
+ *  - GET    /api/jobs          → lists `#agent/job` notes across the vault channels;
  *  - POST   /api/jobs          → 400 on bad cron / unknown / non-vault channel;
- *                                200 + writes a #agent-job note on success;
- *  - POST   /api/jobs/:id/run  → fires now (injects an inbound #agent-message note);
+ *                                200 + writes a #agent/job note on success;
+ *  - POST   /api/jobs/:id/run  → fires now (injects an inbound #agent/message note);
  *  - DELETE /api/jobs/:id      → deletes the job note.
  *
  * The vault REST API is stubbed via `globalThis.fetch` (no live vault); the hub
@@ -112,7 +112,7 @@ describe("/api/jobs — auth", () => {
 });
 
 describe("GET /api/jobs — list", () => {
-  test("lists #agent-job notes from the vault", async () => {
+  test("lists #agent/job notes from the vault", async () => {
     const { srv, base } = buildServer();
     stubVault(() =>
       new Response(
@@ -172,7 +172,7 @@ describe("POST /api/jobs — create + validation", () => {
     } finally { srv.stop(true); }
   });
 
-  test("valid → 200 + writes a #agent-job note", async () => {
+  test("valid → 200 + writes a #agent/job note", async () => {
     const { srv, base } = buildServer();
     const calls = stubVault((url, init) => {
       // The job POST is to /api/notes; everything else (ensureSchema PUTs) is benign.
@@ -194,7 +194,7 @@ describe("POST /api/jobs — create + validation", () => {
       expect(body.job.noteId).toBe("Channels/eng/jobs/x"); // vault note id for addressing
       const post = calls.find((c) => c.url.endsWith("/api/notes") && c.init.method === "POST")!;
       const sent = JSON.parse(String(post.init.body));
-      expect(sent.tags).toEqual(["#agent-job"]);
+      expect(sent.tags).toEqual(["#agent/job"]);
       expect(sent.content).toBe("do it"); // trimmed
       expect(sent.metadata.enabled).toBe("true");
       expect(sent.metadata.jobId).toBe("x");
@@ -203,7 +203,7 @@ describe("POST /api/jobs — create + validation", () => {
 });
 
 describe("POST /api/jobs/:id/run — fire now", () => {
-  test("injects an inbound #agent-message note + returns ok", async () => {
+  test("injects an inbound #agent/message note + returns ok", async () => {
     const { srv, base } = buildServer();
     const calls = stubVault((url, init) => {
       if (url.includes("/api/notes") && (init.method ?? "GET") === "GET") {
@@ -221,10 +221,10 @@ describe("POST /api/jobs/:id/run — fire now", () => {
       const res = await fetch(`${base}/api/jobs/${encodeURIComponent("Channels/eng/jobs/x")}/run`, { method: "POST", headers: adminAuth });
       expect(res.status).toBe(200);
       expect((await res.json()).ok).toBe(true);
-      // The injected note is INBOUND with the #agent-message tags.
+      // The injected note is INBOUND with the #agent/message tags.
       const inject = calls.find((c) => c.url.endsWith("/api/notes") && c.init.method === "POST")!;
       const sent = JSON.parse(String(inject.init.body));
-      expect(sent.tags).toEqual(["#agent-message", "#agent-message/inbound"]);
+      expect(sent.tags).toEqual(["#agent/message", "#agent/message/inbound"]);
       expect(sent.metadata.sender).toBe("runner:Channels/eng/jobs/x");
     } finally { srv.stop(true); }
   });

--- a/src/daemon.test.ts
+++ b/src/daemon.test.ts
@@ -347,7 +347,7 @@ describe("Layer 2 — http-ui UI endpoints require a token (401 with none)", () 
 
 // ---------------------------------------------------------------------------
 // Vault inbound webhook: POST /api/vault/inbound. A vault trigger POSTs here on
-// a new inbound #agent-message note; the daemon validates the per-channel
+// a new inbound #agent/message note; the daemon validates the per-channel
 // shared secret, resolves the channel from note.metadata.channel, and hands the
 // note to the channel's VaultTransport.ingestInbound (which emits → wakes the
 // session). Secret auth, unknown-channel 404, idempotency by note id.
@@ -388,7 +388,7 @@ describe("Vault inbound webhook — POST /api/vault/inbound", () => {
   function body(
     noteId: string,
     extraMeta: Record<string, unknown> = {},
-    tags: string[] = ["#agent-message", "#agent-message/inbound"],
+    tags: string[] = ["#agent/message", "#agent/message/inbound"],
   ) {
     return JSON.stringify({
       trigger: "channel-inbound",
@@ -543,13 +543,13 @@ describe("Vault inbound webhook — POST /api/vault/inbound", () => {
     }
   });
 
-  test("#agent-message/outbound-tagged note is ack'd 200 but NOT emitted (belt-and-suspenders)", async () => {
+  test("#agent/message/outbound-tagged note is ack'd 200 but NOT emitted (belt-and-suspenders)", async () => {
     const { srv, base, emitted } = buildVaultServer();
     try {
       const res = await fetch(`${base}/api/vault/inbound?secret=${SECRET}`, {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: body("ob-1", { direction: "outbound" }, ["#agent-message", "#agent-message/outbound"]),
+        body: body("ob-1", { direction: "outbound" }, ["#agent/message", "#agent/message/outbound"]),
       });
       expect(res.status).toBe(200);
       expect(emitted).toHaveLength(0);

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -2754,7 +2754,14 @@ export function createFetchHandler(
       if (!vault) {
         return json({ error: "body.vault is required (multiple def-vaults configured)" }, 400);
       }
-      const result = await agentDefs.reload(vault, noteId, body.event);
+      // Coerce `event` to the declared union (it's an untrusted webhook body) — any
+      // unrecognized value becomes `undefined` (a hint only; reload() re-reads ground
+      // truth regardless, but keep the runtime honest with the type contract).
+      const event =
+        body.event === "created" || body.event === "updated" || body.event === "deleted"
+          ? body.event
+          : undefined;
+      const result = await agentDefs.reload(vault, noteId, event);
       return json({ ok: true, reloaded: result });
     }
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -482,8 +482,8 @@ async function removeChannelLive(
  * through: resolve the channel's transport from the live `channels` map and call its
  * `reply()` — the SAME outbound path the interactive `reply` tool uses, so a
  * programmatic reply is durable + renders in the chat UI exactly like an
- * interactive one. For a VaultTransport this writes a `#agent-message/outbound`
- * note; the vault inbound trigger keys on `#agent-message/inbound`, so writing the
+ * interactive one. For a VaultTransport this writes a `#agent/message/outbound`
+ * note; the vault inbound trigger keys on `#agent/message/inbound`, so writing the
  * reply CANNOT re-trigger the inbound webhook (verified: no loop). `inReplyTo`
  * threads the reply to the inbound note id.
  *
@@ -569,11 +569,11 @@ export function createDefaultProgrammaticRegistry(
  * Transport choice (documented in the PR): a DEDICATED per-channel SSE stream
  * (`/api/channels/<ch>/turn-events`) over the existing {@link ClientRegistry},
  * NOT the durable-message poll. Rationale — the chat already POLLs vault channels
- * for their DURABLE transcript (the `#agent-message` notes, the record of truth);
+ * for their DURABLE transcript (the `#agent/message` notes, the record of truth);
  * turn progress is EPHEMERAL and chunk-frequent, so polling would be coarse + would
  * surface partial state as if durable. An SSE stream is the clean real-time fit and
  * reuses the registry/`sseFrame` infra already in the daemon. The durable path is
- * untouched: the final `result` still becomes the `#agent-message/outbound` note,
+ * untouched: the final `result` still becomes the `#agent/message/outbound` note,
  * and the live stream is purely additive progress that the UI finalizes against it.
  *
  * Keyed by channel; fans out to every subscriber on that channel. A 0-subscriber
@@ -1186,7 +1186,7 @@ ${SHELL_JS}
     var ch = currentChannel();
     if (!ch) { setStatus("no channel", ""); sendBtn.disabled = true; return; }
     updateSetup(ch);
-    // Vault channels read/write the durable #agent-message store via the daemon
+    // Vault channels read/write the durable #agent/message store via the daemon
     // (load transcript + poll); http-ui channels use the ephemeral SSE path below.
     if (isVault(ch)) { connectVault(ch); return; }
     setStatus("connecting…", "");
@@ -1863,7 +1863,7 @@ export function createFetchHandler(
     // ---------------------------------------------------------------------
     // Scheduled-jobs API — the runner (design 2026-06-17). A job is "an
     // automated human": send message M to a vault agent A on cron S. Storage is
-    // VAULT-NATIVE (`#agent-job` notes in the target channel's vault); these
+    // VAULT-NATIVE (`#agent/job` notes in the target channel's vault); these
     // routes read/write through the shared `jobStore`. ALL gated on
     // `agent:admin` (operator-only, like /api/channels). The runner does the
     // injecting; these routes just CRUD the durable job notes (+ fire-now).
@@ -2535,7 +2535,7 @@ export function createFetchHandler(
     }
 
     // Vault inbound webhook — a vault trigger POSTs here when a new
-    // `#agent-message/inbound` note appears. Resolves the target channel from
+    // `#agent/message/inbound` note appears. Resolves the target channel from
     // `note.metadata.channel`, asserts it's a vault-transport channel, and hands
     // the note to that transport's `ingestInbound`, which `ctx.emit`s it →
     // wakes the subscribed bridge / MCP session.
@@ -2629,7 +2629,7 @@ export function createFetchHandler(
     // view (design 2026-06-16 build item #1): the chat subscribes here to watch a
     // PROGRAMMATIC turn work in real time — interim assistant text + tool_use, then a
     // done/error lifecycle event. EPHEMERAL by design: no backlog/replay (the durable
-    // record is the `#agent-message/outbound` note the turn still writes). A channel
+    // record is the `#agent/message/outbound` note the turn still writes). A channel
     // with no programmatic agent simply never receives a `turn` frame (the stream
     // stays open + idle). Open to any live channel — unknown channel still opens the
     // stream (it just never emits), matching the low-stakes ephemeral contract.
@@ -2713,7 +2713,7 @@ export function createFetchHandler(
     // on `agent:send`, same scope http-ui's send uses). The daemon owns this for
     // vault transports because the http-ui transport's ingestHttp only matches its
     // OWN channel name; a vault channel needs the daemon to dispatch. For a vault
-    // channel the daemon writes a `#agent-message/inbound` note via the channel's
+    // channel the daemon writes a `#agent/message/inbound` note via the channel's
     // stored vault token — which WAKES the session through the existing vault
     // trigger (we do NOT also emit; that would double-wake). http-ui channels fall
     // through to their transport's ingestHttp (unchanged), so this guard handles
@@ -2955,7 +2955,7 @@ function main(): void {
   const terminalWs = createTerminalWsHandlers();
 
   // The vault-native scheduled-job store + the runner (design 2026-06-17). The
-  // store reads/writes `#agent-job` notes in each vault channel's vault; the
+  // store reads/writes `#agent/job` notes in each vault channel's vault; the
   // runner ticks every 30s, loading jobs from the store, firing due ones by
   // injecting an inbound note onto the job's vault channel (the existing trigger →
   // agent-turn → outbound flow does the rest). Shared with the fetch handler so
@@ -3089,7 +3089,7 @@ function main(): void {
   void reregisterProgrammaticAgents(programmatic, channels);
 
   // Start the runner's scheduled-job tick (design 2026-06-17). Tolerant of an
-  // empty/missing job set (no `#agent-job` notes → idle) and of a daemon with no
+  // empty/missing job set (no `#agent/job` notes → idle) and of a daemon with no
   // vault channels (listAll queries nothing → idle). A job targeting a now-deleted
   // channel sets lastStatus:error on fire rather than throwing the tick. The tick
   // is `unref`'d so it never keeps the process alive on its own.

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -57,6 +57,7 @@ import {
   type DefVaultBinding,
   type InstantiateDeps,
 } from "./agent-defs.ts";
+import { resolveDefVaults } from "./def-vaults.ts";
 import { VaultJobStore, validateJob, vaultTransportFor, type Job } from "./jobs.ts";
 import { Runner, realTickDriver } from "./runner.ts";
 import { nextRunAfter } from "./cron.ts";
@@ -117,7 +118,7 @@ import { readPersistedSpec, interpretPersistedBackend, sessionWorkspace } from "
 import { normalizeChannel } from "./sandbox/types.ts";
 import { CredentialNotConfiguredError } from "./credentials.ts";
 import { MintError } from "./mint-token.ts";
-import { validateHubJwt } from "./hub-jwt.ts";
+import { validateHubJwt, getHubOrigin } from "./hub-jwt.ts";
 import {
   handleProtectedResource,
   handleAuthorizationServer,
@@ -3241,15 +3242,48 @@ function main(): void {
   console.log(`parachute-agent: runner started (scheduled-job tick)`);
 
   // VAULT-NATIVE AGENT DEFINITIONS (design 2026-06-17-vault-native-agents, Phase 4a).
-  // The registry + reload webhook are wired (above); the def-vault BINDINGS that fill
-  // it are resolved by the config layer (next commit). With no bindings the registry
-  // is empty — the reactive route is a no-op ack and the vault-native path is idle.
-  // ADDITIVE to channels.json (both paths coexist).
-  void agentDefs;
+  // Resolve the def-vault bindings (agent-vaults.json, or the minted single-`default`
+  // default), add each to the registry, and instantiate every `#agent/definition`
+  // note in them — each becomes a live agent (a vault channel + a programmatic agent).
+  // Fire-and-forget so a slow/unreachable vault never blocks the daemon from serving;
+  // the reload webhook (POST /api/vault/agent-def) keeps them in sync reactively, and
+  // a poll fallback re-syncs vaults without trigger support. Best-effort throughout —
+  // a def-vault failure is logged and never affects channels.json-defined channels.
+  let agentDefPoll: ReturnType<typeof setInterval> | undefined;
+  void (async () => {
+    let managerBearer: string | null = null;
+    try {
+      managerBearer = resolveSpawnDeps().managerBearer;
+    } catch {
+      // No operator token yet — resolveDefVaults handles the null (idle vault-native
+      // path; channels.json unaffected).
+    }
+    const bindings = await resolveDefVaults({ hubOrigin: getHubOrigin(), managerBearer });
+    for (const b of bindings) agentDefs.addVault(b);
+    if (bindings.length === 0) return; // nothing bound — vault-native path idle.
+    const n = await agentDefs.loadAll();
+    console.log(
+      `parachute-agent: vault-native agent defs — ${n} instantiated from ${bindings.length} def-vault(s).`,
+    );
+    // Poll fallback (every 60s) for vaults without trigger support: re-load all defs
+    // so a created/updated/deleted note converges even with no webhook. The reload
+    // webhook is the fast path; this is the safety net. `unref` so it never holds the
+    // process open. Cheap + idempotent (re-instantiate replaces in place).
+    const interval = parseInt(process.env.PARACHUTE_AGENT_DEF_POLL_MS ?? "", 10) || 60_000;
+    agentDefPoll = setInterval(() => {
+      void agentDefs.loadAll().catch((err) => {
+        console.error(`parachute-agent: agent-def poll failed (continuing): ${(err as Error).message}`);
+      });
+    }, interval);
+    agentDefPoll.unref?.();
+  })().catch((err) => {
+    console.error(`parachute-agent: vault-native agent-def boot failed (continuing): ${(err as Error).message}`);
+  });
 
   // Graceful shutdown — stop the runner + all transports.
   async function shutdown(): Promise<void> {
     runner.stop();
+    if (agentDefPoll) clearInterval(agentDefPoll);
     await Promise.allSettled([...channels.values()].map((c) => c.transport.stop()));
     server.stop();
     process.exit(0);

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -52,6 +52,11 @@ import {
   type ChannelEntry,
 } from "./registry.ts";
 import { VaultTransport, AGENT_VAULT_TRIGGER_TEMPLATE } from "./transports/vault.ts";
+import {
+  AgentDefRegistry,
+  type DefVaultBinding,
+  type InstantiateDeps,
+} from "./agent-defs.ts";
 import { VaultJobStore, validateJob, vaultTransportFor, type Job } from "./jobs.ts";
 import { Runner, realTickDriver } from "./runner.ts";
 import { nextRunAfter } from "./cron.ts";
@@ -471,6 +476,65 @@ async function removeChannelLive(
   }
   channels.delete(name);
   return true;
+}
+
+// ---------------------------------------------------------------------------
+// Vault-native agent definitions (design 2026-06-17-vault-native-agents, Phase 4a)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the vault `ChannelEntry` for a vault-native agent's wake channel, from its
+ * def-vault binding. The agent's conversation lives in its def-vault, so the channel
+ * is a `vault` transport pointed at the SAME vault + token the def registry reads
+ * from (own-vault scoping — 4a). This is the exact `ChannelEntry` shape the existing
+ * create-agent flow + boot persist; we just synthesize it from the binding instead
+ * of from channels.json (the note IS the definition).
+ */
+export function defVaultChannelEntry(name: string, binding: DefVaultBinding): ChannelEntry {
+  return {
+    name,
+    transport: "vault",
+    config: {
+      vault: binding.vault,
+      ...(binding.vaultUrl ? { vaultUrl: binding.vaultUrl } : {}),
+      token: binding.token,
+    },
+  };
+}
+
+/**
+ * Build the {@link InstantiateDeps} the {@link AgentDefRegistry} drives, wired to the
+ * SAME machinery the create-agent flow + boot use — so a vault-defined agent comes up
+ * byte-for-byte like a UI-created one, only its SOURCE differs (a note, not a form):
+ *   - ensureChannel    → `addChannelLive` with a vault `ChannelEntry` from the binding;
+ *   - setupAndRegister → `setupProgrammaticSpawn` (persist spec.json) + `programmatic.register`;
+ *   - deregister       → `programmatic.deregister`;
+ *   - removeChannel    → `removeChannelLive`.
+ *
+ * `setupProgrammaticSpawn` resolves the Claude credential early — a missing one
+ * throws `CredentialNotConfiguredError`, which the registry catches + stamps the
+ * note `status: error` (the agent can't run turns without auth; the note surfaces
+ * the gap rather than registering a dead agent). Secrets stay local throughout.
+ */
+export function buildInstantiateDeps(
+  channels: Map<string, Channel>,
+  registry: ClientRegistry,
+  deliveryState: DeliveryState,
+  programmatic: ProgrammaticAgentRegistry,
+): InstantiateDeps {
+  return {
+    ensureChannel: async (name, binding) => {
+      await addChannelLive(channels, registry, defVaultChannelEntry(name, binding), deliveryState, programmatic);
+    },
+    setupAndRegister: async (spec) => {
+      // Persist spec.json (so boot re-register + per-turn deliver find the workspace)
+      // then register — the same two steps the web programmatic spawn runs.
+      setupProgrammaticSpawn(spec);
+      await programmatic.register({ ...spec, backend: "programmatic" });
+    },
+    deregister: async (name) => programmatic.deregister(name),
+    removeChannel: async (name) => removeChannelLive(channels, name),
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -1492,6 +1556,13 @@ export function createFetchHandler(
      * still works in a plain createFetchHandler).
      */
     runner?: Runner;
+    /**
+     * The vault-native agent-def registry (design 2026-06-17-vault-native-agents,
+     * Phase 4a). The `POST /api/vault/agent-def` reload webhook drives it. `main`
+     * passes the boot instance; tests inject one. Optional — when absent, the reload
+     * route is a clean no-op ack (a daemon with no def-vaults configured).
+     */
+    agentDefs?: AgentDefRegistry;
   },
 ): (req: Request, server?: { upgrade: (req: Request, opts: { data: TerminalWsData }) => boolean }) => Promise<Response> {
   // Spawn/list/kill operations behind the web agents surface. Lazily defaulted to
@@ -1526,6 +1597,11 @@ export function createFetchHandler(
   // /api/jobs routes; `main` shares its boot instance with the runner so the routes
   // and the scheduler operate on the same vault.
   const jobStore: VaultJobStore = opts?.jobStore ?? new VaultJobStore(channels);
+
+  // The vault-native agent-def registry (Phase 4a). Optional — when absent the
+  // reload webhook is a no-op ack (a daemon with no def-vaults). `main` passes the
+  // boot instance so the route reloads the same set the boot instantiated.
+  const agentDefs: AgentDefRegistry | undefined = opts?.agentDefs;
 
   // Install the MCP connect hook: when an MCP session's GET push stream goes live
   // (mcp-http's handleMcp GET branch → fireConnectReplay — NOT at registration,
@@ -2624,6 +2700,63 @@ export function createFetchHandler(
       return json({ ok: true });
     }
 
+    // ---------------------------------------------------------------------
+    // Vault-native agent-def RELOAD webhook — POST /api/vault/agent-def
+    // (design 2026-06-17-vault-native-agents, Phase 4a). A vault trigger on
+    // `#agent/definition` created/updated/deleted POSTs here; we reload that one
+    // agent (per-note granularity). Mirrors /api/vault/inbound's auth (hub JWT,
+    // scope agent:send — the trigger is a vault→module action) and its uniform-401.
+    // Body: { event?, vault?, note: { id, ... } }. `vault` names the source
+    // def-vault (the hub fills it / it defaults to the single configured one when
+    // exactly one is bound). Externally `<hub>/agent/api/vault/agent-def`.
+    // ---------------------------------------------------------------------
+    if (req.method === "POST" && url.pathname === "/api/vault/agent-def") {
+      const denied = await requireScope(req, url, SCOPE_SEND);
+      if (denied) return json({ error: "unauthorized" }, 401);
+      if (!agentDefs) {
+        // No def-vaults configured — nothing to reload. Clean ack (the trigger
+        // shouldn't have fired, but don't error a benign delivery).
+        return json({ ok: true, reloaded: "skipped" });
+      }
+      let body: {
+        event?: "created" | "updated" | "deleted";
+        vault?: string;
+        note?: { id?: string; path?: string; metadata?: Record<string, unknown> };
+      };
+      try {
+        body = (await req.json()) as typeof body;
+      } catch {
+        return json({ error: "invalid JSON body" }, 400);
+      }
+      const noteId =
+        typeof body.note?.id === "string" && body.note.id
+          ? body.note.id
+          : typeof body.note?.path === "string"
+            ? body.note.path
+            : undefined;
+      if (!noteId) {
+        return json({ error: "body must include note.id" }, 400);
+      }
+      // Resolve the source vault: the explicit `vault` field, else the sole
+      // configured def-vault (the single-vault default — unambiguous), else 400.
+      let vault = typeof body.vault === "string" && body.vault ? body.vault : undefined;
+      if (!vault) {
+        const names = agentDefs.list();
+        const distinct = new Set([...names.map((d) => d.vault)]);
+        // Fall back to the lone bound vault even with zero live defs yet.
+        if (agentDefs.vaultCount === 1) {
+          vault = agentDefs.soleVaultName();
+        } else if (distinct.size === 1) {
+          vault = [...distinct][0];
+        }
+      }
+      if (!vault) {
+        return json({ error: "body.vault is required (multiple def-vaults configured)" }, 400);
+      }
+      const result = await agentDefs.reload(vault, noteId, body.event);
+      return json({ ok: true, reloaded: result });
+    }
+
     // Turn-event SSE — GET /api/channels/<ch>/turn-events (chat-facing; gated on
     // `agent:read`, same scope as the transcript poll + /ui/events). The streaming
     // view (design 2026-06-16 build item #1): the chat subscribes here to watch a
@@ -2987,7 +3120,18 @@ function main(): void {
     driver: realTickDriver(),
   });
 
-  const fetchHandler = createFetchHandler(channels, registry, { deliveryState, programmatic, turnEvents, jobStore, runner });
+  // The vault-native agent-def registry (design 2026-06-17-vault-native-agents,
+  // Phase 4a). Reads `#agent/definition` notes from the configured def-vaults and
+  // instantiates each as a live agent (a vault channel + a programmatic agent) via
+  // the SAME machinery the create-agent flow uses (buildInstantiateDeps). Constructed
+  // here (empty) so it's shared with the fetch handler's reload webhook; the boot
+  // resolve below (resolveDefVaults → addVault → loadAll) fills it. ADDITIVE to
+  // channels.json — both paths coexist.
+  const agentDefs = new AgentDefRegistry(
+    buildInstantiateDeps(channels, registry, deliveryState, programmatic),
+  );
+
+  const fetchHandler = createFetchHandler(channels, registry, { deliveryState, programmatic, turnEvents, jobStore, runner, agentDefs });
   const server = Bun.serve<TerminalWsData, never>({
     port: PORT,
     hostname: "127.0.0.1",
@@ -3095,6 +3239,13 @@ function main(): void {
   // is `unref`'d so it never keeps the process alive on its own.
   runner.start();
   console.log(`parachute-agent: runner started (scheduled-job tick)`);
+
+  // VAULT-NATIVE AGENT DEFINITIONS (design 2026-06-17-vault-native-agents, Phase 4a).
+  // The registry + reload webhook are wired (above); the def-vault BINDINGS that fill
+  // it are resolved by the config layer (next commit). With no bindings the registry
+  // is empty — the reactive route is a no-op ack and the vault-native path is idle.
+  // ADDITIVE to channels.json (both paths coexist).
+  void agentDefs;
 
   // Graceful shutdown — stop the runner + all transports.
   async function shutdown(): Promise<void> {

--- a/src/def-vaults.test.ts
+++ b/src/def-vaults.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Unit tests for the def-vault config (design 2026-06-17-vault-native-agents,
+ * Phase 4a "Commit 3"). Sandboxed to a throwaway state dir (NEVER the operator's
+ * ~/.parachute); the mint is driven by an injected fetch — deterministic, no real hub.
+ */
+
+import { describe, test, expect, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, statSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  readDefVaultsFile,
+  writeDefVaultsFile,
+  defVaultsFilePath,
+  resolveDefVaults,
+  DEFAULT_DEF_VAULT_NAME,
+} from "./def-vaults.ts";
+
+const dirs: string[] = [];
+function freshDir(): string {
+  const d = mkdtempSync(join(tmpdir(), "agent-defvaults-"));
+  dirs.push(d);
+  return d;
+}
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+/** A fake hub mint endpoint returning a scripted token. */
+function fakeMint(token: string): { fetchFn: typeof fetch; calls: Array<Record<string, unknown>> } {
+  const calls: Array<Record<string, unknown>> = [];
+  const fetchFn = (async (_url: string | URL | Request, init?: RequestInit) => {
+    calls.push(JSON.parse(String(init?.body ?? "{}")));
+    return new Response(JSON.stringify({ token, jti: "j", expires_at: "", scope: "vault:default:write" }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof fetch;
+  return { fetchFn, calls };
+}
+
+describe("agent-vaults.json read/write", () => {
+  test("readDefVaultsFile returns null when absent", () => {
+    expect(readDefVaultsFile(freshDir())).toBeNull();
+  });
+
+  test("write then read round-trips; file is 0600", () => {
+    const dir = freshDir();
+    writeDefVaultsFile({ vaults: [{ vault: "default", vaultUrl: "http://x", token: "t" }] }, dir);
+    const back = readDefVaultsFile(dir);
+    expect(back?.vaults).toEqual([{ vault: "default", vaultUrl: "http://x", token: "t" }]);
+    const mode = statSync(defVaultsFilePath(dir)).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  test("a malformed file throws (operator error, not silently defaulted)", () => {
+    const dir = freshDir();
+    writeFileSync(defVaultsFilePath(dir), JSON.stringify({ nope: true }));
+    expect(() => readDefVaultsFile(dir)).toThrow(/"vaults" array/);
+  });
+
+  test("an entry missing vault throws", () => {
+    const dir = freshDir();
+    writeFileSync(defVaultsFilePath(dir), JSON.stringify({ vaults: [{ token: "t" }] }));
+    expect(() => readDefVaultsFile(dir)).toThrow(/non-empty "vault"/);
+  });
+});
+
+describe("resolveDefVaults", () => {
+  test("explicit agent-vaults.json wins (multi-vault, verbatim tokens, no mint)", async () => {
+    const dir = freshDir();
+    writeDefVaultsFile(
+      {
+        vaults: [
+          { vault: "default", vaultUrl: "http://127.0.0.1:1940", token: "tok-default" },
+          { vault: "research", vaultUrl: "http://127.0.0.1:1940", token: "tok-research" },
+        ],
+      },
+      dir,
+    );
+    const { fetchFn, calls } = fakeMint("SHOULD-NOT-BE-USED");
+    const bindings = await resolveDefVaults({ stateDir: dir, managerBearer: "op", fetchFn });
+    expect(bindings.map((b) => b.vault)).toEqual(["default", "research"]);
+    expect(bindings[0]!.token).toBe("tok-default");
+    expect(bindings[1]!.token).toBe("tok-research");
+    // No mint when the file carries tokens.
+    expect(calls).toHaveLength(0);
+  });
+
+  test("no file + a manager bearer → mints a default vault:default:write token + persists", async () => {
+    const dir = freshDir();
+    const { fetchFn, calls } = fakeMint("minted-token");
+    const bindings = await resolveDefVaults({
+      stateDir: dir,
+      hubOrigin: "http://127.0.0.1:1939",
+      managerBearer: "operator-bearer",
+      fetchFn,
+    });
+    expect(bindings).toHaveLength(1);
+    expect(bindings[0]).toMatchObject({ vault: DEFAULT_DEF_VAULT_NAME, token: "minted-token" });
+    // Minted with the vault:default:write scope, attenuated to the operator bearer.
+    expect(calls[0]!.scope).toBe("vault:default:write");
+    // Persisted so a restart reuses it (no re-mint).
+    expect(existsSync(defVaultsFilePath(dir))).toBe(true);
+    const persisted = readDefVaultsFile(dir);
+    expect(persisted?.vaults[0]!.token).toBe("minted-token");
+  });
+
+  test("persist:false → mints but does NOT write the file", async () => {
+    const dir = freshDir();
+    const { fetchFn } = fakeMint("minted");
+    const bindings = await resolveDefVaults({
+      stateDir: dir,
+      managerBearer: "op",
+      fetchFn,
+      persist: false,
+    });
+    expect(bindings).toHaveLength(1);
+    expect(existsSync(defVaultsFilePath(dir))).toBe(false);
+  });
+
+  test("no file + no manager bearer → NO bindings (vault-native path idle; channels.json unaffected)", async () => {
+    const bindings = await resolveDefVaults({ stateDir: freshDir(), managerBearer: null });
+    expect(bindings).toEqual([]);
+  });
+
+  test("a mint failure → no bindings (best-effort; boot is not crashed)", async () => {
+    const dir = freshDir();
+    const fetchFn = (async () =>
+      new Response(JSON.stringify({ error: "invalid_scope" }), { status: 400 })) as unknown as typeof fetch;
+    const bindings = await resolveDefVaults({ stateDir: dir, managerBearer: "op", fetchFn });
+    expect(bindings).toEqual([]);
+    // Nothing persisted on a failed mint.
+    expect(existsSync(defVaultsFilePath(dir))).toBe(false);
+  });
+});

--- a/src/def-vaults.ts
+++ b/src/def-vaults.ts
@@ -31,6 +31,8 @@ import type { DefVaultBinding } from "./agent-defs.ts";
 export const DEFAULT_DEF_VAULT_NAME = "default";
 /** The loopback vault REST origin (the local vault daemon). */
 export const DEFAULT_DEF_VAULT_URL = "http://127.0.0.1:1940";
+/** The loopback HUB origin (the mint-token endpoint lives on the hub, NOT the vault). */
+export const DEFAULT_HUB_ORIGIN = "http://127.0.0.1:1939";
 
 /** The on-disk shape of `agent-vaults.json`. */
 export interface DefVaultsFile {
@@ -134,7 +136,7 @@ export async function resolveDefVaults(deps: ResolveDefVaultsDeps = {}): Promise
     const minted = await mintScopedToken(
       { scope: vaultScope(DEFAULT_DEF_VAULT_NAME, "write") },
       {
-        hubOrigin: deps.hubOrigin ?? DEFAULT_DEF_VAULT_URL,
+        hubOrigin: deps.hubOrigin ?? DEFAULT_HUB_ORIGIN,
         managerBearer: deps.managerBearer,
         ...(deps.fetchFn ? { fetchFn: deps.fetchFn } : {}),
       },

--- a/src/def-vaults.ts
+++ b/src/def-vaults.ts
@@ -1,0 +1,163 @@
+/**
+ * Def-vault binding/config — which vault(s) the module reads `#agent/definition`
+ * notes from, and the token it uses (design `2026-06-17-vault-native-agents.md`,
+ * Phase 4a "Commit 3").
+ *
+ * Modelled on `channels.json`: a small JSON file in the agent state dir
+ * (`agent-vaults.json`) holding a LIST of def-vaults. The architecture is a list
+ * (NOT single-vault) so opening up multi-vault later is appending an entry, not a
+ * refactor (design "Decided: multi-vault — any vault can define agents"). It
+ * DEFAULTS to a single entry for the local `default` vault when no file exists.
+ *
+ * The token is a `vault:<name>:write` hub JWT — read (query the defs) + write (stamp
+ * the `status` field + the agents' message/job notes). For the default local vault,
+ * when the file carries no token we MINT one at boot the same way channels/jobs get
+ * theirs (`mint-token.ts`, attenuated to the operator bearer). PER-VAULT SCOPING
+ * (load-bearing, 4a): the token is scoped to its own vault only — an agent defined in
+ * vault X reaches only X. The file is read 0600 (it can carry a token).
+ *
+ * This path is ADDITIVE to `channels.json` — both coexist. channels.json defines
+ * channels the old way; def-vaults define vault-native agents. Neither replaces the
+ * other.
+ */
+
+import { readFileSync, existsSync, writeFileSync, chmodSync, mkdirSync } from "fs";
+import { join } from "path";
+import { defaultStateDir } from "./registry.ts";
+import { mintScopedToken, vaultScope, MintError } from "./mint-token.ts";
+import type { DefVaultBinding } from "./agent-defs.ts";
+
+/** The local vault every install has by default — the design's `default` vault. */
+export const DEFAULT_DEF_VAULT_NAME = "default";
+/** The loopback vault REST origin (the local vault daemon). */
+export const DEFAULT_DEF_VAULT_URL = "http://127.0.0.1:1940";
+
+/** The on-disk shape of `agent-vaults.json`. */
+export interface DefVaultsFile {
+  /** The def-vaults this install reads agent definitions from (default: one). */
+  vaults: DefVaultBinding[];
+}
+
+/** Absolute path to `agent-vaults.json` in a state dir. */
+export function defVaultsFilePath(stateDir?: string): string {
+  return join(stateDir ?? defaultStateDir(), "agent-vaults.json");
+}
+
+/**
+ * Read `agent-vaults.json` as a plain {@link DefVaultsFile}. Returns null if the
+ * file is absent (the caller then applies the single-`default` default). Throws on a
+ * malformed file (a present-but-broken config is an operator error worth surfacing,
+ * not silently defaulting away).
+ */
+export function readDefVaultsFile(stateDir?: string): DefVaultsFile | null {
+  const file = defVaultsFilePath(stateDir);
+  if (!existsSync(file)) return null;
+  const parsed = JSON.parse(readFileSync(file, "utf8")) as DefVaultsFile;
+  if (!parsed || !Array.isArray(parsed.vaults)) {
+    throw new Error(`def-vaults: ${file} must have a "vaults" array`);
+  }
+  for (const v of parsed.vaults) {
+    if (!v || typeof v.vault !== "string" || v.vault.length === 0) {
+      throw new Error(`def-vaults: each entry needs a non-empty "vault" (got ${JSON.stringify(v)})`);
+    }
+  }
+  return parsed;
+}
+
+/**
+ * Persist `agent-vaults.json` (0600 — it can carry a token). Creates the state dir
+ * if needed. Used to materialize the default config after a boot mint so a restart
+ * reuses the same binding instead of re-minting.
+ */
+export function writeDefVaultsFile(file: DefVaultsFile, stateDir?: string): void {
+  const dir = stateDir ?? defaultStateDir();
+  mkdirSync(dir, { recursive: true });
+  const path = defVaultsFilePath(dir);
+  writeFileSync(path, JSON.stringify(file, null, 2) + "\n", { mode: 0o600 });
+  chmodSync(path, 0o600);
+}
+
+/** Wiring for the boot resolve (injected for tests — no real hub/mint/fs). */
+export interface ResolveDefVaultsDeps {
+  /** Agent state dir (default: the resolved state dir). */
+  stateDir?: string;
+  /** Hub origin for the default-vault token mint. */
+  hubOrigin?: string;
+  /** The operator bearer the default-vault mint is attenuated against. null = no mint. */
+  managerBearer?: string | null;
+  /** fetch override for the mint client (tests). */
+  fetchFn?: typeof fetch;
+  /** Persist the minted default config back to disk so a restart reuses it. Default true. */
+  persist?: boolean;
+}
+
+/**
+ * Resolve the def-vault bindings for this install. Order:
+ *
+ *   1. `agent-vaults.json` present → use its entries verbatim (each carries its own
+ *      token). This is the multi-vault + explicit-token path.
+ *   2. Absent → the SINGLE-`default` default: a binding for the local `default`
+ *      vault. If a `managerBearer` is available, MINT a `vault:default:write` token
+ *      (attenuated to the operator bearer) and — when `persist` — write the resulting
+ *      config so a restart reuses it (no re-mint). With no manager bearer (hub not
+ *      provisioned yet), we return NO bindings (the module starts idle on the
+ *      vault-native path; channels.json still works) rather than a tokenless binding
+ *      that would 401 on every query.
+ *
+ * Returns the bindings to hand the {@link AgentDefRegistry}. Best-effort on the mint:
+ * a mint failure is logged + yields no bindings (don't crash boot — the channels.json
+ * path is unaffected).
+ */
+export async function resolveDefVaults(deps: ResolveDefVaultsDeps = {}): Promise<DefVaultBinding[]> {
+  const stateDir = deps.stateDir ?? defaultStateDir();
+
+  // 1. Explicit config file wins.
+  const file = readDefVaultsFile(stateDir);
+  if (file) {
+    return file.vaults.map((v) => ({
+      vault: v.vault,
+      ...(v.vaultUrl ? { vaultUrl: v.vaultUrl } : {}),
+      token: v.token,
+    }));
+  }
+
+  // 2. Default: the local `default` vault. Mint its write token if we can.
+  if (!deps.managerBearer) {
+    console.warn(
+      "agent-defs: no operator token — skipping the default def-vault (the vault-native " +
+        "agent path is idle until the hub is provisioned; channels.json is unaffected).",
+    );
+    return [];
+  }
+  let token: string;
+  try {
+    const minted = await mintScopedToken(
+      { scope: vaultScope(DEFAULT_DEF_VAULT_NAME, "write") },
+      {
+        hubOrigin: deps.hubOrigin ?? DEFAULT_DEF_VAULT_URL,
+        managerBearer: deps.managerBearer,
+        ...(deps.fetchFn ? { fetchFn: deps.fetchFn } : {}),
+      },
+    );
+    token = minted.token;
+  } catch (err) {
+    const detail = err instanceof MintError ? err.message : (err as Error).message;
+    console.error(`agent-defs: minting the default def-vault token failed (continuing): ${detail}`);
+    return [];
+  }
+
+  const binding: DefVaultBinding = {
+    vault: DEFAULT_DEF_VAULT_NAME,
+    vaultUrl: DEFAULT_DEF_VAULT_URL,
+    token,
+  };
+  // Materialize the config so a restart reuses this binding (no re-mint each boot).
+  if (deps.persist !== false) {
+    try {
+      writeDefVaultsFile({ vaults: [binding] }, stateDir);
+    } catch (err) {
+      console.warn(`agent-defs: persisting the default def-vault config failed (continuing): ${(err as Error).message}`);
+    }
+  }
+  return [binding];
+}

--- a/src/delivery-state.ts
+++ b/src/delivery-state.ts
@@ -2,7 +2,7 @@
  * Per-channel delivery high-water-mark — the spine of the no-silent-loss fix.
  *
  * THE PROBLEM. The vault-backed inbound pipeline wakes a session by `ctx.emit`
- * fanning a new `#agent-message/inbound` note to whatever SSE bridges + HTTP
+ * fanning a new `#agent/message/inbound` note to whatever SSE bridges + HTTP
  * MCP sessions are live on the channel. But:
  *  - the daemon acks the vault trigger `{ok:true}` regardless of how many
  *    subscribers actually received it, and the vault stamps `..._rendered_at` on

--- a/src/jobs.test.ts
+++ b/src/jobs.test.ts
@@ -126,7 +126,7 @@ describe("VaultJobStore — vault-native CRUD", () => {
     const jobs = await store.listAll();
     // Only ONE vault transport in the map → queried exactly once (telegram is skipped).
     expect(urls.filter((u) => u.includes("/api/notes")).length).toBe(1);
-    expect(urls[0]).toContain("tag=%23agent-job");
+    expect(urls[0]).toContain("tag=%23agent%2Fjob");
     expect(jobs).toHaveLength(2);
     expect(jobs[0]).toMatchObject({
       id: "note-1",
@@ -138,7 +138,7 @@ describe("VaultJobStore — vault-native CRUD", () => {
     expect(jobs[1]!.enabled).toBe(false); // "false" string → disabled
   });
 
-  test("upsert writes a #agent-job note via the target channel's vault", async () => {
+  test("upsert writes a #agent/job note via the target channel's vault", async () => {
     const { channels } = channelsWithVault();
     const calls: { url: string; init: RequestInit }[] = [];
     globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
@@ -156,7 +156,7 @@ describe("VaultJobStore — vault-native CRUD", () => {
     expect(saved.noteId).toBe("Channels/uni-dev/jobs/morning");
     expect(calls).toHaveLength(1);
     const body = JSON.parse(String(calls[0]!.init.body));
-    expect(body.tags).toEqual(["#agent-job"]);
+    expect(body.tags).toEqual(["#agent/job"]);
     expect(body.path).toBe("Channels/uni-dev/jobs/morning");
     expect(body.metadata.jobId).toBe("morning"); // slug persisted for stable display
     expect(body.content).toBe("Run the morning weave");

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -4,10 +4,10 @@
  *
  * A scheduled job is "an automated human": send message M to agent (channel) A on
  * schedule S. The runner does NOT execute anything — it authors an inbound
- * `#agent-message/inbound` note on a schedule, and the existing vault trigger →
+ * `#agent/message/inbound` note on a schedule, and the existing vault trigger →
  * agent-turn → outbound flow does the rest.
  *
- * STORAGE IS VAULT-NATIVE (Aaron's call, 2026-06-17): a job IS a `#agent-job`
+ * STORAGE IS VAULT-NATIVE (Aaron's call, 2026-06-17): a job IS a `#agent/job`
  * note in the TARGET channel's vault — durable, queryable, and renderable by any
  * surface, converging with the blueprint's "vault as the spine" and the future
  * `tag:job` idea. There is NO jobs.json. The vault note I/O lives on
@@ -37,7 +37,7 @@ export interface JobSchedule {
 
 /**
  * One scheduled job. The in-memory shape the runner + API operate on; persisted as
- * a `#agent-job` vault note (see the store below). `id` is the slug (also the
+ * a `#agent/job` vault note (see the store below). `id` is the slug (also the
  * `runner:<id>` sender provenance + the note path segment).
  */
 export interface Job {
@@ -152,7 +152,7 @@ export function vaultTransportFor(
 
 /**
  * The vault-native job store. Same read-all / upsert / remove interface the file
- * store had, now backed by `#agent-job` vault notes via the channel's
+ * store had, now backed by `#agent/job` vault notes via the channel's
  * `VaultTransport`. Each method resolves the target channel's vault transport (the
  * channel carries the vault binding + write token) and delegates the I/O to it.
  *
@@ -205,7 +205,7 @@ export class VaultJobStore {
   }
 
   /**
-   * Create or replace a job (by slug id) as a `#agent-job` note in its target
+   * Create or replace a job (by slug id) as a `#agent/job` note in its target
    * channel's vault. Throws if the target channel isn't a live vault channel
    * (the API validates this first, so it's a guard, not the primary check).
    * Returns the persisted job with its `noteId` filled in (the `id` stays the slug).

--- a/src/mint-token.test.ts
+++ b/src/mint-token.test.ts
@@ -68,12 +68,12 @@ describe("mintScopedToken — happy path", () => {
       {
         scope: "vault:default:read",
         audience: "vault.default",
-        permissions: { scoped_tags: ["#agent-message"] },
+        permissions: { scoped_tags: ["#agent/message"] },
       },
       depsWith(hub.fetchFn),
     );
     expect(hub.calls[0]!.body.audience).toBe("vault.default");
-    expect(hub.calls[0]!.body.permissions).toEqual({ scoped_tags: ["#agent-message"] });
+    expect(hub.calls[0]!.body.permissions).toEqual({ scoped_tags: ["#agent/message"] });
   });
 });
 

--- a/src/mint-token.ts
+++ b/src/mint-token.ts
@@ -26,7 +26,7 @@ export interface MintRequest {
   /** TTL in seconds. Omitted = hub default (~90d non-ephemeral). */
   expiresIn?: number;
   /**
-   * Extra JWT claims, e.g. `{ scoped_tags: ["#agent-message"] }` for a
+   * Extra JWT claims, e.g. `{ scoped_tags: ["#agent/message"] }` for a
    * tag-scoped vault token. Passed through as the mint API's `permissions`.
    */
   permissions?: Record<string, unknown>;

--- a/src/programmatic-wiring.test.ts
+++ b/src/programmatic-wiring.test.ts
@@ -287,7 +287,7 @@ describe("inbound for a programmatic channel → deliver → outbound note", () 
         note: {
           id: noteId,
           content,
-          tags: ["#agent-message", "#agent-message/inbound"],
+          tags: ["#agent/message", "#agent/message/inbound"],
           metadata: { channel, direction: "inbound", sender: "aaron", ts: "2026-06-16T00:00:01Z" },
         },
       }),

--- a/src/provision-agent.test.ts
+++ b/src/provision-agent.test.ts
@@ -26,7 +26,7 @@ describe("vaultConnectionBody (the canonical vault-backed-channel connection)", 
     // The inbound-tag filter is the loop-avoidance contract (CLAUDE.md "Vault
     // integration"): fire on the inbound CHILD tag only; require channel metadata;
     // skip already-rendered notes.
-    expect(body.source.filter.tags).toEqual(["#agent-message/inbound"]);
+    expect(body.source.filter.tags).toEqual(["#agent/message/inbound"]);
     expect(body.source.filter.has_metadata).toEqual(["channel"]);
     expect(body.source.filter.missing_metadata).toEqual(["channel_inbound_rendered_at"]);
     expect(body.sink.module).toBe("agent");

--- a/src/provision-agent.ts
+++ b/src/provision-agent.ts
@@ -58,7 +58,7 @@ export function vaultConnectionBody(name: string, vault: string): {
       vault,
       event: "note.created",
       filter: {
-        tags: ["#agent-message/inbound"],
+        tags: ["#agent/message/inbound"],
         has_metadata: ["channel"],
         missing_metadata: ["channel_inbound_rendered_at"],
       },
@@ -122,7 +122,7 @@ export const PROVISION_JS = `
           vault: vault,
           event: "note.created",
           filter: {
-            tags: ["#agent-message/inbound"],
+            tags: ["#agent/message/inbound"],
             has_metadata: ["channel"],
             missing_metadata: ["channel_inbound_rendered_at"]
           }

--- a/src/sandbox/types.ts
+++ b/src/sandbox/types.ts
@@ -51,7 +51,7 @@ export interface AgentVaultSpec {
   access: "read" | "write" | "admin";
   /**
    * Optional tag scope — narrows the minted vault token to these tags via the
-   * `permissions.scoped_tags` claim (e.g. `["#agent-message"]`). Omitted = the
+   * `permissions.scoped_tags` claim (e.g. `["#agent/message"]`). Omitted = the
    * verb's full scope across the vault.
    */
   tags?: string[];
@@ -104,7 +104,7 @@ export type AgentChannel = string | AgentChannelSpec;
  *  - `"programmatic"` (the DEFAULT for a NEW spawn request, per Aaron's gating
  *    decision 2026-06-16): NO resident process. An inbound message becomes one
  *    on-demand `claude -p --resume <sid>` turn ({@link AgentBackend}); the reply is
- *    posted back as an outbound `#agent-message/outbound` note. No idle session →
+ *    posted back as an outbound `#agent/message/outbound` note. No idle session →
  *    nothing to go deaf, no reconnect, no replay, no consent gate. The reliable
  *    primary path; best for clean per-message "do a task, report back" turns.
  *  - `"interactive"` (the original tmux path; now the opt-in/"advanced" backend): an

--- a/src/spawn-agent-cli.test.ts
+++ b/src/spawn-agent-cli.test.ts
@@ -16,7 +16,7 @@ describe("parseArgs — name + channels + vault + egress + mounts → the right 
       "--channel",
       "ops:read",
       "--vault",
-      "default:read:#agent-message,#decision",
+      "default:read:#agent/message,#decision",
       "--egress",
       "registry.npmjs.org,github.com",
       "--mount",
@@ -38,7 +38,7 @@ describe("parseArgs — name + channels + vault + egress + mounts → the right 
     expect(spec!.vault).toEqual({
       name: "default",
       access: "read",
-      tags: ["#agent-message", "#decision"],
+      tags: ["#agent/message", "#decision"],
     });
 
     // Egress: additive host list, comma-split.

--- a/src/spawn-agent.test.ts
+++ b/src/spawn-agent.test.ts
@@ -379,7 +379,7 @@ describe("spawnAgent — full wiring with stubs (no real token)", () => {
     const spec: AgentSpec = {
       name: "aaron-dev",
       channels: ["aaron-dev"],
-      vault: { name: "default", access: "read", tags: ["#agent-message"] },
+      vault: { name: "default", access: "read", tags: ["#agent/message"] },
       network: "restricted", // exercise the egress floor; scoped reads are the default (step 6)
     };
     const res = await spawnAgent(spec, baseDeps({ tmux, sandboxEngine: engine }));
@@ -501,13 +501,13 @@ describe("spawnAgent — full wiring with stubs (no real token)", () => {
     const spec: AgentSpec = {
       name: "weaver",
       channels: ["c"],
-      vault: { name: "default", access: "read", tags: ["#agent-message"] },
+      vault: { name: "default", access: "read", tags: ["#agent/message"] },
     };
     await spawnAgent(spec, baseDeps({ fetchFn }));
     const vaultCall = calls.find((c) => String(c.scope).startsWith("vault:"));
     expect(vaultCall).toBeDefined();
     expect(vaultCall!.scope).toBe("vault:default:read");
-    expect(vaultCall!.permissions).toEqual({ scoped_tags: ["#agent-message"] });
+    expect(vaultCall!.permissions).toEqual({ scoped_tags: ["#agent/message"] });
   });
 
   test("idempotent: an already-running session is a no-op", async () => {
@@ -605,7 +605,7 @@ describe("spawnAgent — full wiring with stubs (no real token)", () => {
     const spec: AgentSpec = {
       name: "weaver",
       channels: [{ name: "weave", access: "read" }],
-      vault: { name: "default", access: "read", tags: ["#agent-message"] },
+      vault: { name: "default", access: "read", tags: ["#agent/message"] },
       network: "restricted",
       egress: ["registry.npmjs.org"],
     };

--- a/src/transports/vault.test.ts
+++ b/src/transports/vault.test.ts
@@ -5,24 +5,24 @@
  * capture the outbound note write, and `ctx.emit` is recorded to assert inbound
  * delivery. They cover:
  *   - reply(): writes the right POST .../api/notes tagged BOTH the queryable parent
- *     `#agent-message` AND the directional child `#agent-message/outbound` (no
+ *     `#agent/message` AND the directional child `#agent/message/outbound` (no
  *     `outbound` metadata key), with direction, channel, Bearer token; returns the id;
  *   - reply(): threads in_reply_to when the bridge passes it;
  *   - loadTranscript(): DUAL-READS — a note tagged only the LEGACY `#channel-message`
- *     still appears (the impl unions a `#agent-message` and a `#channel-message`
- *     query by note id);
+ *     (or the interim `#agent-message`) still appears (the impl unions a
+ *     `#agent/message`, an `#agent-message`, and a `#channel-message` query by note id);
  *   - ingestInbound(): emits the inbound content + meta onto its channel;
- *   - ingestInbound(): IGNORES a `#agent-message/outbound`-tagged note AND a LEGACY
+ *   - ingestInbound(): IGNORES a `#agent/message/outbound`-tagged note AND a LEGACY
  *     `#channel-message/outbound`-tagged note (loop avoidance, dual-read);
- *   - schema: `AGENT_VAULT_TAG_SCHEMA` declares BOTH the new and the legacy tag
- *     families (7 entries) so pre-rename history keeps its inheritance;
+ *   - schema: `AGENT_VAULT_TAG_SCHEMA` declares the `#agent/*` namespace rollup PLUS
+ *     the interim + legacy tag families so pre-namespace history keeps its inheritance;
  *   - registry: a vault channel instantiates from config.
  *
- * TAG RENAME — channel→agent (rule 2). WRITE assertions expect the NEW
- * `#agent-message*` tags; READ assertions ALSO exercise the legacy
- * `#channel-message*` family (dual-read). The `metadata.channel` routing key, the
- * channel-name slugs, `?channel=`, the `Channel*` types, and the `channel/<name>/`
- * note path prefix are DOMAIN — unchanged.
+ * TAG NAMESPACE — `#agent/*` (design 2026-06-17-vault-native-agents). WRITE
+ * assertions expect the NEW `#agent/message*` tags; READ assertions ALSO exercise
+ * the interim `#agent-message*` and legacy `#channel-message*` families (dual-read).
+ * The `metadata.channel` routing key, the channel-name slugs, `?channel=`, the
+ * `Channel*` types, and the `channel/<name>/` note path prefix are DOMAIN — unchanged.
  */
 
 import { describe, test, expect, afterEach } from "bun:test";
@@ -58,7 +58,7 @@ function baseConfig() {
 }
 
 describe("VaultTransport — reply (outbound note write)", () => {
-  test("reply() POSTs .../api/notes tagged #agent-message/outbound + direction + channel + Bearer", async () => {
+  test("reply() POSTs .../api/notes tagged #agent/message + #agent/message/outbound + direction + channel + Bearer", async () => {
     const calls: { url: string; init: RequestInit }[] = [];
     globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
       calls.push({ url: String(url), init: init ?? {} });
@@ -89,16 +89,19 @@ describe("VaultTransport — reply (outbound note write)", () => {
       metadata: Record<string, string>;
     };
     expect(sent.content).toBe("the reply text");
-    // Two orthogonal tags: the parent `#agent-message` is carried LITERALLY so
+    // Two orthogonal tags: the parent `#agent/message` is carried LITERALLY so
     // the note is queryable under it (a slash is namespace, NOT query inheritance —
-    // a child-only-tagged note is invisible to a `tag:#agent-message` query), and
-    // the directional child `#agent-message/outbound` is the trigger discriminator.
-    // We WRITE only the NEW tags; dual-read recognizes the legacy family on READ.
-    expect(sent.tags).toEqual(["#agent-message", "#agent-message/outbound"]);
+    // a child-only-tagged note is invisible to a `tag:#agent/message` query), and
+    // the directional child `#agent/message/outbound` is the trigger discriminator.
+    // We WRITE only the NEW namespaced tags; dual-read recognizes the interim +
+    // legacy families on READ.
+    expect(sent.tags).toEqual(["#agent/message", "#agent/message/outbound"]);
     // Regression guard: the queryable parent tag MUST be present literally.
-    expect(sent.tags).toContain("#agent-message");
-    expect(sent.tags).toContain("#agent-message/outbound");
-    // Loop-avoidance / write-discipline: we NEVER write the legacy tags going forward.
+    expect(sent.tags).toContain("#agent/message");
+    expect(sent.tags).toContain("#agent/message/outbound");
+    // Loop-avoidance / write-discipline: we NEVER write the interim/legacy tags going forward.
+    expect(sent.tags).not.toContain("#agent-message");
+    expect(sent.tags).not.toContain("#agent-message/outbound");
     expect(sent.tags).not.toContain("#channel-message");
     expect(sent.tags).not.toContain("#channel-message/outbound");
     // The note PATH prefix is DOMAIN (`channel/<name>/`) — unchanged by the rename.
@@ -157,10 +160,11 @@ describe("VaultTransport — loadTranscript (read the durable store)", () => {
       if (u.includes("/api/notes") && (init?.method ?? "GET") === "GET") {
         getUrls.push(u);
         capturedAuth = (init?.headers as Record<string, string> | undefined)?.authorization ?? "";
-        // The dual-read fires TWO queries (#agent-message + #channel-message).
-        // Serve the NEW-tagged notes on the #agent-message query; an empty array on
-        // the legacy query (the legacy-note dual-read is its own dedicated test).
-        if (u.includes("tag=%23agent-message")) {
+        // The dual-read fires THREE queries (#agent/message + interim
+        // #agent-message + legacy #channel-message). Serve the NEW-tagged notes on
+        // the #agent/message query; an empty array on the interim + legacy queries
+        // (those dual-read paths have their own dedicated tests).
+        if (u.includes("tag=%23agent%2Fmessage")) {
           // Return notes OUT of ts order (prove the ascending sort) + a note from a
           // DIFFERENT channel (prove the client-side channel filter excludes it).
           return new Response(
@@ -168,26 +172,26 @@ describe("VaultTransport — loadTranscript (read the durable store)", () => {
               {
                 id: "n-out",
                 content: "session reply",
-                tags: ["#agent-message", "#agent-message/outbound"],
+                tags: ["#agent/message", "#agent/message/outbound"],
                 metadata: { channel: "eng", direction: "outbound", sender: "session", ts: "2026-06-08T00:00:02Z", in_reply_to: "n-in" },
               },
               {
                 id: "n-other",
                 content: "different channel — must be excluded",
-                tags: ["#agent-message", "#agent-message/inbound"],
+                tags: ["#agent/message", "#agent/message/inbound"],
                 metadata: { channel: "other", direction: "inbound", sender: "x", ts: "2026-06-08T00:00:03Z" },
               },
               {
                 id: "n-in",
                 content: "hi session",
-                tags: ["#agent-message", "#agent-message/inbound"],
+                tags: ["#agent/message", "#agent/message/inbound"],
                 metadata: { channel: "eng", direction: "inbound", sender: "aaron", ts: "2026-06-08T00:00:01Z" },
               },
             ]),
             { status: 200, headers: { "content-type": "application/json" } },
           );
         }
-        // legacy #channel-message query → nothing here.
+        // interim #agent-message + legacy #channel-message queries → nothing here.
         return new Response("[]", { status: 200, headers: { "content-type": "application/json" } });
       }
       // ensureSchema PUTs
@@ -198,14 +202,16 @@ describe("VaultTransport — loadTranscript (read the durable store)", () => {
     await t.start(fakeCtx("eng"));
     const msgs = await t.loadTranscript();
 
-    // DUAL-READ: BOTH the new + legacy parent tags are queried (unioned by id).
+    // DUAL-READ: the new + interim + legacy parent tags are queried (unioned by id).
     // Each query carries the encoded parent tag + include_content, and DELIBERATELY
     // no `metadata=` operator filter (the channel field isn't indexed on a bare
     // vault; we filter client-side). Overfetches the tag so other channels don't
     // crowd us out.
-    const agentGet = getUrls.find((u) => u.includes("tag=%23agent-message"));
+    const agentGet = getUrls.find((u) => u.includes("tag=%23agent%2Fmessage"));
+    const interimGet = getUrls.find((u) => u.includes("tag=%23agent-message"));
     const legacyGet = getUrls.find((u) => u.includes("tag=%23channel-message"));
     expect(agentGet).toBeDefined();
+    expect(interimGet).toBeDefined(); // proves the interim flat tag is also queried (dual-read)
     expect(legacyGet).toBeDefined(); // proves the legacy tag is also queried (dual-read)
     expect(agentGet!.startsWith("http://127.0.0.1:1940/vault/default/api/notes?")).toBe(true);
     expect(agentGet!).toContain("include_content=true");
@@ -226,21 +232,21 @@ describe("VaultTransport — loadTranscript (read the durable store)", () => {
 
   test("DUAL-READ: a note tagged ONLY the LEGACY #channel-message still appears in the transcript", async () => {
     // The dual-read proof (rule 2). The impl issues TWO tag queries — one for the
-    // NEW `#agent-message`, one for the legacy `#channel-message` — and unions the
+    // NEW `#agent/message`, one for the legacy `#channel-message` — and unions the
     // results by note id. A pre-rename note carrying ONLY the legacy tags (and the
     // matching `metadata.channel`) must STILL load, so existing history survives the
     // rename until the one-time re-tag run lands.
     globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
       const u = String(url);
       if (u.includes("/api/notes") && (init?.method ?? "GET") === "GET") {
-        if (u.includes("tag=%23agent-message")) {
+        if (u.includes("tag=%23agent%2Fmessage")) {
           // A NEW-tagged note (post-rename) on this channel.
           return new Response(
             JSON.stringify([
               {
                 id: "n-new",
                 content: "post-rename message",
-                tags: ["#agent-message", "#agent-message/inbound"],
+                tags: ["#agent/message", "#agent/message/inbound"],
                 metadata: { channel: "eng", direction: "inbound", sender: "aaron", ts: "2026-06-08T00:00:02Z" },
               },
             ]),
@@ -284,7 +290,7 @@ describe("VaultTransport — loadTranscript (read the durable store)", () => {
     const dual = {
       id: "n-both",
       content: "re-tagged message",
-      tags: ["#agent-message", "#channel-message", "#agent-message/inbound", "#channel-message/inbound"],
+      tags: ["#agent/message", "#channel-message", "#agent/message/inbound", "#channel-message/inbound"],
       metadata: { channel: "eng", direction: "inbound", sender: "aaron", ts: "2026-06-08T00:00:01Z" },
     };
     globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
@@ -307,14 +313,14 @@ describe("VaultTransport — loadTranscript (read the durable store)", () => {
     globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
       const u = String(url);
       if (u.includes("/api/notes") && (init?.method ?? "GET") === "GET") {
-        // Only the #agent-message query returns notes; the legacy query is empty
+        // Only the #agent/message query returns notes; the legacy query is empty
         // (so the union doesn't double-count by id under dual-read).
-        if (u.includes("tag=%23agent-message")) {
+        if (u.includes("tag=%23agent%2Fmessage")) {
           return new Response(
             JSON.stringify([1, 2, 3, 4].map((i) => ({
               id: "n" + i,
               content: "m" + i,
-              tags: ["#agent-message", "#agent-message/inbound"],
+              tags: ["#agent/message", "#agent/message/inbound"],
               metadata: { channel: "eng", direction: "inbound", sender: "aaron", ts: "2026-06-08T00:00:0" + i + "Z" },
             }))),
             { status: 200 },
@@ -335,13 +341,13 @@ describe("VaultTransport — loadTranscript (read the durable store)", () => {
     globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
       const u = String(url);
       if (u.includes("/api/notes") && (init?.method ?? "GET") === "GET") {
-        if (u.includes("tag=%23agent-message")) {
+        if (u.includes("tag=%23agent%2Fmessage")) {
           return new Response(
             JSON.stringify([
               // NEW outbound child → direction inferred "outbound".
-              { id: "a", content: "x", tags: ["#agent-message", "#agent-message/outbound"], metadata: { channel: "eng", ts: "2026-06-08T00:00:01Z" } },
+              { id: "a", content: "x", tags: ["#agent/message", "#agent/message/outbound"], metadata: { channel: "eng", ts: "2026-06-08T00:00:01Z" } },
               // No direction signal at all → defaults to "inbound".
-              { id: "b", content: "y", tags: ["#agent-message", "#agent-message/inbound"], metadata: { channel: "eng", ts: "2026-06-08T00:00:02Z" } },
+              { id: "b", content: "y", tags: ["#agent/message", "#agent/message/inbound"], metadata: { channel: "eng", ts: "2026-06-08T00:00:02Z" } },
             ]),
             { status: 200 },
           );
@@ -383,7 +389,7 @@ describe("VaultTransport — loadTranscript (read the durable store)", () => {
 });
 
 describe("VaultTransport — writeInbound (the chat's send → wakes the session)", () => {
-  test("POSTs an INBOUND note tagged [#agent-message, #agent-message/inbound] with direction + channel + sender + Bearer", async () => {
+  test("POSTs an INBOUND note tagged [#agent/message, #agent/message/inbound] with direction + channel + sender + Bearer", async () => {
     const calls: { url: string; init: RequestInit }[] = [];
     globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
       calls.push({ url: String(url), init: init ?? {} });
@@ -412,11 +418,11 @@ describe("VaultTransport — writeInbound (the chat's send → wakes the session
     };
     expect(sent.content).toBe("wake up");
     // The INBOUND tag pair — the child is the trigger discriminator that wakes the session.
-    expect(sent.tags).toEqual(["#agent-message", "#agent-message/inbound"]);
-    expect(sent.tags).toContain("#agent-message");
-    expect(sent.tags).toContain("#agent-message/inbound");
+    expect(sent.tags).toEqual(["#agent/message", "#agent/message/inbound"]);
+    expect(sent.tags).toContain("#agent/message");
+    expect(sent.tags).toContain("#agent/message/inbound");
     // It must NOT carry the outbound tag (that would be a reply, never wake).
-    expect(sent.tags).not.toContain("#agent-message/outbound");
+    expect(sent.tags).not.toContain("#agent/message/outbound");
     // Write-discipline: never write the legacy tag family going forward.
     expect(sent.tags).not.toContain("#channel-message");
     expect(sent.metadata.channel).toBe("eng");
@@ -470,7 +476,7 @@ describe("VaultTransport — ingestInbound", () => {
     t.ingestInbound({
       id: "note-in-1",
       content: "hello session",
-      tags: ["#agent-message", "#agent-message/inbound"],
+      tags: ["#agent/message", "#agent/message/inbound"],
       metadata: { channel: "eng", direction: "inbound", sender: "aaron", ts: "2026-06-08T00:00:00Z" },
     });
     expect(ctx.emitted).toHaveLength(1);
@@ -484,14 +490,14 @@ describe("VaultTransport — ingestInbound", () => {
     expect(m.meta.direction).toBe("inbound");
   });
 
-  test("IGNORES a #agent-message/outbound-tagged note (loop avoidance)", () => {
+  test("IGNORES a #agent/message/outbound-tagged note (loop avoidance)", () => {
     const t = new VaultTransport(baseConfig());
     const ctx = fakeCtx("eng");
     void t.start(ctx);
     t.ingestInbound({
       id: "our-own-reply",
       content: "I am awake",
-      tags: ["#agent-message", "#agent-message/outbound"],
+      tags: ["#agent/message", "#agent/message/outbound"],
       metadata: { channel: "eng", direction: "outbound", sender: "session" },
     });
     expect(ctx.emitted).toHaveLength(0);
@@ -545,14 +551,34 @@ describe("VaultTransport — ensureSchema (tag-schema declaration on connect)", 
 
     expect(calls).toHaveLength(AGENT_VAULT_TAG_SCHEMA.length);
 
-    // Parent (NEW) — no parent_names, just a description. Plain `#` → `%23`.
-    const parent = calls[0]!;
-    expect(parent.url).toBe(
-      "http://127.0.0.1:1940/vault/default/api/tags/%23agent-message",
+    // Namespace ROOT `#agent` — no parent_names, just a description. Plain `#` → `%23`.
+    const root = calls[0]!;
+    expect(root.url).toBe(
+      "http://127.0.0.1:1940/vault/default/api/tags/%23agent",
     );
-    expect(parent.init.method).toBe("PUT");
-    expect((parent.init.headers as Record<string, string>).authorization).toBe(
+    expect(root.init.method).toBe("PUT");
+    expect((root.init.headers as Record<string, string>).authorization).toBe(
       "Bearer write-token-xyz",
+    );
+    const rootBody = JSON.parse(String(root.init.body)) as {
+      description?: string;
+      parent_names?: string[];
+    };
+    expect("parent_names" in rootBody).toBe(false);
+
+    // Definition (NEW) — name carries `#` + `/`; rolls up to the namespace root.
+    const def = calls[1]!;
+    expect(def.url).toBe(
+      "http://127.0.0.1:1940/vault/default/api/tags/%23agent%2Fdefinition",
+    );
+    expect(decodeURIComponent(def.url.split("/api/tags/")[1]!)).toBe("#agent/definition");
+    const defBody = JSON.parse(String(def.init.body)) as { parent_names?: string[] };
+    expect(defBody.parent_names).toEqual(["#agent"]);
+
+    // Message parent (NEW) — rolls up to the namespace root.
+    const parent = calls[2]!;
+    expect(parent.url).toBe(
+      "http://127.0.0.1:1940/vault/default/api/tags/%23agent%2Fmessage",
     );
     const parentBody = JSON.parse(String(parent.init.body)) as {
       description?: string;
@@ -561,60 +587,78 @@ describe("VaultTransport — ensureSchema (tag-schema declaration on connect)", 
     expect(parentBody.description).toBe(
       "A message in a Parachute channel (parent of /inbound + /outbound).",
     );
-    expect("parent_names" in parentBody).toBe(false);
+    expect(parentBody.parent_names).toEqual(["#agent"]);
 
     // Inbound child (NEW) — name carries BOTH `#` and `/`. The vault route matches a
     // single path segment (`[^/]+`) then decodeURIComponent's it, so the `/` MUST
     // be encoded as `%2F` (a bare slash would fail the single-segment match → 404).
-    const inbound = calls[1]!;
+    const inbound = calls[3]!;
     expect(inbound.url).toBe(
-      "http://127.0.0.1:1940/vault/default/api/tags/%23agent-message%2Finbound",
+      "http://127.0.0.1:1940/vault/default/api/tags/%23agent%2Fmessage%2Finbound",
     );
     // Confirm the encoding decodes back to the literal tag name the vault stores.
     const encodedSegment = inbound.url.split("/api/tags/")[1]!;
-    expect(decodeURIComponent(encodedSegment)).toBe("#agent-message/inbound");
+    expect(decodeURIComponent(encodedSegment)).toBe("#agent/message/inbound");
     const inboundBody = JSON.parse(String(inbound.init.body)) as {
       description?: string;
       parent_names?: string[];
     };
-    expect(inboundBody.parent_names).toEqual(["#agent-message"]);
+    expect(inboundBody.parent_names).toEqual(["#agent/message"]);
     expect(inboundBody.description).toBe(
       "Human→session message; the vault trigger fires on this.",
     );
 
     // Outbound child (NEW) — same encoding, parent declared.
-    const outbound = calls[2]!;
+    const outbound = calls[4]!;
     expect(outbound.url).toBe(
-      "http://127.0.0.1:1940/vault/default/api/tags/%23agent-message%2Foutbound",
+      "http://127.0.0.1:1940/vault/default/api/tags/%23agent%2Fmessage%2Foutbound",
     );
     expect(decodeURIComponent(outbound.url.split("/api/tags/")[1]!)).toBe(
-      "#agent-message/outbound",
+      "#agent/message/outbound",
     );
     const outboundBody = JSON.parse(String(outbound.init.body)) as { parent_names?: string[] };
-    expect(outboundBody.parent_names).toEqual(["#agent-message"]);
+    expect(outboundBody.parent_names).toEqual(["#agent/message"]);
+
+    // Job (NEW) — rolls up to the namespace root.
+    const job = calls[5]!;
+    expect(decodeURIComponent(job.url.split("/api/tags/")[1]!)).toBe("#agent/job");
+    const jobBody = JSON.parse(String(job.init.body)) as { parent_names?: string[] };
+    expect(jobBody.parent_names).toEqual(["#agent"]);
   });
 
-  test("schema declares BOTH the new and the legacy tag families (dual-read, 7 entries)", async () => {
-    // DUAL-READ (rule 2): AGENT_VAULT_TAG_SCHEMA keeps declaring the LEGACY
-    // `#channel-message*` inheritance so pre-rename history keeps its parent/child
-    // expansion until the one-time re-tag run lands. Exactly 7 entries:
-    //   #agent-message{,/inbound,/outbound}, #agent-job,
-    //   #channel-message{,/inbound,/outbound}.
+  test("schema declares the #agent/* namespace rollup PLUS the interim + legacy families (dual-read, 12 entries)", async () => {
+    // The `#agent/*` namespace (design 2026-06-17-vault-native-agents) rolls up
+    // definitions, messages, and jobs to the `#agent` root. DUAL-READ: the schema
+    // ALSO keeps declaring the interim flat `#agent-message*` AND legacy
+    // `#channel-message*` inheritance so pre-namespace history keeps its parent/child
+    // expansion until the one-time re-tag run lands. Exactly 12 entries.
     const names = AGENT_VAULT_TAG_SCHEMA.map((e) => e.name);
     expect(names).toEqual([
+      "#agent",
+      "#agent/definition",
+      "#agent/message",
+      "#agent/message/inbound",
+      "#agent/message/outbound",
+      "#agent/job",
       "#agent-message",
       "#agent-message/inbound",
       "#agent-message/outbound",
-      "#agent-job",
       "#channel-message",
       "#channel-message/inbound",
       "#channel-message/outbound",
     ]);
-    // The legacy children still declare the legacy parent (inheritance preserved).
-    const legacyInbound = AGENT_VAULT_TAG_SCHEMA.find((e) => e.name === "#channel-message/inbound")!;
-    const legacyOutbound = AGENT_VAULT_TAG_SCHEMA.find((e) => e.name === "#channel-message/outbound")!;
-    expect(legacyInbound.parent_names).toEqual(["#channel-message"]);
-    expect(legacyOutbound.parent_names).toEqual(["#channel-message"]);
+    // The namespace children all roll up to the `#agent` root (the human rollup).
+    const byName = (n: string) => AGENT_VAULT_TAG_SCHEMA.find((e) => e.name === n)!;
+    expect(byName("#agent/definition").parent_names).toEqual(["#agent"]);
+    expect(byName("#agent/message").parent_names).toEqual(["#agent"]);
+    expect(byName("#agent/job").parent_names).toEqual(["#agent"]);
+    expect(byName("#agent/message/inbound").parent_names).toEqual(["#agent/message"]);
+    expect(byName("#agent/message/outbound").parent_names).toEqual(["#agent/message"]);
+    // The interim + legacy children still declare their own parents (inheritance preserved).
+    expect(byName("#agent-message/inbound").parent_names).toEqual(["#agent-message"]);
+    expect(byName("#agent-message/outbound").parent_names).toEqual(["#agent-message"]);
+    expect(byName("#channel-message/inbound").parent_names).toEqual(["#channel-message"]);
+    expect(byName("#channel-message/outbound").parent_names).toEqual(["#channel-message"]);
   });
 
   test("schema is sourced from AGENT_VAULT_TAG_SCHEMA — declares exactly its entries", async () => {
@@ -664,7 +708,7 @@ describe("VaultTransport — ensureSchema (tag-schema declaration on connect)", 
     t.ingestInbound({
       id: "n1",
       content: "still works",
-      tags: ["#agent-message", "#agent-message/inbound"],
+      tags: ["#agent/message", "#agent/message/inbound"],
       metadata: { channel: "eng", direction: "inbound", sender: "aaron" },
     });
     expect(ctx.emitted).toHaveLength(1);
@@ -714,7 +758,7 @@ describe("VaultTransport — injectInbound (runner seam)", () => {
     expect(noteCalls).toHaveLength(1);
     const body = JSON.parse(String(noteCalls[0]!.init.body));
     // Inbound: BOTH the parent + the inbound child (the trigger discriminator).
-    expect(body.tags).toEqual(["#agent-message", "#agent-message/inbound"]);
+    expect(body.tags).toEqual(["#agent/message", "#agent/message/inbound"]);
     expect(body.content).toBe("Run the morning weave");
     expect(body.metadata.direction).toBe("inbound");
     expect(body.metadata.sender).toBe("runner:morning");
@@ -736,7 +780,7 @@ describe("VaultTransport — injectInbound (runner seam)", () => {
 });
 
 describe("VaultTransport — scheduled-job notes (vault-native store)", () => {
-  test("listJobNotes queries by #agent-job + maps metadata; skips malformed", async () => {
+  test("listJobNotes queries by #agent/job + maps metadata; skips malformed", async () => {
     const urls: string[] = [];
     globalThis.fetch = (async (url: string | URL | Request) => {
       urls.push(String(url));
@@ -762,7 +806,7 @@ describe("VaultTransport — scheduled-job notes (vault-native store)", () => {
 
     const t = new VaultTransport(baseConfig());
     const jobs = await t.listJobNotes();
-    expect(urls[0]).toContain("tag=%23agent-job");
+    expect(urls[0]).toContain("tag=%23agent%2Fjob");
     expect(urls[0]).toContain("include_content=true");
     expect(jobs).toHaveLength(2);
     // id = the slug from metadata.jobId; noteId = the vault note id.
@@ -777,7 +821,7 @@ describe("VaultTransport — scheduled-job notes (vault-native store)", () => {
     await expect(t.listJobNotes()).rejects.toThrow(/list jobs failed \(502\)/);
   });
 
-  test("upsertJobNote POSTs a #agent-job note at the deterministic path", async () => {
+  test("upsertJobNote POSTs a #agent/job note at the deterministic path", async () => {
     const calls: { url: string; init: RequestInit }[] = [];
     globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
       calls.push({ url: String(url), init: init ?? {} });
@@ -798,7 +842,7 @@ describe("VaultTransport — scheduled-job notes (vault-native store)", () => {
     expect(r.id).toBe("Channels/eng/jobs/m");
     const body = JSON.parse(String(calls[0]!.init.body));
     expect(body.path).toBe("Channels/eng/jobs/m");
-    expect(body.tags).toEqual(["#agent-job"]);
+    expect(body.tags).toEqual(["#agent/job"]);
     expect(body.metadata.enabled).toBe("true");
     expect(body.metadata.jobId).toBe("m"); // slug persisted for stable display
   });

--- a/src/transports/vault.ts
+++ b/src/transports/vault.ts
@@ -1,29 +1,38 @@
 /**
  * vault transport for parachute-agent.
  *
- * A channel backed by `#agent-message` notes in a Parachute vault. The vault
+ * A channel backed by `#agent/message` notes in a Parachute vault. The vault
  * becomes the persistence layer + the inter-module event bus; the channel is the
  * adapter that wakes a session on a new note and writes the session's reply back
  * as a note.
  *
- * TAG RENAME — DUAL-READ (channel→agent rename,
+ * TAG NAMESPACE (`#agent/*`, module-owned — design
+ * `2026-06-17-vault-native-agents.md`). The `#agent` prefix is owned entirely by
+ * the agent module: every vault object the module manages hangs off it —
+ * `#agent/definition` (the agent def), `#agent/message{,/inbound,/outbound}` (a
+ * conversation turn), `#agent/job` (a scheduled trigger). Vault-native agents
+ * (Phase 4a) moved the flat `#agent-message*` / `#agent-job` tags into this
+ * namespace (`#agent/message*` / `#agent/job`).
+ *
+ * TAG RENAME — DUAL-READ (the EARLIER channel→agent rename,
  * `parachute-patterns/migrations/2026-06-17-channel-to-agent.md` rule 2). The
- * message tag moved `#channel-message*` → `#agent-message*`. We WRITE only the
- * NEW `#agent-message*` tags going forward, but on READ we recognize BOTH the new
- * and the legacy tags — so existing `#channel-message` history still loads in the
- * transcript and a still-live legacy trigger (delivering an old-tagged note)
+ * message tag first moved `#channel-message*` → `#agent-message*`, and now
+ * `#agent-message*` → `#agent/message*`. We WRITE only the NEWEST `#agent/message*`
+ * tags going forward, but on READ we recognize BOTH the legacy `#channel-message*`
+ * AND the interim `#agent-message*` tags — so all pre-namespace history still loads
+ * in the transcript and a still-live legacy trigger (delivering an old-tagged note)
  * still routes. A one-time re-tag run + the legacy trigger's re-registration are
  * Aaron's-hand cutover steps; dual-read keeps everything working until then.
  *
  * How it differs from telegram / http-ui — the "external party" is the vault:
  *  - Inbound (human → session): a vault trigger POSTs the daemon's
- *    `/api/vault/inbound` webhook when a new `#agent-message/inbound` note
+ *    `/api/vault/inbound` webhook when a new `#agent/message/inbound` note
  *    appears; the daemon resolves the channel from `note.metadata.channel` and
  *    calls this transport's `ingestInbound(note)`, which `ctx.emit(...)`s →
  *    routes to the bridge / MCP session subscribed to that channel and wakes it.
  *  - Outbound (session → human): when the session calls the `reply` tool, the
  *    bridge POSTs `/api/reply {channel,...}`; the daemon dispatches to this
- *    transport's `reply()`, which writes a `#agent-message/outbound` note via
+ *    transport's `reply()`, which writes a `#agent/message/outbound` note via
  *    the vault REST API (`POST <vaultUrl>/vault/<vault>/api/notes`).
  *
  * Tagging model — two ORTHOGONAL axes (this was a footgun; read carefully).
@@ -31,24 +40,24 @@
  * it implies NOTHING about query inheritance. `query-notes { tag: "X" }` matches
  * descendants by the `tags.parent_names` graph, which is declared explicitly via
  * `update-tag`, NOT inferred from the name. So a note tagged ONLY
- * `#agent-message/inbound` is INVISIBLE to a `tag: "#agent-message"` query
+ * `#agent/message/inbound` is INVISIBLE to a `tag: "#agent/message"` query
  * unless that inheritance was separately declared. We don't want to depend on
  * per-vault schema setup, so every note carries BOTH tags literally:
- *  - the parent `#agent-message` — the QUERYABLE membership tag (a UI lists a
- *    channel's whole transcript, both directions, with one `tag: "#agent-message"`
+ *  - the parent `#agent/message` — the QUERYABLE membership tag (a UI lists a
+ *    channel's whole transcript, both directions, with one `tag: "#agent/message"`
  *    + `metadata.channel` query, because the parent is literally present);
- *  - a directional child — the trigger DISCRIMINATOR (`#agent-message/inbound`
- *    on inbound, `#agent-message/outbound` on outbound).
+ *  - a directional child — the trigger DISCRIMINATOR (`#agent/message/inbound`
+ *    on inbound, `#agent/message/outbound` on outbound).
  *
- * Loop avoidance (load-bearing). An outbound reply is itself an `#agent-message`
+ * Loop avoidance (load-bearing). An outbound reply is itself an `#agent/message`
  * note; if the trigger fired on it the session would wake on its own reply forever.
  * The vault trigger predicate does EXACT tag membership, so it's keyed on the
- * inbound child only — `tags: ["#agent-message/inbound"]` — which an outbound
+ * inbound child only — `tags: ["#agent/message/inbound"]` — which an outbound
  * note (parent + `/outbound`) never carries, so a reply can't wake its own session.
  * As belt-and-suspenders, `ingestInbound` also drops any note tagged
- * `#agent-message/outbound` / the legacy `#channel-message/outbound` (or
- * `direction: "outbound"`) — so even a mis-wired trigger can never wake us on our
- * own reply.
+ * `#agent/message/outbound` / the interim `#agent-message/outbound` / the legacy
+ * `#channel-message/outbound` (or `direction: "outbound"`) — so even a mis-wired
+ * trigger can never wake us on our own reply.
  */
 
 import type {
@@ -82,8 +91,8 @@ export interface VaultTransportConfig {
 export interface InboundNote {
   id: string;
   content?: string;
-  /** The note's tags — carries `#agent-message/{inbound,outbound}` (or the legacy
-   *  `#channel-message/*` on pre-rename notes) for loop avoidance. */
+  /** The note's tags — carries `#agent/message/{inbound,outbound}` (or the prior
+   *  `#agent-message/*` / `#channel-message/*` on pre-namespace notes) for loop avoidance. */
   tags?: string[];
   metadata?: Record<string, unknown>;
 }
@@ -165,40 +174,68 @@ export interface ChannelMessage {
 
 const DEFAULT_VAULT_URL = "http://127.0.0.1:1940";
 const DEFAULT_PATH_PREFIX = "channel";
-/** Parent tag (NEW) — carried LITERALLY on every note WE write; query this +
- *  metadata.channel to see BOTH directions of a channel (the slash children are
- *  namespace, not inheritance). */
-const AGENT_MESSAGE_TAG = "#agent-message";
+/** Parent tag (NEW, namespaced) — carried LITERALLY on every note WE write; query
+ *  this + metadata.channel to see BOTH directions of a channel (the slash children
+ *  are namespace, not inheritance). */
+const AGENT_MESSAGE_TAG = "#agent/message";
 /** Inbound child (NEW) — the vault trigger fires on this exact tag (never matches outbound → no loop). */
-const AGENT_MESSAGE_INBOUND_TAG = "#agent-message/inbound";
+const AGENT_MESSAGE_INBOUND_TAG = "#agent/message/inbound";
 /** Outbound child (NEW) — replies carry this; the trigger's exact-match predicate excludes it. */
-const AGENT_MESSAGE_OUTBOUND_TAG = "#agent-message/outbound";
+const AGENT_MESSAGE_OUTBOUND_TAG = "#agent/message/outbound";
 
 // ---------------------------------------------------------------------------
-// LEGACY tags (pre-rename) — DUAL-READ only. We never WRITE these going forward,
-// but we recognize them on READ so pre-rename history loads + a still-live legacy
-// trigger keeps routing. See the file header (dual-read, rule 2).
+// PRIOR tags (pre-namespace) — DUAL-READ only. We never WRITE these going forward,
+// but we recognize them on READ so pre-namespace history loads + a still-live prior
+// trigger keeps routing. See the file header (dual-read).
+//
+//  - LEGACY  `#channel-message*` — the original channel-era tag (the earliest
+//    rename's prior layer).
+//  - INTERIM `#agent-message*`    — the flat agent tag that preceded the `#agent/*`
+//    namespace (the namespace migration's prior layer).
 // ---------------------------------------------------------------------------
 const LEGACY_MESSAGE_TAG = "#channel-message";
 const LEGACY_MESSAGE_INBOUND_TAG = "#channel-message/inbound";
 const LEGACY_MESSAGE_OUTBOUND_TAG = "#channel-message/outbound";
+const INTERIM_MESSAGE_TAG = "#agent-message";
+const INTERIM_MESSAGE_INBOUND_TAG = "#agent-message/inbound";
+const INTERIM_MESSAGE_OUTBOUND_TAG = "#agent-message/outbound";
 
-/** The message parent tags we recognize on READ (new + legacy) — the transcript
- *  query unions both so existing `#channel-message` history still appears. */
-const READ_MESSAGE_TAGS = [AGENT_MESSAGE_TAG, LEGACY_MESSAGE_TAG] as const;
-/** The outbound child tags we recognize on READ (new + legacy) for direction /
- *  loop-avoidance detection. */
-const READ_OUTBOUND_TAGS = [AGENT_MESSAGE_OUTBOUND_TAG, LEGACY_MESSAGE_OUTBOUND_TAG] as const;
+/** The message parent tags we recognize on READ (new + interim + legacy) — the
+ *  transcript query unions all so pre-namespace history still appears. */
+const READ_MESSAGE_TAGS = [AGENT_MESSAGE_TAG, INTERIM_MESSAGE_TAG, LEGACY_MESSAGE_TAG] as const;
+/** The outbound child tags we recognize on READ (new + interim + legacy) for
+ *  direction / loop-avoidance detection. */
+const READ_OUTBOUND_TAGS = [
+  AGENT_MESSAGE_OUTBOUND_TAG,
+  INTERIM_MESSAGE_OUTBOUND_TAG,
+  LEGACY_MESSAGE_OUTBOUND_TAG,
+] as const;
+
+/**
+ * The module-owned root namespace tag. Declared (with the three children rolling up
+ * to it via `parent_names`) so a human `tag:#agent` query expands to EVERYTHING the
+ * module owns — definitions, messages, jobs. The module itself never queries by this
+ * (it always queries the exact leaf tag); it exists for the nice human rollup, per
+ * the design's namespacing decision.
+ */
+export const AGENT_ROOT_TAG = "#agent";
+
+/**
+ * Agent-definition tag — a vault-native agent IS a `#agent/definition` note (design
+ * `2026-06-17-vault-native-agents.md`). The note BODY is the system prompt; the note
+ * METADATA is the config (name, backend, workspace, isolation, the def-vault binding).
+ * The module reads these notes from a def-vault and instantiates each as a live agent.
+ */
+export const AGENT_DEFINITION_TAG = "#agent/definition";
 
 /**
  * Scheduled-job tag — the runner's vault-native job store (design
  * `2026-06-17-runner-scheduled-agent-turns.md`). A job IS a vault note carrying
  * this parent tag; queryable + durable + surface-renderable, exactly like
- * `#agent-message`. Introduced in Phase 2 already under the module's new identity
- * ("Parachute Agent") — `#agent-job`. Left UNCHANGED by this rename (it never
- * carried the legacy `#channel-` prefix).
+ * `#agent/message`. Introduced in Phase 2 as the flat `#agent-job`; moved into the
+ * `#agent/*` namespace (`#agent/job`) by the vault-native-agents work (Phase 4a).
  */
-const AGENT_JOB_TAG = "#agent-job";
+const AGENT_JOB_TAG = "#agent/job";
 /** Default path prefix under which job notes are written: `Channels/<ch>/jobs/<id>`. */
 const JOB_PATH_PREFIX = "Channels";
 
@@ -208,17 +245,22 @@ const JOB_PATH_PREFIX = "Channels";
  * This is the declarative complement to the "tag both parent + child" fail-safe
  * in `reply()` / inbound writes. A slash in a Parachute tag NAME is namespace-only
  * — it carries NO query inheritance. Inheritance is the `parent_names` graph,
- * declared via the vault's tag-schema API. By DECLARING that
- * `#agent-message/{inbound,outbound}` have parent `#agent-message`, a default
- * `tag:#agent-message` query expands to include the children semantically — so
- * a UI listing a channel's transcript works off the parent even for notes that
- * only carry the child tag.
+ * declared via the vault's tag-schema API. We declare the full `#agent/*`
+ * namespace rollup (design `2026-06-17-vault-native-agents.md`):
+ *   - `#agent/definition`        → parent `#agent`
+ *   - `#agent/message`           → parent `#agent`
+ *   - `#agent/message/inbound`   → parent `#agent/message`
+ *   - `#agent/message/outbound`  → parent `#agent/message`
+ *   - `#agent/job`               → parent `#agent`
+ * so a human `tag:#agent` query rolls up to EVERYTHING the module owns, and
+ * `tag:#agent/message` rolls up to both directions — without the module's own
+ * exact-leaf queries depending on per-vault schema.
  *
- * DUAL-READ: we ALSO keep declaring the LEGACY `#channel-message*` schema (rule
- * 2). The legacy parent/children inheritance must stay declared so a UI querying
- * the old parent still expands to pre-rename children until the one-time re-tag
- * run completes. New writes use the new tags; the legacy entries are read-side
- * scaffolding, retired in a later contract cycle.
+ * DUAL-READ: we ALSO keep declaring the prior `#agent-message*` (interim) and
+ * `#channel-message*` (legacy) schema. Their parent/children inheritance must stay
+ * declared so a UI querying an old parent still expands to pre-namespace children
+ * until the one-time re-tag run completes. New writes use the namespaced tags; the
+ * prior entries are read-side scaffolding, retired in a later contract cycle.
  *
  * This matches the vault's "clients bring their own tag schema" principle: the
  * WRITING module provisions its own tag schema at connect-time. It's MODULE-OWNED
@@ -235,7 +277,17 @@ export const AGENT_VAULT_TAG_SCHEMA: ReadonlyArray<{
   parent_names?: string[];
 }> = [
   {
+    name: AGENT_ROOT_TAG,
+    description: "The agent module's namespace root — rolls up definitions, messages, and jobs.",
+  },
+  {
+    name: AGENT_DEFINITION_TAG,
+    parent_names: [AGENT_ROOT_TAG],
+    description: "A vault-native agent definition — body is the system prompt, metadata is the config.",
+  },
+  {
     name: AGENT_MESSAGE_TAG,
+    parent_names: [AGENT_ROOT_TAG],
     description: "A message in a Parachute channel (parent of /inbound + /outbound).",
   },
   {
@@ -250,13 +302,31 @@ export const AGENT_VAULT_TAG_SCHEMA: ReadonlyArray<{
   },
   {
     name: AGENT_JOB_TAG,
+    parent_names: [AGENT_ROOT_TAG],
     description: "A scheduled job — the runner injects this note's message on its cron schedule.",
+  },
+  // --- Interim (dual-read) — the flat `#agent-message*` tags that preceded the
+  //     `#agent/*` namespace. Declared so pre-namespace history keeps its
+  //     inheritance until the one-time re-tag run lands. Never written going forward. ---
+  {
+    name: INTERIM_MESSAGE_TAG,
+    description: "Interim flat message tag (pre #agent/* namespace); read-only — see #agent/message.",
+  },
+  {
+    name: INTERIM_MESSAGE_INBOUND_TAG,
+    parent_names: [INTERIM_MESSAGE_TAG],
+    description: "Interim inbound message tag (pre-namespace); read-only.",
+  },
+  {
+    name: INTERIM_MESSAGE_OUTBOUND_TAG,
+    parent_names: [INTERIM_MESSAGE_TAG],
+    description: "Interim outbound message tag (pre-namespace); read-only.",
   },
   // --- Legacy (dual-read) — declared so pre-rename history keeps its inheritance
   //     until the one-time re-tag run lands. Never written going forward. ---
   {
     name: LEGACY_MESSAGE_TAG,
-    description: "Legacy message tag (pre channel→agent rename); read-only — see #agent-message.",
+    description: "Legacy message tag (pre channel→agent rename); read-only — see #agent/message.",
   },
   {
     name: LEGACY_MESSAGE_INBOUND_TAG,
@@ -286,10 +356,10 @@ export const AGENT_VAULT_TAG_SCHEMA: ReadonlyArray<{
  * The hub also injects `action.auth.bearer` (not in the template — it's a secret
  * the hub mints).
  *
- * The predicate matches a NEW inbound note (`#agent-message/inbound`) that
+ * The predicate matches a NEW inbound note (`#agent/message/inbound`) that
  * carries a `channel` metadata field and hasn't been rendered yet. Loop avoidance
  * is by the inbound CHILD tag: an outbound (reply) note carries
- * `#agent-message/outbound`, never the inbound child, so it never fires this.
+ * `#agent/message/outbound`, never the inbound child, so it never fires this.
  * (The `channel` metadata field + `channel_inbound_rendered_at` marker are the
  * internal routing plumbing — UNCHANGED by the rename; only the TAG moved.)
  */
@@ -297,7 +367,7 @@ export const AGENT_VAULT_TRIGGER_TEMPLATE = {
   name: "channel_inbound_<channel>", // hub substitutes the channel name
   events: ["created"],
   when: {
-    tags: ["#agent-message/inbound"],
+    tags: ["#agent/message/inbound"],
     has_metadata: ["channel"],
     missing_metadata: ["channel_inbound_rendered_at"],
   },
@@ -365,7 +435,7 @@ export class VaultTransport implements Transport {
    * "Routes with tag name" block + `routing.ts` `apiPath.startsWith("/tags")`).
    * Because the route matches a SINGLE path segment (`[^/]+`, no literal slash)
    * and decodes it, the tag name — which contains BOTH `#` and `/`
-   * (`#agent-message/inbound`) — must be `encodeURIComponent`'d so the `#`
+   * (`#agent/message/inbound`) — must be `encodeURIComponent`'d so the `#`
    * becomes `%23` and the `/` becomes `%2F`; the route then decodes that back to
    * the literal name. A bare `/` in the URL would fail the `[^/]+` match → 404,
    * silently dropping the declaration. The PUT body is `{ description?, parent_names? }`.
@@ -376,8 +446,8 @@ export class VaultTransport implements Transport {
   async ensureSchema(): Promise<void> {
     for (const entry of AGENT_VAULT_TAG_SCHEMA) {
       try {
-        // Single-segment, percent-encoded name: `#agent-message/inbound` →
-        // `%23agent-message%2Finbound`. The vault decodes it back to the literal.
+        // Single-segment, percent-encoded name: `#agent/message/inbound` →
+        // `%23agent%2Fmessage%2Finbound`. The vault decodes it back to the literal.
         const url = `${this.vaultUrl}/vault/${this.vault}/api/tags/${encodeURIComponent(entry.name)}`;
         const body: { description?: string; parent_names?: string[] } = {};
         if (entry.description !== undefined) body.description = entry.description;
@@ -433,7 +503,7 @@ export class VaultTransport implements Transport {
     const metadata: Record<string, string> = {
       channel,
       // `direction` stays as a human/UI convenience field. The loop-avoidance
-      // source of truth is now the `#agent-message/outbound` TAG below — the
+      // source of truth is now the `#agent/message/outbound` TAG below — the
       // trigger fires on the inbound child tag only, so this note never wakes us.
       direction: "outbound",
       sender: "session",
@@ -496,16 +566,17 @@ export class VaultTransport implements Transport {
    * note, this returns BOTH inbound and outbound — the slash children are
    * namespace, not query inheritance, so we never key off them here.
    *
-   * DUAL-READ (channel→agent rename, rule 2): we union the NEW `#agent-message`
-   * parent and the LEGACY `#channel-message` parent — two queries deduped by note
-   * id — so pre-rename history still appears alongside new messages. We WRITE only
-   * the new tag; this read-side union is dropped in a later contract cycle.
+   * DUAL-READ: we union the NEW `#agent/message` parent, the interim
+   * `#agent-message` parent, and the legacy `#channel-message` parent — three
+   * queries deduped by note id — so pre-namespace history still appears alongside
+   * new messages. We WRITE only the namespaced tag; this read-side union is dropped
+   * in a later contract cycle.
    *
    *   GET <vaultUrl>/vault/<vault>/api/notes
-   *       ?tag=%23agent-message               (the `#` MUST be percent-encoded)
+   *       ?tag=%23agent%2Fmessage             (the `#` + `/` MUST be percent-encoded)
    *       &include_content=true               (we need the bodies)
    *       &limit=<n>                          (default 200)
-   *   ... and again with ?tag=%23channel-message (legacy), unioned client-side.
+   *   ... and again with ?tag=%23agent-message + ?tag=%23channel-message, unioned client-side.
    *
    * The vault returns a bare JSON array of note objects ({id, content, tags,
    * metadata, ...}). Direction comes from `metadata.direction`, falling back to
@@ -618,7 +689,7 @@ export class VaultTransport implements Transport {
   /**
    * Write a human→session INBOUND note — the chat's "send". This mirrors
    * `reply()` exactly except the tags + direction: the inbound CHILD tag
-   * (`#agent-message/inbound`) is what the vault trigger fires on, so writing
+   * (`#agent/message/inbound`) is what the vault trigger fires on, so writing
    * this note WAKES the subscribed session via the existing vault trigger. We do
    * NOT also `ctx.emit` — that would double-wake (one wake from the trigger, one
    * from here). The trigger is the single wake path; this is purely the write.
@@ -651,7 +722,7 @@ export class VaultTransport implements Transport {
         path,
         // Parent (queryable membership) + inbound child (the trigger discriminator
         // that wakes the session). Both literal — the child alone is invisible to
-        // a `tag:#agent-message` query. We WRITE only the NEW tags.
+        // a `tag:#agent/message` query. We WRITE only the NEW tags.
         tags: [AGENT_MESSAGE_TAG, AGENT_MESSAGE_INBOUND_TAG],
         metadata,
       }),
@@ -683,7 +754,7 @@ export class VaultTransport implements Transport {
    * never touches the turn.
    *
    * Mechanically this is `writeInbound` with runner provenance: BOTH the parent
-   * `#agent-message` (queryable) and the inbound child `#agent-message/inbound`
+   * `#agent/message` (queryable) and the inbound child `#agent/message/inbound`
    * (the trigger discriminator that wakes the session), `direction: "inbound"`,
    * and `sender` defaulting to a `runner:<jobId>` marker so the transcript shows
    * who authored it. We deliberately do NOT stamp `channel_inbound_rendered_at`
@@ -701,7 +772,7 @@ export class VaultTransport implements Transport {
 
   // -------------------------------------------------------------------------
   // Scheduled-job notes — the runner's VAULT-NATIVE job store (design
-  // 2026-06-17). A job IS a `#agent-job` note in THIS channel's vault. These
+  // 2026-06-17). A job IS a `#agent/job` note in THIS channel's vault. These
   // methods own the vault I/O (URL + token + encoding) so jobs.ts stays a thin,
   // storage-agnostic facade — token handling lives in ONE place (the transport),
   // mirroring loadTranscript / writeInbound. The channel's existing
@@ -710,7 +781,7 @@ export class VaultTransport implements Transport {
 
   /**
    * List the scheduled-job notes in THIS channel's vault. Queries by the parent
-   * `#agent-job` tag (URLSearchParams encodes `#`→`%23`) and returns ALL job
+   * `#agent/job` tag (URLSearchParams encodes `#`→`%23`, `/`→`%2F`) and returns ALL job
    * notes in the vault — the CALLER filters by `metadata.channel` (same index-free
    * pattern as loadTranscript; we don't assume a `channel` index exists). Throws
    * on a non-ok vault response so the API surfaces a clear error rather than a
@@ -719,7 +790,7 @@ export class VaultTransport implements Transport {
   async listJobNotes(opts?: { limit?: number }): Promise<JobNote[]> {
     const limit = opts?.limit ?? 500;
     const params = new URLSearchParams();
-    params.set("tag", AGENT_JOB_TAG); // → %23agent-job
+    params.set("tag", AGENT_JOB_TAG); // → %23agent%2Fjob
     params.set("include_content", "true");
     params.set("limit", String(limit));
     const url = `${this.vaultUrl}/vault/${this.vault}/api/notes?${params.toString()}`;
@@ -860,14 +931,14 @@ export class VaultTransport implements Transport {
   // -------------------------------------------------------------------------
 
   /**
-   * Deliver an inbound `#agent-message/inbound` note onto this channel: emit it
+   * Deliver an inbound `#agent/message/inbound` note onto this channel: emit it
    * so the subscribed bridge / MCP session wakes. Called by the daemon's
    * `/api/vault/inbound` webhook after it has resolved the channel.
    *
    * Belt-and-suspenders over the trigger predicate: a note tagged outbound — the
-   * new `#agent-message/outbound` OR (dual-read) the legacy
-   * `#channel-message/outbound` — OR explicitly `direction: "outbound"` is IGNORED
-   * — we never wake on our own reply, even if a mis-wired trigger delivers one.
+   * new `#agent/message/outbound` OR (dual-read) the interim `#agent-message/outbound`
+   * / the legacy `#channel-message/outbound` — OR explicitly `direction: "outbound"`
+   * is IGNORED — we never wake on our own reply, even if a mis-wired trigger delivers one.
    */
   ingestInbound(note: InboundNote): void {
     if (!this.ctx) throw new Error("vault transport: not started");

--- a/src/transports/vault.ts
+++ b/src/transports/vault.ts
@@ -377,6 +377,28 @@ export const AGENT_VAULT_TRIGGER_TEMPLATE = {
   },
 } as const;
 
+/**
+ * The vault trigger that keeps vault-native agent DEFINITIONS in sync (design
+ * `2026-06-17-vault-native-agents.md`, Phase 4a). On a `#agent/definition` note
+ * created/updated/deleted, the hub POSTs the def-reload webhook; the daemon reloads
+ * that ONE agent (created/updated → re-instantiate; deleted → deregister). MODULE-
+ * OWNED DATA — the module declares the trigger it needs; the hub fills the origin +
+ * the `action.auth.bearer` (a minted `agent:send` token, the same auth as the inbound
+ * trigger). One trigger per def-vault (no per-note placeholder — the predicate is the
+ * whole `#agent/definition` tag). A poll fallback covers vaults without trigger support.
+ */
+export const AGENT_DEF_VAULT_TRIGGER_TEMPLATE = {
+  name: "agent_def_reload",
+  events: ["created", "updated", "deleted"],
+  when: {
+    tags: ["#agent/definition"],
+  },
+  action: {
+    webhook: "<hub-origin>/agent/api/vault/agent-def", // hub fills origin + the auth.bearer
+    send: "json",
+  },
+} as const;
+
 export class VaultTransport implements Transport {
   readonly kind = "vault";
 


### PR DESCRIPTION
Realizes **Phase 4a** of the [vault-native agents design](./design/2026-06-17-vault-native-agents.md) — an agent becomes a **`#agent/definition` vault note** instead of a local `channels.json` + `spec.json`. The note **body is the system prompt**; the note **metadata is the config**. The module reads `#agent/definition` notes from a configured **def-vault** (default: the local `default` vault) and instantiates each as a live agent (a vault channel + a registered programmatic agent), reactively (note created/updated/deleted → reload). 4a is **own-vault only** — the 4b connector/approval layer is deferred.

## The three commits

**1 — `#agent/*` tag-namespace migration** (`refactor(tags)`)
The `#agent` namespace is module-owned. Migrated the flat tags into it: `#agent-message{,/inbound,/outbound}` → `#agent/message*`, `#agent-job` → `#agent/job`, plus the NEW `#agent/definition` + the `#agent` namespace root. The tag schema now declares `parent_names` for the full rollup (`#agent` → definition/message/job; `#agent/message` → its children) so a human `tag:#agent` query expands to everything the module owns — while the module still queries the EXACT leaf tag and keeps the tag-both parent+child floor (loop avoidance + transcript listing never depend on per-vault schema). `metadata.channel` is unchanged. **DUAL-READ**: the prior flat `#agent-message*` joins the legacy `#channel-message*` family as READ-only recognition (loadTranscript unions all three; ingestInbound + schema cover them); we only ever WRITE the namespaced tags. No data migration (live test data was wiped). Updated the trigger filters (vault.ts, provision-agent.ts, `.parachute/module.json`), CLAUDE.md + README, and **all tests in lockstep**.

**2 — vault-native agent-def registry + reactive lifecycle + status** (`feat(agent-defs)`)
New `src/agent-defs.ts` (modelled on the Phase-2 `VaultJobStore` analog):
- `parseAgentDef(note)` → the canonical `AgentSpec` (body → `systemPrompt`; metadata → name/backend/systemPromptMode/workspace/filesystem/network/egress/mounts). Wake channel = the agent name (agent ≡ channel); vault binding = the def-vault, write-scoped (own-vault). **Reuses the existing `AgentSpec` type** — only its SOURCE changes.
- `DefVaultClient` — the index-free `#agent/definition` query + the status PATCH.
- `AgentDefRegistry` — boot `loadAll`, per-note `reload` (created/updated → re-instantiate; deleted → deregister), `deregisterAllForVault`. Idempotent; best-effort per vault AND per note.
- **Instantiate reuses the create-agent machinery** (`buildInstantiateDeps`): `addChannelLive` + `setupProgrammaticSpawn` (persists spec.json → boot re-register + per-turn deliver find the workspace) + `programmatic.register`.
- **Reactive trigger**: new `POST /api/vault/agent-def` webhook (mirrors `/api/vault/inbound` — hub JWT `agent:send`, uniform-401) + `AGENT_DEF_VAULT_TRIGGER_TEMPLATE` (module-owned, on `#agent/definition` created/updated/deleted). A 60s poll fallback covers vaults without trigger support.
- **Status field**: after resolving a def the registry PATCHes the note's `status` (own-vault → `enabled`; declares external connections → `pending` listing them) — "is this agent live?" is one MCP/surface query.

**3 — def-vault binding/config** (`feat(def-vaults)`)
New `src/def-vaults.ts` — a **LIST** of def-vaults in `~/.parachute/agent/agent-vaults.json` (architecture must not hard-code single-vault), defaulting to one entry for the local `default` vault. Explicit file wins (verbatim tokens); absent + an operator bearer → **mints** a `vault:default:write` token (reusing `mint-token.ts`, attenuated to the operator bearer) + persists so a restart reuses it; absent + no bearer → idle (channels.json unaffected). Boot wires resolve → addVault → loadAll. ADDITIVE to channels.json — both paths coexist.

## Reuse seams
`AgentSpec` (only its source moves), `addChannelLive`, `programmatic.register`, `setupProgrammaticSpawn`, `mintScopedToken`, the vault REST encoding — the registry is small because it stands on the landed machinery (the design's "near-stateless executor").

## Deferred to 4b
Cross-vault / MCP / external-service **connectors + the hub Connections approval flow**. A def MAY declare a `uses: […]` field — we PARSE + surface it (status `pending` lists it) but do NOT grant it. **Secrets never live in a note** — the Claude OAuth token + service creds stay in the local store, injected at run time.

## Gates
- `bun test ./src` → **861 pass / 0 fail** (40 new tests; baseline was 821).
- `bun run typecheck` → only the **2 pre-existing `src/bridge.ts` TS2589** errors (untouched), no new type errors.
- New tests: tag-namespace migration (schema + filters + 3-query dual-read), `parseAgentDef` (note → AgentSpec, defaults, validation, no-secret-leak), the registry instantiate/reload/deregister (injected deps + mocked fetch, no `mock.module` leak), the status PATCH, the def-vault config + mint, and the `/api/vault/agent-def` route.

## For the reviewer — flagging the risky bits
- **Tag-migration completeness** — Commit 1 touches 29 files; the dual-read interim/legacy layering in `vault.ts` is intentional (the only remaining `#agent-message*` references). The vault.test.ts dual-read now exercises three queries; the schema test asserts the 12-entry rollup.
- **Reload/dedup logic** — `reload` always re-reads ground truth (a stale "created" that was since deleted tears down); idempotent re-instantiate replaces by name; `reload(deleted)` skips the fetch.
- **def→AgentSpec mapping** — own-vault binding is injected (the note never names its own vault); a parse failure stamps `status: error` rather than registering a malformed agent; an instantiate failure (e.g. missing Claude credential) stamps `error` and leaves any prior registration intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)