### PR TITLE
feat(channel-backend): core slice — queue + routing fork + MCP pull surface (phases 1-2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,6 +242,7 @@ Bearer `vault:<name>:write`).
 | `PARACHUTE_AGENT_PORT` | `1941` | Daemon HTTP port — back-compat override for a daemon run *outside* the supervisor. Used only when `PORT` is unset. |
 | `PARACHUTE_AGENT_URL` | `http://127.0.0.1:1941` | Bridge → daemon URL |
 | `PARACHUTE_AGENT_STATE_DIR` | `~/.parachute/agent` | Token, access config, inbox |
+| `PARACHUTE_AGENT_SWEEP_MS` | `30000` | **Daemon:** cadence of the channel-backend claim-sweep tick (auto-releases `in-flight` inbound claims older than the 15-min TTL back to `pending`, so a crashed/abandoned session can't strand a channel queue). |
 | `PARACHUTE_HUB_ORIGIN` | `http://127.0.0.1:1939` | **Daemon:** hub's public origin for JWT `iss` validation. Required on an exposed deployment (the loopback default is dev-only); hub-as-supervisor sets it. |
 | `PARACHUTE_AGENT_TOKEN` | (none) | **Bridge:** hub-issued agent JWT presented as Bearer. The launcher mints + injects it; unset = no auth header (dev only). Default mint TTL is the hub's non-ephemeral default (~90d); re-launch re-mints. |
 

--- a/src/agent-defs.test.ts
+++ b/src/agent-defs.test.ts
@@ -210,10 +210,23 @@ describe("parseAgentDef", () => {
     ).toThrow(/network/);
   });
 
-  test("rejects backend:interactive for 4a (not yet wired for vault defs)", () => {
+  test("rejects backend:interactive (retired — design 2026-06-18)", () => {
     expect(() =>
       parseAgentDef({ id: "n", content: "x", metadata: { name: "a", backend: "interactive" } }, { vault: "v" }),
     ).toThrow(/interactive/);
+  });
+
+  test("accepts backend:channel (design 2026-06-18-channel-backend), threads it onto the spec", () => {
+    const def = parseAgentDef(
+      { id: "Agents/laptop", content: "You are the laptop agent.", metadata: { name: "laptop", backend: "channel" } },
+      { vault: "default" },
+    );
+    expect(def.spec.backend).toBe("channel");
+    expect(def.name).toBe("laptop");
+    // The body is still the system prompt (the session adopts it on next-message).
+    expect(def.spec.systemPrompt).toBe("You are the laptop agent.");
+    // Wake channel = the agent name (agent ≡ channel) — same collapse as programmatic.
+    expect(def.spec.channels).toEqual(["laptop"]);
   });
 
   test("rejects a relative workspace path", () => {

--- a/src/agent-defs.ts
+++ b/src/agent-defs.ts
@@ -204,25 +204,26 @@ export function parseAgentDef(note: {
     );
   }
 
-  // Backend — default programmatic (the reliable primary path; interactive is the
-  // gated opt-in, selectable but not the default for a vault def). 4a: the
-  // vault-native instantiate path is programmatic-only — `interactive` is NOT yet
-  // wired for vault defs (it forces a tmux spawn the def path doesn't drive). So we
-  // REJECT it here with a clear message (→ status:error on the note) rather than
-  // silently demoting to programmatic. Supporting interactive for vault defs is a
-  // later increment.
+  // Backend — default programmatic (the reliable primary path). A vault-native def
+  // may select EITHER `programmatic` (the daemon runs `claude -p` turns) OR `channel`
+  // (the design 2026-06-18-channel-backend path — the turn is handled by a Claude Code
+  // session the operator connects to the channel's MCP endpoint; the daemon runs no
+  // turn, the inbound notes accumulate as a durable queue). `interactive` (the retired
+  // tmux path) is REJECTED with a clear message (→ status:error on the note) rather
+  // than silently demoting — `channel` is what it was reaching for, done right.
   let backend: AgentBackendKind = "programmatic";
   const rawBackend = metaStr(meta.backend);
   if (rawBackend !== undefined) {
     if (rawBackend === "interactive") {
       throw new AgentDefParseError(
-        `#agent/definition note ${noteId}: the "interactive" backend is not yet supported for ` +
-          `vault-native defs — use "programmatic" (the default).`,
+        `#agent/definition note ${noteId}: the "interactive" backend is retired — use ` +
+          `"programmatic" (daemon-run turns, the default) or "channel" (handled by a Claude ` +
+          `Code session you connect to the channel).`,
       );
     }
-    if (rawBackend !== "programmatic") {
+    if (rawBackend !== "programmatic" && rawBackend !== "channel") {
       throw new AgentDefParseError(
-        `#agent/definition note ${noteId}: backend must be "programmatic"`,
+        `#agent/definition note ${noteId}: backend must be "programmatic" or "channel"`,
       );
     }
     backend = rawBackend;

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -372,7 +372,15 @@ export function buildSpecFromBody(body: unknown): AgentSpec {
   // file on disk, so existing interactive agents are never silently migrated.
   if (b.backend !== undefined && b.backend !== null) {
     if (b.backend !== "interactive" && b.backend !== "programmatic") {
-      throw new SpawnRequestError('body.backend must be "interactive" or "programmatic"');
+      // `channel` is a valid backend kind but is VAULT-NATIVE only — define a
+      // channel agent as a #agent/definition note, not via this web spawn POST
+      // (the create-agent UX for channel is phase 5). Spell that out so a
+      // `backend:"channel"` POST gets a useful error, not a misleading one.
+      throw new SpawnRequestError(
+        b.backend === "channel"
+          ? 'channel-backend agents are vault-native — define them as an #agent/definition note, not via this endpoint'
+          : 'body.backend must be "programmatic" or "interactive"',
+      );
     }
     spec.backend = b.backend;
   } else {

--- a/src/backends/channel-queue.test.ts
+++ b/src/backends/channel-queue.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Tests for the CHANNEL-backend queue registry (`src/backends/channel-queue.ts`) —
+ * the parallel-to-ProgrammaticAgentRegistry registry a `backend:channel` agent's
+ * connected Claude Code session pulls from (design 2026-06-18-channel-backend.md).
+ *
+ * A FAKE store (implements {@link ChannelQueueStore}) stands in for the channel's
+ * VaultTransport: it holds inbound notes in memory with a mutable `status`/`claimedAt`
+ * (the vault IS the queue + source of truth), and records outbound replies. So the
+ * claim/reply/release/sweep semantics + the restart-safety (re-read from the store)
+ * are asserted with no real vault.
+ */
+
+import { describe, test, expect } from "bun:test";
+import {
+  ChannelQueueRegistry,
+  type ChannelQueueStore,
+} from "./channel-queue.ts";
+import type { AgentSpec } from "../sandbox/types.ts";
+import type { InboundQueueNote, InboundStatus } from "../transports/vault.ts";
+
+/**
+ * A fake durable inbound-note store. Notes live in a Map (id → note); `reply` records
+ * outbound writes. Mirrors the VaultTransport methods the registry calls. The status
+ * mutations persist in the Map, so re-reading models the vault's restart-safety.
+ */
+class FakeStore implements ChannelQueueStore {
+  readonly notes = new Map<string, InboundQueueNote>();
+  readonly outbound: Array<{ text: string; inReplyTo?: string }> = [];
+  /** If set, the NEXT `setInboundStatus` throws this (to test claim-fail safety). */
+  throwOnNextSetStatus: Error | null = null;
+  /** If set, `reply` throws this (to test reply-before-handled ordering). */
+  throwOnReply: Error | null = null;
+
+  add(note: InboundQueueNote): void {
+    this.notes.set(note.id, note);
+  }
+
+  async listInboundQueue(): Promise<InboundQueueNote[]> {
+    // Ascending by ts (the real transport sorts this way), returning COPIES so the
+    // registry can't mutate the store except through setInboundStatus (models the
+    // vault round-trip — the registry reads values, then PATCHes).
+    return [...this.notes.values()]
+      .map((n) => ({ ...n }))
+      .sort((a, b) => (a.ts < b.ts ? -1 : a.ts > b.ts ? 1 : 0));
+  }
+
+  async setInboundStatus(id: string, status: InboundStatus, claimedAt?: string | null): Promise<void> {
+    if (this.throwOnNextSetStatus) {
+      const e = this.throwOnNextSetStatus;
+      this.throwOnNextSetStatus = null;
+      throw e;
+    }
+    const note = this.notes.get(id);
+    if (!note) throw new Error(`fake store: no note ${id}`);
+    note.status = status;
+    if (claimedAt === null) delete note.claimedAt;
+    else if (claimedAt !== undefined) note.claimedAt = claimedAt;
+  }
+
+  async reply(args: { text: string; inReplyTo?: string }): Promise<{ sent: string[] }> {
+    if (this.throwOnReply) throw this.throwOnReply;
+    this.outbound.push({ text: args.text, ...(args.inReplyTo ? { inReplyTo: args.inReplyTo } : {}) });
+    return { sent: [`outbound-${this.outbound.length}`] };
+  }
+}
+
+const specFor = (name: string, systemPrompt?: string): AgentSpec => ({
+  name,
+  channels: [name],
+  backend: "channel",
+  ...(systemPrompt ? { systemPrompt } : {}),
+});
+
+const inbound = (id: string, text: string, ts: string, status: InboundStatus = "pending"): InboundQueueNote => ({
+  id,
+  text,
+  sender: "operator",
+  ts,
+  status,
+});
+
+describe("ChannelQueueRegistry — registration", () => {
+  test("register indexes by channel + name; deregister drops it", () => {
+    const reg = new ChannelQueueRegistry();
+    const store = new FakeStore();
+    expect(reg.hasChannel("laptop")).toBe(false);
+    reg.register(specFor("laptop"), store);
+    expect(reg.hasChannel("laptop")).toBe(true);
+    expect(reg.hasName("laptop")).toBe(true);
+    expect(reg.channels()).toEqual(["laptop"]);
+    expect(reg.deregister("laptop")).toBe(true);
+    expect(reg.hasChannel("laptop")).toBe(false);
+    expect(reg.deregister("laptop")).toBe(false); // already gone.
+  });
+
+  test("register throws for a spec with no channel", () => {
+    const reg = new ChannelQueueRegistry();
+    expect(() => reg.register({ name: "x", channels: [], backend: "channel" }, new FakeStore())).toThrow(/no channel/);
+  });
+});
+
+describe("ChannelQueueRegistry — pending peek", () => {
+  test("counts only pending; previews the oldest-first", async () => {
+    const reg = new ChannelQueueRegistry();
+    const store = new FakeStore();
+    store.add(inbound("a", "first message", "2026-06-18T10:00:00Z"));
+    store.add(inbound("b", "second message", "2026-06-18T10:01:00Z"));
+    store.add(inbound("c", "already handled", "2026-06-18T09:00:00Z", "handled"));
+    reg.register(specFor("laptop"), store);
+
+    const view = await reg.pending("laptop");
+    expect(view.count).toBe(2); // c is handled, excluded.
+    expect(view.items.map((i) => i.id)).toEqual(["a", "b"]); // oldest-first.
+    expect(view.items[0]!.preview).toBe("first message");
+  });
+
+  test("a non-channel channel yields an empty no-op view", async () => {
+    const reg = new ChannelQueueRegistry();
+    const view = await reg.pending("unknown");
+    expect(view).toEqual({ count: 0, items: [] });
+  });
+});
+
+describe("ChannelQueueRegistry — claimNext (single-claim)", () => {
+  test("claims the OLDEST pending, sets in-flight + claimedAt, returns text + systemPrompt", async () => {
+    const reg = new ChannelQueueRegistry();
+    const store = new FakeStore();
+    store.add(inbound("b", "newer", "2026-06-18T10:05:00Z"));
+    store.add(inbound("a", "older", "2026-06-18T10:00:00Z"));
+    reg.register(specFor("laptop", "You are the laptop agent."), store);
+
+    const claimed = await reg.claimNext("laptop", () => new Date("2026-06-18T11:00:00Z"));
+    expect(claimed).not.toBeNull();
+    expect(claimed!.id).toBe("a"); // oldest.
+    expect(claimed!.text).toBe("older");
+    expect(claimed!.inReplyTo).toBe("a");
+    expect(claimed!.systemPrompt).toBe("You are the laptop agent."); // the def body → persona.
+    // The store note flipped to in-flight + got a claimedAt (the durable claim).
+    expect(store.notes.get("a")!.status).toBe("in-flight");
+    expect(store.notes.get("a")!.claimedAt).toBe("2026-06-18T11:00:00.000Z");
+  });
+
+  test("a SECOND claimNext does not return the same message (single-claim)", async () => {
+    const reg = new ChannelQueueRegistry();
+    const store = new FakeStore();
+    store.add(inbound("a", "older", "2026-06-18T10:00:00Z"));
+    store.add(inbound("b", "newer", "2026-06-18T10:05:00Z"));
+    reg.register(specFor("laptop"), store);
+
+    const first = await reg.claimNext("laptop");
+    const second = await reg.claimNext("laptop");
+    expect(first!.id).toBe("a");
+    expect(second!.id).toBe("b"); // a is now in-flight → not re-presented; b is next.
+    const third = await reg.claimNext("laptop");
+    expect(third).toBeNull(); // nothing pending left.
+  });
+
+  test("returns null when none pending", async () => {
+    const reg = new ChannelQueueRegistry();
+    const store = new FakeStore();
+    store.add(inbound("a", "done", "2026-06-18T10:00:00Z", "handled"));
+    reg.register(specFor("laptop"), store);
+    expect(await reg.claimNext("laptop")).toBeNull();
+  });
+
+  test("a claim PATCH failure surfaces + leaves the note pending (no hand-out)", async () => {
+    const reg = new ChannelQueueRegistry();
+    const store = new FakeStore();
+    store.add(inbound("a", "older", "2026-06-18T10:00:00Z"));
+    reg.register(specFor("laptop"), store);
+    store.throwOnNextSetStatus = new Error("vault 500");
+    await expect(reg.claimNext("laptop")).rejects.toThrow(/vault 500/);
+    expect(store.notes.get("a")!.status).toBe("pending"); // not lost — retryable.
+  });
+});
+
+describe("ChannelQueueRegistry — reply (outbound + mark handled)", () => {
+  test("writes the outbound via the store reply, THEN marks the inbound handled", async () => {
+    const reg = new ChannelQueueRegistry();
+    const store = new FakeStore();
+    store.add(inbound("a", "question", "2026-06-18T10:00:00Z", "in-flight"));
+    store.notes.get("a")!.claimedAt = "2026-06-18T10:01:00Z";
+    reg.register(specFor("laptop"), store);
+
+    const sent = await reg.reply("laptop", { inReplyTo: "a", text: "the answer" });
+    expect(sent.sent.length).toBe(1);
+    // Outbound recorded through the SAME reply seam (threads inReplyTo).
+    expect(store.outbound).toEqual([{ text: "the answer", inReplyTo: "a" }]);
+    // Inbound marked handled + claimedAt cleared.
+    expect(store.notes.get("a")!.status).toBe("handled");
+    expect(store.notes.get("a")!.claimedAt).toBeUndefined();
+  });
+
+  test("if the outbound write fails, the inbound is NOT marked handled (retryable)", async () => {
+    const reg = new ChannelQueueRegistry();
+    const store = new FakeStore();
+    store.add(inbound("a", "question", "2026-06-18T10:00:00Z", "in-flight"));
+    reg.register(specFor("laptop"), store);
+    store.throwOnReply = new Error("vault write 500");
+
+    await expect(reg.reply("laptop", { inReplyTo: "a", text: "x" })).rejects.toThrow(/vault write 500/);
+    expect(store.notes.get("a")!.status).toBe("in-flight"); // still claimed, not handled.
+    expect(store.outbound.length).toBe(0);
+  });
+
+  test("reply for an unregistered channel throws", async () => {
+    const reg = new ChannelQueueRegistry();
+    await expect(reg.reply("nope", { text: "x" })).rejects.toThrow(/no channel-backend agent/);
+  });
+});
+
+describe("ChannelQueueRegistry — release", () => {
+  test("returns an in-flight note to pending + clears claimedAt", async () => {
+    const reg = new ChannelQueueRegistry();
+    const store = new FakeStore();
+    store.add(inbound("a", "q", "2026-06-18T10:00:00Z", "in-flight"));
+    store.notes.get("a")!.claimedAt = "2026-06-18T10:01:00Z";
+    reg.register(specFor("laptop"), store);
+
+    await reg.release("laptop", "a");
+    expect(store.notes.get("a")!.status).toBe("pending");
+    expect(store.notes.get("a")!.claimedAt).toBeUndefined();
+    // It's claimable again.
+    const claimed = await reg.claimNext("laptop");
+    expect(claimed!.id).toBe("a");
+  });
+});
+
+describe("ChannelQueueRegistry — sweepExpired (TTL auto-release)", () => {
+  test("resets a STALE in-flight note to pending; leaves a fresh one alone", async () => {
+    const ttl = 15 * 60 * 1000; // 15 min.
+    const reg = new ChannelQueueRegistry({ claimTtlMs: ttl });
+    const store = new FakeStore();
+    const now = new Date("2026-06-18T12:00:00Z");
+    // 'stale' claimed 20 min ago (> TTL) → released; 'fresh' claimed 5 min ago → kept.
+    store.add({ id: "stale", text: "s", sender: "operator", ts: "2026-06-18T11:00:00Z", status: "in-flight", claimedAt: "2026-06-18T11:40:00Z" });
+    store.add({ id: "fresh", text: "f", sender: "operator", ts: "2026-06-18T11:30:00Z", status: "in-flight", claimedAt: "2026-06-18T11:55:00Z" });
+    store.add(inbound("pend", "p", "2026-06-18T11:45:00Z")); // already pending — untouched.
+    reg.register(specFor("laptop"), store);
+
+    const released = await reg.sweepExpired(now);
+    expect(released).toBe(1);
+    expect(store.notes.get("stale")!.status).toBe("pending");
+    expect(store.notes.get("stale")!.claimedAt).toBeUndefined();
+    expect(store.notes.get("fresh")!.status).toBe("in-flight"); // still fresh.
+    expect(store.notes.get("pend")!.status).toBe("pending");
+  });
+
+  test("an in-flight note with no claimedAt is left alone (can't judge its age)", async () => {
+    const reg = new ChannelQueueRegistry({ claimTtlMs: 1000 });
+    const store = new FakeStore();
+    store.add(inbound("a", "q", "2026-06-18T10:00:00Z", "in-flight")); // no claimedAt.
+    reg.register(specFor("laptop"), store);
+    const released = await reg.sweepExpired(new Date("2026-06-18T12:00:00Z"));
+    expect(released).toBe(0);
+    expect(store.notes.get("a")!.status).toBe("in-flight");
+  });
+
+  test("one channel's store error doesn't abort the sweep of the others", async () => {
+    const reg = new ChannelQueueRegistry({ claimTtlMs: 1000 });
+    const bad = new FakeStore();
+    bad.listInboundQueue = async () => {
+      throw new Error("vault down");
+    };
+    const good = new FakeStore();
+    good.add({ id: "stale", text: "s", sender: "operator", ts: "t", status: "in-flight", claimedAt: "2026-06-18T00:00:00Z" });
+    reg.register(specFor("bad"), bad);
+    reg.register(specFor("good"), good);
+    const released = await reg.sweepExpired(new Date("2026-06-18T12:00:00Z"));
+    expect(released).toBe(1); // good swept despite bad throwing.
+    expect(good.notes.get("stale")!.status).toBe("pending");
+  });
+});
+
+describe("ChannelQueueRegistry — restart safety (vault is the source of truth)", () => {
+  test("a claim survives a 'restart' (a fresh registry reading the same store)", async () => {
+    const store = new FakeStore();
+    store.add(inbound("a", "q1", "2026-06-18T10:00:00Z"));
+    store.add(inbound("b", "q2", "2026-06-18T10:05:00Z"));
+
+    // Registry instance #1 claims 'a'.
+    const reg1 = new ChannelQueueRegistry();
+    reg1.register(specFor("laptop"), store);
+    const claimed = await reg1.claimNext("laptop");
+    expect(claimed!.id).toBe("a");
+
+    // "Daemon restart": a BRAND-NEW registry over the SAME durable store. The claim
+    // (status:in-flight on note 'a') persisted — so the new registry's first claim is
+    // 'b' (a is still in-flight, not re-presented), and a handled message would not
+    // reappear either. The vault is the source of truth, not in-memory state.
+    const reg2 = new ChannelQueueRegistry();
+    reg2.register(specFor("laptop"), store);
+    const afterRestart = await reg2.claimNext("laptop");
+    expect(afterRestart!.id).toBe("b");
+    expect(store.notes.get("a")!.status).toBe("in-flight"); // claim survived.
+
+    // Replying (post-restart) marks 'b' handled; a re-read never re-presents it.
+    await reg2.reply("laptop", { inReplyTo: "b", text: "answer" });
+    expect(store.notes.get("b")!.status).toBe("handled");
+    expect(await reg2.pending("laptop")).toEqual({ count: 0, items: [] });
+  });
+});

--- a/src/backends/channel-queue.ts
+++ b/src/backends/channel-queue.ts
@@ -1,0 +1,310 @@
+/**
+ * The CHANNEL-backend queue registry (design 2026-06-18-channel-backend.md, phase 1).
+ *
+ * The PARALLEL to {@link ProgrammaticAgentRegistry}, NOT a reuse of it. A
+ * `backend: "channel"` agent runs NO `claude -p` and has NO drain worker: the turn
+ * is handled by a Claude Code session the OPERATOR runs and connects to the channel's
+ * MCP endpoint. The inbound `#agent/message/inbound` notes themselves ARE the queue
+ * (the vault is the queue + the source of truth), and their claim `status`
+ * (`pending | in-flight | handled`) lives on the note, so a claim survives a daemon
+ * restart and a handled message is never re-presented.
+ *
+ * ── Why a separate registry (the daemon routing fork) ────────────────────────────
+ * The programmatic registry's drain worker reads `deliver()`'s `reply` synchronously
+ * and OWNS the outbound write. A channel agent has no synchronous turn and its
+ * outbound is written by the MCP `reply` tool — reusing that worker would double-write
+ * (worker + tool) or drop the reply (worker sees an empty `deliver`). So the fork is
+ * at the daemon ROUTER: inbound for a `channel` agent routes HERE and is NOT enqueued
+ * to the programmatic worker. This registry exposes only queue operations the MCP
+ * surface calls — there is no in-process `deliver`-produces-reply.
+ *
+ * ── The queue operations (called by the channel MCP surface, phase 2) ────────────
+ *   - `pending(channel)`   → count + a peek (ids/previews) of `status:pending` inbound.
+ *   - `claimNext(channel)` → oldest `pending` → set `in-flight` + `claimedAt`; returns
+ *                            { id, text, inReplyTo, systemPrompt }. Single-claim (two
+ *                            sessions don't double-handle). null when none pending.
+ *   - `reply(channel, …)`  → write the outbound note via the SAME vault-transport
+ *                            `reply()` the programmatic worker uses (durable, threads,
+ *                            shows in chat UI, tagged outbound so it can't re-trigger
+ *                            the inbound webhook), THEN set the inbound `handled`.
+ *   - `release(channel,id)`→ `in-flight` → `pending` (the session is giving up).
+ *   - `sweepExpired(now)`  → `in-flight` notes claimed > TTL ago → `pending` (so a
+ *                            crashed session can't strand the queue). Wired into the
+ *                            daemon's periodic tick.
+ *
+ * CARDINALITY: one channel : one agent (the channel IS the agent's conduit). The
+ * surface deliberately doesn't bake "channel == agent" so deep that adding an optional
+ * agent filter to `claimNext` later would be a breaking change — the operations key on
+ * the channel name only, and the per-channel record carries the agent's spec.
+ */
+
+import type { AgentSpec } from "../sandbox/types.ts";
+import type { InboundQueueNote, InboundStatus } from "../transports/vault.ts";
+
+/**
+ * The storage seam the registry operates a channel's queue through — the durable
+ * inbound-note store (the daemon wires this to the channel's VaultTransport; tests
+ * inject a fake). Mirrors the vault-transport methods 1:1 so the seam is thin.
+ */
+export interface ChannelQueueStore {
+  /** List this channel's inbound queue notes, ascending by ts (oldest first). */
+  listInboundQueue(opts?: { limit?: number }): Promise<InboundQueueNote[]>;
+  /** Set an inbound note's claim status (+ optionally claimedAt; `null` clears it). */
+  setInboundStatus(id: string, status: InboundStatus, claimedAt?: string | null): Promise<void>;
+  /** Write an outbound reply (the SAME `#agent/message/outbound` path the worker uses). */
+  reply(args: { text: string; inReplyTo?: string }): Promise<{ sent: string[] }>;
+}
+
+/** The default in-flight claim TTL (design: 15 min comfortably covers an operator turn). */
+export const DEFAULT_CLAIM_TTL_MS = 15 * 60 * 1000;
+
+/** A peek at the pending queue — count + a bounded preview of the waiting items. */
+export interface PendingView {
+  /** How many inbound messages are `pending` (unclaimed) on this channel. */
+  count: number;
+  /** A bounded preview (oldest-first) for "you have N messages waiting" affordances. */
+  items: Array<{ id: string; preview: string }>;
+}
+
+/** The claimed message `claimNext` returns — everything a session needs to be the agent. */
+export interface ClaimedMessage {
+  /** The inbound note id — pass it back as `inReplyTo` on `reply`. */
+  id: string;
+  /** The message text to work on. */
+  text: string;
+  /** The note id this turn threads to (== `id`, surfaced explicitly for the reply call). */
+  inReplyTo: string;
+  /**
+   * The agent's system prompt (the `#agent/definition` body) — the session adopts the
+   * persona by treating this as its instructions for the reply. Adopting it is the
+   * SESSION's responsibility (MCP can't force a system prompt on the caller); the MCP
+   * server INSTRUCTIONS reinforce the convention. Empty string when the def has none.
+   */
+  systemPrompt: string;
+}
+
+/** One registered channel-backend agent: its spec + the store its queue lives in. */
+interface ChannelRecord {
+  /** The agent slug (the spec name) == the wake channel (agent ≡ channel). */
+  name: string;
+  /** The channel the queue + MCP surface key on. */
+  channel: string;
+  /** The spec — carries the systemPrompt the session adopts on `next-message`. */
+  spec: AgentSpec;
+  /** The durable inbound-note store (the channel's VaultTransport, in production). */
+  store: ChannelQueueStore;
+}
+
+/** How many pending items the `pending` peek returns at most (a nudge, not a dump). */
+const PENDING_PEEK_CAP = 20;
+/** How long a pending preview snippet is (characters). */
+const PREVIEW_LEN = 120;
+
+/**
+ * The daemon's registry of CHANNEL-backend agents + their durable queues. Keyed by
+ * CHANNEL (the inbound-routing index + the MCP-surface lookup are both O(1)). One
+ * instance per daemon, constructed at boot; the store is injected per-agent so tests
+ * drive it with a fake store, no real vault.
+ */
+export class ChannelQueueRegistry {
+  /** channel → record. */
+  private readonly byChannel = new Map<string, ChannelRecord>();
+  /** name → channel (the lifecycle index; an agent has exactly one channel). */
+  private readonly nameToChannel = new Map<string, string>();
+  private readonly claimTtlMs: number;
+
+  constructor(opts?: { claimTtlMs?: number }) {
+    this.claimTtlMs = opts?.claimTtlMs ?? DEFAULT_CLAIM_TTL_MS;
+  }
+
+  /**
+   * Register (or replace) a channel-backend agent. Lightweight: index the record by
+   * channel + name. Idempotent-replace by name (a reload / boot re-register swaps the
+   * spec + store in place). Throws if the spec declares no channel.
+   */
+  register(spec: AgentSpec, store: ChannelQueueStore): void {
+    if (spec.channels.length === 0) {
+      throw new Error(`channel-queue registry: spec "${spec.name}" declares no channels`);
+    }
+    const channel = channelOf(spec);
+    // If the name moved channels (rare), drop the stale channel index.
+    const priorChannel = this.nameToChannel.get(spec.name);
+    if (priorChannel !== undefined && priorChannel !== channel) {
+      this.byChannel.delete(priorChannel);
+    }
+    this.byChannel.set(channel, { name: spec.name, channel, spec, store });
+    this.nameToChannel.set(spec.name, channel);
+  }
+
+  /** Deregister a channel-backend agent by NAME — drop its indexes. The durable queue
+   *  notes stay in the vault (deregistering an agent doesn't delete its history). */
+  deregister(name: string): boolean {
+    const channel = this.nameToChannel.get(name);
+    if (channel === undefined) return false;
+    this.byChannel.delete(channel);
+    this.nameToChannel.delete(name);
+    return true;
+  }
+
+  /** Is a channel-backend agent registered for this channel? (the routing-fork check) */
+  hasChannel(channel: string): boolean {
+    return this.byChannel.has(channel);
+  }
+
+  /** Is a channel-backend agent registered under this name? (the mutual-exclusion check) */
+  hasName(name: string): boolean {
+    return this.nameToChannel.has(name);
+  }
+
+  /** All registered channels (for /health + the sweep + tests). */
+  channels(): string[] {
+    return [...this.byChannel.keys()];
+  }
+
+  /**
+   * Peek the pending queue for a channel: the count of `status:pending` inbound + a
+   * bounded oldest-first preview. A no-op shape `{ count: 0, items: [] }` for an
+   * unregistered (non-channel) channel — the MCP surface gates cleanly on a non-channel
+   * channel rather than erroring.
+   */
+  async pending(channel: string): Promise<PendingView> {
+    const rec = this.byChannel.get(channel);
+    if (!rec) return { count: 0, items: [] };
+    const notes = await rec.store.listInboundQueue();
+    const pendingNotes = notes.filter((n) => n.status === "pending");
+    const items = pendingNotes
+      .slice(0, PENDING_PEEK_CAP)
+      .map((n) => ({ id: n.id, preview: preview(n.text) }));
+    return { count: pendingNotes.length, items };
+  }
+
+  /**
+   * Claim the OLDEST `pending` inbound for a channel: set it `in-flight` + stamp
+   * `claimedAt = now`, then return it (+ the agent's system prompt). The status flip to
+   * `in-flight` (the vault is the source of truth) is what makes a SEQUENTIAL second
+   * `claimNext` skip it: each call re-reads the live queue, so once the first claim's
+   * PATCH lands the note is no longer `pending`. Returns null when none pending (or for
+   * an unregistered channel).
+   *
+   * CLAIM-RACE SCOPE (honest): the claim PATCH is `force:true` (last-write-wins, no
+   * precondition), so TWO TRULY-CONCURRENT `claimNext` calls (e.g. the same channel
+   * connected from two sessions, both listing before either PATCHes) can both return the
+   * SAME note → a double-handle (two replies). The `channel` model is one-operator-
+   * session-at-a-time, so this is narrow; a double-handle is non-corrupting (a duplicate
+   * reply) and the TTL sweep can't even strand it. Hardening to a compare-and-swap claim
+   * (`if_updated_at` + re-list on 428) for the multi-session case is tracked as a
+   * follow-up (agent#101). Don't claim race-safety here that the `force:true` PATCH
+   * doesn't provide.
+   */
+  async claimNext(channel: string, now: () => Date = () => new Date()): Promise<ClaimedMessage | null> {
+    const rec = this.byChannel.get(channel);
+    if (!rec) return null;
+    const notes = await rec.store.listInboundQueue();
+    const oldest = notes.find((n) => n.status === "pending"); // listInboundQueue is ascending by ts.
+    if (!oldest) return null;
+    // Commit the claim (status → in-flight + claimedAt) BEFORE returning — the flip is
+    // the single-claim guarantee. If the PATCH throws, we don't return the note (the
+    // caller gets the error; the note stays pending for a retry).
+    await rec.store.setInboundStatus(oldest.id, "in-flight", now().toISOString());
+    return {
+      id: oldest.id,
+      text: oldest.text,
+      inReplyTo: oldest.id,
+      systemPrompt: rec.spec.systemPrompt ?? "",
+    };
+  }
+
+  /**
+   * Reply to an inbound on a channel: write the outbound `#agent/message/outbound`
+   * note via the SAME vault-transport `reply()` the programmatic worker uses (durable,
+   * threads `inReplyTo`, renders in the chat UI, tagged outbound so it can NEVER
+   * re-trigger the inbound webhook — loop-safe), THEN mark the inbound `handled` and
+   * clear its `claimedAt`. Order matters: the outbound is written FIRST so a failure to
+   * persist the reply leaves the inbound un-handled (the session can retry) rather than
+   * marking it done with no reply. Returns the outbound note id(s). Throws for an
+   * unregistered channel (the MCP surface maps it to a tool error).
+   */
+  async reply(channel: string, args: { inReplyTo?: string; text: string }): Promise<{ sent: string[] }> {
+    const rec = this.byChannel.get(channel);
+    if (!rec) throw new Error(`channel-queue registry: no channel-backend agent for "${channel}"`);
+    const sent = await rec.store.reply({
+      text: args.text,
+      ...(args.inReplyTo ? { inReplyTo: args.inReplyTo } : {}),
+    });
+    // Mark handled only AFTER the outbound is durably written. Clear claimedAt so a
+    // handled note doesn't linger with a stale claim timestamp.
+    if (args.inReplyTo) {
+      await rec.store.setInboundStatus(args.inReplyTo, "handled", null);
+    }
+    return sent;
+  }
+
+  /**
+   * Release an in-flight claim back to `pending` (the session is giving up). Clears
+   * `claimedAt`. Idempotent at the vault level (re-setting pending is harmless). Throws
+   * for an unregistered channel.
+   */
+  async release(channel: string, id: string): Promise<void> {
+    const rec = this.byChannel.get(channel);
+    if (!rec) throw new Error(`channel-queue registry: no channel-backend agent for "${channel}"`);
+    await rec.store.setInboundStatus(id, "pending", null);
+  }
+
+  /**
+   * TTL auto-release: across EVERY registered channel, reset to `pending` any
+   * `in-flight` note whose `claimedAt` is older than the claim TTL — so a crashed /
+   * abandoned session can't strand the queue. Best-effort + per-channel-isolated: one
+   * channel's store error is logged and never aborts the others. Returns the number of
+   * notes released. Wired into the daemon's periodic tick.
+   *
+   * An `in-flight` note with NO usable `claimedAt` is left alone (we can't judge its
+   * age) — defensive; in practice `claimNext` always stamps one.
+   */
+  async sweepExpired(now: Date = new Date()): Promise<number> {
+    let released = 0;
+    const cutoff = now.getTime() - this.claimTtlMs;
+    for (const rec of this.byChannel.values()) {
+      let notes: InboundQueueNote[];
+      try {
+        notes = await rec.store.listInboundQueue();
+      } catch (err) {
+        console.warn(
+          `channel-queue: sweep list for "${rec.channel}" failed (continuing): ${(err as Error).message}`,
+        );
+        continue;
+      }
+      for (const n of notes) {
+        if (n.status !== "in-flight") continue;
+        if (!n.claimedAt) continue; // can't judge age — leave it.
+        const claimedMs = new Date(n.claimedAt).getTime();
+        if (Number.isNaN(claimedMs) || claimedMs > cutoff) continue; // fresh enough.
+        try {
+          await rec.store.setInboundStatus(n.id, "pending", null);
+          released++;
+          console.log(
+            `channel-queue: auto-released stale in-flight note ${n.id} on "${rec.channel}" ` +
+              `(claimed ${n.claimedAt}, TTL ${this.claimTtlMs}ms).`,
+          );
+        } catch (err) {
+          console.warn(
+            `channel-queue: sweep release of ${n.id} on "${rec.channel}" failed (continuing): ` +
+              `${(err as Error).message}`,
+          );
+        }
+      }
+    }
+    return released;
+  }
+}
+
+/** The wake channel for a spec (its first channel) — agent ≡ channel for a channel def. */
+function channelOf(spec: AgentSpec): string {
+  const first = spec.channels[0]!;
+  return typeof first === "string" ? first : first.name;
+}
+
+/** A bounded single-line preview of a message body (for the pending peek). */
+function preview(text: string): string {
+  const oneLine = text.replace(/\s+/g, " ").trim();
+  return oneLine.length > PREVIEW_LEN ? `${oneLine.slice(0, PREVIEW_LEN - 1)}…` : oneLine;
+}

--- a/src/channel-backend-wiring.test.ts
+++ b/src/channel-backend-wiring.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Tests for the CHANNEL-backend daemon wiring (design 2026-06-18-channel-backend.md,
+ * phases 1-2) — the two load-bearing seams:
+ *
+ *   1. The DAEMON ROUTING FORK (`contextFor`): an inbound for a `backend:channel`
+ *      agent must NOT enqueue to the ProgrammaticAgentRegistry (no `claude -p`) and
+ *      lands as a durable queue note; an inbound for a programmatic agent still
+ *      enqueues as before (no regression).
+ *   2. The CHANNEL MCP SURFACE (`dispatchChannelTool`): pending / next-message /
+ *      reply / release dispatch to the ChannelQueueRegistry; the outbound from `reply`
+ *      goes through the channel transport's reply (the `#agent/message/outbound` path —
+ *      loop-safe).
+ *
+ * Fakes throughout — no real vault / hub / tmux.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { contextFor } from "./daemon.ts";
+import { ClientRegistry } from "./routing.ts";
+import { DeliveryState } from "./delivery-state.ts";
+import {
+  ProgrammaticAgentRegistry,
+  type WriteOutbound,
+} from "./backends/registry.ts";
+import {
+  ChannelQueueRegistry,
+  type ChannelQueueStore,
+} from "./backends/channel-queue.ts";
+import { dispatchChannelTool } from "./mcp-http.ts";
+import { SCOPE_READ, SCOPE_WRITE } from "./auth.ts";
+import type { AgentBackend, AgentHandle, AgentStatus, DeliverResult } from "./backends/types.ts";
+import type { AgentSpec } from "./sandbox/types.ts";
+import type { InboundQueueNote, InboundStatus } from "./transports/vault.ts";
+
+// --- fakes -----------------------------------------------------------------
+
+/** A programmatic backend whose `deliver` (the `claude -p` turn) records calls. */
+class FakeProgrammaticBackend implements AgentBackend {
+  readonly kind = "programmatic";
+  readonly delivered: string[] = [];
+  async start(spec: AgentSpec): Promise<AgentHandle> {
+    return { backend: this.kind, channel: spec.channels[0] as string, name: spec.name, spec };
+  }
+  async deliver(_handle: AgentHandle, message: string): Promise<DeliverResult> {
+    this.delivered.push(message);
+    return { ok: true, reply: `auto:${message}` };
+  }
+  async stop(): Promise<void> {}
+  async status(): Promise<AgentStatus> {
+    return { live: true };
+  }
+}
+
+function noopWriteOutbound(): WriteOutbound {
+  return async () => {};
+}
+
+/** A fake channel-queue store: in-memory notes + recorded outbound. */
+class FakeStore implements ChannelQueueStore {
+  readonly notes = new Map<string, InboundQueueNote>();
+  readonly outbound: Array<{ text: string; inReplyTo?: string }> = [];
+  add(n: InboundQueueNote): void {
+    this.notes.set(n.id, n);
+  }
+  async listInboundQueue(): Promise<InboundQueueNote[]> {
+    return [...this.notes.values()].map((n) => ({ ...n })).sort((a, b) => (a.ts < b.ts ? -1 : 1));
+  }
+  async setInboundStatus(id: string, status: InboundStatus, claimedAt?: string | null): Promise<void> {
+    const n = this.notes.get(id)!;
+    n.status = status;
+    if (claimedAt === null) delete n.claimedAt;
+    else if (claimedAt !== undefined) n.claimedAt = claimedAt;
+  }
+  async reply(args: { text: string; inReplyTo?: string }): Promise<{ sent: string[] }> {
+    this.outbound.push({ text: args.text, ...(args.inReplyTo ? { inReplyTo: args.inReplyTo } : {}) });
+    return { sent: ["out-1"] };
+  }
+}
+
+const channelSpec = (name: string, systemPrompt?: string): AgentSpec => ({
+  name,
+  channels: [name],
+  backend: "channel",
+  ...(systemPrompt ? { systemPrompt } : {}),
+});
+
+// --- 1. the daemon routing fork --------------------------------------------
+
+describe("daemon routing fork (contextFor) — channel vs programmatic", () => {
+  test("a channel-backend inbound does NOT enqueue to the programmatic worker", async () => {
+    const backend = new FakeProgrammaticBackend();
+    const programmatic = new ProgrammaticAgentRegistry({ backend, writeOutbound: noopWriteOutbound() });
+    const channelQueue = new ChannelQueueRegistry();
+    const store = new FakeStore();
+    // Register a CHANNEL agent for "laptop" (its queue store is the fake).
+    channelQueue.register(channelSpec("laptop"), store);
+
+    const registry = new ClientRegistry();
+    const ctx = contextFor(registry, "laptop", new DeliveryState(), programmatic, channelQueue);
+    // Simulate the vault trigger delivering an inbound for the channel.
+    ctx.emit({
+      channel: "laptop",
+      content: "handle this when you're around",
+      meta: { note_id: "note-1", ts: "2026-06-18T10:00:00Z" },
+      source: "vault",
+    });
+
+    // THE ASSERTION: the programmatic worker was NOT invoked (no `claude -p` turn).
+    expect(backend.delivered).toEqual([]);
+    // And the durable note is the queue item — it's pending (the trigger creates it as
+    // status:pending; emit doesn't mutate it). The note already lives in the vault; the
+    // channel registry reads it on the next pull.
+    store.add({ id: "note-1", text: "handle this when you're around", sender: "operator", ts: "2026-06-18T10:00:00Z", status: "pending" });
+    const view = await channelQueue.pending("laptop");
+    expect(view.count).toBe(1);
+  });
+
+  test("a programmatic inbound STILL enqueues to the worker (no regression)", async () => {
+    const backend = new FakeProgrammaticBackend();
+    const programmatic = new ProgrammaticAgentRegistry({ backend, writeOutbound: noopWriteOutbound() });
+    await programmatic.register({ name: "eng", channels: ["eng"], backend: "programmatic" });
+    const channelQueue = new ChannelQueueRegistry(); // no channel agent for "eng".
+
+    const registry = new ClientRegistry();
+    const ctx = contextFor(registry, "eng", new DeliveryState(), programmatic, channelQueue);
+    ctx.emit({ channel: "eng", content: "do a task", meta: { note_id: "n-eng" }, source: "vault" });
+
+    // The serial worker drains async — wait for the turn to run.
+    for (let i = 0; i < 200 && backend.delivered.length === 0; i++) {
+      await new Promise<void>((r) => setTimeout(r, 1));
+    }
+    expect(backend.delivered).toEqual(["do a task"]); // the programmatic path is untouched.
+  });
+
+  test("the channel fork is checked FIRST — a name in BOTH registries routes to channel", async () => {
+    // Defense-in-depth: even if a programmatic agent somehow shares the channel, the
+    // channel check short-circuits (the fork is explicit + first), so no `claude -p`.
+    const backend = new FakeProgrammaticBackend();
+    const programmatic = new ProgrammaticAgentRegistry({ backend, writeOutbound: noopWriteOutbound() });
+    await programmatic.register({ name: "dual", channels: ["dual"], backend: "programmatic" });
+    const channelQueue = new ChannelQueueRegistry();
+    channelQueue.register(channelSpec("dual"), new FakeStore());
+
+    const ctx = contextFor(new ClientRegistry(), "dual", new DeliveryState(), programmatic, channelQueue);
+    ctx.emit({ channel: "dual", content: "x", meta: {}, source: "vault" });
+    await new Promise<void>((r) => setTimeout(r, 10));
+    expect(backend.delivered).toEqual([]); // channel won the fork.
+  });
+});
+
+// --- 2. the channel MCP surface --------------------------------------------
+
+const RW = [SCOPE_READ, SCOPE_WRITE];
+
+function parse(result: { content: Array<{ type: "text"; text: string }> }): unknown {
+  return JSON.parse(result.content[0]!.text);
+}
+
+describe("channel MCP surface (dispatchChannelTool)", () => {
+  test("pending → { count, items }", async () => {
+    const reg = new ChannelQueueRegistry();
+    const store = new FakeStore();
+    store.add({ id: "a", text: "hi", sender: "operator", ts: "2026-06-18T10:00:00Z", status: "pending" });
+    reg.register(channelSpec("laptop"), store);
+
+    const r = await dispatchChannelTool("laptop", reg, RW, "pending", {});
+    expect(r.isError).toBeUndefined();
+    expect(parse(r)).toEqual({ count: 1, items: [{ id: "a", preview: "hi" }] });
+  });
+
+  test("next-message claims + returns id/text/inReplyTo/systemPrompt", async () => {
+    const reg = new ChannelQueueRegistry();
+    const store = new FakeStore();
+    store.add({ id: "a", text: "the question", sender: "operator", ts: "2026-06-18T10:00:00Z", status: "pending" });
+    reg.register(channelSpec("laptop", "You are laptop."), store);
+
+    const r = await dispatchChannelTool("laptop", reg, RW, "next-message", {});
+    const claimed = parse(r) as { id: string; text: string; inReplyTo: string; systemPrompt: string };
+    expect(claimed.id).toBe("a");
+    expect(claimed.text).toBe("the question");
+    expect(claimed.inReplyTo).toBe("a");
+    expect(claimed.systemPrompt).toBe("You are laptop.");
+    expect(store.notes.get("a")!.status).toBe("in-flight");
+  });
+
+  test("next-message returns a null-message sentinel when the queue is empty", async () => {
+    const reg = new ChannelQueueRegistry();
+    reg.register(channelSpec("laptop"), new FakeStore());
+    const r = await dispatchChannelTool("laptop", reg, RW, "next-message", {});
+    expect(parse(r)).toEqual({ message: null, note: "no pending messages" });
+  });
+
+  test("reply writes the outbound (loop-safe path) + marks handled", async () => {
+    const reg = new ChannelQueueRegistry();
+    const store = new FakeStore();
+    store.add({ id: "a", text: "q", sender: "operator", ts: "2026-06-18T10:00:00Z", status: "in-flight", claimedAt: "2026-06-18T10:01:00Z" });
+    reg.register(channelSpec("laptop"), store);
+
+    const r = await dispatchChannelTool("laptop", reg, RW, "reply", { inReplyTo: "a", text: "the answer" });
+    expect(r.isError).toBeUndefined();
+    // The outbound went through the channel transport's reply seam — which writes a
+    // `#agent/message/outbound` note (loop-safe; the inbound trigger never fires on it).
+    expect(store.outbound).toEqual([{ text: "the answer", inReplyTo: "a" }]);
+    expect(store.notes.get("a")!.status).toBe("handled");
+  });
+
+  test("release un-claims back to pending", async () => {
+    const reg = new ChannelQueueRegistry();
+    const store = new FakeStore();
+    store.add({ id: "a", text: "q", sender: "operator", ts: "t", status: "in-flight", claimedAt: "2026-06-18T10:00:00Z" });
+    reg.register(channelSpec("laptop"), store);
+
+    const r = await dispatchChannelTool("laptop", reg, RW, "release", { id: "a" });
+    expect(r.isError).toBeUndefined();
+    expect(store.notes.get("a")!.status).toBe("pending");
+  });
+
+  test("write tools require agent:write; a read-only token is refused", async () => {
+    const reg = new ChannelQueueRegistry();
+    reg.register(channelSpec("laptop"), new FakeStore());
+    for (const tool of ["next-message", "reply", "release"]) {
+      const r = await dispatchChannelTool("laptop", reg, [SCOPE_READ], tool, { id: "a", text: "x" });
+      expect(r.isError).toBe(true);
+      expect(r.content[0]!.text).toContain(SCOPE_WRITE);
+    }
+    // pending is read-only — works with a read token.
+    const ok = await dispatchChannelTool("laptop", reg, [SCOPE_READ], "pending", {});
+    expect(ok.isError).toBeUndefined();
+  });
+
+  test("a non-channel channel gates cleanly (tool error, not a crash)", async () => {
+    const reg = new ChannelQueueRegistry(); // nothing registered.
+    const r = await dispatchChannelTool("nope", reg, RW, "pending", {});
+    expect(r.isError).toBe(true);
+    expect(r.content[0]!.text).toContain("no channel-backend agent");
+  });
+});

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -114,6 +114,10 @@ import {
   type WriteOutbound,
   type TurnEventSink,
 } from "./backends/registry.ts";
+import {
+  ChannelQueueRegistry,
+  type ChannelQueueStore,
+} from "./backends/channel-queue.ts";
 import { AgentSessionState } from "./agent-session-state.ts";
 import { readPersistedSpec, interpretPersistedBackend, sessionWorkspace } from "./spawn-agent.ts";
 import { normalizeChannel } from "./sandbox/types.ts";
@@ -244,10 +248,27 @@ export function contextFor(
   channel: string,
   deliveryState: DeliveryState,
   programmatic?: ProgrammaticAgentRegistry,
+  channelQueue?: ChannelQueueRegistry,
 ): TransportContext {
   return {
     channel,
     emit(msg: InboundMessage): void {
+      // ── DAEMON ROUTING FORK (design 2026-06-18-channel-backend.md, the load-bearing
+      // change). Route inbound by the agent's BACKEND:
+      //
+      //   backend: channel → the ChannelQueueRegistry path. The inbound
+      //     `#agent/message/inbound` note IS the queue item (durable in the vault,
+      //     status:pending by default). There is NO `claude -p`, NO serial worker, and
+      //     NO live push — a connected Claude Code session PULLS it via the channel MCP
+      //     surface. So a channel inbound is a NO-OP here beyond its own durability:
+      //     we MUST NOT enqueue to the programmatic worker (that would run a turn the
+      //     channel model deliberately doesn't), and we don't advance the delivery
+      //     high-water-mark (there's no live subscriber to deliver to; the durable note
+      //     queue + claim status is the durability, not replay). Checked FIRST so a
+      //     channel agent NEVER falls through to the programmatic enqueue below.
+      if (channelQueue?.hasChannel(channel)) {
+        return;
+      }
       // PROGRAMMATIC ROUTING (design 2026-06-16 step 3). If a programmatic agent is
       // registered for this channel, the inbound becomes one on-demand `claude -p`
       // turn — ENQUEUE it (the per-channel serial worker drains it) and do NOT also
@@ -441,6 +462,7 @@ async function addChannelLive(
   entry: ChannelEntry,
   deliveryState: DeliveryState,
   programmatic?: ProgrammaticAgentRegistry,
+  channelQueue?: ChannelQueueRegistry,
 ): Promise<Channel> {
   const existing = channels.get(entry.name);
   if (existing) {
@@ -456,7 +478,7 @@ async function addChannelLive(
   const transport = instantiateTransport(entry);
   const channel: Channel = { name: entry.name, transport, entry };
   channels.set(entry.name, channel);
-  await transport.start(contextFor(registry, entry.name, deliveryState, programmatic));
+  await transport.start(contextFor(registry, entry.name, deliveryState, programmatic, channelQueue));
   return channel;
 }
 
@@ -523,19 +545,80 @@ export function buildInstantiateDeps(
   registry: ClientRegistry,
   deliveryState: DeliveryState,
   programmatic: ProgrammaticAgentRegistry,
+  channelQueue: ChannelQueueRegistry,
 ): InstantiateDeps {
   return {
     ensureChannel: async (name, binding) => {
-      await addChannelLive(channels, registry, defVaultChannelEntry(name, binding), deliveryState, programmatic);
+      await addChannelLive(
+        channels,
+        registry,
+        defVaultChannelEntry(name, binding),
+        deliveryState,
+        programmatic,
+        channelQueue,
+      );
     },
     setupAndRegister: async (spec) => {
+      // ── BACKEND FORK (design 2026-06-18-channel-backend.md). A `channel` agent
+      // does NOT register with the programmatic registry (no `claude -p`, no serial
+      // worker) — it registers with the ChannelQueueRegistry, whose store is the
+      // agent's live VaultTransport (the durable inbound-note queue). A `programmatic`
+      // agent takes the existing path (persist spec.json + register the serial worker).
+      if (spec.backend === "channel") {
+        const store = channelQueueStoreFor(channels, spec.channels[0]);
+        if (!store) {
+          throw new Error(
+            `cannot register channel-backend agent "${spec.name}": its wake channel is not a ` +
+              `live vault transport (the queue needs the vault as its durable store)`,
+          );
+        }
+        channelQueue.register(spec, store);
+        return;
+      }
       // Persist spec.json (so boot re-register + per-turn deliver find the workspace)
       // then register — the same two steps the web programmatic spawn runs.
       setupProgrammaticSpawn(spec);
       await programmatic.register({ ...spec, backend: "programmatic" });
     },
-    deregister: async (name) => programmatic.deregister(name),
+    // Deregister covers BOTH registries — an agent lives in exactly one, and
+    // deregister is a no-op (returns false) where it isn't registered. OR the two so
+    // a reload/delete tears the agent down regardless of its backend.
+    deregister: async (name) => {
+      const fromProgrammatic = await programmatic.deregister(name);
+      const fromChannel = channelQueue.deregister(name);
+      return fromProgrammatic || fromChannel;
+    },
     removeChannel: async (name) => removeChannelLive(channels, name),
+  };
+}
+
+/**
+ * Build a {@link ChannelQueueStore} for a channel name from its live VaultTransport —
+ * the durable inbound-note queue a CHANNEL-backend agent's connected session pulls
+ * from (design 2026-06-18). Returns null when the channel isn't a live vault transport
+ * (a channel agent's queue REQUIRES the vault as its source of truth). The store is a
+ * thin adapter over the transport's `listInboundQueue` / `setInboundStatus` / `reply`
+ * — the same `reply()` the programmatic worker uses, so the outbound is durable +
+ * loop-safe (tagged `#agent/message/outbound`, which the inbound trigger never fires on).
+ */
+export function channelQueueStoreFor(
+  channels: Map<string, Channel>,
+  channelName: string | { name: string } | undefined,
+): ChannelQueueStore | null {
+  const name = typeof channelName === "string" ? channelName : channelName?.name;
+  if (!name) return null;
+  const vt = channels.get(name)?.transport;
+  if (!(vt instanceof VaultTransport)) return null;
+  return {
+    listInboundQueue: (opts) => vt.listInboundQueue(opts),
+    setInboundStatus: (id, status, claimedAt) => vt.setInboundStatus(id, status, claimedAt),
+    reply: async (args) => {
+      return vt.reply({
+        channel: name,
+        text: args.text,
+        ...(args.inReplyTo ? { meta: { in_reply_to: args.inReplyTo } } : {}),
+      });
+    },
   };
 }
 
@@ -1542,6 +1625,15 @@ export function createFetchHandler(
     deliveryState?: DeliveryState;
     programmatic?: ProgrammaticAgentRegistry;
     /**
+     * The CHANNEL-backend queue registry (design 2026-06-18-channel-backend.md) — the
+     * durable inbound-note queue + claim tracker a connected Claude Code session pulls
+     * from via the channel MCP surface (`next-message` / `pending` / `reply` /
+     * `release`). `main` passes the boot instance (the SAME one the transports'
+     * `contextFor` routing fork checks); tests inject a fake-store-backed instance.
+     * Optional — when absent, the channel MCP tools no-op (no channel agents).
+     */
+    channelQueue?: ChannelQueueRegistry;
+    /**
      * The per-channel turn-event SSE registry (the streaming view, design build
      * item #1). The `/api/channels/<ch>/turn-events` SSE route registers subscribers
      * here; the programmatic registry's turn-event sink fans out to them. `main`
@@ -1591,6 +1683,13 @@ export function createFetchHandler(
   // and threads the turn-event sink so its turns stream to this handler's `turnEvents`.
   const programmatic: ProgrammaticAgentRegistry =
     opts?.programmatic ?? createDefaultProgrammaticRegistry(channels, buildTurnEventSink(turnEvents));
+
+  // The CHANNEL-backend queue registry (design 2026-06-18). `main` shares its boot
+  // instance (the SAME one the transports' `contextFor` routing fork checks + the
+  // channel MCP surface dispatches to). Defaulted to a fresh instance so a plain
+  // createFetchHandler still serves the channel MCP tools (it just has no channel
+  // agents registered until one is instantiated). Tests inject a fake-store-backed one.
+  const channelQueue: ChannelQueueRegistry = opts?.channelQueue ?? new ChannelQueueRegistry();
 
   // Per-channel delivery high-water-mark store (the no-silent-loss spine). The
   // daemon's `main` passes the boot-time instance; tests that don't care get a
@@ -1906,7 +2005,7 @@ export function createFetchHandler(
         return json({ error: `failed to write channels.json: ${(err as Error).message}` }, 500);
       }
       try {
-        await addChannelLive(channels, registry, entry, deliveryState, programmatic);
+        await addChannelLive(channels, registry, entry, deliveryState, programmatic, channelQueue);
       } catch (err) {
         return json(
           {
@@ -2971,7 +3070,7 @@ export function createFetchHandler(
         // Unreachable in practice (requireScope passed); fall back to read-only.
         scopes = [SCOPE_READ];
       }
-      return handleMcp(req, channel, transport, scopes);
+      return handleMcp(req, channel, transport, scopes, channelQueue);
     }
 
     // Give each transport a chance to handle a route the daemon didn't. Runs
@@ -3095,6 +3194,16 @@ function main(): void {
   // its interim progress to `turnEvents` (the chat's live view).
   const programmatic = createDefaultProgrammaticRegistry(channels, buildTurnEventSink(turnEvents));
 
+  // The CHANNEL-backend queue registry (design 2026-06-18-channel-backend.md),
+  // constructed ONCE at boot and shared by the fetch handler (the channel MCP surface),
+  // the transports' `contextFor` (the routing fork — a channel inbound is NOT enqueued
+  // to the programmatic worker), the agent-def instantiate path (a `backend:channel`
+  // def registers here, not with programmatic), and the periodic sweep below. The
+  // durable queue + claim state lives on the inbound notes in each channel's vault, so
+  // this registry holds no per-message state of its own — it's the claim/peek/reply
+  // surface over those notes.
+  const channelQueue = new ChannelQueueRegistry();
+
   // The terminal WS handler set (pty↔socket relay + backpressure flow control,
   // src/terminal.ts). One handler object serves every terminal connection;
   // per-connection state lives on `ws.data`. The fetch handler routes accepted
@@ -3142,10 +3251,10 @@ function main(): void {
   // resolve below (resolveDefVaults → addVault → loadAll) fills it. ADDITIVE to
   // channels.json — both paths coexist.
   const agentDefs = new AgentDefRegistry(
-    buildInstantiateDeps(channels, registry, deliveryState, programmatic),
+    buildInstantiateDeps(channels, registry, deliveryState, programmatic, channelQueue),
   );
 
-  const fetchHandler = createFetchHandler(channels, registry, { deliveryState, programmatic, turnEvents, jobStore, runner, agentDefs });
+  const fetchHandler = createFetchHandler(channels, registry, { deliveryState, programmatic, channelQueue, turnEvents, jobStore, runner, agentDefs });
   const server = Bun.serve<TerminalWsData, never>({
     port: PORT,
     hostname: "127.0.0.1",
@@ -3230,7 +3339,7 @@ function main(): void {
   // still serve the channels that did come up. Pass the programmatic registry so a
   // channel with a registered programmatic agent routes inbound to its serial queue.
   for (const channel of [...channels.values()]) {
-    addChannelLive(channels, registry, channel.entry, deliveryState, programmatic).catch((err) => {
+    addChannelLive(channels, registry, channel.entry, deliveryState, programmatic, channelQueue).catch((err) => {
       console.error(`parachute-agent: transport "${channel.name}" start failed:`, err);
     });
   }
@@ -3253,6 +3362,20 @@ function main(): void {
   // is `unref`'d so it never keeps the process alive on its own.
   runner.start();
   console.log(`parachute-agent: runner started (scheduled-job tick)`);
+
+  // CHANNEL-BACKEND CLAIM TTL SWEEP (design 2026-06-18-channel-backend.md). A periodic
+  // tick scans every channel-backend agent's in-flight inbound notes and resets any
+  // claimed longer than the claim TTL (15 min) back to `pending` — so a crashed /
+  // abandoned connected session can't strand the queue. Cheap + idempotent (a
+  // channel with no channel agents lists nothing). `unref` so it never holds the
+  // process open; runs at the same 30s cadence as the runner tick.
+  const sweepIntervalMs = parseInt(process.env.PARACHUTE_AGENT_SWEEP_MS ?? "", 10) || 30_000;
+  const channelSweep = setInterval(() => {
+    void channelQueue.sweepExpired().catch((err) => {
+      console.error(`parachute-agent: channel-queue sweep failed (continuing): ${(err as Error).message}`);
+    });
+  }, sweepIntervalMs);
+  channelSweep.unref?.();
 
   // VAULT-NATIVE AGENT DEFINITIONS (design 2026-06-17-vault-native-agents, Phase 4a).
   // Resolve the def-vault bindings (agent-vaults.json, or the minted single-`default`
@@ -3305,6 +3428,7 @@ function main(): void {
   // Graceful shutdown — stop the runner + all transports.
   async function shutdown(): Promise<void> {
     runner.stop();
+    clearInterval(channelSweep);
     if (agentDefPoll) clearInterval(agentDefPoll);
     await Promise.allSettled([...channels.values()].map((c) => c.transport.stop()));
     server.stop();

--- a/src/mcp-http.ts
+++ b/src/mcp-http.ts
@@ -47,6 +47,7 @@ import type {
   DownloadArgs,
 } from "./transport.ts";
 import { SCOPE_WRITE, grantsScope } from "./auth.ts";
+import type { ChannelQueueRegistry } from "./backends/channel-queue.ts";
 
 // ---------------------------------------------------------------------------
 // Per-channel session registry
@@ -412,6 +413,157 @@ const TOOL_DEFS = [
 // MCP path is the principled read. If they ever need to match, relax the bridge, not this.)
 const WRITE_TOOLS = new Set(["reply", "react", "edit_message"]);
 
+// ---------------------------------------------------------------------------
+// CHANNEL-BACKEND tool surface — the MCP pull/reply protocol (design
+// 2026-06-18-channel-backend.md, phase 2). When the channel has a `backend:channel`
+// agent registered, the session connects + PULLs the durable queue instead of being
+// pushed to: `pending` / `next-message` / `reply` / `release`, dispatched to the
+// {@link ChannelQueueRegistry}. The session "is" the agent by adopting the
+// systemPrompt `next-message` returns (the def body) — reinforced by INSTRUCTIONS
+// below, since MCP can't force a system prompt on the caller.
+// ---------------------------------------------------------------------------
+
+const CHANNEL_INSTRUCTIONS = [
+  "You are connected to a Parachute CHANNEL — a durable queue of messages a human sent to an agent you are handling. Nothing is pushed to you; you PULL.",
+  "",
+  "THE LOOP, every time you're ready to handle a message:",
+  "  1. `pending` — see how many messages are waiting (count + a preview of each).",
+  "  2. `next-message` — claim the oldest waiting message. It returns { id, text, inReplyTo, systemPrompt }.",
+  "  3. TREAT THE RETURNED `systemPrompt` AS YOUR INSTRUCTIONS FOR THIS REPLY — it is the agent's persona/role. Adopt it: answer as that agent would.",
+  "  4. Do the work in this session (your full tools, your env).",
+  "  5. `reply` { inReplyTo: <the claimed id>, text: <your answer> } — this writes the reply back to the human and marks the message handled.",
+  "",
+  "If you claim a message with `next-message` but can't handle it, call `release` { id } to return it to the queue for another session (or your next pass). Claimed messages auto-release after a while if you go away, so the queue never gets stranded.",
+  "",
+  "The human reads ONLY what you send via `reply`. Your transcript text is invisible to them — always finish a handled message with a `reply`.",
+].join("\n");
+
+/** The channel-backend pull/reply tool list (design 2026-06-18, phase 2). */
+const CHANNEL_TOOL_DEFS = [
+  {
+    name: "pending",
+    description:
+      "How many inbound messages are waiting on this channel + a preview of each (id + a short text snippet). Use it to decide whether to pull. Read-only — claims nothing.",
+    inputSchema: { type: "object" as const, properties: {}, required: [] as string[] },
+  },
+  {
+    name: "next-message",
+    description:
+      "Claim the OLDEST waiting message and return it: { id, text, inReplyTo, systemPrompt }. Marks it in-flight so another connected session won't also handle it. Treat the returned systemPrompt as your instructions for the reply (it is the agent's persona). Returns nothing-to-do when the queue is empty. Pass the returned id back as `reply`'s inReplyTo.",
+    inputSchema: { type: "object" as const, properties: {}, required: [] as string[] },
+  },
+  {
+    name: "reply",
+    description:
+      "Send your answer back to the human AND mark the claimed message handled. inReplyTo is the id you got from next-message (threads the reply); text is your answer. Writes a durable outbound note that shows in the chat UI.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        inReplyTo: {
+          type: "string",
+          description: "The message id you claimed via next-message (threads the reply + marks it handled).",
+        },
+        text: { type: "string", description: "Your reply text." },
+      },
+      required: ["text"] as string[],
+    },
+  },
+  {
+    name: "release",
+    description:
+      "Un-claim a message you claimed but won't handle — returns it to the waiting queue (status pending) for another session or your next pass. id is the message id from next-message.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        id: { type: "string", description: "The message id to release back to pending." },
+      },
+      required: ["id"] as string[],
+    },
+  },
+];
+
+/** Channel-backend tools that mutate the queue/write outbound require agent:write
+ *  (`pending` + `next-message`... next-message claims, so it mutates → write; pending
+ *  is read-only). reply + release + next-message mutate; pending is read. */
+const CHANNEL_WRITE_TOOLS = new Set(["next-message", "reply", "release"]);
+
+/**
+ * Dispatch one CHANNEL-backend tool call to the {@link ChannelQueueRegistry},
+ * enforcing write scope on the mutating tools. Returns a tool-error result (not a
+ * throw) when no channel-backend agent is registered for `channel` — so a session that
+ * connected to a non-channel channel and called these tools gets a clean "not a channel
+ * agent" message rather than a crash. Pure over its inputs (the daemon's per-session
+ * handler + the unit tests both call it).
+ */
+export async function dispatchChannelTool(
+  channel: string,
+  channelQueue: ChannelQueueRegistry,
+  scopes: string[],
+  name: string,
+  args: Record<string, unknown>,
+): Promise<ToolResult> {
+  // Gate cleanly for a non-channel channel — these tools are meaningful only when a
+  // backend:channel agent is registered. (The daemon also only serves CHANNEL_TOOL_DEFS
+  // when the agent is registered, so a well-behaved client never reaches here for a
+  // non-channel channel — but a hand-crafted call should fail gracefully, not 500.)
+  if (!channelQueue.hasChannel(channel)) {
+    return {
+      content: [{ type: "text", text: `channel "${channel}" has no channel-backend agent — the pull/reply tools are not available here` }],
+      isError: true,
+    };
+  }
+  if (CHANNEL_WRITE_TOOLS.has(name) && !grantsScope(scopes, SCOPE_WRITE)) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: `tool "${name}" requires the ${SCOPE_WRITE} scope, which this connection's token lacks`,
+        },
+      ],
+      isError: true,
+    };
+  }
+  try {
+    switch (name) {
+      case "pending": {
+        const view = await channelQueue.pending(channel);
+        return { content: [{ type: "text", text: JSON.stringify(view) }] };
+      }
+      case "next-message": {
+        const claimed = await channelQueue.claimNext(channel);
+        if (!claimed) {
+          return { content: [{ type: "text", text: JSON.stringify({ message: null, note: "no pending messages" }) }] };
+        }
+        return { content: [{ type: "text", text: JSON.stringify(claimed) }] };
+      }
+      case "reply": {
+        const text = typeof args.text === "string" ? args.text : "";
+        const inReplyTo = typeof args.inReplyTo === "string" ? args.inReplyTo : undefined;
+        const sent = await channelQueue.reply(channel, { text, ...(inReplyTo ? { inReplyTo } : {}) });
+        const ids = sent.sent;
+        return {
+          content: [{ type: "text", text: `replied + marked handled (outbound id: ${ids.join(", ")})` }],
+        };
+      }
+      case "release": {
+        const id = typeof args.id === "string" ? args.id : "";
+        if (!id) {
+          return { content: [{ type: "text", text: "release requires an id" }], isError: true };
+        }
+        await channelQueue.release(channel, id);
+        return { content: [{ type: "text", text: `released ${id} back to pending` }] };
+      }
+      default:
+        return { content: [{ type: "text", text: `unknown channel tool: ${name}` }], isError: true };
+    }
+  } catch (err) {
+    return {
+      content: [{ type: "text", text: `${name} failed: ${err instanceof Error ? err.message : String(err)}` }],
+      isError: true,
+    };
+  }
+}
+
 /** Fold a top-level chat_id into meta, mirroring the daemon's mergeMeta. */
 function mergeMeta(args: Record<string, unknown>): Record<string, string> {
   const meta: Record<string, string> = {};
@@ -426,7 +578,19 @@ function mergeMeta(args: Record<string, unknown>): Record<string, string> {
  * the closure reads the live value). `channel` is threaded so outbound args
  * carry the right channel context.
  */
-function buildServer(channel: string, transport: Transport, session: McpSession): Server {
+function buildServer(
+  channel: string,
+  transport: Transport,
+  session: McpSession,
+  channelQueue?: ChannelQueueRegistry,
+): Server {
+  // ── CHANNEL-BACKEND FORK (design 2026-06-18). When a `backend:channel` agent is
+  // registered for this channel, serve the PULL/REPLY surface (pending / next-message
+  // / reply / release) + its reinforcing INSTRUCTIONS, dispatched to the
+  // ChannelQueueRegistry. Otherwise serve the existing push surface (reply / react /
+  // edit / download), dispatched to the transport. Resolved at connect time — a
+  // channel doesn't switch backends under a live session.
+  const isChannelBackend = !!channelQueue?.hasChannel(channel);
   const server = new Server(
     // Per-channel name (`agent-<name>`) so it reads clearly in `/mcp` and lines
     // up with the `--dangerously-load-development-channels=server:agent-<name>`
@@ -440,22 +604,22 @@ function buildServer(channel: string, transport: Transport, session: McpSession)
         },
         tools: {},
       },
-      instructions: INSTRUCTIONS,
+      instructions: isChannelBackend ? CHANNEL_INSTRUCTIONS : INSTRUCTIONS,
     },
   );
 
-  server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOL_DEFS }));
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: isChannelBackend ? CHANNEL_TOOL_DEFS : TOOL_DEFS,
+  }));
 
   // Dispatch reads `session.scopes` live (the daemon refreshes it per request),
   // so a re-auth with a narrower token takes effect on the next tool call.
   server.setRequestHandler(CallToolRequestSchema, async (req) => {
-    const result = await dispatchTool(
-      channel,
-      transport,
-      session.scopes,
-      req.params.name,
-      (req.params.arguments ?? {}) as Record<string, unknown>,
-    );
+    const args = (req.params.arguments ?? {}) as Record<string, unknown>;
+    const result =
+      isChannelBackend && channelQueue
+        ? await dispatchChannelTool(channel, channelQueue, session.scopes, req.params.name, args)
+        : await dispatchTool(channel, transport, session.scopes, req.params.name, args);
     // Our ToolResult is the content/isError subset of the SDK's CallToolResult
     // (which also has a task-variant we never emit); return it as that shape.
     return result as { content: Array<{ type: "text"; text: string }>; isError?: boolean };
@@ -602,6 +766,7 @@ export async function handleMcp(
   channel: string,
   transport: Transport,
   scopes: string[],
+  channelQueue?: ChannelQueueRegistry,
 ): Promise<Response> {
   const sid = req.headers.get("mcp-session-id");
 
@@ -651,7 +816,7 @@ export async function handleMcp(
     },
   });
 
-  const server = buildServer(channel, transport, session);
+  const server = buildServer(channel, transport, session, channelQueue);
   session.server = server;
   session.transport = httpTransport;
 

--- a/src/sandbox/types.ts
+++ b/src/sandbox/types.ts
@@ -99,7 +99,8 @@ export interface AgentChannelSpec {
 export type AgentChannel = string | AgentChannelSpec;
 
 /**
- * Which backend drives the agent (design 2026-06-16-pluggable-agent-backend.md):
+ * Which backend drives the agent (design 2026-06-16-pluggable-agent-backend.md +
+ * 2026-06-18-channel-backend.md):
  *
  *  - `"programmatic"` (the DEFAULT for a NEW spawn request, per Aaron's gating
  *    decision 2026-06-16): NO resident process. An inbound message becomes one
@@ -107,11 +108,22 @@ export type AgentChannel = string | AgentChannelSpec;
  *    posted back as an outbound `#agent/message/outbound` note. No idle session →
  *    nothing to go deaf, no reconnect, no replay, no consent gate. The reliable
  *    primary path; best for clean per-message "do a task, report back" turns.
- *  - `"interactive"` (the original tmux path; now the opt-in/"advanced" backend): an
- *    idle interactive `claude` in a tmux pane, fed inbound by pushing onto a
- *    subscribed MCP development channel. Carries the deaf-on-restart machinery
- *    (#67/#68/#70/#71) — currently less stable, kept for "watch / drive a live
- *    session" (operator attaches the terminal) and to hedge the billing uncertainty.
+ *  - `"channel"` (design 2026-06-18-channel-backend.md): the turn is delivered over
+ *    a channel to a Claude Code session the OPERATOR runs themselves (their machine,
+ *    their env/creds, unsandboxed) and has connected to the channel's MCP endpoint.
+ *    The daemon runs NO `claude -p`; the inbound `#agent/message/inbound` notes
+ *    accumulate as a durable queue (the vault IS the queue). The connected session
+ *    PULLs the next message (an MCP tool), works, and REPLYs (an MCP tool) — the
+ *    daemon writes the outbound note + marks the inbound handled. Routed to the
+ *    {@link ChannelQueueRegistry}, entirely bypassing the programmatic serial worker
+ *    (the daemon routing fork). Claim state lives on the inbound note's `status`
+ *    (`pending | in-flight | handled`), so it's restart-safe.
+ *  - `"interactive"` (the original tmux path; now RETIRED — design 2026-06-18
+ *    "Retiring interactive"): an idle interactive `claude` in a tmux pane, fed
+ *    inbound by pushing onto a subscribed MCP development channel. Carries the
+ *    deaf-on-restart machinery (#67/#68/#70/#71). Kept in the type for back-compat
+ *    of already-persisted specs; NOT selectable for a vault-native def (parseAgentDef
+ *    rejects it). `channel` supersedes the human-driven-CC need it hedged.
  *
  * DEFAULT-RESOLUTION NOTE — the omitted-field default differs by context, on
  * purpose: a NEW request that omits `backend` resolves to `"programmatic"`
@@ -120,7 +132,7 @@ export type AgentChannel = string | AgentChannelSpec;
  * ({@link interpretPersistedBackend} in `spawn-agent.ts`) — so the flip applies going
  * forward without silently migrating already-running interactive agents.
  */
-export type AgentBackendKind = "interactive" | "programmatic";
+export type AgentBackendKind = "interactive" | "programmatic" | "channel";
 
 /**
  * How a channel's {@link AgentSpec.systemPrompt} composes with Claude Code's own

--- a/src/transports/vault.ts
+++ b/src/transports/vault.ts
@@ -172,6 +172,43 @@ export interface ChannelMessage {
   inReplyTo?: string;
 }
 
+/**
+ * The claim status carried on an `#agent/message/inbound` note for a CHANNEL-backend
+ * agent (design 2026-06-18-channel-backend.md "Claim/ack durability"). The vault is
+ * the source of truth — the status lives on the note so a claim survives a daemon
+ * restart and a handled message is never re-presented.
+ *
+ *  - `pending`   — unhandled; waiting for a connected session to claim it.
+ *  - `in-flight` — claimed by a session (`next-message`); `claimedAt` stamps when.
+ *                  Auto-released back to `pending` after a TTL (the daemon sweep) so a
+ *                  crashed session can't strand the queue.
+ *  - `handled`   — replied to; the outbound note is written. Never re-presented.
+ *
+ * NOTE: programmatic-backend inbound notes do NOT use this field — their turn runs
+ * synchronously in the serial worker; status is meaningful only on the channel path.
+ */
+export type InboundStatus = "pending" | "in-flight" | "handled";
+
+/**
+ * One inbound queue item for a CHANNEL-backend agent — an `#agent/message/inbound`
+ * note as the {@link ChannelQueueRegistry} reads it. Carries the claim `status` +
+ * `claimedAt` (for the TTL sweep) alongside the message text + threading id.
+ */
+export interface InboundQueueNote {
+  /** The vault note id — addresses the note for the status PATCH + threads the reply. */
+  id: string;
+  /** The message text the connected session works on. */
+  text: string;
+  /** Who authored it (metadata.sender). */
+  sender: string;
+  /** ISO timestamp (metadata.ts) — the queue is ordered ascending by this (oldest first). */
+  ts: string;
+  /** The claim status (`pending` when the field is absent — a fresh inbound). */
+  status: InboundStatus;
+  /** ISO timestamp the note was claimed (set with `in-flight`); used by the TTL sweep. */
+  claimedAt?: string;
+}
+
 const DEFAULT_VAULT_URL = "http://127.0.0.1:1940";
 const DEFAULT_PATH_PREFIX = "channel";
 /** Parent tag (NEW, namespaced) — carried LITERALLY on every note WE write; query
@@ -182,6 +219,23 @@ const AGENT_MESSAGE_TAG = "#agent/message";
 const AGENT_MESSAGE_INBOUND_TAG = "#agent/message/inbound";
 /** Outbound child (NEW) — replies carry this; the trigger's exact-match predicate excludes it. */
 const AGENT_MESSAGE_OUTBOUND_TAG = "#agent/message/outbound";
+
+/** Metadata key carrying the channel-queue claim status (design 2026-06-18). */
+const STATUS_META_KEY = "status";
+/** Metadata key carrying the ISO timestamp an inbound was claimed (for the TTL sweep). */
+const CLAIMED_AT_META_KEY = "claimedAt";
+
+/**
+ * Coerce a raw `status` metadata value to an {@link InboundStatus}. The vault stores
+ * metadata as strings; an absent / empty / unrecognized value reads as `pending` (the
+ * safe default — a fresh inbound the trigger just created carries no status, and an
+ * unknown value shouldn't strand the note). Only the two non-default states need an
+ * explicit value.
+ */
+function coerceInboundStatus(v: unknown): InboundStatus {
+  if (v === "in-flight" || v === "handled") return v;
+  return "pending";
+}
 
 // ---------------------------------------------------------------------------
 // PRIOR tags (pre-namespace) — DUAL-READ only. We never WRITE these going forward,
@@ -790,6 +844,108 @@ export class VaultTransport implements Transport {
    */
   async injectInbound(opts: { content: string; sender?: string }): Promise<{ id: string }> {
     return this.writeInbound(opts.content, opts.sender ?? "runner");
+  }
+
+  // -------------------------------------------------------------------------
+  // Channel-queue inbound notes — the durable queue a CHANNEL-backend agent's
+  // connected session pulls from (design 2026-06-18-channel-backend.md). The
+  // inbound `#agent/message/inbound` notes themselves ARE the queue; the claim
+  // `status` (pending | in-flight | handled) lives on each note so the vault is
+  // the source of truth (restart-safe). These methods own the vault I/O (URL +
+  // token + encoding) so the ChannelQueueRegistry stays storage-agnostic — the
+  // same separation jobs.ts has from the job-note I/O. The channel's existing
+  // `vault:<name>:write` token covers GET + the status PATCH; no new mint.
+  // -------------------------------------------------------------------------
+
+  /**
+   * List THIS channel's INBOUND queue notes (the `#agent/message/inbound` notes),
+   * ascending by `ts` (oldest first), carrying the claim `status`/`claimedAt`. The
+   * query is index-free, mirroring {@link loadTranscript}: query by the inbound
+   * CHILD tag (we want inbound only — outbound replies are not queue items) and
+   * filter to this channel CLIENT-SIDE on `metadata.channel` (we don't assume a
+   * `channel` index). A note with NO `status` field reads as `pending` (a fresh
+   * inbound the trigger just created). Throws on a non-ok vault response so the
+   * caller surfaces a clear error rather than a silently-empty queue.
+   */
+  async listInboundQueue(opts?: { limit?: number }): Promise<InboundQueueNote[]> {
+    const channel = this.channel;
+    const limit = opts?.limit ?? 200;
+    // Overfetch (the tag query spans all channels) then keep this channel's items.
+    const fetchLimit = Math.min(Math.max(limit * 4, 500), 2000);
+    const params = new URLSearchParams();
+    params.set("tag", AGENT_MESSAGE_INBOUND_TAG); // → %23agent%2Fmessage%2Finbound
+    params.set("include_content", "true");
+    params.set("limit", String(fetchLimit));
+    const url = `${this.vaultUrl}/vault/${this.vault}/api/notes?${params.toString()}`;
+    const res = await fetch(url, { headers: { authorization: `Bearer ${this.token}` } });
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "");
+      throw new Error(`vault transport: list inbound queue failed (${res.status}) ${detail}`.trim());
+    }
+    type RawNote = { id?: string; content?: string; metadata?: Record<string, unknown> };
+    let notes: RawNote[];
+    try {
+      const parsed = (await res.json()) as unknown;
+      notes = Array.isArray(parsed)
+        ? (parsed as RawNote[])
+        : ((parsed as { notes?: RawNote[] })?.notes ?? []);
+    } catch (err) {
+      throw new Error(
+        `vault transport: list inbound queue — bad JSON from vault: ${(err as Error).message}`,
+      );
+    }
+    const out: InboundQueueNote[] = [];
+    for (const note of notes) {
+      if (typeof note.id !== "string" || !note.id) continue;
+      const meta = note.metadata ?? {};
+      if (meta.channel !== channel) continue; // client-side channel filter (index-free).
+      out.push({
+        id: note.id,
+        text: typeof note.content === "string" ? note.content : "",
+        sender: typeof meta.sender === "string" ? meta.sender : "",
+        ts: typeof meta.ts === "string" ? meta.ts : "",
+        status: coerceInboundStatus(meta[STATUS_META_KEY]),
+        ...(typeof meta[CLAIMED_AT_META_KEY] === "string"
+          ? { claimedAt: meta[CLAIMED_AT_META_KEY] as string }
+          : {}),
+      });
+    }
+    // Ascending by ts; blank-ts notes sort first (stable, deterministic).
+    out.sort((a, b) => (a.ts < b.ts ? -1 : a.ts > b.ts ? 1 : 0));
+    return out;
+  }
+
+  /**
+   * PATCH an inbound note's claim status (+ optionally `claimedAt`), by note id.
+   * Sends ONLY the changed metadata; the vault MERGES it, so the channel/direction/
+   * sender/ts are preserved. `force: true` satisfies the vault's 428 mutation
+   * precondition (the 4a precondition) — safe here: `status`/`claimedAt` are the
+   * module's OWN authoritative claim fields, the body carries no content. Passing
+   * `claimedAt: null` CLEARS the field (written as an empty string) — used on
+   * release/handled so a stale claim timestamp doesn't linger. Throws on a non-ok
+   * vault response (the caller decides whether to surface or swallow).
+   */
+  async setInboundStatus(
+    id: string,
+    status: InboundStatus,
+    claimedAt?: string | null,
+  ): Promise<void> {
+    const metadata: Record<string, string> = { [STATUS_META_KEY]: status };
+    if (claimedAt !== undefined) {
+      metadata[CLAIMED_AT_META_KEY] = claimedAt === null ? "" : claimedAt;
+    }
+    const url = `${this.vaultUrl}/vault/${this.vault}/api/notes/${encodeURIComponent(id)}`;
+    const res = await fetch(url, {
+      method: "PATCH",
+      headers: { "content-type": "application/json", authorization: `Bearer ${this.token}` },
+      body: JSON.stringify({ metadata, force: true }),
+    });
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "");
+      throw new Error(
+        `vault transport: set inbound status ${id} failed (${res.status}) ${detail}`.trim(),
+      );
+    }
   }
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
The core of the `channel` agent backend (design `2026-06-18-channel-backend.md`, phases 1-2). A `backend:channel` agent runs **no `claude -p`** — its inbound `#agent/message/inbound` notes are a durable queue (status on the note); a Claude Code session the operator runs connects to the channel MCP and pulls/replies.

- **Daemon routing fork** (`emit`): channel inbound routes to a new `ChannelQueueRegistry`, checked FIRST + returns before any programmatic enqueue. Programmatic path unchanged.
- **`ChannelQueueRegistry`** — `pending`/`claimNext`/`reply`/`release`/`sweepExpired`. Claim state on the inbound note (`status: pending|in-flight|handled`, restart-safe); reply writes outbound (same loop-safe path the worker uses) THEN marks handled; 15-min TTL sweep (daemon tick) auto-releases stale claims.
- **Channel MCP surface** (`mcp-http.ts`): `pending`/`next-message`/`reply`/`release` tools, write-scope-gated; `pushToChannel` (programmatic streaming) untouched.
- `parseAgentDef` accepts `backend:channel` (vault-native only; web POST stays gated to phase 5).

**Tests:** `bun test src/` **974 pass / 0 fail** (+27: 16 registry, 10 wiring, +1 parse). typecheck clean (pre-existing bridge.ts only). **Reviewed LGTM** (no blockers). **Live-verified:** a `backend:channel` def instantiates + registers as a channel agent (status `enabled`); an inbound note queues as `pending` (routing fork — no programmatic turn).

Follow-ups filed: #101 (CAS single-claim under concurrent sessions), #102 (list channel agents in /api/agents), #103 (prune handled inbound), #104 (biome.json for the repo). Next phases: connect command, retire interactive, create-agent UX. No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)