### PR TITLE
fix(grants): reconcile sends live connection SPECS, not keys (cross-repo key drift)

### DIFF
--- a/src/agent-defs.test.ts
+++ b/src/agent-defs.test.ts
@@ -535,8 +535,8 @@ function fakeGrantsClient(opts: {
   statusByKey?: Record<string, string>;
   /** Record each registered (agent, connection). */
   registered?: Array<{ agent: string; connection: ConnectionSpec }>;
-  /** Record each reconcile (agent, liveKeys) — the #96 grant-GC call. */
-  reconciled?: Array<{ agent: string; liveKeys: string[] }>;
+  /** Record each reconcile (agent, liveConnections) — the #96 grant-GC call. */
+  reconciled?: Array<{ agent: string; liveConnections: ConnectionSpec[] }>;
   /** How many grants the hub reports pruned per reconcile (default 0). */
   prunedPerReconcile?: number;
   /** Make reconcile POSTs 500 (to assert the failure is swallowed). */
@@ -545,8 +545,8 @@ function fakeGrantsClient(opts: {
   const fetchFn = (async (url: string | URL | Request, init?: RequestInit) => {
     const u = String(url);
     if (u.endsWith("/admin/grants/reconcile") && (init?.method ?? "GET") === "POST") {
-      const body = JSON.parse(String(init?.body)) as { agent: string; liveKeys: string[] };
-      opts.reconciled?.push({ agent: body.agent, liveKeys: body.liveKeys });
+      const body = JSON.parse(String(init?.body)) as { agent: string; liveConnections: ConnectionSpec[] };
+      opts.reconciled?.push({ agent: body.agent, liveConnections: body.liveConnections });
       if (opts.reconcileFails) return new Response("boom", { status: 500 });
       return new Response(JSON.stringify({ pruned: opts.prunedPerReconcile ?? 0, prunedIds: [] }), {
         status: 200,
@@ -728,9 +728,9 @@ describe("AgentDefRegistry — grant registration + status (4b)", () => {
 // ---------------------------------------------------------------------------
 
 describe("AgentDefRegistry — grant-GC reconcile (#96)", () => {
-  test("a successful load reconciles with the def's CURRENT connectionKey()s", async () => {
+  test("a successful load reconciles with the def's CURRENT live connection specs", async () => {
     const { deps } = recorderDeps();
-    const reconciled: Array<{ agent: string; liveKeys: string[] }> = [];
+    const reconciled: Array<{ agent: string; liveConnections: ConnectionSpec[] }> = [];
     const grants = fakeGrantsClient({ reconciled });
     const fetchFn = vaultFetch({
       defs: [
@@ -746,31 +746,30 @@ describe("AgentDefRegistry — grant-GC reconcile (#96)", () => {
 
     expect(reconciled).toHaveLength(1);
     expect(reconciled[0]!.agent).toBe("researcher");
-    // The keys sent MUST equal connectionKey() of the parsed wants (env:github + mcp:github
-    // MERGE to one service connection → key env+mcp:github), matching grants.ts exactly.
+    // The SPECS sent MUST equal the parsed wants (env:github + mcp:github MERGE to one
+    // service connection with inject ["env","mcp"]). The hub re-derives the keys.
     const wants: ConnectionSpec[] = [
       { kind: "vault", target: "research", access: "read" },
       { kind: "service", target: "github", inject: ["env", "mcp"] },
     ];
-    expect(reconciled[0]!.liveKeys).toEqual(wants.map((c) => connectionKey(c)));
-    expect(reconciled[0]!.liveKeys).toEqual(["vault:research:read", "env+mcp:github"]);
+    expect(reconciled[0]!.liveConnections).toEqual(wants);
   });
 
-  test("a def with NO wants still reconciles with an empty liveKeys (prunes any leftover)", async () => {
+  test("a def with NO wants still reconciles with empty liveConnections (prunes any leftover)", async () => {
     const { deps } = recorderDeps();
-    const reconciled: Array<{ agent: string; liveKeys: string[] }> = [];
+    const reconciled: Array<{ agent: string; liveConnections: ConnectionSpec[] }> = [];
     const grants = fakeGrantsClient({ reconciled });
     const fetchFn = vaultFetch({
       defs: [{ id: "Agents/uni", content: "role", metadata: { name: "uni" } }],
     });
     const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn, grants });
     await reg.loadAll();
-    expect(reconciled).toEqual([{ agent: "uni", liveKeys: [] }]);
+    expect(reconciled).toEqual([{ agent: "uni", liveConnections: [] }]);
   });
 
   test("a REMOVED def (present in a prior load, gone now) → reconcile(agent, [])", async () => {
     const { deps } = recorderDeps();
-    const reconciled: Array<{ agent: string; liveKeys: string[] }> = [];
+    const reconciled: Array<{ agent: string; liveConnections: ConnectionSpec[] }> = [];
     const grants = fakeGrantsClient({ reconciled });
     // Two notes present at first; the second load drops "researcher".
     const present: Array<{ id: string; content?: string; metadata?: Record<string, unknown> }> = [
@@ -785,8 +784,8 @@ describe("AgentDefRegistry — grant-GC reconcile (#96)", () => {
         // delegate to the fake grants client's fetch by re-issuing through it isn't
         // possible here; instead record reconcile directly.
         if (u.endsWith("/admin/grants/reconcile") && method === "POST") {
-          const body = JSON.parse(String(init?.body)) as { agent: string; liveKeys: string[] };
-          reconciled.push({ agent: body.agent, liveKeys: body.liveKeys });
+          const body = JSON.parse(String(init?.body)) as { agent: string; liveConnections: ConnectionSpec[] };
+          reconciled.push({ agent: body.agent, liveConnections: body.liveConnections });
           return new Response(JSON.stringify({ pruned: 0, prunedIds: [] }), { status: 200 });
         }
         if (method === "PUT") {
@@ -811,15 +810,15 @@ describe("AgentDefRegistry — grant-GC reconcile (#96)", () => {
 
     // The removed agent gets a prune-ALL reconcile.
     const removal = reconciled.find((r) => r.agent === "researcher");
-    expect(removal).toEqual({ agent: "researcher", liveKeys: [] });
+    expect(removal).toEqual({ agent: "researcher", liveConnections: [] });
     // uni (still present, no wants) reconciles with [] too — that's its clean-load prune,
     // NOT a removal; distinguished by the agent name.
-    expect(reconciled.find((r) => r.agent === "uni")).toEqual({ agent: "uni", liveKeys: [] });
+    expect(reconciled.find((r) => r.agent === "uni")).toEqual({ agent: "uni", liveConnections: [] });
   });
 
   test("a delete reload → reconcile(agent, []) (confirmed removal)", async () => {
     const { deps } = recorderDeps();
-    const reconciled: Array<{ agent: string; liveKeys: string[] }> = [];
+    const reconciled: Array<{ agent: string; liveConnections: ConnectionSpec[] }> = [];
     const grants = fakeGrantsClient({ reconciled });
     const fetchFn = vaultFetch({
       defs: [{ id: "Agents/uni", content: "role", metadata: { name: "uni" } }],
@@ -829,12 +828,12 @@ describe("AgentDefRegistry — grant-GC reconcile (#96)", () => {
     reconciled.length = 0; // drop the clean-load reconcile; focus on the delete
     const result = await reg.reload("default", "Agents/uni", "deleted");
     expect(result).toBe("deregistered");
-    expect(reconciled).toEqual([{ agent: "uni", liveKeys: [] }]);
+    expect(reconciled).toEqual([{ agent: "uni", liveConnections: [] }]);
   });
 
   test("a reload that re-reads as GONE (404) → reconcile(agent, []) (confirmed removal)", async () => {
     const { deps } = recorderDeps();
-    const reconciled: Array<{ agent: string; liveKeys: string[] }> = [];
+    const reconciled: Array<{ agent: string; liveConnections: ConnectionSpec[] }> = [];
     const grants = fakeGrantsClient({ reconciled });
     const fetchFn = vaultFetch({
       defs: [{ id: "Agents/uni", content: "role", metadata: { name: "uni" } }],
@@ -845,12 +844,12 @@ describe("AgentDefRegistry — grant-GC reconcile (#96)", () => {
     reconciled.length = 0;
     const result = await reg.reload("default", "Agents/uni"); // no event → GET → 404
     expect(result).toBe("deregistered");
-    expect(reconciled).toEqual([{ agent: "uni", liveKeys: [] }]);
+    expect(reconciled).toEqual([{ agent: "uni", liveConnections: [] }]);
   });
 
   test("SAFETY: a PARSE-FAILING def NEVER reconciles (no prune from an error)", async () => {
     const { deps } = recorderDeps();
-    const reconciled: Array<{ agent: string; liveKeys: string[] }> = [];
+    const reconciled: Array<{ agent: string; liveConnections: ConnectionSpec[] }> = [];
     const grants = fakeGrantsClient({ reconciled });
     const fetchFn = vaultFetch({
       defs: [
@@ -867,7 +866,7 @@ describe("AgentDefRegistry — grant-GC reconcile (#96)", () => {
 
   test("SAFETY: a parse-failing def is NOT later flagged removed (its grants survive)", async () => {
     const { deps } = recorderDeps();
-    const reconciled: Array<{ agent: string; liveKeys: string[] }> = [];
+    const reconciled: Array<{ agent: string; liveConnections: ConnectionSpec[] }> = [];
     const grants = fakeGrantsClient({ reconciled });
     // First load: a CLEAN def. Second load: the SAME note now parse-fails (a transient
     // bad edit). It must NOT be treated as a removal (it's still present in the vault).
@@ -882,8 +881,8 @@ describe("AgentDefRegistry — grant-GC reconcile (#96)", () => {
       const method = init?.method ?? "GET";
       if (method === "PATCH") return new Response(null, { status: 200 });
       if (u.endsWith("/admin/grants/reconcile") && method === "POST") {
-        const body = JSON.parse(String(init?.body)) as { agent: string; liveKeys: string[] };
-        reconciled.push({ agent: body.agent, liveKeys: body.liveKeys });
+        const body = JSON.parse(String(init?.body)) as { agent: string; liveConnections: ConnectionSpec[] };
+        reconciled.push({ agent: body.agent, liveConnections: body.liveConnections });
         return new Response(JSON.stringify({ pruned: 0 }), { status: 200 });
       }
       if (u.includes("/api/notes?") && u.includes("tag=%23agent%2Fdefinition")) {
@@ -903,7 +902,7 @@ describe("AgentDefRegistry — grant-GC reconcile (#96)", () => {
 
   test("SAFETY: a vault LIST failure does NOT prune (no confident read)", async () => {
     const { deps } = recorderDeps();
-    const reconciled: Array<{ agent: string; liveKeys: string[] }> = [];
+    const reconciled: Array<{ agent: string; liveConnections: ConnectionSpec[] }> = [];
     const grants = fakeGrantsClient({ reconciled });
     let listShouldFail = false;
     const present = [{ id: "Agents/uni", content: "role", metadata: { name: "uni" } }];
@@ -912,8 +911,8 @@ describe("AgentDefRegistry — grant-GC reconcile (#96)", () => {
       const method = init?.method ?? "GET";
       if (method === "PATCH") return new Response(null, { status: 200 });
       if (u.endsWith("/admin/grants/reconcile") && method === "POST") {
-        const body = JSON.parse(String(init?.body)) as { agent: string; liveKeys: string[] };
-        reconciled.push({ agent: body.agent, liveKeys: body.liveKeys });
+        const body = JSON.parse(String(init?.body)) as { agent: string; liveConnections: ConnectionSpec[] };
+        reconciled.push({ agent: body.agent, liveConnections: body.liveConnections });
         return new Response(JSON.stringify({ pruned: 0 }), { status: 200 });
       }
       if (u.includes("/api/notes?") && u.includes("tag=%23agent%2Fdefinition")) {
@@ -932,7 +931,7 @@ describe("AgentDefRegistry — grant-GC reconcile (#96)", () => {
 
   test("a reconcile HTTP failure is swallowed — the load does NOT throw / still instantiates", async () => {
     const { deps, calls } = recorderDeps();
-    const reconciled: Array<{ agent: string; liveKeys: string[] }> = [];
+    const reconciled: Array<{ agent: string; liveConnections: ConnectionSpec[] }> = [];
     const grants = fakeGrantsClient({ reconciled, reconcileFails: true }); // reconcile POST 500s
     const patches: Array<{ id: string; status?: string }> = [];
     const fetchFn = vaultFetch({
@@ -944,7 +943,7 @@ describe("AgentDefRegistry — grant-GC reconcile (#96)", () => {
     const n = await reg.loadAll();
     expect(n).toBe(1);
     expect(calls.registered.map((s) => s.name)).toEqual(["uni"]); // still instantiated
-    expect(reconciled).toEqual([{ agent: "uni", liveKeys: [] }]); // it was attempted
+    expect(reconciled).toEqual([{ agent: "uni", liveConnections: [] }]); // it was attempted
   });
 
   test("no grants client → reconcile is a no-op (the vault-native path still runs)", async () => {

--- a/src/agent-defs.ts
+++ b/src/agent-defs.ts
@@ -835,11 +835,11 @@ export class AgentDefRegistry {
       console.warn(`agent-defs: status stamp for "${def.name}" failed (continuing): ${(err as Error).message}`);
     }
     // Grant-GC (#96): a CLEAN successful load is a confident live set, so prune any grant
-    // the agent no longer declares — e.g. a `wants:` entry removed from the def. liveKeys
-    // = the connectionKey() of each CURRENTLY-declared connection (matching exactly how
-    // the hub keyed them at register). SAFETY: only reached AFTER a successful parse +
-    // instantiate; a parse/instantiate failure returns above WITHOUT reconciling, so a
-    // transient error never presents a stale/empty liveKeys that nukes approved grants.
+    // the agent no longer declares — e.g. a `wants:` entry removed from the def. We send
+    // the CURRENTLY-declared connection SPECS; the hub re-derives the keys with its own
+    // connectionKey. SAFETY: only reached AFTER a successful parse + instantiate; a
+    // parse/instantiate failure returns above WITHOUT reconciling, so a transient error
+    // never presents a stale/empty live set that nukes approved grants.
     await this.reconcileLiveKeys(def);
     console.log(`agent-defs: instantiated "${def.name}" from ${note.id} in "${vault}" (status=${status}).`);
     return true;
@@ -857,18 +857,20 @@ export class AgentDefRegistry {
 
   /**
    * Prune the agent's grants down to its CURRENTLY-declared connections (#96 grant-GC,
-   * the clean-load case). Computes `liveKeys` = {@link connectionKey} of each `wants:`
-   * connection (the SAME derivation the hub keyed grants on) and POSTs reconcile — the
-   * hub tears down + removes every grant NOT in that set (e.g. a removed want). A def
-   * with no `wants:` sends an empty liveKeys, which prunes any leftover grant from a
-   * prior `wants:` it no longer declares. Best-effort: no grants client → no-op; a
-   * reconcile failure logs a warning and never throws out of the load path.
+   * the clean-load case). POSTs reconcile with the live connection SPECS (`def.wants`);
+   * the hub re-derives each key with its own connectionKey and tears down + removes every
+   * grant NOT in that set (e.g. a removed want). A def with no `wants:` sends an empty
+   * set, which prunes any leftover grant from a prior `wants:` it no longer declares.
+   * Best-effort: no grants client → no-op; a reconcile failure logs a warning and never
+   * throws out of the load path.
    */
   private async reconcileLiveKeys(def: ParsedAgentDef): Promise<void> {
     if (!this.grants) return;
-    const liveKeys = def.wants.map((c) => connectionKey(c));
+    // Pass the live connection SPECS (def.wants) — the hub derives the keys with
+    // its own connectionKey. (Sending keys we computed via grants.ts connectionKey
+    // would diverge from the hub's for service/tagged/mcp grants → wrong prunes.)
     try {
-      const { pruned } = await this.grants.reconcileGrants(def.name, liveKeys);
+      const { pruned } = await this.grants.reconcileGrants(def.name, def.wants);
       if (pruned > 0) {
         console.log(`agent-defs: pruned ${pruned} stale grant(s) for "${def.name}".`);
       }

--- a/src/grants.test.ts
+++ b/src/grants.test.ts
@@ -281,7 +281,7 @@ describe("GrantsClient.getMaterial (GET /admin/grants/<id>/material)", () => {
 });
 
 describe("GrantsClient.reconcileGrants (POST /admin/grants/reconcile) — #96 grant-GC", () => {
-  test("POSTs { agent, liveKeys } with the manager bearer; returns { pruned, prunedIds }", async () => {
+  test("POSTs { agent, liveConnections } (specs, not keys) with the manager bearer; returns { pruned, prunedIds }", async () => {
     let captured: { url: string; method?: string; auth?: string; body?: unknown } = { url: "" };
     const client = clientWith((async (url: string | URL | Request, init?: RequestInit) => {
       captured = {
@@ -296,23 +296,29 @@ describe("GrantsClient.reconcileGrants (POST /admin/grants/reconcile) — #96 gr
       });
     }) as typeof fetch);
 
-    const out = await client.reconcileGrants("researcher", ["vault:research:read", "env+mcp:github"]);
+    // We send the live connection SPECS, not pre-computed keys (the hub re-derives
+    // keys with its own connectionKey — no cross-repo key-format dependency).
+    const live: ConnectionSpec[] = [
+      { kind: "vault", target: "research", access: "read" },
+      { kind: "service", target: "github", inject: ["env", "mcp"] },
+    ];
+    const out = await client.reconcileGrants("researcher", live);
     expect(captured.url).toBe(`${HUB}/admin/grants/reconcile`);
     expect(captured.method).toBe("POST");
     expect(captured.auth).toBe(`Bearer ${BEARER}`);
     // The field name MUST stay "agent" (deferred rename B1 is NOT in scope).
-    expect(captured.body).toEqual({ agent: "researcher", liveKeys: ["vault:research:read", "env+mcp:github"] });
+    expect(captured.body).toEqual({ agent: "researcher", liveConnections: live });
     expect(out).toEqual({ pruned: 2, prunedIds: ["g1", "g2"] });
   });
 
-  test("an empty liveKeys array (the def is gone → prune ALL) is sent verbatim", async () => {
+  test("an empty liveConnections array (the def is gone → prune ALL) is sent verbatim", async () => {
     let body: unknown;
     const client = clientWith((async (_url: string | URL | Request, init?: RequestInit) => {
       body = JSON.parse(String(init?.body));
       return new Response(JSON.stringify({ pruned: 3, prunedIds: ["a", "b", "c"] }), { status: 200 });
     }) as typeof fetch);
     const out = await client.reconcileGrants("gone", []);
-    expect(body).toEqual({ agent: "gone", liveKeys: [] });
+    expect(body).toEqual({ agent: "gone", liveConnections: [] });
     expect(out.pruned).toBe(3);
   });
 

--- a/src/grants.ts
+++ b/src/grants.ts
@@ -24,9 +24,10 @@
  *         vault   → { kind:"vault",   token, mcpUrl }
  *         service → { kind:"service", token, inject }
  *         (404 unknown id / 409 not-approved)
- *   - POST <hub>/admin/grants/reconcile { agent, liveKeys } → { pruned, prunedIds } (#96
- *         grant-GC): tear down + REMOVE every grant for `agent` whose connectionKey is
- *         NOT in liveKeys (empty liveKeys = the def is gone → prune ALL). Stops a removed
+ *   - POST <hub>/admin/grants/reconcile { agent, liveConnections } → { pruned, prunedIds } (#96
+ *         grant-GC): the hub re-derives each key with ITS connectionKey and tears down +
+ *         REMOVEs every grant for `agent` whose key is NOT among the live specs (empty
+ *         liveConnections = the def is gone → prune ALL). Stops a removed
  *         want / a deleted def from orphaning a live approved grant. Pruning only ever
  *         REMOVES access, so it shares the host-admin Bearer (never an operator cookie).
  *   - Auth: all of these need a `parachute:host:admin` Bearer — we REUSE the module's
@@ -424,30 +425,38 @@ export class GrantsClient {
 
   /**
    * GARBAGE-COLLECT an agent's now-stale grants (parachute-hub #96). `POST
-   * /admin/grants/reconcile { agent, liveKeys }` → `{ pruned, prunedIds }`. The hub
-   * tears down + REMOVES every grant for `agent` whose {@link connectionKey} is NOT in
-   * `liveKeys` (an empty array prunes ALL of the agent's grants — the def is gone). This
-   * is how a removed connection (or a deleted `#agent/definition` note) stops orphaning
-   * a live `approved` grant row.
+   * /admin/grants/reconcile { agent, liveConnections }` → `{ pruned, prunedIds }`. The
+   * hub re-derives each key with ITS OWN connectionKey and tears down + REMOVES every
+   * grant for `agent` whose key is NOT among the live specs (an empty array prunes ALL
+   * of the agent's grants — the def is gone). This is how a removed connection (or a
+   * deleted `#agent/definition` note) stops orphaning a live `approved` grant row.
    *
-   * `liveKeys` MUST be the {@link connectionKey} values for the agent's CURRENTLY-declared
-   * connections — derived from the SAME `parseWants` → `connectionKey` pipeline the hub
-   * keyed each grant on, so a grant the agent still wants is never pruned.
+   * `liveConnections` is the agent's CURRENTLY-declared connection SPECS (`def.wants`).
+   * We send SPECS, not keys, so there's no dependency on this module's connectionKey
+   * matching the hub's — the hub keys them the same way it stored them.
    *
    * SAFETY: only ever call this from a CONFIDENT live set — a clean successful def load
-   * (real `liveKeys`) or a confirmed removal (empty `liveKeys`). NEVER from a parse/load
-   * failure: a transient error must not present an empty/partial `liveKeys` that nukes
+   * (real `liveConnections`) or a confirmed removal (empty array). NEVER from a parse/load
+   * failure: a transient error must not present an empty/partial set that nukes
    * approved grants. Pruning only ever REMOVES access (never escalates), so the host-admin
    * Bearer is the right auth (mirrors PUT/GET /admin/grants) — the same one the module
    * uses for register/list/material. Throws {@link GrantsApiError} on a non-ok response;
    * the caller logs + continues (best-effort — a GC fault must never crash a load).
    */
-  async reconcileGrants(agent: string, liveKeys: string[]): Promise<{ pruned: number; prunedIds?: string[] }> {
+  async reconcileGrants(
+    agent: string,
+    liveConnections: ConnectionSpec[],
+  ): Promise<{ pruned: number; prunedIds?: string[] }> {
+    // Send the live connection SPECS, not pre-computed keys: the hub re-derives
+    // each key with its OWN connectionKey (the one it stored them under). Sending
+    // keys we computed here would couple to the hub's separate connectionKey impl,
+    // which diverges for service / tagged-vault / mixed-case-mcp grants and would
+    // wrongly prune still-wanted grants (caught by live verification 2026-06-18).
     const url = `${this.base}/admin/grants/reconcile`;
     const res = await this.fetchFn(url, {
       method: "POST",
       headers: this.authHeaders({ "content-type": "application/json" }),
-      body: JSON.stringify({ agent, liveKeys }),
+      body: JSON.stringify({ agent, liveConnections }),
     });
     if (!res.ok) {
       const detail = await res.text().catch(() => "");


### PR DESCRIPTION
Pairs with the hub fix. #96's reconcile had the agent compute `connectionKey`s (grants.ts) and POST them; the hub matched against its *own* `connectionKey` (grants-store.ts). The two diverge (service `env:github` vs `service:github`; tagged vault; mixed-case mcp), so a still-wanted grant was wrongly pruned on every reconcile — caught live 2026-06-18.

## Fix
The agent now sends the live connection **specs** (`def.wants`) to `POST /admin/grants/reconcile { agent, liveConnections }`; the hub re-derives keys with its own `connectionKey`. No key computation on the agent side, no cross-repo dependency. Tests updated to assert specs on the wire.

`bun test`: **947 pass, 0 fail**. typecheck clean (only pre-existing `bridge.ts`, agent#97). No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)