### PR TITLE
feat(grants): agent connector grants (Phase 4b-1) — wants, register, inject

### DIFF
--- a/src/agent-defs.test.ts
+++ b/src/agent-defs.test.ts
@@ -21,6 +21,7 @@ import {
   type DefVaultBinding,
   type InstantiateDeps,
 } from "./agent-defs.ts";
+import { GrantsClient, connectionKey, type ConnectionSpec } from "./grants.ts";
 import type { AgentSpec } from "./sandbox/types.ts";
 
 const realFetch = globalThis.fetch;
@@ -116,6 +117,54 @@ describe("parseAgentDef", () => {
       { vault: "default" },
     );
     expect(def.declaredConnections).toEqual(["github", "cloudflare"]);
+  });
+
+  test("parses the structured `wants:` field into connection specs (4b)", () => {
+    const def = parseAgentDef(
+      {
+        id: "n1",
+        content: "role",
+        metadata: {
+          name: "researcher",
+          wants: "vault:research:read#published, env:github, mcp:github, mcp:https://remote/mcp",
+        },
+      },
+      { vault: "default" },
+    );
+    expect(def.wants).toEqual([
+      { kind: "vault", target: "research", access: "read", tags: ["#published"] },
+      { kind: "service", target: "github", inject: ["env", "mcp"] }, // merged
+      { kind: "mcp", target: "https://remote/mcp" },
+    ]);
+    // No grants client wired (pure resolveDefStatus) → pending listing the conn keys.
+    expect(resolveDefStatus(def)).toEqual({
+      status: "pending",
+      pending: def.wants.map((c) => connectionKey(c)),
+    });
+  });
+
+  test("a def with no `wants:` → wants is [] (own-vault only → enabled)", () => {
+    const def = parseAgentDef(
+      { id: "n1", content: "role", metadata: { name: "x" } },
+      { vault: "default" },
+    );
+    expect(def.wants).toEqual([]);
+    expect(resolveDefStatus(def)).toEqual({ status: "enabled" });
+  });
+
+  test("a MALFORMED `wants:` makes the WHOLE def a parse error (no half-instantiate)", () => {
+    expect(() =>
+      parseAgentDef(
+        { id: "n1", content: "role", metadata: { name: "x", wants: "vault:research" } },
+        { vault: "default" },
+      ),
+    ).toThrow(AgentDefParseError);
+    expect(() =>
+      parseAgentDef(
+        { id: "n1", content: "role", metadata: { name: "x", wants: "smtp:server" } },
+        { vault: "default" },
+      ),
+    ).toThrow(/unknown kind/);
   });
 
   test("parses JSON-array mounts; ignores malformed entries", () => {
@@ -471,5 +520,189 @@ describe("AgentDefRegistry — lifecycle", () => {
     reg.addVault({ vault: "research", token: "t" });
     expect(reg.soleVaultName()).toBeUndefined();
     expect(reg.vaultCount).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AgentDefRegistry — 4b grant registration + status (design 2026-06-17-agent-connectors-4b)
+// ---------------------------------------------------------------------------
+
+/** A fake GrantsClient that records PUTs and returns a configurable per-connection
+ *  status. The hub isn't deployed in the test env — this mocks its grants API. */
+function fakeGrantsClient(opts: {
+  /** connectionKey → the status the hub returns on register. Default "pending". */
+  statusByKey?: Record<string, string>;
+  /** Record each registered (agent, connection). */
+  registered?: Array<{ agent: string; connection: ConnectionSpec }>;
+}): GrantsClient {
+  const fetchFn = (async (url: string | URL | Request, init?: RequestInit) => {
+    const u = String(url);
+    if (u.endsWith("/admin/grants") && (init?.method ?? "GET") === "PUT") {
+      const body = JSON.parse(String(init?.body)) as { agent: string; connection: ConnectionSpec };
+      opts.registered?.push({ agent: body.agent, connection: body.connection });
+      const key = connectionKey(body.connection);
+      const status = opts.statusByKey?.[key] ?? "pending";
+      return new Response(
+        JSON.stringify({ id: `g-${key}`, agent: body.agent, connection: body.connection, status }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    return new Response("{}", { status: 200 });
+  }) as typeof fetch;
+  return new GrantsClient({ hubOrigin: "https://hub.example.com", managerBearer: "MGR", fetchFn });
+}
+
+describe("AgentDefRegistry — grant registration + status (4b)", () => {
+  test("registers each `wants:` connection as a pending grant on instantiate", async () => {
+    const { deps } = recorderDeps();
+    const registered: Array<{ agent: string; connection: ConnectionSpec }> = [];
+    const grants = fakeGrantsClient({ registered }); // all default "pending"
+    const patches: Array<{ id: string; status?: string; pending?: string }> = [];
+    const fetchFn = vaultFetch({
+      defs: [
+        {
+          id: "Agents/researcher",
+          content: "role",
+          metadata: { name: "researcher", wants: "vault:research:read, env:github" },
+        },
+      ],
+      patches,
+    });
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn, grants });
+    await reg.loadAll();
+
+    // Both connections were registered for the agent.
+    expect(registered.map((r) => r.connection.target).sort()).toEqual(["github", "research"]);
+    expect(registered.every((r) => r.agent === "researcher")).toBe(true);
+    // None approved → status pending listing the connection keys.
+    const p = patches.find((x) => x.id === "Agents/researcher")!;
+    expect(p.status).toBe("pending");
+    expect(p.pending).toContain("vault:research:read");
+    expect(p.pending).toContain("env:github");
+  });
+
+  test("status = enabled only once EVERY connection is approved", async () => {
+    const { deps } = recorderDeps();
+    const vaultConn: ConnectionSpec = { kind: "vault", target: "research", access: "read" };
+    const svcConn: ConnectionSpec = { kind: "service", target: "github", inject: ["env"] };
+    const grants = fakeGrantsClient({
+      statusByKey: {
+        [connectionKey(vaultConn)]: "approved",
+        [connectionKey(svcConn)]: "approved",
+      },
+    });
+    const patches: Array<{ id: string; status?: string; pending?: string }> = [];
+    const fetchFn = vaultFetch({
+      defs: [
+        { id: "Agents/r", content: "role", metadata: { name: "r", wants: "vault:research:read, env:github" } },
+      ],
+      patches,
+    });
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn, grants });
+    await reg.loadAll();
+    const p = patches.find((x) => x.id === "Agents/r")!;
+    expect(p.status).toBe("enabled");
+    expect(p.pending).toBe("");
+    expect(reg.list().find((d) => d.name === "r")!.status).toBe("enabled");
+  });
+
+  test("partial approval → pending listing only the UNAPPROVED connection keys", async () => {
+    const { deps } = recorderDeps();
+    const vaultConn: ConnectionSpec = { kind: "vault", target: "research", access: "read" };
+    const grants = fakeGrantsClient({
+      statusByKey: { [connectionKey(vaultConn)]: "approved" }, // github stays pending
+    });
+    const patches: Array<{ id: string; status?: string; pending?: string }> = [];
+    const fetchFn = vaultFetch({
+      defs: [
+        { id: "Agents/r", content: "role", metadata: { name: "r", wants: "vault:research:read, env:github" } },
+      ],
+      patches,
+    });
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn, grants });
+    await reg.loadAll();
+    const p = patches.find((x) => x.id === "Agents/r")!;
+    expect(p.status).toBe("pending");
+    expect(p.pending).toBe("env:github"); // only the unapproved one
+    // The agent STILL instantiated (own-vault runs regardless of grant approval).
+    expect(reg.list().find((d) => d.name === "r")).toBeDefined();
+  });
+
+  test("an mcp-kind want registers + stays pending (parsed, not granted in 4b-1)", async () => {
+    const { deps } = recorderDeps();
+    const registered: Array<{ agent: string; connection: ConnectionSpec }> = [];
+    const grants = fakeGrantsClient({ registered }); // mcp stays "pending"
+    const patches: Array<{ id: string; status?: string; pending?: string }> = [];
+    const fetchFn = vaultFetch({
+      defs: [
+        { id: "Agents/r", content: "role", metadata: { name: "r", wants: "mcp:https://remote/mcp" } },
+      ],
+      patches,
+    });
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn, grants });
+    await reg.loadAll();
+    expect(registered).toHaveLength(1);
+    expect(registered[0]!.connection).toEqual({ kind: "mcp", target: "https://remote/mcp" });
+    const p = patches.find((x) => x.id === "Agents/r")!;
+    expect(p.status).toBe("pending");
+    expect(p.pending).toBe("mcp:https://remote/mcp");
+  });
+
+  test("a malformed `wants:` stamps status error (does not register or instantiate)", async () => {
+    const { deps, calls } = recorderDeps();
+    const registered: Array<{ agent: string; connection: ConnectionSpec }> = [];
+    const grants = fakeGrantsClient({ registered });
+    const patches: Array<{ id: string; status?: string }> = [];
+    const fetchFn = vaultFetch({
+      defs: [{ id: "Agents/bad", content: "role", metadata: { name: "bad", wants: "vault:research" } }],
+      patches,
+    });
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn, grants });
+    const n = await reg.loadAll();
+    expect(n).toBe(0);
+    expect(calls.registered).toHaveLength(0); // never instantiated
+    expect(registered).toHaveLength(0); // never registered a grant
+    expect(patches.find((p) => p.id === "Agents/bad")!.status).toBe("error");
+  });
+
+  test("a grant-registration FAILURE is non-fatal → connection counts as pending", async () => {
+    const { deps, calls } = recorderDeps();
+    // A grants client whose PUT 500s.
+    const fetchFn500 = (async (url: string | URL | Request, init?: RequestInit) => {
+      if (String(url).endsWith("/admin/grants") && init?.method === "PUT") {
+        return new Response("boom", { status: 500 });
+      }
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+    const grants = new GrantsClient({ hubOrigin: "https://hub.example.com", managerBearer: "MGR", fetchFn: fetchFn500 });
+    const patches: Array<{ id: string; status?: string; pending?: string }> = [];
+    const fetchFn = vaultFetch({
+      defs: [{ id: "Agents/r", content: "role", metadata: { name: "r", wants: "vault:research:read" } }],
+      patches,
+    });
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn, grants });
+    const count = await reg.loadAll();
+    // The agent STILL instantiated (own-vault) — a hub blip never blocks it.
+    expect(count).toBe(1);
+    expect(calls.registered.map((s) => s.name)).toEqual(["r"]);
+    const p = patches.find((x) => x.id === "Agents/r")!;
+    expect(p.status).toBe("pending");
+    expect(p.pending).toBe("vault:research:read");
+  });
+
+  test("setGrantsClient(null) → falls back to the pure status (no registration)", async () => {
+    const { deps } = recorderDeps();
+    const patches: Array<{ id: string; status?: string; pending?: string }> = [];
+    const fetchFn = vaultFetch({
+      defs: [{ id: "Agents/r", content: "role", metadata: { name: "r", wants: "vault:research:read" } }],
+      patches,
+    });
+    // No grants client at all → resolveDefStatus fallback (pending listing conn keys).
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn });
+    reg.setGrantsClient(null);
+    await reg.loadAll();
+    const p = patches.find((x) => x.id === "Agents/r")!;
+    expect(p.status).toBe("pending");
+    expect(p.pending).toBe("vault:research:read");
   });
 });

--- a/src/agent-defs.ts
+++ b/src/agent-defs.ts
@@ -46,6 +46,14 @@ import {
   type AgentMount,
 } from "./sandbox/types.ts";
 import { AGENT_DEFINITION_TAG } from "./transports/vault.ts";
+import {
+  parseWants,
+  connectionKey,
+  resolveConnectionStatus,
+  WantsParseError,
+  GrantsClient,
+  type ConnectionSpec,
+} from "./grants.ts";
 
 const DEFAULT_DEF_VAULT_URL = "http://127.0.0.1:1940";
 
@@ -85,10 +93,20 @@ export interface ParsedAgentDef {
   spec: AgentSpec;
   /**
    * Declared cross-vault / MCP / external-service connections beyond the def-vault
-   * (the `uses:` field). PARSED + surfaced in 4a; granting is 4b. Empty = own-vault
-   * only → `enabled`.
+   * (the legacy `uses:` field — raw name strings). PARSED + surfaced in 4a; superseded
+   * by the structured `wants:` field in 4b. Kept for back-compat (a 4a-era note that
+   * declared `uses:` still surfaces its names) — but a note SHOULD use `wants:` (see
+   * {@link wants}). Empty = no legacy declarations.
    */
   declaredConnections: string[];
+  /**
+   * Declared connections in the STRUCTURED 4b form (the `wants:` field) — vault /
+   * service / mcp connection specs the agent wants to reach beyond its def-vault
+   * (design 2026-06-17-agent-connectors-4b.md). REGISTERED as pending grants on
+   * instantiate + injected (when approved) at spawn — granting is operator-approved
+   * in the hub. Empty = own-vault only.
+   */
+  wants: ConnectionSpec[];
 }
 
 /** A failed parse — the note isn't a well-formed agent def. */
@@ -266,11 +284,26 @@ export function parseAgentDef(note: {
   const mounts = parseMounts(meta.mounts);
   if (mounts.length > 0) spec.mounts = mounts;
 
-  // Declared connections beyond the def-vault (the `uses:` field). PARSED + surfaced;
-  // granting is 4b. Never a secret — these are NAMES (`github`, `vault:research:read`).
+  // Declared connections beyond the def-vault (the legacy `uses:` field). PARSED +
+  // surfaced; never a secret — these are NAMES (`github`, `vault:research:read`).
   const declaredConnections = metaList(meta.uses);
 
-  return { noteId, name, spec, declaredConnections };
+  // STRUCTURED connection declarations (the 4b `wants:` field — design
+  // 2026-06-17-agent-connectors-4b.md). Comma-separated connection specs parsed into
+  // {@link ConnectionSpec}s. A MALFORMED `wants:` → the def is an ERROR (we re-throw
+  // as AgentDefParseError so the registry stamps status:error + doesn't half-
+  // instantiate, design §1). The def-vault is implicit — never appears in `wants:`.
+  let wants: ConnectionSpec[];
+  try {
+    wants = parseWants(meta.wants);
+  } catch (err) {
+    if (err instanceof WantsParseError) {
+      throw new AgentDefParseError(`#agent/definition note ${noteId}: ${err.message}`);
+    }
+    throw err;
+  }
+
+  return { noteId, name, spec, declaredConnections, wants };
 }
 
 /** Parse a metadata `mounts` value (JSON array string or real array) → AgentMount[]. */
@@ -303,16 +336,27 @@ function parseMounts(v: unknown): AgentMount[] {
 }
 
 /**
- * Resolve the status a parsed def gets in 4a. Own-vault only → `enabled`; a def that
- * declares external connections → `pending` (listing them) since 4b hasn't granted
- * them. The agent still runs own-vault either way; this is the queryable signal.
+ * Resolve the status a parsed def gets WITHOUT grant information — the fallback path
+ * (no grants client wired, e.g. hub not provisioned). Own-vault only → `enabled`; a
+ * def that declares ANY connection (legacy `uses:` names OR structured `wants:`) →
+ * `pending` (listing them) since nothing has been granted yet. The agent still runs
+ * own-vault either way; this is the queryable signal.
+ *
+ * When a grants client IS wired, the registry instead registers each `wants:`
+ * connection + resolves status from the hub's grant statuses
+ * (`resolveConnectionStatus` in grants.ts) — `enabled` only once every connection is
+ * approved. This pure function is the no-hub fallback + the legacy-`uses:` path.
  */
 export function resolveDefStatus(def: ParsedAgentDef): {
   status: AgentDefStatus;
   pending?: string[];
 } {
-  if (def.declaredConnections.length > 0) {
-    return { status: "pending", pending: def.declaredConnections };
+  const pending = [
+    ...def.declaredConnections,
+    ...def.wants.map((c) => connectionKey(c)),
+  ];
+  if (pending.length > 0) {
+    return { status: "pending", pending };
   }
   return { status: "enabled" };
 }
@@ -504,12 +548,30 @@ export class AgentDefRegistry {
   /** `${vault}\u0000${noteId}` → the live record. */
   private readonly live = new Map<string, LiveDef>();
   private readonly deps: InstantiateDeps;
+  /**
+   * The hub grants client (4b) — used to REGISTER each def's `wants:` connections as
+   * pending grants on instantiate + resolve status from the hub's grant statuses.
+   * Optional: null when the hub isn't provisioned yet (no manager bearer) — then the
+   * registry falls back to {@link resolveDefStatus} (pending if any connection is
+   * declared) and never registers, so the vault-native path still runs own-vault.
+   */
+  private grants: GrantsClient | null;
 
-  constructor(deps: InstantiateDeps, opts?: { bindings?: DefVaultBinding[]; fetchFn?: typeof fetch }) {
+  constructor(
+    deps: InstantiateDeps,
+    opts?: { bindings?: DefVaultBinding[]; fetchFn?: typeof fetch; grants?: GrantsClient | null },
+  ) {
     this.deps = deps;
+    this.grants = opts?.grants ?? null;
     for (const b of opts?.bindings ?? []) {
       this.addVault(b, opts?.fetchFn);
     }
+  }
+
+  /** Wire (or replace) the hub grants client — set once the manager bearer resolves
+   *  at boot (the constructor runs before the operator token is read). */
+  setGrantsClient(grants: GrantsClient | null): void {
+    this.grants = grants;
   }
 
   /** Register a def-vault binding (additive — multi-vault is appending). */
@@ -636,7 +698,13 @@ export class AgentDefRegistry {
       return false;
     }
 
-    const { status, pending } = resolveDefStatus(def);
+    // Resolve status. 4b: when a grants client is wired AND the def declares `wants:`
+    // connections, REGISTER each as a pending grant with the hub + derive status from
+    // the hub's grant statuses (`enabled` only once every connection is approved).
+    // Otherwise fall back to the pure {@link resolveDefStatus} (pending if anything is
+    // declared, enabled if nothing is). Either way the agent ALREADY ran its own-vault
+    // setup above — an unapproved connection is absent at spawn, never a failure here.
+    const { status, pending } = await this.resolveStatusWithGrants(def);
     this.live.set(this.keyOf(vault, note.id), { vault, noteId: note.id, name: def.name, status });
     // Stamp status — best-effort: a failed stamp doesn't unmake the running agent.
     try {
@@ -646,6 +714,51 @@ export class AgentDefRegistry {
     }
     console.log(`agent-defs: instantiated "${def.name}" from ${note.id} in "${vault}" (status=${status}).`);
     return true;
+  }
+
+  /**
+   * Resolve a def's status, registering its `wants:` connections as PENDING grants
+   * when a grants client is wired (4b). For each declared connection: `PUT
+   * /admin/grants {agent, connection}` (idempotent upsert), collect the returned
+   * status, then derive `enabled` (every connection approved) vs `pending` (listing
+   * the unapproved connection keys). Legacy `uses:` names are appended to `pending`
+   * (they have no grants flow — informational only).
+   *
+   * Best-effort + non-fatal: NO grants client, NO `wants:`, or a registration failure
+   * all fall back to {@link resolveDefStatus} (a connection that couldn't register
+   * counts as unapproved → the def is `pending`, not `error` — the agent still runs
+   * own-vault, the operator can retry the hub). A single connection's PUT failing is
+   * logged + that connection counts as unapproved; the others still register.
+   */
+  private async resolveStatusWithGrants(
+    def: ParsedAgentDef,
+  ): Promise<{ status: AgentDefStatus; pending?: string[] }> {
+    if (!this.grants || def.wants.length === 0) {
+      // No hub wiring / no structured connections → the pure fallback.
+      return resolveDefStatus(def);
+    }
+    const grants = this.grants;
+    const statusByKey = new Map<string, string>();
+    for (const conn of def.wants) {
+      try {
+        const rec = await grants.registerGrant(def.name, conn);
+        statusByKey.set(connectionKey(conn), rec.status);
+      } catch (err) {
+        // A failed registration → the connection counts as unapproved (absent from
+        // statusByKey). Never fatal — the agent runs own-vault; the operator retries.
+        console.warn(
+          `agent-defs: registering grant for "${def.name}" (${connectionKey(conn)}) failed ` +
+            `(treating as pending): ${(err as Error).message}`,
+        );
+      }
+    }
+    const resolved = resolveConnectionStatus(def.wants, statusByKey);
+    // Surface legacy `uses:` names alongside the structured pending keys (no grant flow).
+    const pending = [...(resolved.pending ?? []), ...def.declaredConnections];
+    if (resolved.status === "enabled" && pending.length === 0) {
+      return { status: "enabled" };
+    }
+    return { status: "pending", pending };
   }
 
   /** Tear down the agent for a given (vault, noteId): deregister + drop its channel. */

--- a/src/backends/programmatic.test.ts
+++ b/src/backends/programmatic.test.ts
@@ -35,6 +35,14 @@ import type { SandboxEngine } from "../sandbox/index.ts";
 import type { SandboxRuntimeConfig } from "@anthropic-ai/sandbox-runtime";
 import type { AgentSpec } from "../sandbox/types.ts";
 import { vaultEntryKey, channelEntryKey } from "../agent-mcp-config.ts";
+import {
+  GrantsClient,
+  grantVaultEntryKey,
+  grantServiceEntryKey,
+  serviceMcpUrl,
+  type ConnectionSpec,
+  type GrantMaterial,
+} from "../grants.ts";
 
 let sessionsDir: string;
 let stateDir: string;
@@ -814,5 +822,170 @@ describe("ProgrammaticBackend — start / stop / status", () => {
     const backend = new ProgrammaticBackend(baseDeps(fn));
     const handle = await backend.start(specWithVault());
     expect(await backend.status(handle)).toEqual({ live: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4b — cross-resource grant injection (design 2026-06-17-agent-connectors-4b)
+// ---------------------------------------------------------------------------
+
+/**
+ * A fake hub grants API for the spawn-injection path. `listGrants` returns the given
+ * approved grants; `getMaterial` returns the keyed material (or 404). Records each
+ * material fetch so a test can prove FRESH-each-spawn (no caching).
+ */
+function grantsClientFor(opts: {
+  grants: Array<{ id: string; connection: ConnectionSpec; status: string }>;
+  material?: Record<string, GrantMaterial>;
+  onMaterialCall?: (id: string) => void;
+}): GrantsClient {
+  const fetchFn = (async (url: string | URL | Request) => {
+    const u = String(url);
+    if (u.includes("/admin/grants/")) {
+      const id = u.split("/admin/grants/")[1]!.replace("/material", "");
+      opts.onMaterialCall?.(id);
+      const m = opts.material?.[id];
+      if (!m) return new Response("no", { status: 404 });
+      return new Response(JSON.stringify(m), { status: 200 });
+    }
+    return new Response(
+      JSON.stringify({
+        grants: opts.grants.map((g) => ({ id: g.id, agent: "eng", connection: g.connection, status: g.status })),
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  }) as typeof fetch;
+  return new GrantsClient({ hubOrigin: "https://hub.example.com", managerBearer: "MGR", fetchFn });
+}
+
+/** Read the written per-spawn .mcp.json's mcpServers for a session. */
+function readMcpServers(name: string): Record<string, { type: string; url: string; headers?: { Authorization: string } }> {
+  const parsed = JSON.parse(readFileSync(join(sessionsDir, name, ".mcp.json"), "utf8")) as {
+    mcpServers: Record<string, { type: string; url: string; headers?: { Authorization: string } }>;
+  };
+  return parsed.mcpServers;
+}
+
+describe("ProgrammaticBackend.deliver — grant injection (4b)", () => {
+  test("approved VAULT grant → an extra MCP server in --mcp-config (alongside own-vault)", async () => {
+    mkDirs("grant-vault");
+    const conn: ConnectionSpec = { kind: "vault", target: "research", access: "read" };
+    const grants = grantsClientFor({
+      grants: [{ id: "g1", connection: conn, status: "approved" }],
+      material: { g1: { kind: "vault", token: "RTOK", mcpUrl: "https://hub/vault/research/mcp" } },
+    });
+    const { fn } = recordingSpawn({ stdout: successTurn("s", "ok") });
+    const backend = new ProgrammaticBackend(baseDeps(fn, { grants }));
+    const handle = await backend.start(specWithVault("eng"));
+    await backend.deliver(handle, "hi");
+
+    const servers = readMcpServers("eng");
+    // Own def-vault entry still present…
+    expect(servers[vaultEntryKey("default")]).toBeDefined();
+    // …PLUS the granted research vault, namespaced + with its Bearer.
+    const granted = servers[grantVaultEntryKey("research")]!;
+    expect(granted.type).toBe("http");
+    expect(granted.url).toBe("https://hub/vault/research/mcp");
+    expect(granted.headers!.Authorization).toBe("Bearer RTOK");
+  });
+
+  test("approved SERVICE grant (env) → an env var for the agent's shell tools", async () => {
+    mkDirs("grant-env");
+    const conn: ConnectionSpec = { kind: "service", target: "github", inject: ["env"] };
+    const grants = grantsClientFor({
+      grants: [{ id: "g1", connection: conn, status: "approved" }],
+      material: { g1: { kind: "service", token: "ghp_GRANTED", inject: ["env"] } },
+    });
+    const { fn, calls } = recordingSpawn({ stdout: successTurn("s", "ok") });
+    const backend = new ProgrammaticBackend(baseDeps(fn, { grants }));
+    const handle = await backend.start(specWithVault("eng"));
+    await backend.deliver(handle, "hi");
+
+    expect(calls[0]!.env.GITHUB_TOKEN).toBe("ghp_GRANTED");
+    // The granted env var never clobbers the managed Claude auth.
+    expect(calls[0]!.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("OAUTH-CRED-PLACEHOLDER");
+    // No service MCP entry for an env-only grant.
+    expect(readMcpServers("eng")[grantServiceEntryKey("github")]).toBeUndefined();
+  });
+
+  test("approved SERVICE grant (mcp) → the service's MCP server in --mcp-config", async () => {
+    mkDirs("grant-svc-mcp");
+    const conn: ConnectionSpec = { kind: "service", target: "github", inject: ["mcp"] };
+    const grants = grantsClientFor({
+      grants: [{ id: "g1", connection: conn, status: "approved" }],
+      material: { g1: { kind: "service", token: "ghp_MCP", inject: ["mcp"] } },
+    });
+    const { fn, calls } = recordingSpawn({ stdout: successTurn("s", "ok") });
+    const backend = new ProgrammaticBackend(baseDeps(fn, { grants }));
+    const handle = await backend.start(specWithVault("eng"));
+    await backend.deliver(handle, "hi");
+
+    const svc = readMcpServers("eng")[grantServiceEntryKey("github")]!;
+    expect(svc.type).toBe("http");
+    expect(svc.url).toBe(serviceMcpUrl("github")!);
+    expect(svc.headers!.Authorization).toBe("Bearer ghp_MCP");
+    // mcp-only inject → no GITHUB_TOKEN env var.
+    expect(calls[0]!.env.GITHUB_TOKEN).toBeUndefined();
+  });
+
+  test("MCP-KIND grant is NEVER injected in 4b-1 (no material → 404 → absent)", async () => {
+    mkDirs("grant-mcp-kind");
+    const conn: ConnectionSpec = { kind: "mcp", target: "https://remote/mcp" };
+    // Even modeled as "approved", the hub returns no material in 4b-1 (no OAuth).
+    const grants = grantsClientFor({ grants: [{ id: "g1", connection: conn, status: "approved" }] });
+    const { fn } = recordingSpawn({ stdout: successTurn("s", "ok") });
+    const backend = new ProgrammaticBackend(baseDeps(fn, { grants }));
+    const handle = await backend.start(specWithVault("eng"));
+    await backend.deliver(handle, "hi");
+
+    const servers = readMcpServers("eng");
+    // Only the own def-vault entry — the mcp-kind grant added nothing.
+    expect(Object.keys(servers)).toEqual([vaultEntryKey("default")]);
+  });
+
+  test("material is fetched FRESH each spawn (revocation takes effect next turn — no cache)", async () => {
+    mkDirs("grant-fresh");
+    const called: string[] = [];
+    const conn: ConnectionSpec = { kind: "vault", target: "research", access: "read" };
+    const grants = grantsClientFor({
+      grants: [{ id: "g1", connection: conn, status: "approved" }],
+      material: { g1: { kind: "vault", token: "RTOK", mcpUrl: "https://hub/vault/research/mcp" } },
+      onMaterialCall: (id) => called.push(id),
+    });
+    const { fn } = sequencedSpawn([successTurn("s", "one"), successTurn("s", "two")]);
+    const backend = new ProgrammaticBackend(baseDeps(fn, { grants }));
+    const handle = await backend.start(specWithVault("eng"));
+    await backend.deliver(handle, "turn one");
+    await backend.deliver(handle, "turn two");
+    // Two turns → two material fetches (no caching).
+    expect(called).toEqual(["g1", "g1"]);
+  });
+
+  test("a grants-LIST failure is non-fatal — the turn runs with own-vault only", async () => {
+    mkDirs("grant-list-fail");
+    const fetchFn = (async (url: string | URL | Request) => {
+      // mint succeeds (vault token), grants list 500s.
+      if (String(url).includes("/admin/grants")) return new Response("boom", { status: 500 });
+      return fakeMintFetch()(url);
+    }) as typeof fetch;
+    const grants = new GrantsClient({ hubOrigin: "https://hub.example.com", managerBearer: "MGR", fetchFn });
+    const { fn } = recordingSpawn({ stdout: successTurn("s", "ok") });
+    // Use the same fetch for the mint path so the vault token still mints.
+    const backend = new ProgrammaticBackend(baseDeps(fn, { grants, fetchFn }));
+    const handle = await backend.start(specWithVault("eng"));
+    const result = await backend.deliver(handle, "hi");
+    expect(result.ok).toBe(true); // own-vault turn unaffected by the grant blip
+    const servers = readMcpServers("eng");
+    expect(servers[vaultEntryKey("default")]).toBeDefined();
+    expect(Object.keys(servers)).toEqual([vaultEntryKey("default")]); // no grants injected
+  });
+
+  test("NO grants client → today's behavior exactly (own-vault only)", async () => {
+    mkDirs("grant-none");
+    const { fn } = recordingSpawn({ stdout: successTurn("s", "ok") });
+    const backend = new ProgrammaticBackend(baseDeps(fn)); // no grants in deps
+    const handle = await backend.start(specWithVault("eng"));
+    await backend.deliver(handle, "hi");
+    expect(Object.keys(readMcpServers("eng"))).toEqual([vaultEntryKey("default")]);
   });
 });

--- a/src/backends/programmatic.ts
+++ b/src/backends/programmatic.ts
@@ -71,6 +71,7 @@ import {
 } from "../mint-token.ts";
 import { buildAgentMcpConfigJson, vaultEntryKey } from "../agent-mcp-config.ts";
 import { resolveClaudeCredential, resolveChannelEnv } from "../credentials.ts";
+import { resolveInjectedGrants, type GrantsClient } from "../grants.ts";
 import { AgentSessionState } from "../agent-session-state.ts";
 import { parseStreamJsonStream } from "./stream-json.ts";
 import type {
@@ -126,6 +127,25 @@ export interface ProgrammaticBackendDeps {
   sandboxEngine?: SandboxEngine;
   /** fetch override for the mint client (tests). */
   fetchFn?: typeof fetch;
+  /**
+   * The hub grants client (4b — design 2026-06-17-agent-connectors-4b.md). When
+   * wired, each turn fetches the agent's APPROVED cross-resource grants FRESH and
+   * injects their material: granted-vault material → an extra MCP server in the
+   * agent's `--mcp-config`; granted-service material → an env var (e.g. GITHUB_TOKEN)
+   * and/or the service's MCP server. Fetched per-turn (never cached) so a revocation
+   * takes effect on the NEXT spawn. Optional: null/absent → no cross-resource grants
+   * (own-vault only, today's behavior). A grants-list failure is logged + the turn
+   * runs WITHOUT the extra grants (own-vault still works).
+   */
+  grants?: GrantsClient | null;
+  /**
+   * The agent NAME used to key the agent's grants on the hub (`GET
+   * /admin/grants?agent=<name>`). Defaults to `spec.name` when absent. The grants are
+   * keyed by the agent name (= the def's name), which equals `spec.name` for a
+   * vault-native agent. Threaded explicitly so a future channel/agent-name split
+   * doesn't silently fetch the wrong agent's grants.
+   */
+  grantsAgentName?: string;
   /**
    * The subprocess spawner — runs the sandbox-wrapped `claude -p`. Tests inject a
    * fake that emits canned stream-json; the daemon uses the real Bun.spawn adapter.
@@ -312,15 +332,44 @@ export class ProgrammaticBackend implements AgentBackend {
       }
     }
 
-    // Write the (vault-only) strict MCP config 0600 — it inlines the vault token.
-    // No channels[] entry: messaging is the daemon's job, not the agent's. With an
-    // empty `channels`, `channelUrl` is never read (it only builds `/mcp/<channel>`
-    // entry URLs), so we pass "" rather than thread an unrelated origin into a slot
-    // that goes nowhere.
+    // 4b: resolve the agent's APPROVED cross-resource grants FRESH this turn (design
+    // 2026-06-17-agent-connectors-4b.md §3). Granted-vault material → extra MCP
+    // servers (the agent reaches OTHER vaults alongside its own); granted-service
+    // material → env vars (GITHUB_TOKEN, …) and/or the service's MCP server. Fetched
+    // per-turn (never cached) so a revocation takes effect next spawn. Best-effort: a
+    // grants-list failure logs + the turn runs WITHOUT the extra grants — own-vault is
+    // unaffected. The secret material lands ONLY in the ephemeral 0600 .mcp.json + the
+    // child env below; NEVER in a vault note. mcp-kind grants stay pending server-side
+    // in 4b-1 (no OAuth) → getMaterial returns null for them → never injected.
+    let grantMcpEntries: { name: string; url: string; token: string }[] = [];
+    let grantEnv: Record<string, string> = {};
+    if (this.deps.grants) {
+      const agentName = this.deps.grantsAgentName ?? spec.name;
+      try {
+        const injected = await resolveInjectedGrants(this.deps.grants, agentName);
+        grantMcpEntries = injected.mcpEntries;
+        grantEnv = injected.env;
+      } catch (err) {
+        // A failed grant LIST aborts only the cross-resource injection — the turn
+        // still runs with own-vault. (A revoked-mid-list / hub blip class.)
+        console.warn(
+          `parachute-agent: resolving grants for "${agentName}" failed (running this turn ` +
+            `WITHOUT cross-resource grants — own-vault unaffected): ${(err as Error).message}`,
+        );
+      }
+    }
+
+    // Write the strict MCP config 0600 — it inlines the vault token + any granted-
+    // resource tokens. No channels[] entry: messaging is the daemon's job, not the
+    // agent's. With an empty `channels`, `channelUrl` is never read (it only builds
+    // `/mcp/<channel>` entry URLs), so we pass "" rather than thread an unrelated
+    // origin into a slot that goes nowhere. The granted MCP servers are added as
+    // `otherMcps` (each with its own Bearer) — additive to the own-vault entry.
     const mcpConfigJson = buildAgentMcpConfigJson({
       channelUrl: "",
       channels: [],
       ...(vaultArg ? { vault: vaultArg } : {}),
+      ...(grantMcpEntries.length > 0 ? { otherMcps: grantMcpEntries } : {}),
     });
     mkdirSync(workspace, { recursive: true });
     const mcpConfigPath = join(workspace, ".mcp.json");
@@ -381,13 +430,22 @@ export class ProgrammaticBackend implements AgentBackend {
     );
     const homeEnv = seedAgentHome(workspace, { mcpServers: mcpServerNames, projectRoot: cwd });
 
+    // Merge the granted-service env (GITHUB_TOKEN, …) with the operator-scoped
+    // per-channel env. The per-channel store wins on a key collision (it's the
+    // explicit operator override); both go in at the SAME (lowest) precedence layer of
+    // buildAgentChildEnv — which then applies its denylist (ANTHROPIC_API_KEY /
+    // CLAUDE_API_KEY / CLAUDE_CODE_OAUTH_TOKEN can NEVER be set from either source) and
+    // sets CLAUDE_CODE_OAUTH_TOKEN LAST, so a granted var can never clobber the
+    // session's managed auth or the subscription-billing guarantee.
+    const mergedChannelEnv: Record<string, string> = { ...grantEnv, ...channelEnv };
+
     // Layer the scrubbed agent env UNDER the sandbox wrapper's env; the HOME/config/
     // temp vars layer LAST so they win. CLAUDE_CODE_OAUTH_TOKEN injected;
     // ANTHROPIC_API_KEY/CLAUDE_API_KEY absent (the subscription-billing guarantee).
     const childEnv = buildAgentChildEnv(
       this.deps.parentEnv ?? process.env,
       claudeOauthToken,
-      channelEnv,
+      mergedChannelEnv,
     );
     const launchEnv: Record<string, string | undefined> = {
       ...childEnv,

--- a/src/backends/programmatic.ts
+++ b/src/backends/programmatic.ts
@@ -344,6 +344,11 @@ export class ProgrammaticBackend implements AgentBackend {
     let grantMcpEntries: { name: string; url: string; token: string }[] = [];
     let grantEnv: Record<string, string> = {};
     if (this.deps.grants) {
+      // The grants are keyed on the hub by the AGENT name, which for vault-native defs
+      // is `spec.name`. `grantsAgentName` is an explicit override reserved for a future
+      // channel-name≠agent-name split; today no caller sets it, so it falls through to
+      // `spec.name` — do NOT set it unless that split lands (else you'd fetch the wrong
+      // agent's grants).
       const agentName = this.deps.grantsAgentName ?? spec.name;
       try {
         const injected = await resolveInjectedGrants(this.deps.grants, agentName);

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -58,6 +58,7 @@ import {
   type InstantiateDeps,
 } from "./agent-defs.ts";
 import { resolveDefVaults } from "./def-vaults.ts";
+import { GrantsClient } from "./grants.ts";
 import { VaultJobStore, validateJob, vaultTransportFor, type Job } from "./jobs.ts";
 import { Runner, realTickDriver } from "./runner.ts";
 import { nextRunAfter } from "./cron.ts";
@@ -603,6 +604,11 @@ export function createDefaultProgrammaticRegistry(
       sessionState,
       spawnFn: realProgrammaticSpawn(),
       ...(deps.claudeBin ? { claudeBin: deps.claudeBin } : {}),
+      // 4b: the hub grants client — reuses the manager bearer (same operator token
+      // the vault-token mint uses). Lets each `claude -p` turn inject the agent's
+      // APPROVED cross-resource grants (other-vault MCP, service env/MCP). design
+      // 2026-06-17-agent-connectors-4b.md.
+      grants: new GrantsClient({ hubOrigin: deps.hubOrigin, managerBearer: deps.managerBearer }),
     };
   } catch {
     // No operator token yet — construct with placeholders; a per-turn mint will
@@ -3264,6 +3270,15 @@ function main(): void {
     } catch {
       // No operator token yet — resolveDefVaults handles the null (idle vault-native
       // path; channels.json unaffected).
+    }
+    // 4b: wire the hub grants client now the manager bearer is resolved (the registry
+    // was constructed before the operator token was read). With it, each def's `wants:`
+    // connections register as pending grants on instantiate + status derives from the
+    // hub's grant statuses. No bearer → null → the registry falls back to the pure
+    // status (pending if anything is declared) and the vault-native path still runs
+    // own-vault. design 2026-06-17-agent-connectors-4b.md.
+    if (managerBearer) {
+      agentDefs.setGrantsClient(new GrantsClient({ hubOrigin: getHubOrigin(), managerBearer }));
     }
     const bindings = await resolveDefVaults({ hubOrigin: getHubOrigin(), managerBearer });
     for (const b of bindings) agentDefs.addVault(b);

--- a/src/grants.test.ts
+++ b/src/grants.test.ts
@@ -1,0 +1,489 @@
+/**
+ * Unit tests for agent connectors — approval-gated grants (design
+ * 2026-06-17-agent-connectors-4b.md, slice 4b-1).
+ *
+ * Deterministic — `fetch` is INJECTED into GrantsClient (no global mock, nothing to
+ * restore); the parse + status + injection helpers are pure. Covered:
+ *   - parseWants: every spec form (vault verb + tag-scope, env/mcp service merge,
+ *     mcp:url), malformed → WantsParseError, array vs comma-string input;
+ *   - connectionKey: stable across re-parse + tag ordering;
+ *   - GrantsClient: register (PUT) / list (GET) / material (GET, 404+409→null) — the
+ *     wire contract + the manager-bearer auth header;
+ *   - resolveConnectionStatus: enabled iff all approved, else pending listing keys;
+ *   - resolveInjectedGrants: vault→mcp-entry, service env, service mcp, mcp-kind not
+ *     injected, fresh-fetch-each-call (not cached), per-material-fault isolation.
+ */
+
+import { describe, test, expect } from "bun:test";
+import {
+  parseWants,
+  connectionKey,
+  resolveConnectionStatus,
+  resolveInjectedGrants,
+  serviceEnvVar,
+  serviceMcpUrl,
+  grantVaultEntryKey,
+  grantServiceEntryKey,
+  GrantsClient,
+  GrantsApiError,
+  WantsParseError,
+  type ConnectionSpec,
+  type GrantMaterial,
+} from "./grants.ts";
+
+// ---------------------------------------------------------------------------
+// parseWants
+// ---------------------------------------------------------------------------
+
+describe("parseWants — spec forms", () => {
+  test("vault:<name>:<verb>", () => {
+    expect(parseWants("vault:research:read")).toEqual([
+      { kind: "vault", target: "research", access: "read" },
+    ]);
+    expect(parseWants("vault:ops:write")).toEqual([
+      { kind: "vault", target: "ops", access: "write" },
+    ]);
+  });
+
+  test("vault with one or more #tag suffixes", () => {
+    expect(parseWants("vault:research:read#published")).toEqual([
+      { kind: "vault", target: "research", access: "read", tags: ["#published"] },
+    ]);
+    expect(parseWants("vault:research:read#published#wip")).toEqual([
+      { kind: "vault", target: "research", access: "read", tags: ["#published", "#wip"] },
+    ]);
+  });
+
+  test("env:<service> → service inject:[env]", () => {
+    expect(parseWants("env:github")).toEqual([
+      { kind: "service", target: "github", inject: ["env"] },
+    ]);
+  });
+
+  test("mcp:<service> (non-url) → service inject:[mcp]", () => {
+    expect(parseWants("mcp:github")).toEqual([
+      { kind: "service", target: "github", inject: ["mcp"] },
+    ]);
+  });
+
+  test("env:<svc> + mcp:<svc> for the same service MERGE → inject:[env,mcp]", () => {
+    expect(parseWants("env:github, mcp:github")).toEqual([
+      { kind: "service", target: "github", inject: ["env", "mcp"] },
+    ]);
+    // Order-independent: mcp first then env still merges to [env,mcp] (canonical order).
+    expect(parseWants("mcp:github, env:github")).toEqual([
+      { kind: "service", target: "github", inject: ["env", "mcp"] },
+    ]);
+  });
+
+  test("mcp:<https-url> → kind mcp (parsed; deferred to 4b-2)", () => {
+    expect(parseWants("mcp:https://remote.example.com/mcp")).toEqual([
+      { kind: "mcp", target: "https://remote.example.com/mcp" },
+    ]);
+    expect(parseWants("mcp:http://localhost:9000/mcp")).toEqual([
+      { kind: "mcp", target: "http://localhost:9000/mcp" },
+    ]);
+  });
+
+  test("a mixed list keeps first-seen order; services merge in place", () => {
+    const got = parseWants(
+      "vault:research:read#pub, env:github, vault:ops:write, mcp:github, env:cloudflare",
+    );
+    expect(got).toEqual([
+      { kind: "vault", target: "research", access: "read", tags: ["#pub"] },
+      { kind: "service", target: "github", inject: ["env", "mcp"] }, // merged at first pos
+      { kind: "vault", target: "ops", access: "write" },
+      { kind: "service", target: "cloudflare", inject: ["env"] },
+    ]);
+  });
+
+  test("accepts a real array (a vault that didn't stringify)", () => {
+    expect(parseWants(["vault:a:read", "env:github"])).toEqual([
+      { kind: "vault", target: "a", access: "read" },
+      { kind: "service", target: "github", inject: ["env"] },
+    ]);
+  });
+
+  test("empty / undefined / null → []", () => {
+    expect(parseWants(undefined)).toEqual([]);
+    expect(parseWants(null)).toEqual([]);
+    expect(parseWants("")).toEqual([]);
+    expect(parseWants("  ,  ")).toEqual([]);
+    expect(parseWants([])).toEqual([]);
+  });
+});
+
+describe("parseWants — malformed → WantsParseError", () => {
+  test("no kind prefix (no colon)", () => {
+    expect(() => parseWants("github")).toThrow(WantsParseError);
+  });
+  test("unknown kind", () => {
+    expect(() => parseWants("smtp:server")).toThrow(/unknown kind/);
+  });
+  test("vault without a verb", () => {
+    expect(() => parseWants("vault:research")).toThrow(/needs a verb/);
+  });
+  test("vault with a bad verb", () => {
+    expect(() => parseWants("vault:research:admin")).toThrow(/read.*write/);
+    expect(() => parseWants("vault:research:delete")).toThrow(WantsParseError);
+  });
+  test("vault with a non-slug name", () => {
+    // The list is comma/space-separated, so a slug-breaking char is `.`/`@`/… not a space.
+    expect(() => parseWants("vault:bad.name:read")).toThrow(/slug/);
+  });
+  test("service with a non-slug name", () => {
+    expect(() => parseWants("env:bad.name")).toThrow(/slug/);
+  });
+  test("mcp with a non-http(s) url-looking target is treated as a service slug → bad slug", () => {
+    // "ftp://x" doesn't match http(s) → treated as a service name → not a slug.
+    expect(() => parseWants("mcp:ftp://x")).toThrow(/slug/);
+  });
+  test("one malformed entry in a list throws (no half-parse)", () => {
+    expect(() => parseWants("vault:a:read, garbage")).toThrow(WantsParseError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// connectionKey — stable identity
+// ---------------------------------------------------------------------------
+
+describe("connectionKey", () => {
+  test("stable across a re-parse of the same wants entry", () => {
+    const a = parseWants("vault:research:read#a#b")[0]!;
+    const b = parseWants("vault:research:read#a#b")[0]!;
+    expect(connectionKey(a)).toBe(connectionKey(b));
+  });
+  test("tag order does not change the key", () => {
+    const ab = parseWants("vault:r:read#a#b")[0]!;
+    const ba = parseWants("vault:r:read#b#a")[0]!;
+    expect(connectionKey(ab)).toBe(connectionKey(ba));
+  });
+  test("service key reflects merged inject; vault key reflects verb", () => {
+    expect(connectionKey({ kind: "service", target: "github", inject: ["env", "mcp"] })).toBe(
+      "env+mcp:github",
+    );
+    expect(connectionKey({ kind: "vault", target: "ops", access: "write" })).toBe("vault:ops:write");
+    expect(connectionKey({ kind: "mcp", target: "https://x/mcp" })).toBe("mcp:https://x/mcp");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GrantsClient — the wire contract
+// ---------------------------------------------------------------------------
+
+const HUB = "https://hub.example.com";
+const BEARER = "MANAGER-OPERATOR-TOKEN";
+
+function clientWith(fetchFn: typeof fetch): GrantsClient {
+  return new GrantsClient({ hubOrigin: HUB, managerBearer: BEARER, fetchFn });
+}
+
+describe("GrantsClient.registerGrant (PUT /admin/grants)", () => {
+  test("PUTs { agent, connection } with the manager bearer; returns the record", async () => {
+    let captured: { url: string; method?: string; auth?: string; body?: unknown } = { url: "" };
+    const conn: ConnectionSpec = { kind: "vault", target: "research", access: "read" };
+    const client = clientWith((async (url: string | URL | Request, init?: RequestInit) => {
+      captured = {
+        url: String(url),
+        method: init?.method,
+        auth: (init?.headers as Record<string, string>)?.authorization,
+        body: JSON.parse(String(init?.body)),
+      };
+      return new Response(
+        JSON.stringify({ id: "g1", agent: "researcher", connection: conn, status: "pending" }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch);
+
+    const rec = await client.registerGrant("researcher", conn);
+    expect(captured.url).toBe(`${HUB}/admin/grants`);
+    expect(captured.method).toBe("PUT");
+    expect(captured.auth).toBe(`Bearer ${BEARER}`);
+    expect(captured.body).toEqual({ agent: "researcher", connection: conn });
+    expect(rec).toEqual({ id: "g1", agent: "researcher", connection: conn, status: "pending" });
+  });
+
+  test("throws GrantsApiError carrying the status on a non-ok response", async () => {
+    const client = clientWith((async () => new Response("nope", { status: 403 })) as unknown as typeof fetch);
+    await expect(
+      client.registerGrant("a", { kind: "vault", target: "v", access: "read" }),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+});
+
+describe("GrantsClient.listGrants (GET /admin/grants?agent=)", () => {
+  test("GETs with the agent query + bearer; returns the grants array", async () => {
+    let url = "";
+    let auth = "";
+    const client = clientWith((async (u: string | URL | Request, init?: RequestInit) => {
+      url = String(u);
+      auth = (init?.headers as Record<string, string>)?.authorization ?? "";
+      return new Response(
+        JSON.stringify({
+          grants: [
+            { id: "g1", agent: "a", connection: { kind: "vault", target: "v", access: "read" }, status: "approved" },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch);
+
+    const grants = await client.listGrants("a");
+    expect(url).toBe(`${HUB}/admin/grants?agent=a`);
+    expect(auth).toBe(`Bearer ${BEARER}`);
+    expect(grants).toHaveLength(1);
+    expect(grants[0]!.status).toBe("approved");
+  });
+
+  test("missing grants array → [] (defensive)", async () => {
+    const client = clientWith((async () => new Response("{}", { status: 200 })) as unknown as typeof fetch);
+    expect(await client.listGrants("a")).toEqual([]);
+  });
+
+  test("throws on a non-ok response", async () => {
+    const client = clientWith((async () => new Response("err", { status: 500 })) as unknown as typeof fetch);
+    await expect(client.listGrants("a")).rejects.toThrow(GrantsApiError);
+  });
+});
+
+describe("GrantsClient.getMaterial (GET /admin/grants/<id>/material)", () => {
+  test("returns the vault material on 200", async () => {
+    const mat: GrantMaterial = { kind: "vault", token: "VTOK", mcpUrl: "https://v/mcp" };
+    let url = "";
+    const client = clientWith((async (u: string | URL | Request) => {
+      url = String(u);
+      return new Response(JSON.stringify(mat), { status: 200 });
+    }) as typeof fetch);
+    expect(await client.getMaterial("g1")).toEqual(mat);
+    expect(url).toBe(`${HUB}/admin/grants/g1/material`);
+  });
+
+  test("404 (unknown id) → null", async () => {
+    const client = clientWith((async () => new Response("no", { status: 404 })) as unknown as typeof fetch);
+    expect(await client.getMaterial("ghost")).toBeNull();
+  });
+
+  test("409 (not approved) → null", async () => {
+    const client = clientWith((async () => new Response("pending", { status: 409 })) as unknown as typeof fetch);
+    expect(await client.getMaterial("g-pending")).toBeNull();
+  });
+
+  test("any other non-ok throws", async () => {
+    const client = clientWith((async () => new Response("boom", { status: 500 })) as unknown as typeof fetch);
+    await expect(client.getMaterial("g1")).rejects.toThrow(GrantsApiError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveConnectionStatus
+// ---------------------------------------------------------------------------
+
+describe("resolveConnectionStatus", () => {
+  const vault: ConnectionSpec = { kind: "vault", target: "research", access: "read" };
+  const svc: ConnectionSpec = { kind: "service", target: "github", inject: ["env"] };
+
+  test("no connections → enabled", () => {
+    expect(resolveConnectionStatus([], new Map())).toEqual({ status: "enabled" });
+  });
+  test("all approved → enabled", () => {
+    const m = new Map([
+      [connectionKey(vault), "approved"],
+      [connectionKey(svc), "approved"],
+    ]);
+    expect(resolveConnectionStatus([vault, svc], m)).toEqual({ status: "enabled" });
+  });
+  test("any unapproved (pending / missing) → pending listing the keys", () => {
+    const m = new Map([[connectionKey(vault), "approved"]]); // svc missing
+    expect(resolveConnectionStatus([vault, svc], m)).toEqual({
+      status: "pending",
+      pending: [connectionKey(svc)],
+    });
+  });
+  test("a pending grant status counts as not approved", () => {
+    const m = new Map([[connectionKey(vault), "pending"]]);
+    expect(resolveConnectionStatus([vault], m)).toEqual({
+      status: "pending",
+      pending: [connectionKey(vault)],
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// service env / mcp maps
+// ---------------------------------------------------------------------------
+
+describe("service env var + mcp url maps", () => {
+  test("known services map to canonical env var names", () => {
+    expect(serviceEnvVar("github")).toBe("GITHUB_TOKEN");
+    expect(serviceEnvVar("cloudflare")).toBe("CLOUDFLARE_API_TOKEN");
+  });
+  test("unknown service defaults to <TARGET>_TOKEN upper-snake", () => {
+    expect(serviceEnvVar("my-svc")).toBe("MY_SVC_TOKEN");
+    expect(serviceEnvVar("openai")).toBe("OPENAI_TOKEN");
+  });
+  test("github has a known MCP url; an unknown service has none", () => {
+    expect(serviceMcpUrl("github")).toMatch(/^https:\/\//);
+    expect(serviceMcpUrl("cloudflare")).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveInjectedGrants — approved grants → mcp entries + env
+// ---------------------------------------------------------------------------
+
+/** A grants client whose list returns `grants` + whose material is keyed by grant id. */
+function injectionClient(opts: {
+  grants: Array<{ id: string; connection: ConnectionSpec; status: string }>;
+  material?: Record<string, GrantMaterial | "404" | "409" | "throw">;
+  onMaterialCall?: (id: string) => void;
+}): GrantsClient {
+  const fetchFn = (async (url: string | URL | Request) => {
+    const u = String(url);
+    if (u.includes("/admin/grants/")) {
+      const id = u.split("/admin/grants/")[1]!.replace("/material", "");
+      opts.onMaterialCall?.(id);
+      const m = opts.material?.[id];
+      if (!m || m === "404") return new Response("no", { status: 404 });
+      if (m === "409") return new Response("pending", { status: 409 });
+      if (m === "throw") return new Response("boom", { status: 500 });
+      return new Response(JSON.stringify(m), { status: 200 });
+    }
+    // list
+    return new Response(
+      JSON.stringify({
+        grants: opts.grants.map((g) => ({ id: g.id, agent: "a", connection: g.connection, status: g.status })),
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  }) as typeof fetch;
+  return new GrantsClient({ hubOrigin: HUB, managerBearer: BEARER, fetchFn });
+}
+
+describe("resolveInjectedGrants", () => {
+  test("approved vault grant → an MCP entry (namespaced key)", async () => {
+    const conn: ConnectionSpec = { kind: "vault", target: "research", access: "read" };
+    const client = injectionClient({
+      grants: [{ id: "g1", connection: conn, status: "approved" }],
+      material: { g1: { kind: "vault", token: "VTOK", mcpUrl: "https://hub/vault/research/mcp" } },
+    });
+    const out = await resolveInjectedGrants(client, "a");
+    expect(out.mcpEntries).toEqual([
+      { name: grantVaultEntryKey("research"), url: "https://hub/vault/research/mcp", token: "VTOK" },
+    ]);
+    expect(out.env).toEqual({});
+  });
+
+  test("approved service grant (env) → an env var, no MCP entry", async () => {
+    const conn: ConnectionSpec = { kind: "service", target: "github", inject: ["env"] };
+    const client = injectionClient({
+      grants: [{ id: "g1", connection: conn, status: "approved" }],
+      material: { g1: { kind: "service", token: "GHTOK", inject: ["env"] } },
+    });
+    const out = await resolveInjectedGrants(client, "a");
+    expect(out.env).toEqual({ GITHUB_TOKEN: "GHTOK" });
+    expect(out.mcpEntries).toEqual([]);
+  });
+
+  test("approved service grant (mcp) → an MCP entry for the known service URL", async () => {
+    const conn: ConnectionSpec = { kind: "service", target: "github", inject: ["mcp"] };
+    const client = injectionClient({
+      grants: [{ id: "g1", connection: conn, status: "approved" }],
+      material: { g1: { kind: "service", token: "GHTOK", inject: ["mcp"] } },
+    });
+    const out = await resolveInjectedGrants(client, "a");
+    expect(out.mcpEntries).toEqual([
+      { name: grantServiceEntryKey("github"), url: serviceMcpUrl("github")!, token: "GHTOK" },
+    ]);
+    expect(out.env).toEqual({});
+  });
+
+  test("service granted env+mcp → both an env var AND an MCP entry", async () => {
+    const conn: ConnectionSpec = { kind: "service", target: "github", inject: ["env", "mcp"] };
+    const client = injectionClient({
+      grants: [{ id: "g1", connection: conn, status: "approved" }],
+      material: { g1: { kind: "service", token: "GHTOK", inject: ["env", "mcp"] } },
+    });
+    const out = await resolveInjectedGrants(client, "a");
+    expect(out.env).toEqual({ GITHUB_TOKEN: "GHTOK" });
+    expect(out.mcpEntries).toEqual([
+      { name: grantServiceEntryKey("github"), url: serviceMcpUrl("github")!, token: "GHTOK" },
+    ]);
+  });
+
+  test("service with inject:[mcp] but no known MCP url → env kept, mcp skipped (no throw)", async () => {
+    const conn: ConnectionSpec = { kind: "service", target: "cloudflare", inject: ["env", "mcp"] };
+    const client = injectionClient({
+      grants: [{ id: "g1", connection: conn, status: "approved" }],
+      material: { g1: { kind: "service", token: "CFTOK", inject: ["env", "mcp"] } },
+    });
+    const out = await resolveInjectedGrants(client, "a");
+    expect(out.env).toEqual({ CLOUDFLARE_API_TOKEN: "CFTOK" });
+    expect(out.mcpEntries).toEqual([]); // no known cloudflare MCP url → skipped
+  });
+
+  test("only APPROVED grants are fetched (pending/revoked skipped, no material call)", async () => {
+    const called: string[] = [];
+    const client = injectionClient({
+      grants: [
+        { id: "g1", connection: { kind: "vault", target: "a", access: "read" }, status: "pending" },
+        { id: "g2", connection: { kind: "service", target: "github", inject: ["env"] }, status: "revoked" },
+        { id: "g3", connection: { kind: "vault", target: "b", access: "read" }, status: "approved" },
+      ],
+      material: { g3: { kind: "vault", token: "BTOK", mcpUrl: "https://hub/vault/b/mcp" } },
+      onMaterialCall: (id) => called.push(id),
+    });
+    const out = await resolveInjectedGrants(client, "a");
+    // Only the approved grant's material was fetched.
+    expect(called).toEqual(["g3"]);
+    expect(out.mcpEntries).toEqual([
+      { name: grantVaultEntryKey("b"), url: "https://hub/vault/b/mcp", token: "BTOK" },
+    ]);
+  });
+
+  test("mcp-kind grant: even if (erroneously) approved, getMaterial 409/404 → not injected", async () => {
+    // In 4b-1 an mcp-kind grant stays pending server-side; model it as 409 here.
+    const client = injectionClient({
+      grants: [{ id: "g1", connection: { kind: "mcp", target: "https://remote/mcp" }, status: "approved" }],
+      material: { g1: "409" },
+    });
+    const out = await resolveInjectedGrants(client, "a");
+    expect(out.mcpEntries).toEqual([]);
+    expect(out.env).toEqual({});
+  });
+
+  test("a single material fetch fault is isolated — the other grants still inject", async () => {
+    const client = injectionClient({
+      grants: [
+        { id: "g1", connection: { kind: "vault", target: "a", access: "read" }, status: "approved" },
+        { id: "g2", connection: { kind: "service", target: "github", inject: ["env"] }, status: "approved" },
+      ],
+      material: {
+        g1: "throw", // 500 → fetch throws GrantsApiError → skipped
+        g2: { kind: "service", token: "GHTOK", inject: ["env"] },
+      },
+    });
+    const out = await resolveInjectedGrants(client, "a");
+    expect(out.mcpEntries).toEqual([]); // g1's vault entry skipped
+    expect(out.env).toEqual({ GITHUB_TOKEN: "GHTOK" }); // g2 still injected
+  });
+
+  test("a list failure propagates (caller spawns without grants)", async () => {
+    const fetchFn = (async () => new Response("boom", { status: 500 })) as unknown as typeof fetch;
+    const client = new GrantsClient({ hubOrigin: HUB, managerBearer: BEARER, fetchFn });
+    await expect(resolveInjectedGrants(client, "a")).rejects.toThrow(GrantsApiError);
+  });
+
+  test("material is fetched FRESH each call (not cached across spawns)", async () => {
+    const called: string[] = [];
+    const client = injectionClient({
+      grants: [{ id: "g1", connection: { kind: "vault", target: "a", access: "read" }, status: "approved" }],
+      material: { g1: { kind: "vault", token: "VTOK", mcpUrl: "https://hub/vault/a/mcp" } },
+      onMaterialCall: (id) => called.push(id),
+    });
+    await resolveInjectedGrants(client, "a");
+    await resolveInjectedGrants(client, "a");
+    // Two spawns → two material fetches (no cache between them — revocation takes
+    // effect next spawn precisely because we re-fetch).
+    expect(called).toEqual(["g1", "g1"]);
+  });
+});

--- a/src/grants.test.ts
+++ b/src/grants.test.ts
@@ -138,6 +138,10 @@ describe("parseWants — malformed → WantsParseError", () => {
     // "ftp://x" doesn't match http(s) → treated as a service name → not a slug.
     expect(() => parseWants("mcp:ftp://x")).toThrow(/slug/);
   });
+  test("a service whose env-var collides with the Claude-auth denylist is rejected at parse", () => {
+    // `claude-code-oauth` → CLAUDE_CODE_OAUTH_TOKEN (denylisted). Caught at define-time.
+    expect(() => parseWants("env:claude-code-oauth")).toThrow(/protected env var/);
+  });
   test("one malformed entry in a list throws (no half-parse)", () => {
     expect(() => parseWants("vault:a:read, garbage")).toThrow(WantsParseError);
   });

--- a/src/grants.ts
+++ b/src/grants.ts
@@ -1,0 +1,569 @@
+/**
+ * Agent connectors — approval-gated cross-resource GRANTS (design
+ * 2026-06-17-agent-connectors-4b.md, slice 4b-1).
+ *
+ * 4a gave an agent its OWN def-vault. 4b lets a `#agent/definition` note DECLARE
+ * what it wants to reach BEYOND that — other local vaults, external services
+ * (GitHub, Cloudflare), and (parsed-but-deferred to 4b-2) remote MCP/OAuth servers.
+ * Every extra reach is OPERATOR-APPROVED in the hub; every secret stays in the hub's
+ * grant store; the agent module is the CONSUMER that fetches approved material at
+ * spawn + injects it into the ephemeral per-spawn `.mcp.json` + env.
+ *
+ * THE ONE INVARIANT (design §"The one invariant"): a vault note can only REQUEST, it
+ * can never GRANT. This module:
+ *   - parses the note's `wants:` into structured {@link ConnectionSpec}s ({@link parseWants});
+ *   - REGISTERS each as a PENDING grant with the hub (`PUT /admin/grants`) — that is
+ *     the request, not a grant; worst case it sits `pending`;
+ *   - at spawn, fetches only APPROVED grants' MATERIAL (`GET …/material`) and injects
+ *     it. Unapproved/pending/error connections are simply ABSENT — never a failure.
+ *
+ * THE WIRE CONTRACT (parachute-hub PR #668 — consume, do not redesign):
+ *   - PUT  <hub>/admin/grants          { agent, connection } → { id, agent, connection, status, reason? }
+ *   - GET  <hub>/admin/grants?agent=<> → { grants: [{ id, agent, connection, status, reason?, approvedAt? }] }
+ *   - GET  <hub>/admin/grants/<id>/material → APPROVED only:
+ *         vault   → { kind:"vault",   token, mcpUrl }
+ *         service → { kind:"service", token, inject }
+ *         (404 unknown id / 409 not-approved)
+ *   - Auth: all three need a `parachute:host:admin` Bearer — we REUSE the module's
+ *     existing host-admin-capable MANAGER BEARER (the operator token it mints vault
+ *     tokens with; see mint-token.ts / spawn-deps.ts). NO new auth path.
+ *   - approve/revoke are operator-only via the hub UI — the module NEVER calls those.
+ *
+ * SECURITY: grant material is SECRET (tokens). It only ever lands in the ephemeral,
+ * 0600 per-spawn `.mcp.json` + the child env — NEVER in a vault note. Material is
+ * fetched FRESH each spawn (design: revocation takes effect on the next spawn), so we
+ * deliberately do NOT cache it.
+ */
+
+// ---------------------------------------------------------------------------
+// Connection spec — the structured form of one `wants:` entry
+// ---------------------------------------------------------------------------
+
+/**
+ * A declared connection beyond the def-vault. Matches the hub's `connection` spec
+ * shape exactly (design §"The hub grants API", connection spec):
+ *   `{ kind, target, access?, tags?, inject? }`
+ * — `access`/`tags` are vault-only; `inject` is service-only (`("env"|"mcp")[]`).
+ */
+export interface ConnectionSpec {
+  /** Resource kind. `vault`/`service` are wired in 4b-1; `mcp` is parsed-but-deferred. */
+  kind: "vault" | "service" | "mcp";
+  /**
+   * The resource target — a vault name (`research`), a service name (`github`),
+   * or, for `kind:"mcp"`, the remote MCP https URL.
+   */
+  target: string;
+  /** Vault access verb. Vault-only. */
+  access?: "read" | "write";
+  /** Vault tag-scope (one or more `#tag`). Vault-only. */
+  tags?: string[];
+  /** Injection shape(s) for a service credential. Service-only. */
+  inject?: ("env" | "mcp")[];
+}
+
+/** A malformed `wants:` entry — the whole def is an error (no half-instantiate). */
+export class WantsParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WantsParseError";
+  }
+}
+
+/**
+ * A STABLE, canonical key for a connection — the (agent, connection) grant key the
+ * status `pending:[…]` list reports + the hub upserts on. Derived purely from the
+ * spec so a re-parse of the same `wants:` yields the same key (idempotent upsert).
+ *
+ *   vault   → `vault:<target>:<access>[#tag…]`   (tags sorted for stability)
+ *   service → `<inject-joined>:<target>`          e.g. `env+mcp:github`
+ *   mcp     → `mcp:<url>`
+ */
+export function connectionKey(c: ConnectionSpec): string {
+  if (c.kind === "vault") {
+    const tags = c.tags && c.tags.length > 0 ? [...c.tags].sort().join("") : "";
+    return `vault:${c.target}:${c.access ?? "read"}${tags}`;
+  }
+  if (c.kind === "service") {
+    const inject = (c.inject && c.inject.length > 0 ? [...c.inject].sort() : ["env"]).join("+");
+    return `${inject}:${c.target}`;
+  }
+  return `mcp:${c.target}`;
+}
+
+/** A vault name slug — the `<name>` segment in `vault:<name>:<verb>`. */
+const VAULT_NAME_SLUG = /^[a-zA-Z0-9_-]+$/;
+/** A service name slug — `github`, `cloudflare`, … */
+const SERVICE_NAME_SLUG = /^[a-zA-Z0-9_-]+$/;
+
+/**
+ * Parse the `wants:` metadata field — a comma-separated list of connection specs —
+ * into structured {@link ConnectionSpec}s. PURE, no I/O.
+ *
+ * Spec forms (design §"The connection declaration"):
+ *   - `vault:<name>:<read|write>` with optional `#tag` suffix(es):
+ *       `vault:research:read`              → {kind:"vault", target:"research", access:"read"}
+ *       `vault:research:read#published#wip`→ {…, tags:["#published","#wip"]}
+ *     (the agent's OWN def-vault is implicit — never in `wants:`; the def-vault binding
+ *      drives `spec.vault`, not this.)
+ *   - `env:<service>`  → {kind:"service", target:"<service>", inject:["env"]}
+ *     `mcp:<service>`  → {kind:"service", target:"<service>", inject:["mcp"]}
+ *     BOTH for the same service MERGE → inject:["env","mcp"].
+ *   - `mcp:<https-url>`→ {kind:"mcp", target:"<url>"}  (parsed; deferred to 4b-2).
+ *
+ * Disambiguation of `mcp:<x>`: an `<x>` that starts with `http://` or `https://` is
+ * a remote MCP (`kind:"mcp"`); otherwise it's a service MCP-injection (`mcp:github`).
+ *
+ * Accepts a real array OR the comma/space-joined string the vault stringifies arrays
+ * into. A MALFORMED entry throws {@link WantsParseError} — the caller stamps the def
+ * `status:error` rather than half-instantiating (design §1 "a malformed `wants:` →
+ * the def is an error").
+ */
+export function parseWants(raw: unknown): ConnectionSpec[] {
+  const entries = toEntries(raw);
+  if (entries.length === 0) return [];
+
+  // Service connections accumulate by target so `env:github` + `mcp:github` merge to
+  // one connection with inject:["env","mcp"] (design §1). Keyed by service target.
+  const services = new Map<string, Set<"env" | "mcp">>();
+  // Insertion order of services (Map preserves it, but we re-emit at the end so the
+  // overall ordering = first-seen across all kinds).
+  const out: ConnectionSpec[] = [];
+  // Placeholder index per service so the merged service lands at its first position.
+  const servicePos = new Map<string, number>();
+
+  for (const entry of entries) {
+    const spec = parseOneWant(entry);
+    if (spec.kind === "service") {
+      const modes = services.get(spec.target);
+      if (modes) {
+        for (const m of spec.inject ?? []) modes.add(m);
+        continue; // already placeheld at first position
+      }
+      const set = new Set<"env" | "mcp">(spec.inject ?? []);
+      services.set(spec.target, set);
+      servicePos.set(spec.target, out.length);
+      out.push(spec); // placeholder; finalized below with the merged inject
+      continue;
+    }
+    out.push(spec);
+  }
+
+  // Finalize each service connection's merged inject (stable order: env before mcp).
+  for (const [target, modes] of services) {
+    const pos = servicePos.get(target)!;
+    const inject = (["env", "mcp"] as const).filter((m) => modes.has(m));
+    out[pos] = { kind: "service", target, inject };
+  }
+
+  return out;
+}
+
+/** Coerce a `wants:` metadata value (array or comma/space string) → clean entries. */
+function toEntries(raw: unknown): string[] {
+  let parts: string[] = [];
+  if (Array.isArray(raw)) {
+    parts = raw.map((x) => (typeof x === "string" ? x : String(x)));
+  } else if (typeof raw === "string") {
+    parts = raw.split(/[,\s]+/);
+  } else if (raw === undefined || raw === null) {
+    return [];
+  } else {
+    parts = [String(raw)];
+  }
+  return parts.map((s) => s.trim()).filter((s) => s.length > 0);
+}
+
+/** Parse ONE `wants:` entry string. Throws {@link WantsParseError} on a malformed one. */
+function parseOneWant(entry: string): ConnectionSpec {
+  const colon = entry.indexOf(":");
+  if (colon < 0) {
+    throw new WantsParseError(
+      `wants: "${entry}" is malformed — expected "<kind>:<target>…" ` +
+        `(e.g. "vault:research:read", "env:github", "mcp:https://…").`,
+    );
+  }
+  const prefix = entry.slice(0, colon);
+  const rest = entry.slice(colon + 1);
+
+  switch (prefix) {
+    case "vault":
+      return parseVaultWant(entry, rest);
+    case "env":
+      return parseServiceWant(entry, rest, "env");
+    case "mcp":
+      // `mcp:` is overloaded: a remote-MCP URL (kind:"mcp", 4b-2) vs a service MCP
+      // injection (kind:"service", inject:["mcp"], 4b-1). An http(s) target is the URL form.
+      if (/^https?:\/\//i.test(rest)) return parseMcpUrlWant(entry, rest);
+      return parseServiceWant(entry, rest, "mcp");
+    default:
+      throw new WantsParseError(
+        `wants: "${entry}" has unknown kind "${prefix}" — expected one of ` +
+          `vault | env | mcp.`,
+      );
+  }
+}
+
+/** Parse `vault:<name>:<read|write>[#tag…]`. */
+function parseVaultWant(entry: string, rest: string): ConnectionSpec {
+  // rest = "<name>:<verb>[#tag…]". Split on the FIRST colon (name has no colon).
+  const colon = rest.indexOf(":");
+  if (colon < 0) {
+    throw new WantsParseError(
+      `wants: "${entry}" is malformed — a vault connection needs a verb: ` +
+        `"vault:<name>:<read|write>".`,
+    );
+  }
+  const name = rest.slice(0, colon);
+  let verbAndTags = rest.slice(colon + 1);
+  if (!VAULT_NAME_SLUG.test(name)) {
+    throw new WantsParseError(
+      `wants: "${entry}" — vault name "${name}" must be a slug (alphanumeric, dash, underscore).`,
+    );
+  }
+  // Tag suffix: everything from the first `#` onward, split into individual `#tag`s.
+  let tags: string[] | undefined;
+  const hash = verbAndTags.indexOf("#");
+  if (hash >= 0) {
+    const tagStr = verbAndTags.slice(hash);
+    verbAndTags = verbAndTags.slice(0, hash);
+    tags = tagStr
+      .split("#")
+      .map((t) => t.trim())
+      .filter((t) => t.length > 0)
+      .map((t) => `#${t}`);
+    if (tags.length === 0) tags = undefined;
+  }
+  const verb = verbAndTags.trim();
+  if (verb !== "read" && verb !== "write") {
+    throw new WantsParseError(
+      `wants: "${entry}" — vault access must be "read" or "write" (got "${verb}").`,
+    );
+  }
+  return { kind: "vault", target: name, access: verb, ...(tags ? { tags } : {}) };
+}
+
+/** Parse `env:<service>` / `mcp:<service>` into one service connection. */
+function parseServiceWant(entry: string, service: string, mode: "env" | "mcp"): ConnectionSpec {
+  const target = service.trim();
+  if (!SERVICE_NAME_SLUG.test(target)) {
+    throw new WantsParseError(
+      `wants: "${entry}" — service name "${target}" must be a slug (alphanumeric, dash, underscore).`,
+    );
+  }
+  return { kind: "service", target, inject: [mode] };
+}
+
+/** Parse `mcp:<https-url>` — a remote MCP (parsed; deferred to 4b-2). */
+function parseMcpUrlWant(entry: string, url: string): ConnectionSpec {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new WantsParseError(`wants: "${entry}" — "${url}" is not a valid URL.`);
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new WantsParseError(`wants: "${entry}" — remote MCP URL must be http(s) (got "${parsed.protocol}").`);
+  }
+  return { kind: "mcp", target: url };
+}
+
+// ---------------------------------------------------------------------------
+// The hub grants-API client (consume parachute-hub #668)
+// ---------------------------------------------------------------------------
+
+/** A grant record as the hub returns it (PUT result / GET list element). No secrets. */
+export interface GrantRecord {
+  /** The hub-assigned grant id (used to fetch material). */
+  id: string;
+  /** The agent name the grant belongs to. */
+  agent: string;
+  /** The connection spec (echoed back). */
+  connection: ConnectionSpec;
+  /** Lifecycle: `pending` (registered, not approved), `approved`, `revoked`, `error`. */
+  status: string;
+  /** Optional human reason (e.g. why it errored). */
+  reason?: string;
+  /** ISO timestamp the operator approved it (approved grants). */
+  approvedAt?: string;
+}
+
+/** Approved-grant material — APPROVED only. A discriminated union by `kind`. */
+export type GrantMaterial =
+  | { kind: "vault"; token: string; mcpUrl: string }
+  | { kind: "service"; token: string; inject: ("env" | "mcp")[] };
+
+/** A failed grants-API call — carries the HTTP status for the caller to branch on. */
+export class GrantsApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = "GrantsApiError";
+  }
+}
+
+export interface GrantsClientDeps {
+  /** Hub public origin (the grants API lives on the hub, not the vault). */
+  hubOrigin: string;
+  /**
+   * The module's host-admin-capable MANAGER BEARER — the SAME operator token it
+   * mints vault tokens with (mint-token.ts). All three grants endpoints require a
+   * `parachute:host:admin` Bearer; we reuse this credential, no new auth path.
+   */
+  managerBearer: string;
+  /** Inject fetch for tests. Defaults to global fetch. */
+  fetchFn?: typeof fetch;
+}
+
+function stripTrailingSlash(url: string): string {
+  return url.replace(/\/$/, "");
+}
+
+/**
+ * Thin client for the hub's grants API (parachute-hub #668). Three calls the module
+ * makes — register (PUT), list (GET), fetch-material (GET …/material). It NEVER
+ * approves/revokes (operator-only via the hub UI). All requests carry the manager
+ * bearer (`parachute:host:admin`).
+ */
+export class GrantsClient {
+  private readonly base: string;
+  private readonly managerBearer: string;
+  private readonly fetchFn: typeof fetch;
+
+  constructor(deps: GrantsClientDeps) {
+    if (!deps.hubOrigin) throw new Error("GrantsClient: hubOrigin is required");
+    if (!deps.managerBearer) throw new Error("GrantsClient: managerBearer is required");
+    this.base = stripTrailingSlash(deps.hubOrigin);
+    this.managerBearer = deps.managerBearer;
+    this.fetchFn = deps.fetchFn ?? fetch;
+  }
+
+  private authHeaders(extra?: Record<string, string>): Record<string, string> {
+    return { authorization: `Bearer ${this.managerBearer}`, ...(extra ?? {}) };
+  }
+
+  /**
+   * Register (idempotent upsert) a PENDING grant request for `(agent, connection)`.
+   * `PUT /admin/grants { agent, connection }` → the grant record (status, usually
+   * `pending` on first register; an already-approved grant returns its current
+   * status). Throws {@link GrantsApiError} on a non-ok response.
+   */
+  async registerGrant(agent: string, connection: ConnectionSpec): Promise<GrantRecord> {
+    const url = `${this.base}/admin/grants`;
+    const res = await this.fetchFn(url, {
+      method: "PUT",
+      headers: this.authHeaders({ "content-type": "application/json" }),
+      body: JSON.stringify({ agent, connection }),
+    });
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "");
+      throw new GrantsApiError(`register grant failed (${res.status}) ${detail}`.trim(), res.status);
+    }
+    return (await res.json()) as GrantRecord;
+  }
+
+  /**
+   * List the grants for an agent — `GET /admin/grants?agent=<name>` → `{ grants }`.
+   * No secrets (status only). Throws on a non-ok response.
+   */
+  async listGrants(agent: string): Promise<GrantRecord[]> {
+    const url = `${this.base}/admin/grants?agent=${encodeURIComponent(agent)}`;
+    const res = await this.fetchFn(url, { headers: this.authHeaders() });
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "");
+      throw new GrantsApiError(`list grants failed (${res.status}) ${detail}`.trim(), res.status);
+    }
+    const parsed = (await res.json()) as { grants?: GrantRecord[] };
+    return Array.isArray(parsed.grants) ? parsed.grants : [];
+  }
+
+  /**
+   * Fetch a grant's MATERIAL — `GET /admin/grants/<id>/material`. APPROVED only:
+   * the hub 404s an unknown id and 409s a not-yet-approved grant — both return null
+   * (the connection is simply absent this spawn, never a failure). Any OTHER non-ok
+   * throws {@link GrantsApiError} (a real fault the caller should log). The result
+   * is SECRET (a token) — fetched fresh each spawn, never cached.
+   */
+  async getMaterial(id: string): Promise<GrantMaterial | null> {
+    const url = `${this.base}/admin/grants/${encodeURIComponent(id)}/material`;
+    const res = await this.fetchFn(url, { headers: this.authHeaders() });
+    if (res.status === 404 || res.status === 409) return null;
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "");
+      throw new GrantsApiError(`get grant material failed (${res.status}) ${detail}`.trim(), res.status);
+    }
+    return (await res.json()) as GrantMaterial;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Status resolution — enabled vs pending from registered grants
+// ---------------------------------------------------------------------------
+
+/** The resolved status for a def after its connections are registered. */
+export interface ConnectionStatus {
+  /** `enabled` iff every declared connection is `approved`; else `pending`. */
+  status: "enabled" | "pending";
+  /** The connection keys NOT yet approved (only when `pending`). */
+  pending?: string[];
+}
+
+/**
+ * Resolve the def's status from its declared connections + each one's registered
+ * grant status (design §2). `enabled` ONLY if EVERY connection is `approved`; else
+ * `pending` listing the unapproved connection keys. No connections → `enabled`.
+ *
+ * `grantStatusByKey` maps a {@link connectionKey} → the hub's grant status. A
+ * connection with no entry (registration failed / not found) counts as NOT approved.
+ */
+export function resolveConnectionStatus(
+  connections: ConnectionSpec[],
+  grantStatusByKey: Map<string, string>,
+): ConnectionStatus {
+  if (connections.length === 0) return { status: "enabled" };
+  const pending: string[] = [];
+  for (const c of connections) {
+    const key = connectionKey(c);
+    if (grantStatusByKey.get(key) !== "approved") pending.push(key);
+  }
+  if (pending.length === 0) return { status: "enabled" };
+  return { status: "pending", pending };
+}
+
+// ---------------------------------------------------------------------------
+// Spawn-time injection — approved grant material → MCP-config entries + env vars
+// ---------------------------------------------------------------------------
+
+/** Known service → the env var name its token injects as. Default: `<TARGET>_TOKEN`. */
+const SERVICE_ENV_VAR: Record<string, string> = {
+  github: "GITHUB_TOKEN",
+  cloudflare: "CLOUDFLARE_API_TOKEN",
+};
+
+/** Known service → its remote MCP server URL (for the `inject:["mcp"]` shape). */
+const SERVICE_MCP_URL: Record<string, string> = {
+  github: "https://api.githubcopilot.com/mcp/",
+};
+
+/** The env var name a service's token injects as (known map ?? `<TARGET>_TOKEN`). */
+export function serviceEnvVar(service: string): string {
+  return SERVICE_ENV_VAR[service] ?? `${service.toUpperCase().replace(/[^A-Z0-9]+/g, "_")}_TOKEN`;
+}
+
+/** The known remote-MCP URL for a service, or undefined (no MCP injection for it). */
+export function serviceMcpUrl(service: string): string | undefined {
+  return SERVICE_MCP_URL[service];
+}
+
+/** One MCP server entry to ADD to the agent's `--mcp-config` from a grant. */
+export interface InjectedMcpEntry {
+  /** Entry key in `mcpServers` (unique per granted resource). */
+  name: string;
+  /** Streamable-HTTP MCP URL. */
+  url: string;
+  /** Bearer token for the Authorization header. */
+  token: string;
+}
+
+/** The result of resolving an agent's approved grants into spawn-injectable bits. */
+export interface InjectedGrants {
+  /** MCP servers to ADD to the existing per-spawn `.mcp.json` (vault + service-mcp). */
+  mcpEntries: InjectedMcpEntry[];
+  /** Env vars to set for the agent's shell tools (service env injections). */
+  env: Record<string, string>;
+}
+
+/**
+ * Resolve an agent's APPROVED grants into spawn-injectable MCP entries + env vars
+ * (design §3). Fetches the agent's grant LIST, then for each `approved` grant fetches
+ * its MATERIAL FRESH (never cached — revocation takes effect next spawn) and maps it:
+ *
+ *   - vault material (`{token, mcpUrl}`)            → an MCP server entry (the agent
+ *       reaches the OTHER vault alongside its own).
+ *   - service material, inject includes `"env"`     → an env var (github→GITHUB_TOKEN,
+ *       cloudflare→CLOUDFLARE_API_TOKEN, default `<TARGET>_TOKEN`).
+ *   - service material, inject includes `"mcp"`     → the service's MCP server entry
+ *       (known-service→URL map; a service with no known MCP logs + SKIPS the mcp
+ *       inject, keeping the env one).
+ *   - mcp-kind grants (remote MCP / OAuth) are NOT injected in 4b-1 (no OAuth) — they
+ *       only ever sit `pending` server-side, so `getMaterial` returns null for them.
+ *
+ * The MCP-entry KEYS are namespaced (`grant-vault-<name>`, `grant-service-<svc>`) so
+ * they never collide with the agent's own def-vault entry (`parachute-vault-<name>`).
+ *
+ * Best-effort + isolated: the grant LIST failing throws (the caller logs + spawns
+ * WITHOUT injected grants — own-vault still works); a SINGLE material fetch failing
+ * is logged + skipped (that one connection is absent; the rest inject). Secrets only
+ * flow into the returned struct → the ephemeral 0600 spawn config; never logged.
+ */
+export async function resolveInjectedGrants(
+  client: GrantsClient,
+  agent: string,
+): Promise<InjectedGrants> {
+  const mcpEntries: InjectedMcpEntry[] = [];
+  const env: Record<string, string> = {};
+
+  const grants = await client.listGrants(agent); // throws → caller spawns without grants
+  for (const g of grants) {
+    if (g.status !== "approved") continue; // only approved grants have material
+    let material: GrantMaterial | null;
+    try {
+      material = await client.getMaterial(g.id);
+    } catch (err) {
+      // A single material fetch fault must not sink the others — that connection is
+      // simply absent this spawn. Never log the token (there is none in the error).
+      console.warn(
+        `parachute-agent: fetching grant material for "${agent}" (${connectionKey(g.connection)}) ` +
+          `failed (skipping this connection): ${(err as Error).message}`,
+      );
+      continue;
+    }
+    if (!material) continue; // 404/409 — not actually approved/available right now
+
+    if (material.kind === "vault") {
+      mcpEntries.push({
+        name: grantVaultEntryKey(g.connection.target),
+        url: material.mcpUrl,
+        token: material.token,
+      });
+      continue;
+    }
+
+    // service material — inject env and/or mcp per the material's `inject` list.
+    const service = g.connection.target;
+    const inject = material.inject ?? [];
+    if (inject.includes("env")) {
+      env[serviceEnvVar(service)] = material.token;
+    }
+    if (inject.includes("mcp")) {
+      const url = serviceMcpUrl(service);
+      if (url) {
+        mcpEntries.push({
+          name: grantServiceEntryKey(service),
+          url,
+          token: material.token,
+        });
+      } else {
+        // No known MCP URL for this service — keep the env inject, skip the mcp one.
+        console.warn(
+          `parachute-agent: service "${service}" granted with inject:"mcp" but no known MCP URL — ` +
+            `skipping the MCP injection (the env injection, if any, still applies).`,
+        );
+      }
+    }
+  }
+
+  return { mcpEntries, env };
+}
+
+/** MCP entry key for a GRANTED vault — namespaced so it never collides with the
+ *  agent's OWN def-vault entry (`parachute-vault-<name>`). */
+export function grantVaultEntryKey(vault: string): string {
+  return `grant-vault-${vault}`;
+}
+
+/** MCP entry key for a GRANTED service MCP server. */
+export function grantServiceEntryKey(service: string): string {
+  return `grant-service-${service}`;
+}

--- a/src/grants.ts
+++ b/src/grants.ts
@@ -35,6 +35,8 @@
  * deliberately do NOT cache it.
  */
 
+import { DENYLISTED_ENV } from "./credentials.ts";
+
 // ---------------------------------------------------------------------------
 // Connection spec — the structured form of one `wants:` entry
 // ---------------------------------------------------------------------------
@@ -248,6 +250,16 @@ function parseServiceWant(entry: string, service: string, mode: "env" | "mcp"): 
   if (!SERVICE_NAME_SLUG.test(target)) {
     throw new WantsParseError(
       `wants: "${entry}" — service name "${target}" must be a slug (alphanumeric, dash, underscore).`,
+    );
+  }
+  // Reject a service whose env-var would collide with the Claude-auth denylist
+  // (e.g. a service named `claude-code-oauth` → CLAUDE_CODE_OAUTH_TOKEN). The
+  // spawn-time denylist already drops it (security intact), but surface it HERE at
+  // define-time so the operator sees the problem rather than a silent spawn-warn.
+  if (DENYLISTED_ENV.has(serviceEnvVar(target))) {
+    throw new WantsParseError(
+      `wants: "${entry}" — service "${target}" maps to the protected env var ${serviceEnvVar(target)}, ` +
+        `which a grant can never set (it's the session's managed Claude auth).`,
     );
   }
   return { kind: "service", target, inject: [mode] };


### PR DESCRIPTION
Agent-module side of **Phase 4b slice 1 — connector grants** (design [`design/2026-06-17-agent-connectors-4b.md`](./design/2026-06-17-agent-connectors-4b.md)). Builds on 4a's `#agent/definition` registry. An agent can now declare connections **beyond its def-vault** — other local vaults + external services (GitHub, Cloudflare) — every reach **operator-approved in the hub**, every secret **local**, injected at spawn. Pairs with the already-built hub grants API ([parachute-hub #668](https://github.com/ParachuteComputer/parachute-hub/pull/668)).

## The `wants:` syntax (new `#agent/definition` metadata field)
Comma-separated connection specs (the agent's OWN def-vault is implicit — never declared):
- `vault:<name>:<read|write>` with optional `#tag` suffix(es) → `vault:research:read#published#wip`
- `env:<service>` → service env injection (e.g. `GITHUB_TOKEN`); `mcp:<service>` → the service's MCP server. Both for the same service **merge** to `inject:["env","mcp"]`.
- `mcp:<https-url>` → a remote MCP — **parsed but deferred to 4b-2** (no OAuth yet; stays `pending`).

A malformed `wants:` makes the whole def a parse error (`status: error`, clear message) — no half-instantiate.

## Grants-API integration (consumes hub #668, does not redesign)
- On (re)instantiate, the registry `PUT /admin/grants {agent, connection}` for each connection (idempotent upsert), collects each status, and stamps the note: **`enabled`** only if every connection is `approved`, else **`pending`** with the unapproved connection keys. Uses the 4a `patchStatus` (`force:true`).
- Auth reuses the module's **existing host-admin manager bearer** (the operator token it mints vault tokens with) — no new auth path. The module never calls approve/revoke (operator-only via the hub UI).
- The agent **always instantiates + runs** with its def-vault + whatever IS approved; unapproved connections are simply absent.

## Injection at spawn (`claude -p` per-turn, programmatic backend)
Each turn fetches the agent's **approved** grants and their material **FRESH** (never cached — revocation takes effect next spawn), then:
- **vault material** (`{token, mcpUrl}`) → an extra MCP server in `--mcp-config` (`type:http` + `Authorization: Bearer`), namespaced (`grant-vault-<name>`) alongside the own-vault entry.
- **service env** (`inject:["env"]`) → an env var (`github→GITHUB_TOKEN`, `cloudflare→CLOUDFLARE_API_TOKEN`, default `<TARGET>_TOKEN`).
- **service mcp** (`inject:["mcp"]`) → the service's MCP server (known-service→URL map; no known MCP → log + skip the mcp inject, keep env).

Secrets land **only** in the ephemeral 0600 spawn `.mcp.json` + child env, **never** a vault note. `--strict-mcp-config` kept; granted env rides the existing hardened `buildAgentChildEnv` path, so it can never clobber `CLAUDE_CODE_OAUTH_TOKEN` or smuggle an API key (denylist defense-in-depth).

## Deferred to 4b-2
`mcp`-kind (remote vault / remote MCP) connections: registered + surfaced in status, **stay pending** server-side, **never injected** in 4b-1 (no OAuth). The hub-as-OAuth-client consent-once + refresh flow is 4b-2.

## Tests & gates
Unit tests **mock the hub** faithful to the #668 contract (register/list/material + 404/409, manager-bearer header) — global-fetch swap restored / injected deps, no `mock.module` leak. Cover: wants-parse (all spec forms + tag-scope + merge + malformed→error), grant-registration on instantiate, status enabled-vs-pending-vs-partial, spawn injection (vault→mcp-config; service env; service mcp), fresh-fetch-not-cached, mcp-kind-stays-pending-not-injected, list-failure non-fatal.

- `bun test ./src` → **925 pass / 0 fail** (47 files)
- `bun run typecheck` → clean except the **2 pre-existing `src/bridge.ts` TS2589** (left untouched per the brief)
- No version bump.

**NOTE:** live end-to-end verification (the real grant→inject→use loop) is pending the hub #668 deploy — the orchestrator does the real-path check after hub merges (4a's lesson: mocked tests miss real-path bugs, so the mocks are kept faithful to the contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)