### PR TITLE
fix(vault): note-metadata PATCH writes need force:true (was silently 428ing)

### DIFF
--- a/src/agent-defs.test.ts
+++ b/src/agent-defs.test.ts
@@ -241,6 +241,9 @@ describe("DefVaultClient", () => {
     expect(body.metadata.status).toBe("enabled");
     // Always sets pending (empty here) so a prior list doesn't go stale.
     expect(body.metadata.pending).toBe("");
+    // MUST carry the vault mutation precondition or the PATCH 428s (the real-vault
+    // bug this guards): `force: true` since status is the module's own derived field.
+    expect(body.force).toBe(true);
   });
 
   test("patchStatus writes the pending list joined when pending", async () => {

--- a/src/agent-defs.ts
+++ b/src/agent-defs.ts
@@ -426,7 +426,12 @@ export class DefVaultClient {
     const res = await this.fetchFn(url, {
       method: "PATCH",
       headers: { "content-type": "application/json", authorization: `Bearer ${this.token}` },
-      body: JSON.stringify({ metadata }),
+      // `force: true` satisfies the vault's mutation precondition (it 428s without
+      // `if_updated_at` or `force`). Safe: `status`/`pending` are the module's OWN
+      // authoritative derived fields, the body carries no content, and the vault
+      // MERGES metadata ({...existing, ...body.metadata}) so name/backend are kept.
+      // (Without this the status stamp silently 428'd — caught via live testing.)
+      body: JSON.stringify({ metadata, force: true }),
     });
     if (!res.ok) {
       const detail = await res.text().catch(() => "");

--- a/src/transports/vault.test.ts
+++ b/src/transports/vault.test.ts
@@ -857,7 +857,10 @@ describe("VaultTransport — scheduled-job notes (vault-native store)", () => {
     await t.patchJobNote("job-1", { lastStatus: "ok", lastRunAt: "t1" });
     expect(calls[0]!.init.method).toBe("PATCH");
     expect(calls[0]!.url).toContain("/api/notes/job-1");
-    expect(JSON.parse(String(calls[0]!.init.body)).metadata).toEqual({ lastRunAt: "t1", lastStatus: "ok" });
+    const patchBody = JSON.parse(String(calls[0]!.init.body));
+    expect(patchBody.metadata).toEqual({ lastRunAt: "t1", lastStatus: "ok" });
+    // MUST carry the vault mutation precondition or the PATCH 428s (real-vault bug).
+    expect(patchBody.force).toBe(true);
   });
 
   test("deleteJobNote DELETEs by id", async () => {

--- a/src/transports/vault.ts
+++ b/src/transports/vault.ts
@@ -927,7 +927,12 @@ export class VaultTransport implements Transport {
       {
         method: "PATCH",
         headers: { "content-type": "application/json", authorization: `Bearer ${this.token}` },
-        body: JSON.stringify({ metadata }),
+        // `force: true` satisfies the vault's mutation precondition (428 without
+        // `if_updated_at`/`force`). Safe: lastRunAt/lastStatus/enabled are the
+        // runner's OWN bookkeeping fields, no content in the body, and the vault
+        // MERGES metadata so the job's cron/message/etc. are preserved. (Without
+        // this the runner's status-write silently 428'd.)
+        body: JSON.stringify({ metadata, force: true }),
       },
     );
     if (!res.ok) {


### PR DESCRIPTION
The vault refuses a note PATCH without `if_updated_at` or `force: true` (428 `precondition_required`). Both note-metadata PATCH writes in the module omitted it, so they **silently 428'd** (the error was swallowed):
- `agent-defs.ts patchStatus` → the `#agent/definition` **status field was never stamped** (4a's status-visibility feature was non-functional against a real vault).
- `vault.ts patchJobNote` → the runner's **`lastRunAt`/`lastStatus` never persisted** (latent Phase 2 bug, same cause).

**Fix:** send `force: true`. Safe — these are each module's own authoritative derived fields, the body carries no content, and the vault MERGES metadata (`{...existing, ...body.metadata}`) so other keys (`name`/`backend`, `cron`/`message`) are preserved.

**Caught via live real-vault testing** — the mocked-fetch unit tests passed while the real vault 428'd. Tests now assert the `force` precondition on both PATCHes so a regression can't silently drop it.

**Verified live:** PATCH with `force: true` → 200, metadata merged (name/backend preserved). Gates: `bun test ./src` 862 pass / 0 fail; typecheck clean except the 2 pre-existing `src/bridge.ts` TS2589.

🤖 Generated with [Claude Code](https://claude.com/claude-code)