### PR TITLE
feat(grants): inject approved remote-MCP grants at spawn (4b-2 agent side)

### DIFF
--- a/src/grants.test.ts
+++ b/src/grants.test.ts
@@ -10,8 +10,9 @@
  *   - GrantsClient: register (PUT) / list (GET) / material (GET, 404+409→null) — the
  *     wire contract + the manager-bearer auth header;
  *   - resolveConnectionStatus: enabled iff all approved, else pending listing keys;
- *   - resolveInjectedGrants: vault→mcp-entry, service env, service mcp, mcp-kind not
- *     injected, fresh-fetch-each-call (not cached), per-material-fault isolation.
+ *   - resolveInjectedGrants: vault→mcp-entry, service env, service mcp, mcp-material
+ *     injection (4b-2: approved→mcp-entry keyed by grant id; unapproved→absent),
+ *     fresh-fetch-each-call (not cached), per-material-fault isolation.
  */
 
 import { describe, test, expect } from "bun:test";
@@ -24,6 +25,7 @@ import {
   serviceMcpUrl,
   grantVaultEntryKey,
   grantServiceEntryKey,
+  grantMcpEntryKey,
   GrantsClient,
   GrantsApiError,
   WantsParseError,
@@ -363,6 +365,22 @@ function injectionClient(opts: {
   return new GrantsClient({ hubOrigin: HUB, managerBearer: BEARER, fetchFn });
 }
 
+describe("grant entry keys — namespaced + mutually distinct", () => {
+  test("grantMcpEntryKey returns grant-mcp-<slug>", () => {
+    expect(grantMcpEntryKey("g1")).toBe("grant-mcp-g1");
+  });
+  test("the three grant entry keys + the def-vault key never collide for the same slug", () => {
+    const slug = "x";
+    const keys = [
+      grantVaultEntryKey(slug),
+      grantServiceEntryKey(slug),
+      grantMcpEntryKey(slug),
+      `parachute-vault-${slug}`, // the agent's OWN def-vault entry prefix
+    ];
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+});
+
 describe("resolveInjectedGrants", () => {
   test("approved vault grant → an MCP entry (namespaced key)", async () => {
     const conn: ConnectionSpec = { kind: "vault", target: "research", access: "read" };
@@ -444,14 +462,82 @@ describe("resolveInjectedGrants", () => {
     ]);
   });
 
-  test("mcp-kind grant: even if (erroneously) approved, getMaterial 409/404 → not injected", async () => {
-    // In 4b-1 an mcp-kind grant stays pending server-side; model it as 409 here.
+  test("approved mcp grant (4b-2) → an MCP entry keyed by grant id, no env", async () => {
+    const conn: ConnectionSpec = { kind: "mcp", target: "https://remote.example.com/vault/eng/mcp" };
     const client = injectionClient({
-      grants: [{ id: "g1", connection: { kind: "mcp", target: "https://remote/mcp" }, status: "approved" }],
-      material: { g1: "409" },
+      grants: [{ id: "gmcp", connection: conn, status: "approved" }],
+      material: { gmcp: { kind: "mcp", token: "MTOK", mcpUrl: "https://remote.example.com/vault/eng/mcp" } },
+    });
+    const out = await resolveInjectedGrants(client, "a");
+    expect(out.mcpEntries).toEqual([
+      { name: grantMcpEntryKey("gmcp"), url: "https://remote.example.com/vault/eng/mcp", token: "MTOK" },
+    ]);
+    expect(out.env).toEqual({});
+  });
+
+  test("an unapproved/pending mcp grant injects NOTHING (getMaterial 409 → absent)", async () => {
+    // A pending mcp grant has no material yet — the hub 409s /material → null → absent.
+    const client = injectionClient({
+      grants: [{ id: "gmcp", connection: { kind: "mcp", target: "https://remote/mcp" }, status: "pending" }],
+      material: { gmcp: "409" },
     });
     const out = await resolveInjectedGrants(client, "a");
     expect(out.mcpEntries).toEqual([]);
+    expect(out.env).toEqual({});
+  });
+
+  test("an approved mcp grant whose material 404s (race) → absent, not an error", async () => {
+    const client = injectionClient({
+      grants: [{ id: "gmcp", connection: { kind: "mcp", target: "https://remote/mcp" }, status: "approved" }],
+      material: { gmcp: "404" },
+    });
+    const out = await resolveInjectedGrants(client, "a");
+    expect(out.mcpEntries).toEqual([]);
+    expect(out.env).toEqual({});
+  });
+
+  test("mixed: approved vault + mcp + service(env) grants all inject with distinct keys", async () => {
+    const client = injectionClient({
+      grants: [
+        { id: "gv", connection: { kind: "vault", target: "research", access: "read" }, status: "approved" },
+        { id: "gm", connection: { kind: "mcp", target: "https://remote/eng/mcp" }, status: "approved" },
+        { id: "gs", connection: { kind: "service", target: "github", inject: ["env"] }, status: "approved" },
+      ],
+      material: {
+        gv: { kind: "vault", token: "VTOK", mcpUrl: "https://hub/vault/research/mcp" },
+        gm: { kind: "mcp", token: "MTOK", mcpUrl: "https://remote/eng/mcp" },
+        gs: { kind: "service", token: "GHTOK", inject: ["env"] },
+      },
+    });
+    const out = await resolveInjectedGrants(client, "a");
+    expect(out.mcpEntries).toEqual([
+      { name: grantVaultEntryKey("research"), url: "https://hub/vault/research/mcp", token: "VTOK" },
+      { name: grantMcpEntryKey("gm"), url: "https://remote/eng/mcp", token: "MTOK" },
+    ]);
+    expect(out.env).toEqual({ GITHUB_TOKEN: "GHTOK" });
+    // The vault + mcp MCP-entry keys are distinct.
+    expect(out.mcpEntries[0]!.name).not.toBe(out.mcpEntries[1]!.name);
+  });
+
+  test("two approved mcp grants for distinct remotes → two entries, keyed by id (no collision)", async () => {
+    // The rationale for keying grantMcpEntryKey on the grant id (not the URL): two
+    // distinct remote MCPs must get distinct entry names. This is that guarantee.
+    const client = injectionClient({
+      grants: [
+        { id: "gm1", connection: { kind: "mcp", target: "https://eng.example/vault/eng/mcp" }, status: "approved" },
+        { id: "gm2", connection: { kind: "mcp", target: "https://ops.example/vault/ops/mcp" }, status: "approved" },
+      ],
+      material: {
+        gm1: { kind: "mcp", token: "T1", mcpUrl: "https://eng.example/vault/eng/mcp" },
+        gm2: { kind: "mcp", token: "T2", mcpUrl: "https://ops.example/vault/ops/mcp" },
+      },
+    });
+    const out = await resolveInjectedGrants(client, "a");
+    expect(out.mcpEntries).toEqual([
+      { name: grantMcpEntryKey("gm1"), url: "https://eng.example/vault/eng/mcp", token: "T1" },
+      { name: grantMcpEntryKey("gm2"), url: "https://ops.example/vault/ops/mcp", token: "T2" },
+    ]);
+    expect(out.mcpEntries[0]!.name).not.toBe(out.mcpEntries[1]!.name);
     expect(out.env).toEqual({});
   });
 

--- a/src/grants.ts
+++ b/src/grants.ts
@@ -299,10 +299,19 @@ export interface GrantRecord {
   approvedAt?: string;
 }
 
-/** Approved-grant material — APPROVED only. A discriminated union by `kind`. */
+/**
+ * Approved-grant material — APPROVED only. A discriminated union by `kind`.
+ *   - `vault`   → a Bearer + the granted vault's MCP URL (inject as an MCP server).
+ *   - `service` → a Bearer + the inject shape(s) (env var and/or service MCP server).
+ *   - `mcp`     → a remote-MCP grant (4b-2): a Bearer + the remote MCP URL. The wire
+ *       shape is byte-identical to `vault` (`{ token, mcpUrl }`) — the hub auto-refreshes
+ *       OAuth tokens behind `/material` and projects only `{ kind, token, mcpUrl }`, so
+ *       the consumer injects it the SAME way as a granted vault.
+ */
 export type GrantMaterial =
   | { kind: "vault"; token: string; mcpUrl: string }
-  | { kind: "service"; token: string; inject: ("env" | "mcp")[] };
+  | { kind: "service"; token: string; inject: ("env" | "mcp")[] }
+  | { kind: "mcp"; token: string; mcpUrl: string };
 
 /** A failed grants-API call — carries the HTTP status for the caller to branch on. */
 export class GrantsApiError extends Error {
@@ -498,11 +507,13 @@ export interface InjectedGrants {
  *   - service material, inject includes `"mcp"`     → the service's MCP server entry
  *       (known-service→URL map; a service with no known MCP logs + SKIPS the mcp
  *       inject, keeping the env one).
- *   - mcp-kind grants (remote MCP / OAuth) are NOT injected in 4b-1 (no OAuth) — they
- *       only ever sit `pending` server-side, so `getMaterial` returns null for them.
+ *   - mcp material (`{token, mcpUrl}`, 4b-2)         → an MCP server entry (the agent
+ *       reaches the remote MCP / OAuth resource). An UNAPPROVED mcp grant has no
+ *       material — `getMaterial` returns null (404/409), so it's simply absent.
  *
- * The MCP-entry KEYS are namespaced (`grant-vault-<name>`, `grant-service-<svc>`) so
- * they never collide with the agent's own def-vault entry (`parachute-vault-<name>`).
+ * The MCP-entry KEYS are namespaced (`grant-vault-<name>`, `grant-service-<svc>`,
+ * `grant-mcp-<grant-id>`) so they never collide with the agent's own def-vault entry
+ * (`parachute-vault-<name>`).
  *
  * Best-effort + isolated: the grant LIST failing throws (the caller logs + spawns
  * WITHOUT injected grants — own-vault still works); a SINGLE material fetch failing
@@ -542,28 +553,52 @@ export async function resolveInjectedGrants(
       continue;
     }
 
-    // service material — inject env and/or mcp per the material's `inject` list.
-    const service = g.connection.target;
-    const inject = material.inject ?? [];
-    if (inject.includes("env")) {
-      env[serviceEnvVar(service)] = material.token;
+    if (material.kind === "mcp") {
+      // Remote-MCP grant (4b-2): the /material wire shape is byte-identical to vault's
+      // (`{token, mcpUrl}`); inject it the SAME way. Key on the grant ID (not the URL)
+      // so two distinct remote MCPs never collide on the entry name.
+      mcpEntries.push({
+        name: grantMcpEntryKey(g.id),
+        url: material.mcpUrl,
+        token: material.token,
+      });
+      continue;
     }
-    if (inject.includes("mcp")) {
-      const url = serviceMcpUrl(service);
-      if (url) {
-        mcpEntries.push({
-          name: grantServiceEntryKey(service),
-          url,
-          token: material.token,
-        });
-      } else {
-        // No known MCP URL for this service — keep the env inject, skip the mcp one.
-        console.warn(
-          `parachute-agent: service "${service}" granted with inject:"mcp" but no known MCP URL — ` +
-            `skipping the MCP injection (the env injection, if any, still applies).`,
-        );
+
+    if (material.kind === "service") {
+      // service material — inject env and/or mcp per the material's `inject` list.
+      const service = g.connection.target;
+      const inject = material.inject ?? [];
+      if (inject.includes("env")) {
+        env[serviceEnvVar(service)] = material.token;
       }
+      if (inject.includes("mcp")) {
+        const url = serviceMcpUrl(service);
+        if (url) {
+          mcpEntries.push({
+            name: grantServiceEntryKey(service),
+            url,
+            token: material.token,
+          });
+        } else {
+          // No known MCP URL for this service — keep the env inject, skip the mcp one.
+          console.warn(
+            `parachute-agent: service "${service}" granted with inject:"mcp" but no known MCP URL — ` +
+              `skipping the MCP injection (the env injection, if any, still applies).`,
+          );
+        }
+      }
+      continue;
     }
+
+    // Exhaustiveness guard (future-safety): every known material kind `continue`s
+    // above, so `material` is `never` here today. If a future kind is added to the
+    // union without a branch, it lands here + is skipped LOUDLY rather than silently
+    // falling into the service path. Never log the token (the struct, not the value).
+    console.warn(
+      `parachute-agent: grant material for "${agent}" has an unhandled kind ` +
+        `"${(material as { kind?: string }).kind}" — skipping (no injection).`,
+    );
   }
 
   return { mcpEntries, env };
@@ -578,4 +613,11 @@ export function grantVaultEntryKey(vault: string): string {
 /** MCP entry key for a GRANTED service MCP server. */
 export function grantServiceEntryKey(service: string): string {
   return `grant-service-${service}`;
+}
+
+/** MCP entry key for a GRANTED remote MCP (4b-2) — keyed by the grant id (stable +
+ *  collision-free) and namespaced so it never collides with `grant-vault-*` /
+ *  `grant-service-*` / the agent's OWN def-vault entry (`parachute-vault-<name>`). */
+export function grantMcpEntryKey(slug: string): string {
+  return `grant-mcp-${slug}`;
 }


### PR DESCRIPTION
The agent-module **consumer half** of Phase 4b-2 — the small change that lets an agent inject an operator-approved **remote MCP** (incl. a remote Parachute vault) as an MCP server in its per-spawn config. Pairs with the hub OAuth-client side (parachute-hub #669, merged) and implements the "Agent module" section of [the 4b-2 design](./design/2026-06-18-agent-connectors-4b2-oauth.md).

## What's here (`src/grants.ts`)
- `GrantMaterial` gains the `mcp` member `{ kind:"mcp"; token; mcpUrl }` — byte-identical wire shape to `vault` material (the hub's `/material` returns `{kind:"mcp", token, mcpUrl}` for an approved mcp grant).
- New exported `grantMcpEntryKey(slug)` → `grant-mcp-<slug>`, namespaced like the vault/service siblings (no collision with `grant-vault-*` / `grant-service-*` / the def-vault `parachute-vault-*`).
- `resolveInjectedGrants` gains a `material.kind === "mcp"` branch → pushes one MCP entry `{ name: grant-mcp-<grantId>, url: mcpUrl, token }` (keyed by grant id so two remote MCPs never collide). Vault/service branches unchanged.
- No `parseWants` change — `mcp:<url>` already parsed to `{kind:"mcp"}` in 4b-1; an unapproved mcp want simply yields no material (absent, not an error) until the operator consents.

## Tests
`src/grants.test.ts` 47 → 52 pass. New cases: `grantMcpEntryKey` shape + 4-way key distinctness; approved mcp injects (keyed by id, no env); pending mcp → absent; approved-but-404 race → absent; mixed approved vault+mcp+service all inject with distinct keys. Full suite **931 pass / 0 fail**.

## Verification
The end-to-end OAuth flow (register → discover+DCR → operator consent → callback code-exchange → material → token authenticates against the live vault MCP → lazy refresh → revoke) was verified live on the hub side (#669). This PR's injection branch is unit-tested against the exact `{kind:"mcp", token, mcpUrl}` material the live hub returns.

Note: two pre-existing `src/bridge.ts` TS2589 typecheck errors exist on `main` (unrelated to this change; no agent CI typecheck gate). Flagged for a separate cleanup.

No version bump (bump+tag on the ship call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)