### PR TITLE
feat(grants): grant-GC — reconcile stale grants on def change/removal (#96)

### DIFF
--- a/src/agent-defs.test.ts
+++ b/src/agent-defs.test.ts
@@ -527,16 +527,32 @@ describe("AgentDefRegistry — lifecycle", () => {
 // AgentDefRegistry — 4b grant registration + status (design 2026-06-17-agent-connectors-4b)
 // ---------------------------------------------------------------------------
 
-/** A fake GrantsClient that records PUTs and returns a configurable per-connection
- *  status. The hub isn't deployed in the test env — this mocks its grants API. */
+/** A fake GrantsClient that records PUTs + reconcile POSTs and returns a configurable
+ *  per-connection status. The hub isn't deployed in the test env — this mocks its
+ *  grants API (register PUT + reconcile POST, #96 grant-GC). */
 function fakeGrantsClient(opts: {
   /** connectionKey → the status the hub returns on register. Default "pending". */
   statusByKey?: Record<string, string>;
   /** Record each registered (agent, connection). */
   registered?: Array<{ agent: string; connection: ConnectionSpec }>;
+  /** Record each reconcile (agent, liveKeys) — the #96 grant-GC call. */
+  reconciled?: Array<{ agent: string; liveKeys: string[] }>;
+  /** How many grants the hub reports pruned per reconcile (default 0). */
+  prunedPerReconcile?: number;
+  /** Make reconcile POSTs 500 (to assert the failure is swallowed). */
+  reconcileFails?: boolean;
 }): GrantsClient {
   const fetchFn = (async (url: string | URL | Request, init?: RequestInit) => {
     const u = String(url);
+    if (u.endsWith("/admin/grants/reconcile") && (init?.method ?? "GET") === "POST") {
+      const body = JSON.parse(String(init?.body)) as { agent: string; liveKeys: string[] };
+      opts.reconciled?.push({ agent: body.agent, liveKeys: body.liveKeys });
+      if (opts.reconcileFails) return new Response("boom", { status: 500 });
+      return new Response(JSON.stringify({ pruned: opts.prunedPerReconcile ?? 0, prunedIds: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
     if (u.endsWith("/admin/grants") && (init?.method ?? "GET") === "PUT") {
       const body = JSON.parse(String(init?.body)) as { agent: string; connection: ConnectionSpec };
       opts.registered?.push({ agent: body.agent, connection: body.connection });
@@ -704,5 +720,242 @@ describe("AgentDefRegistry — grant registration + status (4b)", () => {
     const p = patches.find((x) => x.id === "Agents/r")!;
     expect(p.status).toBe("pending");
     expect(p.pending).toBe("vault:research:read");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AgentDefRegistry — grant garbage-collection / reconcile (#96)
+// ---------------------------------------------------------------------------
+
+describe("AgentDefRegistry — grant-GC reconcile (#96)", () => {
+  test("a successful load reconciles with the def's CURRENT connectionKey()s", async () => {
+    const { deps } = recorderDeps();
+    const reconciled: Array<{ agent: string; liveKeys: string[] }> = [];
+    const grants = fakeGrantsClient({ reconciled });
+    const fetchFn = vaultFetch({
+      defs: [
+        {
+          id: "Agents/researcher",
+          content: "role",
+          metadata: { name: "researcher", wants: "vault:research:read, env:github, mcp:github" },
+        },
+      ],
+    });
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn, grants });
+    await reg.loadAll();
+
+    expect(reconciled).toHaveLength(1);
+    expect(reconciled[0]!.agent).toBe("researcher");
+    // The keys sent MUST equal connectionKey() of the parsed wants (env:github + mcp:github
+    // MERGE to one service connection → key env+mcp:github), matching grants.ts exactly.
+    const wants: ConnectionSpec[] = [
+      { kind: "vault", target: "research", access: "read" },
+      { kind: "service", target: "github", inject: ["env", "mcp"] },
+    ];
+    expect(reconciled[0]!.liveKeys).toEqual(wants.map((c) => connectionKey(c)));
+    expect(reconciled[0]!.liveKeys).toEqual(["vault:research:read", "env+mcp:github"]);
+  });
+
+  test("a def with NO wants still reconciles with an empty liveKeys (prunes any leftover)", async () => {
+    const { deps } = recorderDeps();
+    const reconciled: Array<{ agent: string; liveKeys: string[] }> = [];
+    const grants = fakeGrantsClient({ reconciled });
+    const fetchFn = vaultFetch({
+      defs: [{ id: "Agents/uni", content: "role", metadata: { name: "uni" } }],
+    });
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn, grants });
+    await reg.loadAll();
+    expect(reconciled).toEqual([{ agent: "uni", liveKeys: [] }]);
+  });
+
+  test("a REMOVED def (present in a prior load, gone now) → reconcile(agent, [])", async () => {
+    const { deps } = recorderDeps();
+    const reconciled: Array<{ agent: string; liveKeys: string[] }> = [];
+    const grants = fakeGrantsClient({ reconciled });
+    // Two notes present at first; the second load drops "researcher".
+    const present: Array<{ id: string; content?: string; metadata?: Record<string, unknown> }> = [
+      { id: "Agents/uni", content: "role", metadata: { name: "uni" } },
+      { id: "Agents/researcher", content: "role", metadata: { name: "researcher", wants: "vault:research:read" } },
+    ];
+    const fetchFn = (async (url: string | URL | Request, init?: RequestInit) => {
+      const u = String(url);
+      const method = init?.method ?? "GET";
+      if (method === "PATCH") return new Response(null, { status: 200 });
+      if (u.endsWith("/admin/grants/reconcile") || u.endsWith("/admin/grants")) {
+        // delegate to the fake grants client's fetch by re-issuing through it isn't
+        // possible here; instead record reconcile directly.
+        if (u.endsWith("/admin/grants/reconcile") && method === "POST") {
+          const body = JSON.parse(String(init?.body)) as { agent: string; liveKeys: string[] };
+          reconciled.push({ agent: body.agent, liveKeys: body.liveKeys });
+          return new Response(JSON.stringify({ pruned: 0, prunedIds: [] }), { status: 200 });
+        }
+        if (method === "PUT") {
+          const body = JSON.parse(String(init?.body)) as { agent: string; connection: ConnectionSpec };
+          return new Response(
+            JSON.stringify({ id: "g", agent: body.agent, connection: body.connection, status: "pending" }),
+            { status: 200 },
+          );
+        }
+      }
+      if (u.includes("/api/notes?") && u.includes("tag=%23agent%2Fdefinition")) {
+        return new Response(JSON.stringify(present), { status: 200, headers: { "content-type": "application/json" } });
+      }
+      return new Response("[]", { status: 200 });
+    }) as typeof fetch;
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn, grants });
+    await reg.loadAll(); // first confident read — both present
+    // Drop researcher; second confident read sees only uni.
+    present.splice(1, 1);
+    reconciled.length = 0; // ignore the first-load reconciles; focus on the removal
+    await reg.loadAll();
+
+    // The removed agent gets a prune-ALL reconcile.
+    const removal = reconciled.find((r) => r.agent === "researcher");
+    expect(removal).toEqual({ agent: "researcher", liveKeys: [] });
+    // uni (still present, no wants) reconciles with [] too — that's its clean-load prune,
+    // NOT a removal; distinguished by the agent name.
+    expect(reconciled.find((r) => r.agent === "uni")).toEqual({ agent: "uni", liveKeys: [] });
+  });
+
+  test("a delete reload → reconcile(agent, []) (confirmed removal)", async () => {
+    const { deps } = recorderDeps();
+    const reconciled: Array<{ agent: string; liveKeys: string[] }> = [];
+    const grants = fakeGrantsClient({ reconciled });
+    const fetchFn = vaultFetch({
+      defs: [{ id: "Agents/uni", content: "role", metadata: { name: "uni" } }],
+    });
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn, grants });
+    await reg.loadAll();
+    reconciled.length = 0; // drop the clean-load reconcile; focus on the delete
+    const result = await reg.reload("default", "Agents/uni", "deleted");
+    expect(result).toBe("deregistered");
+    expect(reconciled).toEqual([{ agent: "uni", liveKeys: [] }]);
+  });
+
+  test("a reload that re-reads as GONE (404) → reconcile(agent, []) (confirmed removal)", async () => {
+    const { deps } = recorderDeps();
+    const reconciled: Array<{ agent: string; liveKeys: string[] }> = [];
+    const grants = fakeGrantsClient({ reconciled });
+    const fetchFn = vaultFetch({
+      defs: [{ id: "Agents/uni", content: "role", metadata: { name: "uni" } }],
+      byId: { "Agents/uni": null }, // a later GET says it's gone
+    });
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn, grants });
+    await reg.loadAll();
+    reconciled.length = 0;
+    const result = await reg.reload("default", "Agents/uni"); // no event → GET → 404
+    expect(result).toBe("deregistered");
+    expect(reconciled).toEqual([{ agent: "uni", liveKeys: [] }]);
+  });
+
+  test("SAFETY: a PARSE-FAILING def NEVER reconciles (no prune from an error)", async () => {
+    const { deps } = recorderDeps();
+    const reconciled: Array<{ agent: string; liveKeys: string[] }> = [];
+    const grants = fakeGrantsClient({ reconciled });
+    const fetchFn = vaultFetch({
+      defs: [
+        { id: "Agents/bad", content: "role", metadata: { name: "bad", wants: "vault:research" } }, // malformed wants
+        { id: "Agents/noname", content: "role", metadata: {} }, // no name → parse error
+      ],
+    });
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn, grants });
+    const n = await reg.loadAll();
+    expect(n).toBe(0); // nothing instantiated
+    // NEITHER parse-failing def reconciled — a transient parse error must not nuke grants.
+    expect(reconciled).toEqual([]);
+  });
+
+  test("SAFETY: a parse-failing def is NOT later flagged removed (its grants survive)", async () => {
+    const { deps } = recorderDeps();
+    const reconciled: Array<{ agent: string; liveKeys: string[] }> = [];
+    const grants = fakeGrantsClient({ reconciled });
+    // First load: a CLEAN def. Second load: the SAME note now parse-fails (a transient
+    // bad edit). It must NOT be treated as a removal (it's still present in the vault).
+    const note: { id: string; content?: string; metadata?: Record<string, unknown> } = {
+      id: "Agents/uni",
+      content: "role",
+      metadata: { name: "uni" },
+    };
+    const present = [note];
+    const fetchFn = (async (url: string | URL | Request, init?: RequestInit) => {
+      const u = String(url);
+      const method = init?.method ?? "GET";
+      if (method === "PATCH") return new Response(null, { status: 200 });
+      if (u.endsWith("/admin/grants/reconcile") && method === "POST") {
+        const body = JSON.parse(String(init?.body)) as { agent: string; liveKeys: string[] };
+        reconciled.push({ agent: body.agent, liveKeys: body.liveKeys });
+        return new Response(JSON.stringify({ pruned: 0 }), { status: 200 });
+      }
+      if (u.includes("/api/notes?") && u.includes("tag=%23agent%2Fdefinition")) {
+        return new Response(JSON.stringify(present), { status: 200, headers: { "content-type": "application/json" } });
+      }
+      return new Response("[]", { status: 200 });
+    }) as typeof fetch;
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn, grants });
+    await reg.loadAll(); // clean → reconcile(uni, [])
+    // Now make the same note malformed (remove its name) and reload all.
+    note.metadata = { name: "uni", wants: "vault:research" }; // malformed wants → parse error
+    reconciled.length = 0;
+    await reg.loadAll();
+    // The note is STILL present (just unparseable) → NOT a removal → no reconcile at all.
+    expect(reconciled).toEqual([]);
+  });
+
+  test("SAFETY: a vault LIST failure does NOT prune (no confident read)", async () => {
+    const { deps } = recorderDeps();
+    const reconciled: Array<{ agent: string; liveKeys: string[] }> = [];
+    const grants = fakeGrantsClient({ reconciled });
+    let listShouldFail = false;
+    const present = [{ id: "Agents/uni", content: "role", metadata: { name: "uni" } }];
+    const fetchFn = (async (url: string | URL | Request, init?: RequestInit) => {
+      const u = String(url);
+      const method = init?.method ?? "GET";
+      if (method === "PATCH") return new Response(null, { status: 200 });
+      if (u.endsWith("/admin/grants/reconcile") && method === "POST") {
+        const body = JSON.parse(String(init?.body)) as { agent: string; liveKeys: string[] };
+        reconciled.push({ agent: body.agent, liveKeys: body.liveKeys });
+        return new Response(JSON.stringify({ pruned: 0 }), { status: 200 });
+      }
+      if (u.includes("/api/notes?") && u.includes("tag=%23agent%2Fdefinition")) {
+        if (listShouldFail) return new Response("boom", { status: 500 });
+        return new Response(JSON.stringify(present), { status: 200, headers: { "content-type": "application/json" } });
+      }
+      return new Response("[]", { status: 200 });
+    }) as typeof fetch;
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn, grants });
+    await reg.loadAll(); // confident → seen set = {uni}
+    reconciled.length = 0;
+    listShouldFail = true;
+    await reg.loadAll(); // list 500s → NOT a confident read → no removal diff, no prune
+    expect(reconciled).toEqual([]);
+  });
+
+  test("a reconcile HTTP failure is swallowed — the load does NOT throw / still instantiates", async () => {
+    const { deps, calls } = recorderDeps();
+    const reconciled: Array<{ agent: string; liveKeys: string[] }> = [];
+    const grants = fakeGrantsClient({ reconciled, reconcileFails: true }); // reconcile POST 500s
+    const patches: Array<{ id: string; status?: string }> = [];
+    const fetchFn = vaultFetch({
+      defs: [{ id: "Agents/uni", content: "role", metadata: { name: "uni" } }],
+      patches,
+    });
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn, grants });
+    // Must not throw out of loadAll despite the 500.
+    const n = await reg.loadAll();
+    expect(n).toBe(1);
+    expect(calls.registered.map((s) => s.name)).toEqual(["uni"]); // still instantiated
+    expect(reconciled).toEqual([{ agent: "uni", liveKeys: [] }]); // it was attempted
+  });
+
+  test("no grants client → reconcile is a no-op (the vault-native path still runs)", async () => {
+    const { deps, calls } = recorderDeps();
+    const fetchFn = vaultFetch({
+      defs: [{ id: "Agents/uni", content: "role", metadata: { name: "uni", wants: "vault:research:read" } }],
+    });
+    // No grants client → no reconcile attempted; the agent still instantiates own-vault.
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn });
+    const n = await reg.loadAll();
+    expect(n).toBe(1);
+    expect(calls.registered.map((s) => s.name)).toEqual(["uni"]);
   });
 });

--- a/src/agent-defs.ts
+++ b/src/agent-defs.ts
@@ -146,6 +146,18 @@ function metaList(v: unknown): string[] {
 }
 
 /**
+ * Best-effort, NON-throwing extraction of a def note's agent name (`metadata.name`),
+ * for tracking the seen set + the removed-def grant-GC diff (#96) — distinct from
+ * {@link parseAgentDef}, which validates + throws. Returns undefined when the note has
+ * no usable name (we then carry the prior last-known name forward). Does NOT slug-
+ * validate: a note that once instantiated already passed parse; tracking the raw name
+ * is enough to address its grants for the prune.
+ */
+function nameOfDefNote(note: { metadata?: Record<string, unknown> }): string | undefined {
+  return metaStr(note.metadata?.name);
+}
+
+/**
  * Parse one `#agent/definition` note into a {@link ParsedAgentDef}. PURE — no I/O.
  *
  * Mapping (the design's "note shape"):
@@ -534,6 +546,12 @@ interface LiveDef {
  *     `vault + noteId → LiveDef` map.
  *   - {@link deregisterAllForVault} — drop a whole vault's agents (config change).
  *
+ * Grant-GC (#96): the registry also keeps the hub's grant rows in sync with the live
+ * def set so a removed connection / a deleted def doesn't orphan an approved grant. On
+ * a CONFIDENT signal only — a clean successful instantiate (prune to the def's current
+ * `wants:` keys) or a CONFIRMED removal (deleted/404 → prune ALL) — it POSTs the hub's
+ * reconcile endpoint; a transient parse/list/fetch failure NEVER prunes (safety guard).
+ *
  * Idempotent: re-instantiating the same name swaps the registration in place
  * (`programmatic.register` + `addChannelLive` both replace-by-name), so an update is
  * a clean re-instantiate, not a duplicate. A name collision ACROSS def-vaults (two
@@ -547,6 +565,17 @@ export class AgentDefRegistry {
   private readonly bindings = new Map<string, DefVaultBinding>();
   /** `${vault}\u0000${noteId}` → the live record. */
   private readonly live = new Map<string, LiveDef>();
+  /**
+   * Per-vault set of `#agent/definition` notes seen on the LAST CONFIDENT read —
+   * `noteId → agentName` — the prior-known set the removed-def diff (grant-GC, #96)
+   * compares against. ONLY mutated from a confident signal: a successful vault LIST
+   * (loadAll) or a confirmed single-note removal/instantiate (reload). A note's name is
+   * its parsed `metadata.name`; a present-but-parse-failing note KEEPS its last-known
+   * name (carry-forward) so a transient parse error never drops it from the tracked set
+   * — which would wrongly flag it as removed (safety guard, design "only prune from a
+   * confident live set"). Keyed `vault → (noteId → agentName)`.
+   */
+  private readonly seenDefs = new Map<string, Map<string, string>>();
   private readonly deps: InstantiateDeps;
   /**
    * The hub grants client (4b) — used to REGISTER each def's `wants:` connections as
@@ -606,6 +635,13 @@ export class AgentDefRegistry {
    * vault AND per note: a single vault's list failure (or one note's parse/instantiate
    * failure) is logged and never aborts the others, so one bad def can't sink the set.
    * Returns the count successfully instantiated.
+   *
+   * Grant-GC (#96): after a SUCCESSFUL list (a confident read of the vault's whole def
+   * set), diff the prior-known def set against it — any note that was present and is now
+   * GONE has had its `#agent/definition` note deleted, so its grants are pruned ALL
+   * (`reconcileGrants(agent, [])`). A list FAILURE deliberately skips the diff (we
+   * `continue` BEFORE touching the prior set) so a transient vault outage never presents
+   * an empty current set that would nuke every agent's grants (safety guard).
    */
   async loadAll(): Promise<number> {
     let count = 0;
@@ -615,13 +651,75 @@ export class AgentDefRegistry {
         notes = await client.listDefNotes();
       } catch (err) {
         console.error(`agent-defs: listing defs from vault "${vault}" failed (continuing): ${(err as Error).message}`);
+        // CONFIDENT-SET GUARD: a failed list is NOT a confident read — leave the prior
+        // seen set untouched (no removed-def diff) so a hub/vault blip can't prune grants.
         continue;
       }
+      // The list succeeded → this IS a confident read. Detect removed defs by diffing
+      // the prior seen set (noteId→name) against the ids present now, BEFORE we mutate it.
+      const presentIds = new Set(notes.map((n) => n.id));
+      await this.pruneRemovedDefs(vault, presentIds);
+      // Rebuild the seen set from this confident read (carry-forward last-known names for
+      // notes that fail to parse, so a transient parse error doesn't drop them).
+      this.rebuildSeenDefs(vault, notes);
       for (const note of notes) {
         if (await this.instantiate(vault, note)) count++;
       }
     }
     return count;
+  }
+
+  /**
+   * Reconcile every def that was in the prior seen set for `vault` but is NOT in
+   * `presentIds` (its note was deleted) — `reconcileGrants(agent, [])` prunes ALL its
+   * grants so a deleted def doesn't orphan live approved rows. Best-effort + no-op
+   * without a grants client. Called ONLY with a confident current id set (a successful
+   * list); never on a list failure (see {@link loadAll}).
+   */
+  private async pruneRemovedDefs(vault: string, presentIds: Set<string>): Promise<void> {
+    const prior = this.seenDefs.get(vault);
+    if (!prior) return; // first confident read of this vault — nothing to compare against.
+    for (const [noteId, name] of prior) {
+      if (presentIds.has(noteId)) continue; // still present — not a removal.
+      // Confirmed removal: the def note is gone from a confident vault read.
+      await this.reconcileForRemovedAgent(name);
+    }
+  }
+
+  /**
+   * Rebuild the per-vault seen set from a confident list. Each present note maps
+   * noteId→its parsed `metadata.name`; a note that fails to parse keeps its prior
+   * last-known name (so a transient parse error doesn't drop it from the tracked set
+   * and wrongly flag it removed next pass). A note that never had a name (parse-failed
+   * on first sight) is tracked id-only (empty name) so it isn't re-detected as removed.
+   */
+  private rebuildSeenDefs(
+    vault: string,
+    notes: Array<{ id: string; content?: string; metadata?: Record<string, unknown> }>,
+  ): void {
+    const prior = this.seenDefs.get(vault);
+    const next = new Map<string, string>();
+    for (const note of notes) {
+      const name = nameOfDefNote(note) ?? prior?.get(note.id) ?? "";
+      next.set(note.id, name);
+    }
+    this.seenDefs.set(vault, next);
+  }
+
+  /** Reconcile a CONFIRMED-removed agent's grants away (prune ALL). Best-effort + no-op
+   *  without a grants client / without a known name. */
+  private async reconcileForRemovedAgent(name: string): Promise<void> {
+    if (!this.grants || !name) return;
+    try {
+      const { pruned } = await this.grants.reconcileGrants(name, []);
+      if (pruned > 0) {
+        console.log(`agent-defs: pruned ${pruned} stale grant(s) for removed agent "${name}".`);
+      }
+    } catch (err) {
+      console.warn(
+        `agent-defs: pruning grants for removed agent "${name}" failed (continuing): ${(err as Error).message}`,
+      );
+    }
   }
 
   /**
@@ -644,9 +742,10 @@ export class AgentDefRegistry {
       return "skipped";
     }
     // A delete event: the note is gone — tear down without a fetch (the GET would 404
-    // anyway; skipping it is faster + avoids a confusing 404 log).
+    // anyway; skipping it is faster + avoids a confusing 404 log). A delete is a
+    // CONFIRMED removal → prune the agent's grants (#96).
     if (event === "deleted") {
-      await this.deregisterByNote(vault, noteId);
+      await this.confirmedRemoval(vault, noteId);
       return "deregistered";
     }
     let note: Awaited<ReturnType<DefVaultClient["getNote"]>>;
@@ -654,14 +753,33 @@ export class AgentDefRegistry {
       note = await client.getNote(noteId);
     } catch (err) {
       console.error(`agent-defs: reload fetch of ${noteId} from "${vault}" failed: ${(err as Error).message}`);
+      // A fetch FAILURE is NOT a confirmed removal — skip without pruning grants (safety
+      // guard: never prune from an inconclusive read). The agent + grants stay intact.
       return "skipped";
     }
     if (!note) {
-      // Re-read says it's gone (deleted, or no longer carries the def tag we can see).
-      await this.deregisterByNote(vault, noteId);
+      // Re-read 404 says it's gone (deleted, or no longer carries the def tag we can
+      // see) — a CONFIRMED removal → prune the agent's grants (#96).
+      await this.confirmedRemoval(vault, noteId);
       return "deregistered";
     }
     return (await this.instantiate(vault, note)) ? "instantiated" : "skipped";
+  }
+
+  /**
+   * A CONFIRMED removed def (a `deleted` trigger, or a re-read 404): tear the agent
+   * down AND prune ALL its grants (#96 grant-GC) so a deleted `#agent/definition` note
+   * doesn't orphan live approved rows. The seen-set entry is cleared so a later loadAll
+   * doesn't re-detect (and re-prune) the same removal. Reconcile is best-effort.
+   */
+  private async confirmedRemoval(vault: string, noteId: string): Promise<void> {
+    // The grant holder name comes from the live record if present, else the last-known
+    // name we tracked for this note (a def removed before it ever instantiated).
+    const name =
+      this.live.get(this.keyOf(vault, noteId))?.name ?? this.seenDefs.get(vault)?.get(noteId);
+    await this.deregisterByNote(vault, noteId);
+    this.seenDefs.get(vault)?.delete(noteId);
+    if (name) await this.reconcileForRemovedAgent(name);
   }
 
   /**
@@ -706,14 +824,59 @@ export class AgentDefRegistry {
     // setup above — an unapproved connection is absent at spawn, never a failure here.
     const { status, pending } = await this.resolveStatusWithGrants(def);
     this.live.set(this.keyOf(vault, note.id), { vault, noteId: note.id, name: def.name, status });
+    // Track this note in the per-vault seen set (a confident, freshly-parsed read) so the
+    // removed-def diff (loadAll) and the reload-delete path both address it by name. This
+    // covers the reload single-note path where loadAll's rebuild didn't run.
+    this.recordSeen(vault, note.id, def.name);
     // Stamp status — best-effort: a failed stamp doesn't unmake the running agent.
     try {
       await client.patchStatus(note.id, status, pending);
     } catch (err) {
       console.warn(`agent-defs: status stamp for "${def.name}" failed (continuing): ${(err as Error).message}`);
     }
+    // Grant-GC (#96): a CLEAN successful load is a confident live set, so prune any grant
+    // the agent no longer declares — e.g. a `wants:` entry removed from the def. liveKeys
+    // = the connectionKey() of each CURRENTLY-declared connection (matching exactly how
+    // the hub keyed them at register). SAFETY: only reached AFTER a successful parse +
+    // instantiate; a parse/instantiate failure returns above WITHOUT reconciling, so a
+    // transient error never presents a stale/empty liveKeys that nukes approved grants.
+    await this.reconcileLiveKeys(def);
     console.log(`agent-defs: instantiated "${def.name}" from ${note.id} in "${vault}" (status=${status}).`);
     return true;
+  }
+
+  /** Record a note in the per-vault seen set (noteId → agent name) — a confident read. */
+  private recordSeen(vault: string, noteId: string, name: string): void {
+    let m = this.seenDefs.get(vault);
+    if (!m) {
+      m = new Map<string, string>();
+      this.seenDefs.set(vault, m);
+    }
+    m.set(noteId, name);
+  }
+
+  /**
+   * Prune the agent's grants down to its CURRENTLY-declared connections (#96 grant-GC,
+   * the clean-load case). Computes `liveKeys` = {@link connectionKey} of each `wants:`
+   * connection (the SAME derivation the hub keyed grants on) and POSTs reconcile — the
+   * hub tears down + removes every grant NOT in that set (e.g. a removed want). A def
+   * with no `wants:` sends an empty liveKeys, which prunes any leftover grant from a
+   * prior `wants:` it no longer declares. Best-effort: no grants client → no-op; a
+   * reconcile failure logs a warning and never throws out of the load path.
+   */
+  private async reconcileLiveKeys(def: ParsedAgentDef): Promise<void> {
+    if (!this.grants) return;
+    const liveKeys = def.wants.map((c) => connectionKey(c));
+    try {
+      const { pruned } = await this.grants.reconcileGrants(def.name, liveKeys);
+      if (pruned > 0) {
+        console.log(`agent-defs: pruned ${pruned} stale grant(s) for "${def.name}".`);
+      }
+    } catch (err) {
+      console.warn(
+        `agent-defs: reconciling grants for "${def.name}" failed (continuing): ${(err as Error).message}`,
+      );
+    }
   }
 
   /**
@@ -782,6 +945,11 @@ export class AgentDefRegistry {
 
   /** Tear down every agent from a def-vault (e.g. the vault binding is removed). */
   async deregisterAllForVault(vault: string): Promise<void> {
+    // Drop the seen-defs entry for this vault FIRST (reviewer nit): otherwise the
+    // next confident loadAll would diff the now-unbound vault's stale entries as
+    // "removed" and issue spurious reconcile(agent, []) prunes — but the binding
+    // was dropped, the defs weren't deleted, so their grants must NOT be GC'd.
+    this.seenDefs.delete(vault);
     for (const rec of [...this.live.values()]) {
       if (rec.vault === vault) await this.deregisterByNote(vault, rec.noteId);
     }

--- a/src/grants.test.ts
+++ b/src/grants.test.ts
@@ -280,6 +280,59 @@ describe("GrantsClient.getMaterial (GET /admin/grants/<id>/material)", () => {
   });
 });
 
+describe("GrantsClient.reconcileGrants (POST /admin/grants/reconcile) — #96 grant-GC", () => {
+  test("POSTs { agent, liveKeys } with the manager bearer; returns { pruned, prunedIds }", async () => {
+    let captured: { url: string; method?: string; auth?: string; body?: unknown } = { url: "" };
+    const client = clientWith((async (url: string | URL | Request, init?: RequestInit) => {
+      captured = {
+        url: String(url),
+        method: init?.method,
+        auth: (init?.headers as Record<string, string>)?.authorization,
+        body: JSON.parse(String(init?.body)),
+      };
+      return new Response(JSON.stringify({ pruned: 2, prunedIds: ["g1", "g2"] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch);
+
+    const out = await client.reconcileGrants("researcher", ["vault:research:read", "env+mcp:github"]);
+    expect(captured.url).toBe(`${HUB}/admin/grants/reconcile`);
+    expect(captured.method).toBe("POST");
+    expect(captured.auth).toBe(`Bearer ${BEARER}`);
+    // The field name MUST stay "agent" (deferred rename B1 is NOT in scope).
+    expect(captured.body).toEqual({ agent: "researcher", liveKeys: ["vault:research:read", "env+mcp:github"] });
+    expect(out).toEqual({ pruned: 2, prunedIds: ["g1", "g2"] });
+  });
+
+  test("an empty liveKeys array (the def is gone → prune ALL) is sent verbatim", async () => {
+    let body: unknown;
+    const client = clientWith((async (_url: string | URL | Request, init?: RequestInit) => {
+      body = JSON.parse(String(init?.body));
+      return new Response(JSON.stringify({ pruned: 3, prunedIds: ["a", "b", "c"] }), { status: 200 });
+    }) as typeof fetch);
+    const out = await client.reconcileGrants("gone", []);
+    expect(body).toEqual({ agent: "gone", liveKeys: [] });
+    expect(out.pruned).toBe(3);
+  });
+
+  test("a response with no prunedIds → { pruned } only (defensive)", async () => {
+    const client = clientWith((async () => new Response(JSON.stringify({ pruned: 0 }), { status: 200 })) as unknown as typeof fetch);
+    expect(await client.reconcileGrants("a", [])).toEqual({ pruned: 0 });
+  });
+
+  test("a non-JSON / empty 200 body → pruned defaults to 0 (never throws)", async () => {
+    const client = clientWith((async () => new Response("", { status: 200 })) as unknown as typeof fetch);
+    expect(await client.reconcileGrants("a", [])).toEqual({ pruned: 0 });
+  });
+
+  test("throws GrantsApiError carrying the status on a non-ok response", async () => {
+    const client = clientWith((async () => new Response("nope", { status: 403 })) as unknown as typeof fetch);
+    await expect(client.reconcileGrants("a", [])).rejects.toMatchObject({ status: 403 });
+    await expect(client.reconcileGrants("a", [])).rejects.toThrow(GrantsApiError);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // resolveConnectionStatus
 // ---------------------------------------------------------------------------

--- a/src/grants.ts
+++ b/src/grants.ts
@@ -17,14 +17,19 @@
  *   - at spawn, fetches only APPROVED grants' MATERIAL (`GET …/material`) and injects
  *     it. Unapproved/pending/error connections are simply ABSENT — never a failure.
  *
- * THE WIRE CONTRACT (parachute-hub PR #668 — consume, do not redesign):
+ * THE WIRE CONTRACT (parachute-hub PR #668 + #96 — consume, do not redesign):
  *   - PUT  <hub>/admin/grants          { agent, connection } → { id, agent, connection, status, reason? }
  *   - GET  <hub>/admin/grants?agent=<> → { grants: [{ id, agent, connection, status, reason?, approvedAt? }] }
  *   - GET  <hub>/admin/grants/<id>/material → APPROVED only:
  *         vault   → { kind:"vault",   token, mcpUrl }
  *         service → { kind:"service", token, inject }
  *         (404 unknown id / 409 not-approved)
- *   - Auth: all three need a `parachute:host:admin` Bearer — we REUSE the module's
+ *   - POST <hub>/admin/grants/reconcile { agent, liveKeys } → { pruned, prunedIds } (#96
+ *         grant-GC): tear down + REMOVE every grant for `agent` whose connectionKey is
+ *         NOT in liveKeys (empty liveKeys = the def is gone → prune ALL). Stops a removed
+ *         want / a deleted def from orphaning a live approved grant. Pruning only ever
+ *         REMOVES access, so it shares the host-admin Bearer (never an operator cookie).
+ *   - Auth: all of these need a `parachute:host:admin` Bearer — we REUSE the module's
  *     existing host-admin-capable MANAGER BEARER (the operator token it mints vault
  *     tokens with; see mint-token.ts / spawn-deps.ts). NO new auth path.
  *   - approve/revoke are operator-only via the hub UI — the module NEVER calls those.
@@ -342,10 +347,10 @@ function stripTrailingSlash(url: string): string {
 }
 
 /**
- * Thin client for the hub's grants API (parachute-hub #668). Three calls the module
- * makes — register (PUT), list (GET), fetch-material (GET …/material). It NEVER
- * approves/revokes (operator-only via the hub UI). All requests carry the manager
- * bearer (`parachute:host:admin`).
+ * Thin client for the hub's grants API (parachute-hub #668 + #96). The calls the module
+ * makes — register (PUT), list (GET), fetch-material (GET …/material), and reconcile
+ * (POST …/reconcile, the grant-GC of #96). It NEVER approves/revokes (operator-only via
+ * the hub UI). All requests carry the manager bearer (`parachute:host:admin`).
  */
 export class GrantsClient {
   private readonly base: string;
@@ -415,6 +420,44 @@ export class GrantsClient {
       throw new GrantsApiError(`get grant material failed (${res.status}) ${detail}`.trim(), res.status);
     }
     return (await res.json()) as GrantMaterial;
+  }
+
+  /**
+   * GARBAGE-COLLECT an agent's now-stale grants (parachute-hub #96). `POST
+   * /admin/grants/reconcile { agent, liveKeys }` → `{ pruned, prunedIds }`. The hub
+   * tears down + REMOVES every grant for `agent` whose {@link connectionKey} is NOT in
+   * `liveKeys` (an empty array prunes ALL of the agent's grants — the def is gone). This
+   * is how a removed connection (or a deleted `#agent/definition` note) stops orphaning
+   * a live `approved` grant row.
+   *
+   * `liveKeys` MUST be the {@link connectionKey} values for the agent's CURRENTLY-declared
+   * connections — derived from the SAME `parseWants` → `connectionKey` pipeline the hub
+   * keyed each grant on, so a grant the agent still wants is never pruned.
+   *
+   * SAFETY: only ever call this from a CONFIDENT live set — a clean successful def load
+   * (real `liveKeys`) or a confirmed removal (empty `liveKeys`). NEVER from a parse/load
+   * failure: a transient error must not present an empty/partial `liveKeys` that nukes
+   * approved grants. Pruning only ever REMOVES access (never escalates), so the host-admin
+   * Bearer is the right auth (mirrors PUT/GET /admin/grants) — the same one the module
+   * uses for register/list/material. Throws {@link GrantsApiError} on a non-ok response;
+   * the caller logs + continues (best-effort — a GC fault must never crash a load).
+   */
+  async reconcileGrants(agent: string, liveKeys: string[]): Promise<{ pruned: number; prunedIds?: string[] }> {
+    const url = `${this.base}/admin/grants/reconcile`;
+    const res = await this.fetchFn(url, {
+      method: "POST",
+      headers: this.authHeaders({ "content-type": "application/json" }),
+      body: JSON.stringify({ agent, liveKeys }),
+    });
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "");
+      throw new GrantsApiError(`reconcile grants failed (${res.status}) ${detail}`.trim(), res.status);
+    }
+    const parsed = (await res.json().catch(() => ({}))) as { pruned?: number; prunedIds?: string[] };
+    return {
+      pruned: typeof parsed.pruned === "number" ? parsed.pruned : 0,
+      ...(Array.isArray(parsed.prunedIds) ? { prunedIds: parsed.prunedIds } : {}),
+    };
   }
 }
 


### PR DESCRIPTION
The agent-module side of #96 (grant GC). Pairs with the hub's new `POST /admin/grants/reconcile` (parachute-hub PR). Today a deleted `#agent/definition` leaves its grant rows (and any live approved tokens) orphaned in the hub store; this makes the module prune them.

## What's here
- `GrantsClient.reconcileGrants(agent, liveKeys)` → `POST /admin/grants/reconcile` (manager `parachute:host:admin` Bearer). Best-effort: throws `GrantsApiError` on non-ok, caller catches + warns.
- `AgentDefRegistry`: after a def loads **successfully**, reconcile with `liveKeys = def.wants.map(connectionKey)` (prunes a removed `wants:` entry). A **confirmed removal** (def gone from the vault on a clean load, a `deleted` event, or a re-read 404) → `reconcile(agent, [])` (prune all).
- **Safety guard** (the load-bearing part): reconcile fires **only from a confident live set** — never on a parse failure, a vault-list failure, or an inconclusive single-note fetch. A `seenDefs` map carries last-known names forward so a transient parse error is never mistaken for a removal. Best-effort throughout — a hub blip never blocks instantiation or crashes the daemon.

## Tests / gates
`bun test`: **947 pass, 0 fail**. typecheck clean (only the 2 pre-existing `bridge.ts` TS2589 errors, unrelated — agent#97). Tests cover the wire contract, prune-all, tolerant parse, non-ok throw, and every safety-guard path (parse-fail → no reconcile, list-fail → no prune, reconcile-fail swallowed, carry-forward under second-pass parse failure).

## Review
Independent review: SHIP, no blockers. Folded the `deregisterAllForVault` seenDefs-clear nit (prevents a future spurious prune when a vault binding is dropped). `connectionKey` derivation imports the same function the hub keys on — no drift. No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)