### PR TITLE
feat(agent-ui-v2): Phase 1 — the JSON API layer (agent-defs CRUD, agent-vaults, all-backends /api/agents)

### DIFF
--- a/src/agent-defs.test.ts
+++ b/src/agent-defs.test.ts
@@ -325,6 +325,71 @@ describe("DefVaultClient", () => {
     const client = new DefVaultClient(binding);
     expect(await client.getNote("gone")).toBeNull();
   });
+
+  test("createNote POSTs body + the def tag + metadata, returns the created note", async () => {
+    let captured: { url: string; method: string; body: Record<string, unknown> } | null = null;
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      captured = { url: String(url), method: init?.method ?? "GET", body: JSON.parse(String(init?.body)) };
+      return new Response(JSON.stringify({ id: "Agents/newbot", content: "P", metadata: { name: "newbot" } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+    const client = new DefVaultClient(binding);
+    const created = await client.createNote({
+      content: "P",
+      metadata: { name: "newbot", backend: "programmatic" },
+      path: "Agents/newbot",
+    });
+    expect(created.id).toBe("Agents/newbot");
+    expect(captured!.method).toBe("POST");
+    expect(captured!.url).toContain("/vault/default/api/notes");
+    expect(captured!.body.tags).toEqual(["#agent/definition"]);
+    expect(captured!.body.content).toBe("P");
+    expect((captured!.body.metadata as Record<string, string>).name).toBe("newbot");
+    expect(captured!.body.path).toBe("Agents/newbot");
+  });
+
+  test("createNote throws on a non-ok vault response", async () => {
+    globalThis.fetch = (async () => new Response("nope", { status: 500 })) as unknown as typeof fetch;
+    const client = new DefVaultClient(binding);
+    await expect(
+      client.createNote({ content: "x", metadata: { name: "x" } }),
+    ).rejects.toThrow(/create def failed \(500\)/);
+  });
+
+  test("patchNote sends content/metadata with force:true (the 428 guard)", async () => {
+    let body: Record<string, unknown> = {};
+    let method = "";
+    globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+      method = init?.method ?? "GET";
+      body = JSON.parse(String(init?.body));
+      return new Response(null, { status: 200 });
+    }) as typeof fetch;
+    const client = new DefVaultClient(binding);
+    await client.patchNote("Agents/newbot", { content: "new", metadata: { wants: "vault:r:read" } });
+    expect(method).toBe("PATCH");
+    expect(body.content).toBe("new");
+    expect((body.metadata as Record<string, string>).wants).toBe("vault:r:read");
+    expect(body.force).toBe(true); // satisfies the vault's mutation precondition.
+  });
+
+  test("deleteNote DELETEs the note; a 404 is OK (gone is gone)", async () => {
+    let method = "";
+    globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+      method = init?.method ?? "GET";
+      return new Response("no", { status: 404 });
+    }) as typeof fetch;
+    const client = new DefVaultClient(binding);
+    await client.deleteNote("Agents/gone"); // must NOT throw on 404.
+    expect(method).toBe("DELETE");
+  });
+
+  test("deleteNote throws on a non-404 error", async () => {
+    globalThis.fetch = (async () => new Response("boom", { status: 500 })) as unknown as typeof fetch;
+    const client = new DefVaultClient(binding);
+    await expect(client.deleteNote("n")).rejects.toThrow(/delete def n failed \(500\)/);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/agent-defs.test.ts
+++ b/src/agent-defs.test.ts
@@ -18,6 +18,7 @@ import {
   DefVaultClient,
   AgentDefRegistry,
   AgentDefParseError,
+  AgentDefWriteError,
   type DefVaultBinding,
   type InstantiateDeps,
 } from "./agent-defs.ts";
@@ -588,6 +589,46 @@ describe("AgentDefRegistry — lifecycle", () => {
     const n = await reg.loadAll();
     expect(n).toBe(1);
     expect(calls.registered.map((s) => s.name)).toEqual(["r"]);
+  });
+
+  test("findLiveByNote returns the single match (vault + detail)", async () => {
+    const { deps } = recorderDeps();
+    const fetchFn = vaultFetch({
+      defs: [{ id: "Agents/uni-dev", content: "role", metadata: { name: "uni-dev" } }],
+    });
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn });
+    await reg.loadAll();
+    const found = reg.findLiveByNote("Agents/uni-dev");
+    expect(found).not.toBeNull();
+    expect(found!.vault).toBe("default");
+    expect(found!.detail.name).toBe("uni-dev");
+    expect(reg.findLiveByNote("Agents/ghost")).toBeNull();
+  });
+
+  test("findLiveByNote throws 409 when the SAME noteId is live in two def-vaults (#106 ambiguity)", async () => {
+    const { deps } = recorderDeps();
+    const b2: DefVaultBinding = { vault: "research", vaultUrl: "http://127.0.0.1:1940", token: "t2" };
+    // The vaultFetch helper serves the same def list for ANY vault → both `default` and
+    // `research` vend a def at the SAME note path, so two live entries share the noteId.
+    const fetchFn = vaultFetch({
+      defs: [{ id: "Agents/shared", content: "role", metadata: { name: "shared" } }],
+    });
+    const reg = new AgentDefRegistry(deps, { bindings: [binding, b2], fetchFn });
+    await reg.loadAll();
+    // The note id is live in BOTH vaults — picking one is non-deterministic, so it throws
+    // a 409-class AgentDefWriteError rather than silently mutating an arbitrary one.
+    let caught: unknown;
+    try {
+      reg.findLiveByNote("Agents/shared");
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(AgentDefWriteError);
+    expect((caught as AgentDefWriteError).status).toBe(409);
+    expect((caught as AgentDefWriteError).message).toContain("ambiguous");
+    // The PATCH/DELETE write paths surface the same 409 (they resolve via findLiveByNote).
+    await expect(reg.editDef("Agents/shared", { systemPrompt: "x" })).rejects.toMatchObject({ status: 409 });
+    await expect(reg.deleteDef("Agents/shared")).rejects.toMatchObject({ status: 409 });
   });
 
   test("soleVaultName resolves the single binding (the reload-webhook default)", () => {

--- a/src/agent-defs.ts
+++ b/src/agent-defs.ts
@@ -118,6 +118,22 @@ export class AgentDefParseError extends Error {
 }
 
 /**
+ * A failed def WRITE (create/edit/delete) — carries an HTTP status the daemon route
+ * maps directly (400 validation, 404 unknown note, 409 name collision, 502 a
+ * write/instantiate failure). Distinct from {@link AgentDefParseError} (a note that's
+ * already in the vault but malformed).
+ */
+export class AgentDefWriteError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = "AgentDefWriteError";
+  }
+}
+
+/**
  * Coerce a vault metadata value (the vault stores metadata as strings, but a note
  * authored in another client may carry a real array/number) to a trimmed string.
  */
@@ -495,6 +511,92 @@ export class DefVaultClient {
       throw new Error(`def-vault "${this.vault}": patch status ${noteId} failed (${res.status}) ${detail}`.trim());
     }
   }
+
+  /**
+   * Create a `#agent/definition` note: body = the system prompt, metadata = the
+   * config, tagged the exact def tag (the same tag {@link listDefNotes} queries). The
+   * vault assigns the note id; we return the created note (id + content + metadata) so
+   * the caller can reload it into a live agent immediately. Throws on a non-ok vault
+   * response. The path defaults under `Agents/<name>` (a flat, predictable slug) so a
+   * vault surface groups them; the vault is free to relocate it.
+   */
+  async createNote(args: {
+    content: string;
+    metadata: Record<string, string>;
+    path?: string;
+  }): Promise<{ id: string; content?: string; metadata?: Record<string, unknown> }> {
+    const url = `${this.vaultUrl}/vault/${this.vault}/api/notes`;
+    const body: Record<string, unknown> = {
+      content: args.content,
+      tags: [AGENT_DEFINITION_TAG],
+      metadata: args.metadata,
+    };
+    if (args.path) body.path = args.path;
+    const res = await this.fetchFn(url, {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${this.token}` },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "");
+      throw new Error(`def-vault "${this.vault}": create def failed (${res.status}) ${detail}`.trim());
+    }
+    let parsed: unknown;
+    try {
+      parsed = await res.json();
+    } catch (err) {
+      throw new Error(`def-vault "${this.vault}": create def — bad JSON: ${(err as Error).message}`);
+    }
+    const n = (parsed ?? {}) as {
+      id?: string;
+      note?: { id?: string; content?: string; metadata?: Record<string, unknown> };
+      content?: string;
+      metadata?: Record<string, unknown>;
+    };
+    const note = n.note ?? n;
+    if (typeof note.id !== "string" || !note.id) {
+      throw new Error(`def-vault "${this.vault}": create def succeeded but response had no note id`);
+    }
+    return { id: note.id, content: note.content, metadata: note.metadata };
+  }
+
+  /**
+   * Edit an existing def note: update its body (system prompt) and/or merge metadata
+   * fields. `force: true` satisfies the vault's 428 mutation precondition (the module's
+   * own authoritative edit; the vault MERGES metadata so unspecified fields are kept).
+   * Only the provided fields are sent. Throws on a non-ok vault response.
+   */
+  async patchNote(
+    noteId: string,
+    fields: { content?: string; metadata?: Record<string, string> },
+  ): Promise<void> {
+    const body: Record<string, unknown> = { force: true };
+    if (fields.content !== undefined) body.content = fields.content;
+    if (fields.metadata !== undefined) body.metadata = fields.metadata;
+    const url = `${this.vaultUrl}/vault/${this.vault}/api/notes/${encodeURIComponent(noteId)}`;
+    const res = await this.fetchFn(url, {
+      method: "PATCH",
+      headers: { "content-type": "application/json", authorization: `Bearer ${this.token}` },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "");
+      throw new Error(`def-vault "${this.vault}": patch def ${noteId} failed (${res.status}) ${detail}`.trim());
+    }
+  }
+
+  /** Delete a def note by id. Throws on a non-ok vault response (404 IS ok — gone is gone). */
+  async deleteNote(noteId: string): Promise<void> {
+    const url = `${this.vaultUrl}/vault/${this.vault}/api/notes/${encodeURIComponent(noteId)}`;
+    const res = await this.fetchFn(url, {
+      method: "DELETE",
+      headers: { authorization: `Bearer ${this.token}` },
+    });
+    if (!res.ok && res.status !== 404) {
+      const detail = await res.text().catch(() => "");
+      throw new Error(`def-vault "${this.vault}": delete def ${noteId} failed (${res.status}) ${detail}`.trim());
+    }
+  }
 }
 
 /**
@@ -534,7 +636,44 @@ interface LiveDef {
   name: string;
   /** The resolved status (for /health + observability). */
   status: AgentDefStatus;
+  /** The agent backend the def selected (`programmatic` | `channel`). */
+  backend: AgentBackendKind;
+  /** First ~200 chars of the system prompt (the note body) — a preview, NOT a secret. */
+  systemPromptPreview: string;
+  /** Declared connections still pending approval (the status `pending` list), if any. */
+  pending: string[];
+  /** Structured `wants:` connection keys (surfaced for the UI; never a secret). */
+  wants: string[];
 }
+
+/**
+ * The detailed view of one live vault-native agent the `GET /api/agent-defs` route
+ * returns — everything a UI needs to render + edit it, NO secrets (no tokens). The
+ * channel == the agent name (agent ≡ channel); the vault is the def-vault.
+ */
+export interface AgentDefDetail {
+  /** The vault note id (the create/edit/delete key). */
+  noteId: string;
+  /** The agent name (= wake channel + spec name). */
+  name: string;
+  /** The agent backend (`programmatic` | `channel`). */
+  backend: AgentBackendKind;
+  /** The def-vault this agent is defined in. */
+  vault: string;
+  /** The resolved liveness status (`enabled` | `pending` | `error`). */
+  status: AgentDefStatus;
+  /** Declared connections still pending approval (empty when none). */
+  pending: string[];
+  /** First ~200 chars of the system prompt (the note body) — a preview, NOT the full text. */
+  systemPromptPreview: string;
+  /** Structured `wants:` connection keys the agent declared (empty when own-vault only). */
+  wants: string[];
+  /** The wake channel inbound routes to this agent on (== name). */
+  channel: string;
+}
+
+/** How many chars of the system prompt the detail preview surfaces. */
+export const SYSTEM_PROMPT_PREVIEW_LEN = 200;
 
 /**
  * The vault-native agent-def registry — reads `#agent/definition` notes from the
@@ -610,6 +749,19 @@ export class AgentDefRegistry {
     this.bindings.set(binding.vault, binding);
   }
 
+  /**
+   * Remove a def-vault binding (the client + binding indexes). The caller
+   * ({@link deregisterAllForVault}) tears down the vault's live agents FIRST; this
+   * drops the registry's knowledge of the vault so a later `loadAll` no longer queries
+   * it. Idempotent. Does NOT touch the persisted `agent-vaults.json` — that's the
+   * daemon route's job (the registry has no file knowledge).
+   */
+  removeVault(vault: string): void {
+    this.clients.delete(vault);
+    this.bindings.delete(vault);
+    this.seenDefs.delete(vault);
+  }
+
   /** The number of def-vaults bound (for /health + tests). */
   get vaultCount(): number {
     return this.clients.size;
@@ -624,7 +776,105 @@ export class AgentDefRegistry {
 
   /** The live instantiated defs (for /health + the agents list + tests). */
   list(): ReadonlyArray<{ vault: string; noteId: string; name: string; status: AgentDefStatus }> {
-    return [...this.live.values()].map((d) => ({ ...d }));
+    return [...this.live.values()].map((d) => ({
+      vault: d.vault,
+      noteId: d.noteId,
+      name: d.name,
+      status: d.status,
+    }));
+  }
+
+  /**
+   * The live instantiated defs in the DETAILED `GET /api/agent-defs` shape — backend,
+   * vault, status, pending, the system-prompt PREVIEW (not the full body), wants, and
+   * the wake channel. NO secrets (no tokens). Sorted by name for a stable list.
+   */
+  listDetailed(): AgentDefDetail[] {
+    return [...this.live.values()]
+      .map((d) => ({
+        noteId: d.noteId,
+        name: d.name,
+        backend: d.backend,
+        vault: d.vault,
+        status: d.status,
+        pending: [...d.pending],
+        systemPromptPreview: d.systemPromptPreview,
+        wants: [...d.wants],
+        channel: d.name, // agent ≡ channel.
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  /** Whether a def-vault by this name is configured (the write-path vault guard). */
+  hasVault(vault: string): boolean {
+    return this.clients.has(vault);
+  }
+
+  /** The configured def-vault names (for /api/agent-vaults + the write-path guard). */
+  vaultNames(): string[] {
+    return [...this.clients.keys()];
+  }
+
+  /**
+   * The configured def-vault bindings VERBATIM (carrying their tokens) — for
+   * persisting the live set back to `agent-vaults.json` on an add (so a boot-minted
+   * default's real token is preserved, never clobbered to empty). INTERNAL: this
+   * carries SECRETS — never serialize it to the wire (the wire view is
+   * {@link vaultStatuses}). Returns copies so a caller can't mutate the registry's
+   * bindings in place.
+   */
+  liveBindings(): DefVaultBinding[] {
+    return [...this.bindings.values()].map((b) => ({ ...b }));
+  }
+
+  /**
+   * The configured def-vaults as a non-secret view — name + url + whether a token is
+   * present (NEVER the token VALUE). The `GET /api/agent-vaults` listing's source of
+   * truth (the live registry, not the on-disk file, so a boot-minted binding shows its
+   * token even before the file write lands). Sorted by name.
+   */
+  vaultStatuses(): Array<{ vault: string; url: string; tokenPresent: boolean }> {
+    return [...this.bindings.values()]
+      .map((b) => ({
+        vault: b.vault,
+        url: b.vaultUrl ?? DEFAULT_DEF_VAULT_URL,
+        tokenPresent: typeof b.token === "string" && b.token.length > 0,
+      }))
+      .sort((a, b) => a.vault.localeCompare(b.vault));
+  }
+
+  /**
+   * Whether a note id is a CURRENTLY-LIVE def in a given vault — the write-path guard
+   * for PATCH/DELETE so the routes only ever touch notes this module actually
+   * instantiated as `#agent/definition` agents in a configured def-vault (not an
+   * arbitrary note id an operator passes). Returns the live detail when it is, else
+   * null.
+   */
+  liveDef(vault: string, noteId: string): AgentDefDetail | null {
+    const d = this.live.get(this.keyOf(vault, noteId));
+    if (!d) return null;
+    return {
+      noteId: d.noteId,
+      name: d.name,
+      backend: d.backend,
+      vault: d.vault,
+      status: d.status,
+      pending: [...d.pending],
+      systemPromptPreview: d.systemPromptPreview,
+      wants: [...d.wants],
+      channel: d.name,
+    };
+  }
+
+  /** Find a live def by note id across ALL configured vaults (PATCH/DELETE address
+   *  a note by id; the vault is resolved here). Returns the {vault, detail} or null. */
+  findLiveByNote(noteId: string): { vault: string; detail: AgentDefDetail } | null {
+    for (const d of this.live.values()) {
+      if (d.noteId === noteId) {
+        return { vault: d.vault, detail: this.liveDef(d.vault, noteId)! };
+      }
+    }
+    return null;
   }
 
   private keyOf(vault: string, noteId: string): string {
@@ -767,6 +1017,156 @@ export class AgentDefRegistry {
     return (await this.instantiate(vault, note)) ? "instantiated" : "skipped";
   }
 
+  // ---------------------------------------------------------------------------
+  // Def write path (the v2 API layer) — create / edit / delete a `#agent/definition`
+  // note in a configured def-vault, then reload it into a LIVE agent immediately (the
+  // per-note reload, NOT the 60s poll). The daemon owns the def-vault write token
+  // (def-vaults.ts); these methods drive its client. Validation is the registry's job
+  // (vault configured, name slug, backend valid) so the daemon route stays thin.
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Create a new `#agent/definition` note in `vault` (body = system prompt, metadata =
+   * name/backend/wants/extra), then reload it so the agent is LIVE immediately (no
+   * wait for the trigger or the poll). Returns the created def in the {@link
+   * AgentDefDetail} shape. Throws {@link AgentDefWriteError} on a validation failure
+   * (unknown vault, bad name, bad backend) or a write/reload failure.
+   */
+  async createDef(args: {
+    vault: string;
+    name: string;
+    backend: AgentBackendKind;
+    systemPrompt: string;
+    wants?: string;
+    metadata?: Record<string, string>;
+  }): Promise<AgentDefDetail> {
+    const client = this.clients.get(args.vault);
+    if (!client) {
+      throw new AgentDefWriteError(`unknown def-vault "${args.vault}" (configure it first)`, 400);
+    }
+    if (!NAME_SLUG_RE.test(args.name)) {
+      throw new AgentDefWriteError(
+        `name "${args.name}" must be a slug (alphanumeric, dash, underscore)`,
+        400,
+      );
+    }
+    if (args.backend !== "programmatic" && args.backend !== "channel") {
+      throw new AgentDefWriteError(`backend must be "programmatic" or "channel"`, 400);
+    }
+    // A name collision with a live def (in ANY vault — the wake channel is shared) would
+    // resurrect last-writer-wins on the channel; reject up front for a clean error.
+    for (const d of this.live.values()) {
+      if (d.name === args.name) {
+        throw new AgentDefWriteError(
+          `an agent named "${args.name}" already exists (note ${d.noteId} in "${d.vault}")`,
+          409,
+        );
+      }
+    }
+    const metadata = this.buildDefMetadata(args);
+    const created = await client.createNote({
+      content: args.systemPrompt,
+      metadata,
+      path: `Agents/${args.name}`,
+    });
+    // Reload the just-created note → instantiate it LIVE now (the immediate path).
+    await this.reload(args.vault, created.id, "created");
+    const detail = this.liveDef(args.vault, created.id);
+    if (!detail) {
+      // Instantiation didn't take (a parse/instantiate failure stamps status:error on
+      // the note + returns false). Surface that the note was written but isn't live.
+      throw new AgentDefWriteError(
+        `def note ${created.id} written to "${args.vault}" but failed to instantiate ` +
+          `(check the note's status field for the error)`,
+        502,
+      );
+    }
+    return detail;
+  }
+
+  /**
+   * Edit an existing live def note (body and/or metadata), then reload it so the change
+   * is LIVE immediately. The note MUST be a currently-live def we instantiated in a
+   * configured vault (the daemon resolves the vault; we re-guard here). Returns the
+   * updated detail. Throws {@link AgentDefWriteError} on a miss or a write/reload failure.
+   */
+  async editDef(
+    noteId: string,
+    fields: { systemPrompt?: string; wants?: string; metadata?: Record<string, string> },
+  ): Promise<AgentDefDetail> {
+    const found = this.findLiveByNote(noteId);
+    if (!found) {
+      throw new AgentDefWriteError(`note ${noteId} is not a live agent definition`, 404);
+    }
+    const client = this.clients.get(found.vault);
+    if (!client) {
+      throw new AgentDefWriteError(`unknown def-vault "${found.vault}"`, 400);
+    }
+    const patch: { content?: string; metadata?: Record<string, string> } = {};
+    if (fields.systemPrompt !== undefined) patch.content = fields.systemPrompt;
+    const metadata: Record<string, string> = { ...(fields.metadata ?? {}) };
+    if (fields.wants !== undefined) metadata.wants = fields.wants;
+    if (Object.keys(metadata).length > 0) patch.metadata = metadata;
+    if (patch.content === undefined && patch.metadata === undefined) {
+      throw new AgentDefWriteError(`nothing to edit (provide systemPrompt, wants, or metadata)`, 400);
+    }
+    await client.patchNote(noteId, patch);
+    await this.reload(found.vault, noteId, "updated");
+    const detail = this.liveDef(found.vault, noteId);
+    if (!detail) {
+      throw new AgentDefWriteError(
+        `def note ${noteId} edited but failed to re-instantiate (check the note's status field)`,
+        502,
+      );
+    }
+    return detail;
+  }
+
+  /**
+   * Delete a live def note, then deregister the agent immediately. The note MUST be a
+   * currently-live def we instantiated. Returns the (vault, name) of what was removed.
+   * Throws {@link AgentDefWriteError} on a miss or a delete failure (the deregister
+   * still runs even if it's already gone).
+   */
+  async deleteDef(noteId: string): Promise<{ vault: string; name: string }> {
+    const found = this.findLiveByNote(noteId);
+    if (!found) {
+      throw new AgentDefWriteError(`note ${noteId} is not a live agent definition`, 404);
+    }
+    const client = this.clients.get(found.vault);
+    if (!client) {
+      throw new AgentDefWriteError(`unknown def-vault "${found.vault}"`, 400);
+    }
+    await client.deleteNote(noteId);
+    // Tear the agent down + prune grants — the confirmed-removal path (a delete IS a
+    // confirmed removal); reload with "deleted" skips the (now-404) GET.
+    await this.reload(found.vault, noteId, "deleted");
+    return { vault: found.vault, name: found.detail.name };
+  }
+
+  /**
+   * Build the metadata for a created/edited def note from the API inputs. `name` +
+   * `backend` are the load-bearing config; `wants` is the comma-separated connection
+   * list (omitted when empty); any extra `metadata` the caller passes is merged FIRST
+   * so the explicit name/backend/wants win (the route can't override the validated
+   * name/backend via the metadata bag). NEVER carries a token/secret — secrets stay
+   * local (the parse path never reads creds off a note).
+   */
+  private buildDefMetadata(args: {
+    name: string;
+    backend: AgentBackendKind;
+    wants?: string;
+    metadata?: Record<string, string>;
+  }): Record<string, string> {
+    const metadata: Record<string, string> = { ...(args.metadata ?? {}) };
+    metadata.name = args.name;
+    metadata.backend = args.backend;
+    if (args.wants !== undefined && args.wants.trim().length > 0) {
+      metadata.wants = args.wants;
+    }
+    return metadata;
+  }
+
   /**
    * A CONFIRMED removed def (a `deleted` trigger, or a re-read 404): tear the agent
    * down AND prune ALL its grants (#96 grant-GC) so a deleted `#agent/definition` note
@@ -824,7 +1224,21 @@ export class AgentDefRegistry {
     // declared, enabled if nothing is). Either way the agent ALREADY ran its own-vault
     // setup above — an unapproved connection is absent at spawn, never a failure here.
     const { status, pending } = await this.resolveStatusWithGrants(def);
-    this.live.set(this.keyOf(vault, note.id), { vault, noteId: note.id, name: def.name, status });
+    const fullPrompt = def.spec.systemPrompt ?? "";
+    const systemPromptPreview =
+      fullPrompt.length > SYSTEM_PROMPT_PREVIEW_LEN
+        ? fullPrompt.slice(0, SYSTEM_PROMPT_PREVIEW_LEN)
+        : fullPrompt;
+    this.live.set(this.keyOf(vault, note.id), {
+      vault,
+      noteId: note.id,
+      name: def.name,
+      status,
+      backend: def.spec.backend ?? "programmatic",
+      systemPromptPreview,
+      pending: pending ?? [],
+      wants: def.wants.map((c) => connectionKey(c)),
+    });
     // Track this note in the per-vault seen set (a confident, freshly-parsed read) so the
     // removed-def diff (loadAll) and the reload-delete path both address it by name. This
     // covers the reload single-note path where loadAll's rebuild didn't run.

--- a/src/agent-defs.ts
+++ b/src/agent-defs.ts
@@ -867,14 +867,27 @@ export class AgentDefRegistry {
   }
 
   /** Find a live def by note id across ALL configured vaults (PATCH/DELETE address
-   *  a note by id; the vault is resolved here). Returns the {vault, detail} or null. */
+   *  a note by id; the vault is resolved here). Returns the {vault, detail} or null.
+   *  AMBIGUITY GUARD (#106 review): if two configured def-vaults each vend a note at
+   *  the SAME id, picking the first match is non-deterministic — so throw a 409-class
+   *  {@link AgentDefWriteError} ("specify vault") rather than silently mutating one of
+   *  them. The single-match happy path is unchanged. */
   findLiveByNote(noteId: string): { vault: string; detail: AgentDefDetail } | null {
+    const matches: string[] = [];
     for (const d of this.live.values()) {
-      if (d.noteId === noteId) {
-        return { vault: d.vault, detail: this.liveDef(d.vault, noteId)! };
-      }
+      if (d.noteId === noteId) matches.push(d.vault);
     }
-    return null;
+    if (matches.length === 0) return null;
+    if (matches.length > 1) {
+      throw new AgentDefWriteError(
+        `note ${noteId} is a live agent definition in multiple def-vaults (${matches
+          .sort()
+          .join(", ")}); ambiguous note id across vaults — specify vault`,
+        409,
+      );
+    }
+    const vault = matches[0]!;
+    return { vault, detail: this.liveDef(vault, noteId)! };
   }
 
   private keyOf(vault: string, noteId: string): string {

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -66,17 +66,33 @@ export interface AgentInfo {
   /** Whether the session's workspace (with its .mcp.json) is present on disk. */
   hasWorkspace: boolean;
   /**
-   * Which backend drives this agent. `"interactive"` (the default — a tmux session)
-   * or `"programmatic"` (no tmux; on-demand `claude -p` turns). The list merges
-   * interactive tmux sessions + registered programmatic agents (design 2026-06-16).
+   * Which backend drives this agent. `"interactive"` (a tmux session),
+   * `"programmatic"` (no tmux; on-demand `claude -p` turns), or `"channel"` (no tmux,
+   * no daemon-run turn — a Claude Code session the operator connects to the channel's
+   * MCP endpoint handles the turn; inbound notes accumulate as a durable queue). The
+   * list merges interactive tmux sessions + registered programmatic agents (design
+   * 2026-06-16) + registered channel-backend agents (#102, the v2 API layer).
    */
-  backend: "interactive" | "programmatic";
+  backend: "interactive" | "programmatic" | "channel";
   /**
-   * Programmatic-only live status — `idle` | `working` | `queued:N` (N = pending).
-   * Absent for interactive agents (their liveness is the tmux `attached` flag +
-   * /health's `mcp_sessions`). Present for programmatic agents in place of those.
+   * Live status — for a programmatic agent `idle` | `working` | `queued:N` (N =
+   * pending); for a channel agent `queued:N` (N = pending inbound waiting for the
+   * connected session) or `idle`. Absent for interactive agents (their liveness is
+   * the tmux `attached` flag + /health's `mcp_sessions`).
    */
   status?: string;
+  /**
+   * The wake channel this agent serves (the channel inbound routes to it on). Present
+   * for channel-backend agents (where agent == channel); absent for interactive +
+   * programmatic agents whose channel isn't surfaced in this list shape.
+   */
+  channel?: string;
+  /**
+   * The vault backing this agent's conversation, when known — the def-vault a
+   * vault-native agent's channel is bound to. Present for channel/programmatic agents
+   * instantiated from a `#agent/definition` note; absent otherwise.
+   */
+  vault?: string;
   /**
    * The agent's system-prompt COMPOSITION mode when a per-channel system prompt is
    * set (design 2026-06-16-channel-system-prompt.md) — `"append"` (kept CC's base +

--- a/src/backends/channel-queue.ts
+++ b/src/backends/channel-queue.ts
@@ -162,6 +162,25 @@ export class ChannelQueueRegistry {
   }
 
   /**
+   * The registered channel-backend agents as plain records (name + channel + the
+   * spec's surfaceable, non-secret fields). The `GET /api/agents` list (#102) maps
+   * these into {@link AgentInfo}; tests assert the shape. Sorted by name for a stable
+   * list. NEVER carries a token/secret — the spec's vault binding is a name + access
+   * verb only. The live `pending` count is fetched separately (it's an async vault
+   * read; see {@link pending}) so this accessor stays synchronous + cheap.
+   */
+  list(): Array<{ name: string; channel: string; vault?: string; systemPrompt?: string }> {
+    return [...this.byChannel.values()]
+      .map((rec) => ({
+        name: rec.name,
+        channel: rec.channel,
+        ...(rec.spec.vault?.name ? { vault: rec.spec.vault.name } : {}),
+        ...(rec.spec.systemPrompt ? { systemPrompt: rec.spec.systemPrompt } : {}),
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  /**
    * Peek the pending queue for a channel: the count of `status:pending` inbound + a
    * bounded oldest-first preview. A no-op shape `{ count: 0, items: [] }` for an
    * unregistered (non-channel) channel — the MCP surface gates cleanly on a non-channel

--- a/src/daemon-agent-defs-api.test.ts
+++ b/src/daemon-agent-defs-api.test.ts
@@ -1,0 +1,762 @@
+/**
+ * Integration tests for the agent-UI-v2 API layer (design
+ * 2026-06-18-agent-ui-v2-and-reactivity.md Part 2 Phase 1) on the REAL daemon fetch
+ * handler. Four endpoint groups, each with happy-path + auth-gate (401) + validation
+ * (400):
+ *
+ *   - GET    /api/agents        → now includes channel-backend agents (#102)
+ *   - GET    /api/agent-defs    → lists the vault-native defs (read-scoped, NO secrets)
+ *   - POST   /api/agent-defs    → writes a #agent/definition note + reloads it LIVE
+ *   - PATCH  /api/agent-defs/:n → edits + reloads
+ *   - DELETE /api/agent-defs/:n → deletes + deregisters
+ *   - GET/POST/DELETE /api/agent-vaults → the def-vault list (token-status, no value)
+ *
+ * The hub JWT validator is stubbed (sentinel tokens → fixed scopes) so the accept
+ * paths run without a live hub/JWKS — the same harness daemon-jobs-api.test.ts uses.
+ * The def-vault's vault REST is stubbed via an injected `fetchFn` on the registry's
+ * DefVaultClient (an in-memory note store), so create/edit/delete exercise the real
+ * write+reload path with NO live vault. `addDefVault` is injected so the agent-vaults
+ * POST route is exercised without a live hub mint.
+ */
+import { describe, test, expect, mock, beforeAll, afterAll } from "bun:test";
+import { HubJwtError, looksLikeJwt } from "@openparachute/scope-guard";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Sandbox the state dir — the GET/DELETE /api/agent-vaults routes read/write
+// `agent-vaults.json` via defaultStateDir(); pin it to a throwaway temp dir so the
+// tests never touch the operator's real ~/.parachute/agent (memory:
+// feedback_sandbox_destructive_cli). PARACHUTE_AGENT_STATE_DIR short-circuits the
+// resolver to this dir.
+let stateDir: string;
+let priorStateDir: string | undefined;
+beforeAll(() => {
+  priorStateDir = process.env.PARACHUTE_AGENT_STATE_DIR;
+  stateDir = mkdtempSync(join(tmpdir(), "agent-defs-api-state-"));
+  process.env.PARACHUTE_AGENT_STATE_DIR = stateDir;
+});
+afterAll(() => {
+  if (priorStateDir === undefined) delete process.env.PARACHUTE_AGENT_STATE_DIR;
+  else process.env.PARACHUTE_AGENT_STATE_DIR = priorStateDir;
+  try {
+    rmSync(stateDir, { recursive: true, force: true });
+  } catch {}
+});
+
+const ADMIN_TOKEN = "test-admin-token";
+const READ_TOKEN = "test-read-token";
+mock.module("./hub-jwt.ts", () => ({
+  AGENT_AUDIENCE: "agent",
+  CHANNEL_AUDIENCE: "channel",
+  async validateHubJwt(token: string) {
+    const base = { sub: "test", aud: "agent", jti: undefined, clientId: undefined, vaultScope: undefined };
+    if (token === ADMIN_TOKEN) return { ...base, scopes: ["agent:read", "agent:send", "agent:admin"] };
+    if (token === READ_TOKEN) return { ...base, scopes: ["agent:read"] };
+    throw new HubJwtError("issuer", "invalid token");
+  },
+  HubJwtError,
+  looksLikeJwt,
+  resetJwksCache() {},
+  resetRevocationCache() {},
+}));
+
+import { createFetchHandler } from "./daemon.ts";
+import { ClientRegistry } from "./routing.ts";
+import { AgentDefRegistry, type InstantiateDeps } from "./agent-defs.ts";
+import { ChannelQueueRegistry, type ChannelQueueStore } from "./backends/channel-queue.ts";
+import type { Channel } from "./registry.ts";
+import type { AgentSpec } from "./sandbox/types.ts";
+import type { InboundQueueNote, InboundStatus } from "./transports/vault.ts";
+
+const adminAuth = { authorization: "Bearer " + ADMIN_TOKEN, "content-type": "application/json" } as const;
+const readAuth = { authorization: "Bearer " + READ_TOKEN, "content-type": "application/json" } as const;
+
+// ---------------------------------------------------------------------------
+// A FAKE def-vault: an in-memory note store the registry's DefVaultClient drives via
+// an injected `fetchFn`. Models the vault REST routes the client calls:
+//   GET    /vault/<v>/api/notes?tag=…           → list defs
+//   GET    /vault/<v>/api/notes/<id>            → one note
+//   POST   /vault/<v>/api/notes                 → create (assign an id)
+//   PATCH  /vault/<v>/api/notes/<id>            → merge content/metadata
+//   DELETE /vault/<v>/api/notes/<id>            → remove
+// ---------------------------------------------------------------------------
+interface FakeNote {
+  id: string;
+  content?: string;
+  tags?: string[];
+  metadata: Record<string, unknown>;
+}
+
+class FakeDefVault {
+  readonly notes = new Map<string, FakeNote>();
+  private seq = 0;
+
+  /** Seed a pre-existing def note (so a GET/PATCH/DELETE has something to find). */
+  seed(note: FakeNote): void {
+    this.notes.set(note.id, note);
+  }
+
+  /** The injectable fetch the DefVaultClient uses. Cast to `typeof fetch` (we only
+   *  use the call signature, not `fetch.preconnect`). */
+  fetch = (async (input: URL | RequestInfo, init?: RequestInit) => {
+    const url = new URL(typeof input === "string" ? input : (input as Request).url);
+    const method = (init?.method ?? "GET").toUpperCase();
+    const m = url.pathname.match(/\/vault\/[^/]+\/api\/notes(?:\/(.+))?$/);
+    const noteId = m?.[1] ? decodeURIComponent(m[1]) : undefined;
+
+    const j = (body: unknown, status = 200) =>
+      new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+
+    if (method === "GET" && noteId === undefined) {
+      // List defs (tag filter is implicit — every seeded note is a def here).
+      return j(Array.from(this.notes.values()));
+    }
+    if (method === "GET" && noteId !== undefined) {
+      const note = this.notes.get(noteId);
+      return note ? j(note) : j({ error: "not_found" }, 404);
+    }
+    if (method === "POST" && noteId === undefined) {
+      const body = JSON.parse(String(init?.body ?? "{}")) as {
+        content?: string;
+        tags?: string[];
+        metadata?: Record<string, unknown>;
+        path?: string;
+      };
+      const id = body.path ?? `note-${++this.seq}`;
+      const note: FakeNote = { id, content: body.content, tags: body.tags, metadata: body.metadata ?? {} };
+      this.notes.set(id, note);
+      return j(note, 200);
+    }
+    if (method === "PATCH" && noteId !== undefined) {
+      const note = this.notes.get(noteId);
+      if (!note) return j({ error: "not_found" }, 404);
+      const body = JSON.parse(String(init?.body ?? "{}")) as {
+        content?: string;
+        metadata?: Record<string, unknown>;
+      };
+      if (body.content !== undefined) note.content = body.content;
+      if (body.metadata) note.metadata = { ...note.metadata, ...body.metadata };
+      return j(note);
+    }
+    if (method === "DELETE" && noteId !== undefined) {
+      this.notes.delete(noteId);
+      return j({ ok: true });
+    }
+    return j({ error: "unhandled", method, path: url.pathname }, 500);
+  }) as unknown as typeof fetch;
+}
+
+/** Recorder InstantiateDeps — captures the instantiate/teardown calls, no real I/O. */
+function recordingDeps() {
+  const calls: { ensure: string[]; register: string[]; deregister: string[]; removeChannel: string[] } = {
+    ensure: [],
+    register: [],
+    deregister: [],
+    removeChannel: [],
+  };
+  const deps: InstantiateDeps = {
+    ensureChannel: async (name) => {
+      calls.ensure.push(name);
+    },
+    setupAndRegister: async (spec) => {
+      calls.register.push(spec.name);
+    },
+    deregister: async (name) => {
+      calls.deregister.push(name);
+      return true;
+    },
+    removeChannel: async (name) => {
+      calls.removeChannel.push(name);
+      return true;
+    },
+  };
+  return { deps, calls };
+}
+
+/** Build an AgentDefRegistry bound to one fake def-vault, with recorder deps. */
+function registryWithFakeVault(opts?: { vault?: string; fake?: FakeDefVault }) {
+  const vault = opts?.vault ?? "default";
+  const fake = opts?.fake ?? new FakeDefVault();
+  const { deps, calls } = recordingDeps();
+  const reg = new AgentDefRegistry(deps, {
+    bindings: [{ vault, vaultUrl: "http://127.0.0.1:1940", token: "vtok" }],
+    fetchFn: fake.fetch,
+  });
+  return { reg, fake, calls, vault };
+}
+
+type AddDefVault = (args: { vault: string; url?: string }) => Promise<{
+  vault: string;
+  url: string;
+  tokenPresent: boolean;
+}>;
+
+function serverWith(
+  channels: Map<string, Channel>,
+  o?: {
+    agentDefs?: AgentDefRegistry;
+    channelQueue?: ChannelQueueRegistry;
+    addDefVault?: AddDefVault;
+  },
+) {
+  const registry = new ClientRegistry();
+  const srv = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    idleTimeout: 0,
+    fetch: createFetchHandler(channels, registry, {
+      ...(o?.agentDefs ? { agentDefs: o.agentDefs } : {}),
+      ...(o?.channelQueue ? { channelQueue: o.channelQueue } : {}),
+      ...(o?.addDefVault ? { addDefVault: o.addDefVault } : {}),
+    }),
+  });
+  return { srv, base: `http://127.0.0.1:${srv.port}` };
+}
+
+const emptyChannels = () => new Map<string, Channel>();
+
+// ===========================================================================
+// GET /api/agents — includes channel-backend agents (#102)
+// ===========================================================================
+describe("GET /api/agents includes channel-backend agents (#102)", () => {
+  /** A minimal channel-queue store with a pending count we control. */
+  function storeWithPending(count: number): ChannelQueueStore {
+    const notes: InboundQueueNote[] = Array.from({ length: count }, (_, i) => ({
+      id: `in-${i}`,
+      text: `m${i}`,
+      sender: "operator",
+      ts: `2026-01-0${i + 1}`,
+      status: "pending" as InboundStatus,
+    }));
+    return {
+      listInboundQueue: async () => notes,
+      setInboundStatus: async () => {},
+      reply: async () => ({ sent: [] }),
+    };
+  }
+
+  function channelSpec(name: string, vault?: string): AgentSpec {
+    return {
+      name,
+      channels: [name],
+      backend: "channel",
+      ...(vault ? { vault: { name: vault, access: "write" } } : {}),
+      systemPrompt: "You are the laptop agent.",
+    };
+  }
+
+  test("a registered channel agent appears with backend:channel + queued status + channel + vault", async () => {
+    const channelQueue = new ChannelQueueRegistry();
+    channelQueue.register(channelSpec("laptop", "research"), storeWithPending(2));
+    const { srv, base } = serverWith(emptyChannels(), { channelQueue });
+    const res = await fetch(`${base}/api/agents`, { headers: adminAuth });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { agents: Array<Record<string, unknown>> };
+    const laptop = body.agents.find((a) => a.name === "laptop");
+    expect(laptop).toBeDefined();
+    expect(laptop!.backend).toBe("channel");
+    expect(laptop!.status).toBe("queued:2");
+    expect(laptop!.channel).toBe("laptop");
+    expect(laptop!.vault).toBe("research");
+    // No secret leaked.
+    expect(JSON.stringify(laptop)).not.toContain("vtok");
+    expect(JSON.stringify(laptop)).not.toContain("token");
+    srv.stop();
+  });
+
+  test("an empty pending queue → status idle", async () => {
+    const channelQueue = new ChannelQueueRegistry();
+    channelQueue.register(channelSpec("idlebot"), storeWithPending(0));
+    const { srv, base } = serverWith(emptyChannels(), { channelQueue });
+    const res = await fetch(`${base}/api/agents`, { headers: adminAuth });
+    const body = (await res.json()) as { agents: Array<Record<string, unknown>> };
+    expect(body.agents.find((a) => a.name === "idlebot")!.status).toBe("idle");
+    srv.stop();
+  });
+
+  test("no Authorization → 401 (admin-gated)", async () => {
+    const { srv, base } = serverWith(emptyChannels(), { channelQueue: new ChannelQueueRegistry() });
+    const res = await fetch(`${base}/api/agents`);
+    expect(res.status).toBe(401);
+    srv.stop();
+  });
+});
+
+// ===========================================================================
+// GET /api/agent-defs — list the vault-native defs (read-scoped, no secrets)
+// ===========================================================================
+describe("GET /api/agent-defs", () => {
+  test("no Authorization → 401", async () => {
+    const { reg } = registryWithFakeVault();
+    const { srv, base } = serverWith(emptyChannels(), { agentDefs: reg });
+    const res = await fetch(`${base}/api/agent-defs`);
+    expect(res.status).toBe(401);
+    srv.stop();
+  });
+
+  test("read scope is enough (a read token lists)", async () => {
+    const { reg } = registryWithFakeVault();
+    const { srv, base } = serverWith(emptyChannels(), { agentDefs: reg });
+    const res = await fetch(`${base}/api/agent-defs`, { headers: readAuth });
+    expect(res.status).toBe(200);
+    srv.stop();
+  });
+
+  test("returns the live defs with the detail shape + NO secrets", async () => {
+    const fake = new FakeDefVault();
+    fake.seed({
+      id: "Agents/uni-dev",
+      content: "a".repeat(500), // long prompt → preview truncates to 200.
+      tags: ["#agent/definition"],
+      metadata: { name: "uni-dev", backend: "channel" },
+    });
+    const { reg } = registryWithFakeVault({ fake });
+    await reg.loadAll(); // instantiate the seeded def.
+    const { srv, base } = serverWith(emptyChannels(), { agentDefs: reg });
+    const res = await fetch(`${base}/api/agent-defs`, { headers: readAuth });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { defs: Array<Record<string, unknown>> };
+    expect(body.defs).toHaveLength(1);
+    const d = body.defs[0]!;
+    expect(d.noteId).toBe("Agents/uni-dev");
+    expect(d.name).toBe("uni-dev");
+    expect(d.backend).toBe("channel");
+    expect(d.vault).toBe("default");
+    expect(d.status).toBe("enabled");
+    expect(d.channel).toBe("uni-dev");
+    expect((d.systemPromptPreview as string).length).toBe(200); // truncated.
+    // No token/secret in the listing.
+    expect(JSON.stringify(d)).not.toContain("vtok");
+    srv.stop();
+  });
+
+  test("no agentDefs configured → empty list (200)", async () => {
+    const { srv, base } = serverWith(emptyChannels());
+    const res = await fetch(`${base}/api/agent-defs`, { headers: readAuth });
+    expect(res.status).toBe(200);
+    expect((await res.json()) as { defs: unknown[] }).toEqual({ defs: [] });
+    srv.stop();
+  });
+});
+
+// ===========================================================================
+// POST /api/agent-defs — write a #agent/definition note + reload it LIVE
+// ===========================================================================
+describe("POST /api/agent-defs", () => {
+  test("no Authorization → 401", async () => {
+    const { reg } = registryWithFakeVault();
+    const { srv, base } = serverWith(emptyChannels(), { agentDefs: reg });
+    const res = await fetch(`${base}/api/agent-defs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ vault: "default", name: "x", backend: "programmatic" }),
+    });
+    expect(res.status).toBe(401);
+    srv.stop();
+  });
+
+  test("read scope is insufficient → 403 (admin required)", async () => {
+    const { reg } = registryWithFakeVault();
+    const { srv, base } = serverWith(emptyChannels(), { agentDefs: reg });
+    const res = await fetch(`${base}/api/agent-defs`, {
+      method: "POST",
+      headers: readAuth,
+      body: JSON.stringify({ vault: "default", name: "x", backend: "programmatic" }),
+    });
+    expect(res.status).toBe(403);
+    srv.stop();
+  });
+
+  test("writes a note + the def becomes LIVE (instantiate ran)", async () => {
+    const { reg, fake, calls } = registryWithFakeVault();
+    const { srv, base } = serverWith(emptyChannels(), { agentDefs: reg });
+    const res = await fetch(`${base}/api/agent-defs`, {
+      method: "POST",
+      headers: adminAuth,
+      body: JSON.stringify({
+        vault: "default",
+        name: "newbot",
+        backend: "programmatic",
+        systemPrompt: "You are newbot.",
+        wants: "vault:research:read",
+      }),
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { ok: boolean; def: Record<string, unknown> };
+    expect(body.ok).toBe(true);
+    expect(body.def.name).toBe("newbot");
+    expect(body.def.backend).toBe("programmatic");
+    expect(body.def.status).toBe("pending"); // declared a `wants:` → pending (own-vault runs).
+    expect(body.def.wants).toEqual(["vault:research:read"]);
+    // The note was written to the fake vault, tagged the def tag, body = prompt.
+    const written = [...fake.notes.values()].find((n) => n.metadata.name === "newbot");
+    expect(written).toBeDefined();
+    expect(written!.tags).toContain("#agent/definition");
+    expect(written!.content).toBe("You are newbot.");
+    expect(written!.metadata.backend).toBe("programmatic");
+    // It instantiated LIVE (the per-note reload ran ensureChannel + register) — not
+    // dependent on a trigger or the 60s poll.
+    expect(calls.ensure).toContain("newbot");
+    expect(calls.register).toContain("newbot");
+    // And it shows up in the live listing now.
+    const list = await (await fetch(`${base}/api/agent-defs`, { headers: readAuth })).json() as {
+      defs: Array<{ name: string }>;
+    };
+    expect(list.defs.map((d) => d.name)).toContain("newbot");
+    srv.stop();
+  });
+
+  test("validation: missing vault → 400", async () => {
+    const { reg } = registryWithFakeVault();
+    const { srv, base } = serverWith(emptyChannels(), { agentDefs: reg });
+    const res = await fetch(`${base}/api/agent-defs`, {
+      method: "POST",
+      headers: adminAuth,
+      body: JSON.stringify({ name: "x", backend: "programmatic" }),
+    });
+    expect(res.status).toBe(400);
+    srv.stop();
+  });
+
+  test("validation: bad backend → 400", async () => {
+    const { reg } = registryWithFakeVault();
+    const { srv, base } = serverWith(emptyChannels(), { agentDefs: reg });
+    const res = await fetch(`${base}/api/agent-defs`, {
+      method: "POST",
+      headers: adminAuth,
+      body: JSON.stringify({ vault: "default", name: "x", backend: "interactive" }),
+    });
+    expect(res.status).toBe(400);
+    srv.stop();
+  });
+
+  test("validation: bad name slug → 400", async () => {
+    const { reg } = registryWithFakeVault();
+    const { srv, base } = serverWith(emptyChannels(), { agentDefs: reg });
+    const res = await fetch(`${base}/api/agent-defs`, {
+      method: "POST",
+      headers: adminAuth,
+      body: JSON.stringify({ vault: "default", name: "bad name!", backend: "programmatic" }),
+    });
+    expect(res.status).toBe(400);
+    srv.stop();
+  });
+
+  test("validation: unknown vault → 400", async () => {
+    const { reg } = registryWithFakeVault();
+    const { srv, base } = serverWith(emptyChannels(), { agentDefs: reg });
+    const res = await fetch(`${base}/api/agent-defs`, {
+      method: "POST",
+      headers: adminAuth,
+      body: JSON.stringify({ vault: "nope", name: "x", backend: "programmatic" }),
+    });
+    expect(res.status).toBe(400);
+    srv.stop();
+  });
+});
+
+// ===========================================================================
+// PATCH /api/agent-defs/:noteId — edit + reload
+// ===========================================================================
+describe("PATCH /api/agent-defs/:noteId", () => {
+  async function liveDefServer() {
+    const fake = new FakeDefVault();
+    fake.seed({
+      id: "Agents/uni-dev",
+      content: "old prompt",
+      tags: ["#agent/definition"],
+      metadata: { name: "uni-dev", backend: "programmatic" },
+    });
+    const { reg, calls } = registryWithFakeVault({ fake });
+    await reg.loadAll();
+    const { srv, base } = serverWith(emptyChannels(), { agentDefs: reg });
+    return { srv, base, fake, calls };
+  }
+
+  test("no Authorization → 401", async () => {
+    const { srv, base } = await liveDefServer();
+    const res = await fetch(`${base}/api/agent-defs/${encodeURIComponent("Agents/uni-dev")}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ systemPrompt: "new" }),
+    });
+    expect(res.status).toBe(401);
+    srv.stop();
+  });
+
+  test("edits the note body + re-instantiates LIVE", async () => {
+    const { srv, base, fake, calls } = await liveDefServer();
+    calls.register.length = 0; // clear the loadAll register call.
+    const res = await fetch(`${base}/api/agent-defs/${encodeURIComponent("Agents/uni-dev")}`, {
+      method: "PATCH",
+      headers: adminAuth,
+      body: JSON.stringify({ systemPrompt: "new prompt" }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; def: { name: string } };
+    expect(body.ok).toBe(true);
+    expect(body.def.name).toBe("uni-dev");
+    // The note body was updated in the vault.
+    expect(fake.notes.get("Agents/uni-dev")!.content).toBe("new prompt");
+    // It re-instantiated (the reload ran register again).
+    expect(calls.register).toContain("uni-dev");
+    srv.stop();
+  });
+
+  test("PATCH a note that isn't a live def → 404", async () => {
+    const { srv, base } = await liveDefServer();
+    const res = await fetch(`${base}/api/agent-defs/${encodeURIComponent("Agents/ghost")}`, {
+      method: "PATCH",
+      headers: adminAuth,
+      body: JSON.stringify({ systemPrompt: "x" }),
+    });
+    expect(res.status).toBe(404);
+    srv.stop();
+  });
+
+  test("validation: bad systemPrompt type → 400", async () => {
+    const { srv, base } = await liveDefServer();
+    const res = await fetch(`${base}/api/agent-defs/${encodeURIComponent("Agents/uni-dev")}`, {
+      method: "PATCH",
+      headers: adminAuth,
+      body: JSON.stringify({ systemPrompt: 42 }),
+    });
+    expect(res.status).toBe(400);
+    srv.stop();
+  });
+});
+
+// ===========================================================================
+// DELETE /api/agent-defs/:noteId — delete + deregister
+// ===========================================================================
+describe("DELETE /api/agent-defs/:noteId", () => {
+  async function liveDefServer() {
+    const fake = new FakeDefVault();
+    fake.seed({
+      id: "Agents/uni-dev",
+      content: "p",
+      tags: ["#agent/definition"],
+      metadata: { name: "uni-dev", backend: "programmatic" },
+    });
+    const { reg, calls } = registryWithFakeVault({ fake });
+    await reg.loadAll();
+    const { srv, base } = serverWith(emptyChannels(), { agentDefs: reg });
+    return { srv, base, fake, calls, reg };
+  }
+
+  test("no Authorization → 401", async () => {
+    const { srv, base } = await liveDefServer();
+    const res = await fetch(`${base}/api/agent-defs/${encodeURIComponent("Agents/uni-dev")}`, {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(401);
+    srv.stop();
+  });
+
+  test("deletes the note + deregisters the agent", async () => {
+    const { srv, base, fake, calls, reg } = await liveDefServer();
+    const res = await fetch(`${base}/api/agent-defs/${encodeURIComponent("Agents/uni-dev")}`, {
+      method: "DELETE",
+      headers: adminAuth,
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; name: string; removed: boolean };
+    expect(body.ok).toBe(true);
+    expect(body.name).toBe("uni-dev");
+    expect(body.removed).toBe(true);
+    // The note is gone from the vault.
+    expect(fake.notes.has("Agents/uni-dev")).toBe(false);
+    // The agent was deregistered + its channel removed.
+    expect(calls.deregister).toContain("uni-dev");
+    expect(calls.removeChannel).toContain("uni-dev");
+    // No longer in the live listing.
+    expect(reg.listDetailed()).toHaveLength(0);
+    srv.stop();
+  });
+
+  test("DELETE a note that isn't a live def → 404", async () => {
+    const { srv, base } = await liveDefServer();
+    const res = await fetch(`${base}/api/agent-defs/${encodeURIComponent("Agents/ghost")}`, {
+      method: "DELETE",
+      headers: adminAuth,
+    });
+    expect(res.status).toBe(404);
+    srv.stop();
+  });
+});
+
+// ===========================================================================
+// GET/POST/DELETE /api/agent-vaults — the def-vault list
+// ===========================================================================
+describe("GET /api/agent-vaults", () => {
+  test("no Authorization → 401", async () => {
+    const { reg } = registryWithFakeVault();
+    const { srv, base } = serverWith(emptyChannels(), { agentDefs: reg });
+    const res = await fetch(`${base}/api/agent-vaults`);
+    expect(res.status).toBe(401);
+    srv.stop();
+  });
+
+  test("read scope insufficient → 403", async () => {
+    const { reg } = registryWithFakeVault();
+    const { srv, base } = serverWith(emptyChannels(), { agentDefs: reg });
+    const res = await fetch(`${base}/api/agent-vaults`, { headers: readAuth });
+    expect(res.status).toBe(403);
+    srv.stop();
+  });
+
+  test("lists the bound vaults with token-status, NO token value", async () => {
+    const { reg } = registryWithFakeVault();
+    const { srv, base } = serverWith(emptyChannels(), { agentDefs: reg });
+    const res = await fetch(`${base}/api/agent-vaults`, { headers: adminAuth });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { vaults: Array<{ vault: string; url: string; tokenPresent: boolean }> };
+    const v = body.vaults.find((x) => x.vault === "default");
+    expect(v).toBeDefined();
+    // No raw token in the payload — only the boolean presence.
+    expect(JSON.stringify(body)).not.toContain("vtok");
+    expect(v!.tokenPresent).toBe(true);
+    expect(v!.url).toBe("http://127.0.0.1:1940");
+    srv.stop();
+  });
+});
+
+describe("POST /api/agent-vaults", () => {
+  test("no Authorization → 401", async () => {
+    const { reg } = registryWithFakeVault();
+    const { srv, base } = serverWith(emptyChannels(), { agentDefs: reg });
+    const res = await fetch(`${base}/api/agent-vaults`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ vault: "research" }),
+    });
+    expect(res.status).toBe(401);
+    srv.stop();
+  });
+
+  test("adds a def-vault (injected addDefVault ran) → 201 + re-resolves live", async () => {
+    const { reg } = registryWithFakeVault();
+    const researchVault = new FakeDefVault(); // hermetic — no real loopback.
+    const added: Array<{ vault: string; url?: string }> = [];
+    const addDefVault = async (args: { vault: string; url?: string }) => {
+      added.push(args);
+      // Mirror the real path: register the vault (fake fetch) so a later GET lists it
+      // + a loadAll converges its defs.
+      reg.addVault(
+        { vault: args.vault, vaultUrl: args.url ?? "http://127.0.0.1:1940", token: "minted" },
+        researchVault.fetch,
+      );
+      await reg.loadAll();
+      return { vault: args.vault, url: args.url ?? "http://127.0.0.1:1940", tokenPresent: true };
+    };
+    const { srv, base } = serverWith(emptyChannels(), { agentDefs: reg, addDefVault });
+    const res = await fetch(`${base}/api/agent-vaults`, {
+      method: "POST",
+      headers: adminAuth,
+      body: JSON.stringify({ vault: "research" }),
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { ok: boolean; vault: { vault: string; tokenPresent: boolean } };
+    expect(body.ok).toBe(true);
+    expect(body.vault.vault).toBe("research");
+    expect(body.vault.tokenPresent).toBe(true);
+    // The injected hook ran (mint+persist+load) and the vault is now bound.
+    expect(added).toEqual([{ vault: "research" }]);
+    expect(reg.vaultNames()).toContain("research");
+    srv.stop();
+  });
+
+  test("validation: missing vault → 400", async () => {
+    const { reg } = registryWithFakeVault();
+    const { srv, base } = serverWith(emptyChannels(), { agentDefs: reg, addDefVault: async () => { throw new Error("should not run"); } });
+    const res = await fetch(`${base}/api/agent-vaults`, {
+      method: "POST",
+      headers: adminAuth,
+      body: JSON.stringify({ url: "http://x" }),
+    });
+    expect(res.status).toBe(400);
+    srv.stop();
+  });
+
+  test("validation: bad vault slug → 400", async () => {
+    const { reg } = registryWithFakeVault();
+    const { srv, base } = serverWith(emptyChannels(), { agentDefs: reg, addDefVault: async () => { throw new Error("should not run"); } });
+    const res = await fetch(`${base}/api/agent-vaults`, {
+      method: "POST",
+      headers: adminAuth,
+      body: JSON.stringify({ vault: "bad vault!" }),
+    });
+    expect(res.status).toBe(400);
+    srv.stop();
+  });
+
+  test("a duplicate / failed add → 400 with the error", async () => {
+    const { reg } = registryWithFakeVault();
+    const addDefVault = async () => {
+      throw new Error('def-vault "default" is already configured');
+    };
+    const { srv, base } = serverWith(emptyChannels(), { agentDefs: reg, addDefVault });
+    const res = await fetch(`${base}/api/agent-vaults`, {
+      method: "POST",
+      headers: adminAuth,
+      body: JSON.stringify({ vault: "default" }),
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()) as { error: string }).toMatchObject({ error: expect.stringContaining("already configured") });
+    srv.stop();
+  });
+});
+
+describe("DELETE /api/agent-vaults/:name", () => {
+  /** A registry with TWO bound vaults so a delete doesn't hit the last-vault guard. */
+  function twoVaultRegistry() {
+    const { deps, calls } = recordingDeps();
+    const reg = new AgentDefRegistry(deps, {
+      bindings: [
+        { vault: "default", vaultUrl: "http://127.0.0.1:1940", token: "t1" },
+        { vault: "research", vaultUrl: "http://127.0.0.1:1940", token: "t2" },
+      ],
+    });
+    return { reg, calls };
+  }
+
+  test("no Authorization → 401", async () => {
+    const { reg } = twoVaultRegistry();
+    const { srv, base } = serverWith(emptyChannels(), { agentDefs: reg });
+    const res = await fetch(`${base}/api/agent-vaults/research`, { method: "DELETE" });
+    expect(res.status).toBe(401);
+    srv.stop();
+  });
+
+  test("removes a non-last def-vault → 200 + dropped from the registry", async () => {
+    const { reg } = twoVaultRegistry();
+    const { srv, base } = serverWith(emptyChannels(), { agentDefs: reg });
+    const res = await fetch(`${base}/api/agent-vaults/research`, { method: "DELETE", headers: adminAuth });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; vault: string; removed: boolean };
+    expect(body).toMatchObject({ ok: true, vault: "research", removed: true });
+    expect(reg.vaultNames()).not.toContain("research");
+    expect(reg.vaultNames()).toContain("default");
+    srv.stop();
+  });
+
+  test("removing the LAST def-vault is guarded → 400 (would orphan the module)", async () => {
+    const { reg } = registryWithFakeVault(); // single bound vault.
+    const { srv, base } = serverWith(emptyChannels(), { agentDefs: reg });
+    const res = await fetch(`${base}/api/agent-vaults/default`, { method: "DELETE", headers: adminAuth });
+    expect(res.status).toBe(400);
+    // Still bound (not removed).
+    expect(reg.vaultNames()).toContain("default");
+    srv.stop();
+  });
+
+  test("removing an unknown def-vault → 200 removed:false (idempotent)", async () => {
+    const { reg } = twoVaultRegistry();
+    const { srv, base } = serverWith(emptyChannels(), { agentDefs: reg });
+    const res = await fetch(`${base}/api/agent-vaults/nope`, { method: "DELETE", headers: adminAuth });
+    expect(res.status).toBe(200);
+    expect((await res.json()) as { removed: boolean }).toMatchObject({ removed: false });
+    srv.stop();
+  });
+});

--- a/src/daemon-agent-defs-api.test.ts
+++ b/src/daemon-agent-defs-api.test.ts
@@ -20,7 +20,7 @@
  */
 import { describe, test, expect, mock, beforeAll, afterAll } from "bun:test";
 import { HubJwtError, looksLikeJwt } from "@openparachute/scope-guard";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, chmodSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -62,6 +62,7 @@ mock.module("./hub-jwt.ts", () => ({
 }));
 
 import { createFetchHandler } from "./daemon.ts";
+import { MintError } from "./mint-token.ts";
 import { ClientRegistry } from "./routing.ts";
 import { AgentDefRegistry, type InstantiateDeps } from "./agent-defs.ts";
 import { ChannelQueueRegistry, type ChannelQueueStore } from "./backends/channel-queue.ts";
@@ -454,6 +455,34 @@ describe("POST /api/agent-defs", () => {
     expect(res.status).toBe(400);
     srv.stop();
   });
+
+  test("duplicate name → 409 (collision with a live def)", async () => {
+    // #106 review: seed + load a live def, then POST a second with the SAME name —
+    // createDef rejects the collision up front (AgentDefWriteError 409) before any write.
+    const fake = new FakeDefVault();
+    fake.seed({
+      id: "Agents/uni-dev",
+      content: "p",
+      tags: ["#agent/definition"],
+      metadata: { name: "uni-dev", backend: "programmatic" },
+    });
+    const { reg } = registryWithFakeVault({ fake });
+    await reg.loadAll(); // make "uni-dev" a LIVE def.
+    const { srv, base } = serverWith(emptyChannels(), { agentDefs: reg });
+    const before = fake.notes.size;
+    const res = await fetch(`${base}/api/agent-defs`, {
+      method: "POST",
+      headers: adminAuth,
+      body: JSON.stringify({ vault: "default", name: "uni-dev", backend: "channel" }),
+    });
+    expect(res.status).toBe(409);
+    expect((await res.json()) as { error: string }).toMatchObject({
+      error: expect.stringContaining("already exists"),
+    });
+    // No second note was written — the collision is rejected BEFORE the vault write.
+    expect(fake.notes.size).toBe(before);
+    srv.stop();
+  });
 });
 
 // ===========================================================================
@@ -598,11 +627,17 @@ describe("GET /api/agent-vaults", () => {
     srv.stop();
   });
 
-  test("read scope insufficient → 403", async () => {
+  test("read scope is enough (mirrors GET /api/agent-defs — listing is non-sensitive)", async () => {
+    // #106 review: the listing is {vault,url,tokenPresent} — no secrets — so it's lowered
+    // from admin to read scope, matching the sibling GET /api/agent-defs.
     const { reg } = registryWithFakeVault();
     const { srv, base } = serverWith(emptyChannels(), { agentDefs: reg });
     const res = await fetch(`${base}/api/agent-vaults`, { headers: readAuth });
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { vaults: Array<{ vault: string; tokenPresent: boolean }> };
+    expect(body.vaults.find((x) => x.vault === "default")).toBeDefined();
+    // Still no token value leaked on the read-scoped path.
+    expect(JSON.stringify(body)).not.toContain("vtok");
     srv.stop();
   });
 
@@ -706,6 +741,26 @@ describe("POST /api/agent-vaults", () => {
     expect((await res.json()) as { error: string }).toMatchObject({ error: expect.stringContaining("already configured") });
     srv.stop();
   });
+
+  test("a MintError propagates the hub status (not a generic 500)", async () => {
+    // #106 review: the route maps a MintError to err.status (a hub mint failure carries
+    // its own HTTP status). Inject a hook that throws MintError(429) → assert 429, not 500.
+    const { reg } = registryWithFakeVault();
+    const addDefVault = async () => {
+      throw new MintError("hub rate-limited the mint", 429, "rate_limited");
+    };
+    const { srv, base } = serverWith(emptyChannels(), { agentDefs: reg, addDefVault });
+    const res = await fetch(`${base}/api/agent-vaults`, {
+      method: "POST",
+      headers: adminAuth,
+      body: JSON.stringify({ vault: "research" }),
+    });
+    expect(res.status).toBe(429);
+    expect((await res.json()) as { error: string }).toMatchObject({
+      error: expect.stringContaining("token mint failed"),
+    });
+    srv.stop();
+  });
 });
 
 describe("DELETE /api/agent-vaults/:name", () => {
@@ -759,4 +814,48 @@ describe("DELETE /api/agent-vaults/:name", () => {
     expect((await res.json()) as { removed: boolean }).toMatchObject({ removed: false });
     srv.stop();
   });
+
+  test(
+    "a writeDefVaultsFile failure leaves in-memory state COHERENT (vault still bound, agents NOT torn down)",
+    async () => {
+      // #106 review: the route persists the file FIRST, then deregisters + removes. So a
+      // write failure must leave EVERYTHING untouched. We force the write to fail by making
+      // the sandboxed agent-vaults.json read-only (writeDefVaultsFile → EACCES). The
+      // read-only file lets readDefVaultsFile succeed (read) but the write throws.
+      // Root bypasses file perms (memory: feedback_negative_scans_need_positive_controls),
+      // so skip under uid 0 where the write wouldn't fail.
+      if (typeof process.getuid === "function" && process.getuid() === 0) return;
+
+      const filePath = join(stateDir, "agent-vaults.json");
+      writeFileSync(
+        filePath,
+        JSON.stringify({ vaults: [{ vault: "default" }, { vault: "research" }] }, null, 2),
+        { mode: 0o600 },
+      );
+      chmodSync(filePath, 0o400); // read-only → write throws, read still works.
+      try {
+        const { reg, calls } = twoVaultRegistry();
+        const { srv, base } = serverWith(emptyChannels(), { agentDefs: reg });
+        const res = await fetch(`${base}/api/agent-vaults/research`, {
+          method: "DELETE",
+          headers: adminAuth,
+        });
+        // The durable write failed → 500, BEFORE any in-memory teardown.
+        expect(res.status).toBe(500);
+        expect((await res.json()) as { error: string }).toMatchObject({
+          error: expect.stringContaining("agent-vaults.json"),
+        });
+        // COHERENT: the vault is still bound and its agents were NOT deregistered (the
+        // write-first ordering means a write failure rolls back to a no-op).
+        expect(reg.vaultNames()).toContain("research");
+        expect(reg.vaultNames()).toContain("default");
+        expect(calls.deregister).toHaveLength(0);
+        srv.stop();
+      } finally {
+        // Restore writability so afterAll's rmSync can clean up the file.
+        if (existsSync(filePath)) chmodSync(filePath, 0o600);
+        if (existsSync(filePath)) rmSync(filePath, { force: true });
+      }
+    },
+  );
 });

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -54,10 +54,18 @@ import {
 import { VaultTransport, AGENT_VAULT_TRIGGER_TEMPLATE } from "./transports/vault.ts";
 import {
   AgentDefRegistry,
+  AgentDefWriteError,
   type DefVaultBinding,
   type InstantiateDeps,
 } from "./agent-defs.ts";
-import { resolveDefVaults } from "./def-vaults.ts";
+import {
+  resolveDefVaults,
+  readDefVaultsFile,
+  writeDefVaultsFile,
+  DEFAULT_DEF_VAULT_URL,
+  DEFAULT_HUB_ORIGIN,
+} from "./def-vaults.ts";
+import { mintScopedToken, vaultScope } from "./mint-token.ts";
 import { GrantsClient } from "./grants.ts";
 import { VaultJobStore, validateJob, vaultTransportFor, type Job } from "./jobs.ts";
 import { Runner, realTickDriver } from "./runner.ts";
@@ -593,6 +601,64 @@ export function buildInstantiateDeps(
 }
 
 /**
+ * The real "add a def-vault" implementation behind `POST /api/agent-vaults`: mint the
+ * vault's `vault:<name>:write` token (attenuated to the operator bearer, the SAME path
+ * `resolveDefVaults` mints the default with), persist it into `agent-vaults.json`
+ * (0600 — it carries a token), then `addVault` + `loadAll` for THAT vault so its defs
+ * come up LIVE immediately (no restart). Re-resolves the manager bearer + hub origin at
+ * request time (dynamic-read discipline — a credential set after boot is picked up).
+ * Returns the non-secret view; throws on a missing operator token, a mint refusal, or
+ * a duplicate vault. No-ops cleanly when no registry is wired.
+ */
+function defaultAddDefVault(
+  agentDefs: AgentDefRegistry | undefined,
+): (args: { vault: string; url?: string }) => Promise<{ vault: string; url: string; tokenPresent: boolean }> {
+  return async ({ vault, url }) => {
+    if (!agentDefs) {
+      throw new Error("no def-vault registry configured (the vault-native agent path is idle)");
+    }
+    if (agentDefs.hasVault(vault)) {
+      throw new Error(`def-vault "${vault}" is already configured`);
+    }
+    const vaultUrl = url && url.length > 0 ? url : DEFAULT_DEF_VAULT_URL;
+    // Resolve the operator bearer + hub origin at request time (a credential set after
+    // boot is picked up). A missing operator token → can't mint a child token.
+    let managerBearer: string;
+    try {
+      managerBearer = resolveSpawnDeps().managerBearer;
+    } catch {
+      throw new Error(
+        "cannot mint the def-vault token — no operator token (the hub isn't provisioned yet)",
+      );
+    }
+    if (!managerBearer) {
+      throw new Error(
+        "cannot mint the def-vault token — no operator token (the hub isn't provisioned yet)",
+      );
+    }
+    const minted = await mintScopedToken(
+      { scope: vaultScope(vault, "write") },
+      { hubOrigin: getHubOrigin() || DEFAULT_HUB_ORIGIN, managerBearer },
+    );
+    const binding: DefVaultBinding = { vault, vaultUrl, token: minted.token };
+    // Persist into agent-vaults.json (merge: keep existing entries, append this one).
+    // Source the existing set from the LIVE registry bindings (which carry the real
+    // boot-minted tokens) — NOT a tokenless reconstruction from vaultNames(), which
+    // would clobber a boot-minted default's token to empty on disk and 401 next boot.
+    // Prefer the on-disk file when present (it's the durable record); fall back to the
+    // live bindings when no file has been written yet.
+    const stateDir = defaultStateDir();
+    const existing = readDefVaultsFile(stateDir)?.vaults ?? agentDefs.liveBindings();
+    const merged = [...existing.filter((v) => v.vault !== vault), binding];
+    writeDefVaultsFile({ vaults: merged }, stateDir);
+    // Bring the vault up LIVE: register it + load its defs now (the immediate path).
+    agentDefs.addVault(binding);
+    await agentDefs.loadAll();
+    return { vault, url: vaultUrl, tokenPresent: true };
+  };
+}
+
+/**
  * Build a {@link ChannelQueueStore} for a channel name from its live VaultTransport —
  * the durable inbound-note queue a CHANNEL-backend agent's connected session pulls
  * from (design 2026-06-18). Returns null when the channel isn't a live vault transport
@@ -776,6 +842,48 @@ export function listProgrammaticAgents(programmatic: ProgrammaticAgentRegistry):
       };
     })
     .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Map the registered CHANNEL-backend agents to the {@link AgentInfo} shape the
+ * `/api/agents` list returns (#102 — the v2 API layer stops rejecting `channel`).
+ * A channel agent has no tmux session + no daemon-run turn: its turns are handled by
+ * a Claude Code session the operator connects to the channel's MCP endpoint, and the
+ * inbound notes accumulate as a durable queue. So `attached` is always false, the
+ * `session` label is the conventional `<name>-agent` for display continuity, and the
+ * live `status` is `queued:N` (N = pending inbound waiting for the connected session)
+ * or `idle`. The pending counts are read from the queue in parallel (one vault read
+ * each) — best-effort: a queue read failure degrades that agent's status to `idle`,
+ * never failing the whole list. NEVER surfaces a token/secret.
+ */
+export async function listChannelAgents(channelQueue: ChannelQueueRegistry): Promise<AgentInfo[]> {
+  const dir = defaultSessionsDir();
+  const records = channelQueue.list();
+  return Promise.all(
+    records.map(async (rec) => {
+      let status = "idle";
+      try {
+        const view = await channelQueue.pending(rec.channel);
+        status = view.count > 0 ? `queued:${view.count}` : "idle";
+      } catch {
+        // A queue read failure shouldn't sink the list — show idle, not an error.
+      }
+      const workspace = sessionWorkspace(dir, rec.name);
+      const info: AgentInfo = {
+        name: rec.name,
+        session: `${rec.name}-agent`,
+        attached: false,
+        workspace,
+        hasWorkspace: existsSync(join(workspace, "spec.json")),
+        backend: "channel",
+        status,
+        channel: rec.channel,
+        ...(rec.systemPrompt ? { systemPromptMode: "append" as const } : {}),
+        ...(rec.vault ? { vault: rec.vault } : {}),
+      };
+      return info;
+    }),
+  ).then((infos) => infos.sort((a, b) => a.name.localeCompare(b.name)));
 }
 
 /**
@@ -1599,6 +1707,22 @@ export function isWebSocketUpgrade(req: Request): boolean {
   return (req.headers.get("upgrade") ?? "").toLowerCase() === "websocket";
 }
 
+/**
+ * Coerce an untrusted JSON object into a `Record<string,string>` for a def note's
+ * extra metadata bag — every value stringified (the vault stores metadata as strings).
+ * Non-object input yields an empty map. Used by the agent-def write routes so a caller
+ * passing `{ workspace: "/x", filesystem: "workspace" }` lands as string metadata.
+ */
+function coerceStringMap(v: unknown): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!v || typeof v !== "object" || Array.isArray(v)) return out;
+  for (const [k, val] of Object.entries(v as Record<string, unknown>)) {
+    if (val === undefined || val === null) continue;
+    out[k] = typeof val === "string" ? val : String(val);
+  }
+  return out;
+}
+
 /** Parse + clamp a `?cols=`/`?rows=` query dim to [1, 9999], with a fallback. */
 function clampQueryDim(raw: string | null, fallback: number): number {
   const n = raw === null ? NaN : parseInt(raw, 10);
@@ -1662,6 +1786,19 @@ export function createFetchHandler(
      * route is a clean no-op ack (a daemon with no def-vaults configured).
      */
     agentDefs?: AgentDefRegistry;
+    /**
+     * Add a def-vault to the live registry — the `POST /api/agent-vaults` body of work
+     * (mint the vault's write token, persist `agent-vaults.json`, `addVault` + `loadAll`
+     * for it). Injected so tests exercise the route WITHOUT a live hub mint or a real
+     * vault; `main` leaves it unset and the route uses the real mint
+     * (`mintScopedToken`) + the persisted-file path. Returns the resulting binding's
+     * non-secret view (name + url + token-present).
+     */
+    addDefVault?: (args: { vault: string; url?: string }) => Promise<{
+      vault: string;
+      url: string;
+      tokenPresent: boolean;
+    }>;
   },
 ): (req: Request, server?: { upgrade: (req: Request, opts: { data: TerminalWsData }) => boolean }) => Promise<Response> {
   // Spawn/list/kill operations behind the web agents surface. Lazily defaulted to
@@ -1708,6 +1845,12 @@ export function createFetchHandler(
   // reload webhook is a no-op ack (a daemon with no def-vaults). `main` passes the
   // boot instance so the route reloads the same set the boot instantiated.
   const agentDefs: AgentDefRegistry | undefined = opts?.agentDefs;
+
+  // Add-a-def-vault (the `POST /api/agent-vaults` body of work). Defaulted to the real
+  // mint + persist path so a plain createFetchHandler serves the route; tests inject a
+  // stub so the route is exercised WITHOUT a live hub mint or a real vault. Returns the
+  // resulting binding's non-secret view (name + url + token-present).
+  const addDefVault = opts?.addDefVault ?? defaultAddDefVault(agentDefs);
 
   // Install the MCP connect hook: when an MCP session's GET push stream goes live
   // (mcp-http's handleMcp GET branch → fireConnectReplay — NOT at registration,
@@ -2336,12 +2479,15 @@ export function createFetchHandler(
       if (req.method === "GET") {
         try {
           // The list MERGES interactive tmux sessions + registered programmatic
-          // agents (design 2026-06-16 step 6). Programmatic agents have no tmux
-          // session, so they carry `backend: "programmatic"` + a live `status`
-          // (idle|working|queued:N) instead of `attached`/`mcp_sessions`.
+          // agents (design 2026-06-16 step 6) + registered CHANNEL-backend agents
+          // (#102 — the v2 API layer stops rejecting `channel`). Neither programmatic
+          // nor channel agents have a tmux session, so they carry their `backend` +
+          // a live `status` (idle|working|queued:N) instead of `attached`/`mcp_sessions`;
+          // a channel agent also surfaces its wake `channel` + backing `vault`.
           const interactive = await agentOps.list();
           const programmaticInfos = listProgrammaticAgents(programmatic);
-          return json({ agents: [...interactive, ...programmaticInfos] });
+          const channelInfos = await listChannelAgents(channelQueue);
+          return json({ agents: [...interactive, ...programmaticInfos, ...channelInfos] });
         } catch (err) {
           return json({ error: `failed to list agents: ${(err as Error).message}` }, 500);
         }
@@ -2517,6 +2663,238 @@ export function createFetchHandler(
       const denied = await requireScope(req, url, SCOPE_ADMIN);
       if (denied) return denied;
       return json({ vaults: listVaultNames() });
+    }
+
+    // ---------------------------------------------------------------------
+    // Vault-native agent DEFINITIONS — the v2 API layer (design
+    // 2026-06-18-agent-ui-v2-and-reactivity.md Part 2 Phase 1). A `#agent/definition`
+    // note IS the agent (body = system prompt, metadata = config); these routes
+    // list + create + edit + delete them in a configured def-vault, reloading the
+    // changed note into a LIVE agent IMMEDIATELY (the per-note reload, NOT the 60s
+    // poll). NO secrets surfaced (no tokens). Externally `<hub>/agent/api/agent-defs`.
+    //
+    //   GET    /api/agent-defs           → list (read-scoped) — per def: noteId, name,
+    //                                       backend, vault, status, pending,
+    //                                       systemPromptPreview, wants, channel
+    //   POST   /api/agent-defs           { vault, name, backend, systemPrompt, wants?,
+    //                                       metadata? } → write note + reload live (admin)
+    //   PATCH  /api/agent-defs/<noteId>  { systemPrompt?, wants?, metadata? } → edit +
+    //                                       reload (admin)
+    //   DELETE /api/agent-defs/<noteId>  → delete note + deregister (admin)
+    // ---------------------------------------------------------------------
+    if (url.pathname === "/api/agent-defs" && (req.method === "GET" || req.method === "POST")) {
+      // GET is READ-scoped (a listing, no secrets); POST is admin (it mints/writes).
+      const scope = req.method === "GET" ? SCOPE_READ : SCOPE_ADMIN;
+      const denied = await requireScope(req, url, scope);
+      if (denied) return denied;
+      if (!agentDefs) {
+        // No def-vaults configured — an empty list (GET) / a clear 400 (POST).
+        if (req.method === "GET") return json({ defs: [] });
+        return json({ error: "no def-vaults configured (add one via POST /api/agent-vaults)" }, 400);
+      }
+
+      if (req.method === "GET") {
+        return json({ defs: agentDefs.listDetailed() });
+      }
+
+      // POST — create a new def note + reload it live.
+      let body: { vault?: unknown; name?: unknown; backend?: unknown; systemPrompt?: unknown; wants?: unknown; metadata?: unknown };
+      try {
+        body = (await req.json()) as typeof body;
+      } catch {
+        return json({ error: "invalid JSON body" }, 400);
+      }
+      if (typeof body.vault !== "string" || body.vault.length === 0) {
+        return json({ error: "body.vault (string) is required" }, 400);
+      }
+      if (typeof body.name !== "string" || body.name.length === 0) {
+        return json({ error: "body.name (string) is required" }, 400);
+      }
+      const backend = body.backend === undefined ? "programmatic" : body.backend;
+      if (backend !== "programmatic" && backend !== "channel") {
+        return json({ error: 'body.backend must be "programmatic" or "channel"' }, 400);
+      }
+      if (body.systemPrompt !== undefined && typeof body.systemPrompt !== "string") {
+        return json({ error: "body.systemPrompt must be a string" }, 400);
+      }
+      if (body.wants !== undefined && typeof body.wants !== "string") {
+        return json({ error: "body.wants must be a comma-separated string" }, 400);
+      }
+      if (body.metadata !== undefined && (typeof body.metadata !== "object" || body.metadata === null || Array.isArray(body.metadata))) {
+        return json({ error: "body.metadata must be an object of strings" }, 400);
+      }
+      try {
+        const detail = await agentDefs.createDef({
+          vault: body.vault,
+          name: body.name,
+          backend,
+          systemPrompt: typeof body.systemPrompt === "string" ? body.systemPrompt : "",
+          ...(typeof body.wants === "string" ? { wants: body.wants } : {}),
+          ...(body.metadata ? { metadata: coerceStringMap(body.metadata) } : {}),
+        });
+        return json({ ok: true, def: detail }, 201);
+      } catch (err) {
+        if (err instanceof AgentDefWriteError) return json({ error: err.message }, err.status);
+        return json({ error: `failed to create agent def: ${(err as Error).message}` }, 502);
+      }
+    }
+
+    const defMatch = url.pathname.match(/^\/api\/agent-defs\/(.+)$/);
+    if (defMatch && (req.method === "PATCH" || req.method === "DELETE")) {
+      const denied = await requireScope(req, url, SCOPE_ADMIN);
+      if (denied) return denied;
+      const noteId = decodeURIComponent(defMatch[1]!);
+      if (!agentDefs) {
+        return json({ error: "no def-vaults configured" }, 400);
+      }
+
+      if (req.method === "DELETE") {
+        try {
+          const removed = await agentDefs.deleteDef(noteId);
+          return json({ ok: true, ...removed, removed: true });
+        } catch (err) {
+          if (err instanceof AgentDefWriteError) return json({ error: err.message }, err.status);
+          return json({ error: `failed to delete agent def: ${(err as Error).message}` }, 502);
+        }
+      }
+
+      // PATCH — edit body and/or metadata, reload live.
+      let body: { systemPrompt?: unknown; wants?: unknown; metadata?: unknown };
+      try {
+        body = (await req.json()) as typeof body;
+      } catch {
+        return json({ error: "invalid JSON body" }, 400);
+      }
+      if (body.systemPrompt !== undefined && typeof body.systemPrompt !== "string") {
+        return json({ error: "body.systemPrompt must be a string" }, 400);
+      }
+      if (body.wants !== undefined && typeof body.wants !== "string") {
+        return json({ error: "body.wants must be a comma-separated string" }, 400);
+      }
+      if (body.metadata !== undefined && (typeof body.metadata !== "object" || body.metadata === null || Array.isArray(body.metadata))) {
+        return json({ error: "body.metadata must be an object of strings" }, 400);
+      }
+      try {
+        const detail = await agentDefs.editDef(noteId, {
+          ...(typeof body.systemPrompt === "string" ? { systemPrompt: body.systemPrompt } : {}),
+          ...(typeof body.wants === "string" ? { wants: body.wants } : {}),
+          ...(body.metadata ? { metadata: coerceStringMap(body.metadata) } : {}),
+        });
+        return json({ ok: true, def: detail });
+      } catch (err) {
+        if (err instanceof AgentDefWriteError) return json({ error: err.message }, err.status);
+        return json({ error: `failed to edit agent def: ${(err as Error).message}` }, 502);
+      }
+    }
+
+    // ---------------------------------------------------------------------
+    // Module-level DEF-VAULT list — which vault(s) this module reads
+    // `#agent/definition` notes from (`agent-vaults.json`). Today invisible +
+    // uneditable; the v2 API surfaces + manages it. NO token VALUE surfaced (only
+    // present/absent). Externally `<hub>/agent/api/agent-vaults`. Admin-scoped.
+    //
+    //   GET    /api/agent-vaults         → list { vault, url, tokenPresent } (no value)
+    //   POST   /api/agent-vaults         { vault, url? } → mint token + persist + live
+    //   DELETE /api/agent-vaults/<name>  → drop from file + deregister its agents
+    // ---------------------------------------------------------------------
+    if (url.pathname === "/api/agent-vaults" && (req.method === "GET" || req.method === "POST")) {
+      const denied = await requireScope(req, url, SCOPE_ADMIN);
+      if (denied) return denied;
+
+      if (req.method === "GET") {
+        // Source of truth: the LIVE registry's bound vaults (a boot-minted binding
+        // shows its token even before the file write lands). NEVER the token value. We
+        // fall back to the persisted file only when no registry is wired (idle path),
+        // so the listing isn't silently empty. The url defaults to the loopback vault.
+        if (agentDefs) {
+          return json({ vaults: agentDefs.vaultStatuses() });
+        }
+        let persisted: DefVaultBinding[] = [];
+        try {
+          persisted = readDefVaultsFile(defaultStateDir())?.vaults ?? [];
+        } catch {
+          persisted = [];
+        }
+        const vaults = persisted
+          .map((v) => ({
+            vault: v.vault,
+            url: v.vaultUrl ?? DEFAULT_DEF_VAULT_URL,
+            tokenPresent: typeof v.token === "string" && v.token.length > 0,
+          }))
+          .sort((a, b) => a.vault.localeCompare(b.vault));
+        return json({ vaults });
+      }
+
+      // POST — add a def-vault (mint token + persist + load its defs live).
+      let body: { vault?: unknown; url?: unknown };
+      try {
+        body = (await req.json()) as typeof body;
+      } catch {
+        return json({ error: "invalid JSON body" }, 400);
+      }
+      if (typeof body.vault !== "string" || body.vault.length === 0) {
+        return json({ error: "body.vault (string) is required" }, 400);
+      }
+      if (!/^[a-zA-Z0-9_-]+$/.test(body.vault)) {
+        return json({ error: `body.vault "${body.vault}" must be a slug (alphanumeric, dash, underscore)` }, 400);
+      }
+      if (body.url !== undefined && typeof body.url !== "string") {
+        return json({ error: "body.url must be a string (the vault REST origin)" }, 400);
+      }
+      try {
+        const added = await addDefVault({
+          vault: body.vault,
+          ...(typeof body.url === "string" && body.url.length > 0 ? { url: body.url } : {}),
+        });
+        return json({ ok: true, vault: added }, 201);
+      } catch (err) {
+        if (err instanceof MintError) {
+          return json({ error: `token mint failed: ${err.message}` }, err.status >= 400 && err.status < 600 ? err.status : 502);
+        }
+        // A duplicate / no-operator-token / no-registry error → 400 (operator-actionable).
+        return json({ error: `failed to add def-vault: ${(err as Error).message}` }, 400);
+      }
+    }
+
+    const vaultDelMatch = url.pathname.match(/^\/api\/agent-vaults\/([^/]+)$/);
+    if (vaultDelMatch && req.method === "DELETE") {
+      const denied = await requireScope(req, url, SCOPE_ADMIN);
+      if (denied) return denied;
+      const name = decodeURIComponent(vaultDelMatch[1]!);
+      if (!agentDefs) {
+        return json({ error: "no def-vaults configured" }, 400);
+      }
+      // GUARD: don't remove the last def-vault — that would orphan the module's whole
+      // vault-native path (no vault to define agents in). Mirror the channels.json
+      // posture: removing the only one is a clear 400, not a silent orphan.
+      const names = agentDefs.vaultNames();
+      if (!names.includes(name)) {
+        return json({ ok: true, vault: name, removed: false }, 200);
+      }
+      if (names.length <= 1) {
+        return json(
+          { error: `cannot remove the only def-vault "${name}" — the vault-native agent path would have no vault to define agents in. Add another first.` },
+          400,
+        );
+      }
+      // Tear down its live agents, then drop it from the live registry + the file.
+      try {
+        await agentDefs.deregisterAllForVault(name);
+      } catch (err) {
+        return json({ error: `failed to deregister agents for "${name}": ${(err as Error).message}` }, 502);
+      }
+      // Rewrite agent-vaults.json without this vault (idempotent).
+      try {
+        const stateDir = defaultStateDir();
+        const file = readDefVaultsFile(stateDir);
+        if (file) {
+          writeDefVaultsFile({ vaults: file.vaults.filter((v) => v.vault !== name) }, stateDir);
+        }
+      } catch (err) {
+        return json({ error: `failed to update agent-vaults.json: ${(err as Error).message}` }, 500);
+      }
+      agentDefs.removeVault(name);
+      return json({ ok: true, vault: name, removed: true });
     }
 
     // ---------------------------------------------------------------------

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -652,6 +652,8 @@ function defaultAddDefVault(
     const merged = [...existing.filter((v) => v.vault !== vault), binding];
     writeDefVaultsFile({ vaults: merged }, stateDir);
     // Bring the vault up LIVE: register it + load its defs now (the immediate path).
+    // NOTE: loadAll() reloads ALL configured def-vaults, not just the one just added —
+    // a slight over-read, acceptable at the current handful-of-vaults scale.
     agentDefs.addVault(binding);
     await agentDefs.loadAll();
     return { vault, url: vaultUrl, tokenPresent: true };
@@ -2793,12 +2795,16 @@ export function createFetchHandler(
     // uneditable; the v2 API surfaces + manages it. NO token VALUE surfaced (only
     // present/absent). Externally `<hub>/agent/api/agent-vaults`. Admin-scoped.
     //
-    //   GET    /api/agent-vaults         → list { vault, url, tokenPresent } (no value)
-    //   POST   /api/agent-vaults         { vault, url? } → mint token + persist + live
-    //   DELETE /api/agent-vaults/<name>  → drop from file + deregister its agents
+    //   GET    /api/agent-vaults         → list { vault, url, tokenPresent } (read)
+    //   POST   /api/agent-vaults         { vault, url? } → mint token + persist + live (admin)
+    //   DELETE /api/agent-vaults/<name>  → drop from file + deregister its agents (admin)
     // ---------------------------------------------------------------------
     if (url.pathname === "/api/agent-vaults" && (req.method === "GET" || req.method === "POST")) {
-      const denied = await requireScope(req, url, SCOPE_ADMIN);
+      // GET is READ-scoped to mirror GET /api/agent-defs — the listing is non-sensitive
+      // ({vault,url,tokenPresent}); `tokenPresent` is a boolean, NEVER the token value.
+      // POST is admin (it mints a token + writes config).
+      const scope = req.method === "GET" ? SCOPE_READ : SCOPE_ADMIN;
+      const denied = await requireScope(req, url, scope);
       if (denied) return denied;
 
       if (req.method === "GET") {
@@ -2877,13 +2883,13 @@ export function createFetchHandler(
           400,
         );
       }
-      // Tear down its live agents, then drop it from the live registry + the file.
-      try {
-        await agentDefs.deregisterAllForVault(name);
-      } catch (err) {
-        return json({ error: `failed to deregister agents for "${name}": ${(err as Error).message}` }, 502);
-      }
-      // Rewrite agent-vaults.json without this vault (idempotent).
+      // ORDERING (#106 review): persist the file FIRST, then tear down in-memory state.
+      // The prior order (deregister → write → remove) left an INCOHERENT state on a write
+      // failure: agents already torn down but the vault still in the live registry, while
+      // the on-disk file was unchanged — so a restart re-instantiated agents the operator
+      // had just deleted. Writing first means a write failure leaves EVERYTHING untouched
+      // (vault + agents still live, file unchanged); only after the durable write commits
+      // do we deregister the agents and drop the vault from the live registry.
       try {
         const stateDir = defaultStateDir();
         const file = readDefVaultsFile(stateDir);
@@ -2892,6 +2898,14 @@ export function createFetchHandler(
         }
       } catch (err) {
         return json({ error: `failed to update agent-vaults.json: ${(err as Error).message}` }, 500);
+      }
+      // File is durable without this vault → tear down its live agents + drop it from the
+      // live registry. A deregister failure now leaves the file already-correct, so a
+      // restart converges to the intended (removed) state rather than resurrecting it.
+      try {
+        await agentDefs.deregisterAllForVault(name);
+      } catch (err) {
+        return json({ error: `failed to deregister agents for "${name}": ${(err as Error).message}` }, 502);
       }
       agentDefs.removeVault(name);
       return json({ ok: true, vault: name, removed: true });


### PR DESCRIPTION
Phase 1 of the agent UI v2 (`design/2026-06-18-agent-ui-v2-and-reactivity.md`): the clean JSON API the SPA builds on. No UI here — endpoints + tests.

## Endpoints (8)
- `GET /api/agent-defs` (read) — vault-native agents from the registry (no secrets; systemPrompt preview only).
- `POST/PATCH/DELETE /api/agent-defs` (admin) — create/edit/delete a `#agent/definition` note in a configured def-vault, then **immediate per-note reload** so it goes live instantly (no trigger/poll dependency).
- `GET /api/agent-vaults` (read) — the module-level def-vault list (`vault, url, tokenPresent` — never the token).
- `POST/DELETE /api/agent-vaults` (admin) — add (mint+persist the vault token, re-resolve bindings) / remove (deregister, guard the last vault) a def-vault.
- `GET /api/agents` (admin) — now lists **all backends** incl. `channel` (closes #102).

## Verified
`bun test src/` **1020 pass / 0 fail**; typecheck clean (pre-existing bridge.ts only). Auth: every mutation `agent:admin`, listings `agent:read`, tokens never on the wire. **Live real-path tested** through the proxied API: created a def → `status:enabled` immediately, appeared in `/api/agent-defs` + `/api/agents`, deleted + deregistered cleanly; `/api/agent-vaults` listed the def-vault (no token).

Builder self-caught + fixed a real boot-time bug (tokenless-binding clobber on agent-vaults add → sourced from live bindings). Reviewed LGTM; 5 nits folded (cross-vault `findLiveByNote` ambiguity → 409; partial-state-on-delete-failure ordering; read-scope the listing; +409/MintError tests). Next: Phase 2 (SPA shell + unified Agents view). No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)