### PR TITLE
feat(agent-ui-v2): Phase 2 — SPA shell + read-only unified Agents view (/agent/app/)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "daemon": "bun src/daemon.ts",
     "bridge": "bun src/bridge.ts",
     "spawn-agent": "bun scripts/spawn-agent.ts",
-    "test": "bun test src/",
+    "test": "bun test ./src/",
     "test:e2e": "bun e2e/llm/run.ts",
     "typecheck": "tsc --noEmit"
   },

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "bridge": "bun src/bridge.ts",
     "spawn-agent": "bun scripts/spawn-agent.ts",
     "test": "bun test ./src/",
+    "test:spa": "cd web/ui && bun run test",
+    "test:all": "bun test ./src/ && cd web/ui && bun run test",
     "test:e2e": "bun e2e/llm/run.ts",
     "typecheck": "tsc --noEmit"
   },

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -101,6 +101,7 @@ import { TERMINAL_UI_HTML } from "./terminal-ui.ts";
 import { serveTerminalAsset } from "./terminal-assets.ts";
 import { AGENTS_UI_HTML } from "./agents-ui.ts";
 import { HOME_UI_HTML } from "./home-ui.ts";
+import { isSpaPath, serveSpa, spaDistDir } from "./spa-serve.ts";
 import {
   createRealAgentOps,
   buildSpecFromBody,
@@ -2000,6 +2001,19 @@ export function createFetchHandler(
       return new Response(HOME_UI_HTML, {
         headers: { "content-type": "text/html; charset=utf-8" },
       });
+    }
+
+    // Agent UI v2 SPA (the agent-centric React surface) — served at the NEW
+    // `/app` mount, reachable at `<hub>/agent/app/` over the hub proxy. Coexists
+    // with the daemon-rendered HTML pages above (the design's incremental
+    // migration; the HTML retires in a later phase). Serves `index.html` for the
+    // SPA route(s) + `dist/assets/*` for assets; a missing `dist/` → 503 with a
+    // "run build" hint (dev-checkout case). Loads OPEN (like /ui, /admin, /agents)
+    // so it can bootstrap its hub-minted `agent:admin` token; the `/api/*` calls
+    // it makes are what `requireScope` gates. Bundle path is anchored to the
+    // install dir so a `bun src/daemon.ts` from any cwd finds web/ui/dist/.
+    if (req.method === "GET" && isSpaPath(url.pathname)) {
+      return serveSpa(spaDistDir(INSTALL_DIR), url.pathname);
     }
 
     // Health check — per-channel client counts. Programmatic agents (design

--- a/src/spa-serve.test.ts
+++ b/src/spa-serve.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Tests for the v2 agent SPA bundle serving (`src/spa-serve.ts`) — the daemon's
+ * `/app` mount. Proves: a missing dist 503s with a build hint; the SPA shell is
+ * served for the mount root + client-routed paths; real assets serve with the
+ * right content-type; path traversal is blocked; the mount-path predicate is
+ * exact.
+ */
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  SPA_MOUNT,
+  isSpaPath,
+  serveSpa,
+  spaContentType,
+  spaDistDir,
+} from "./spa-serve.ts";
+
+describe("isSpaPath", () => {
+  test("matches the mount root + sub-paths only", () => {
+    expect(isSpaPath("/app")).toBe(true);
+    expect(isSpaPath("/app/")).toBe(true);
+    expect(isSpaPath("/app/agents")).toBe(true);
+    expect(isSpaPath("/app/assets/index-abc.js")).toBe(true);
+    // NOT the daemon-rendered HTML pages or other routes.
+    expect(isSpaPath("/agents")).toBe(false);
+    expect(isSpaPath("/apple")).toBe(false);
+    expect(isSpaPath("/api/agents")).toBe(false);
+    expect(isSpaPath("/")).toBe(false);
+  });
+});
+
+describe("spaContentType", () => {
+  test("maps the realistic Vite output extensions", () => {
+    expect(spaContentType("/x/index.html")).toContain("text/html");
+    expect(spaContentType("/x/index-abc.js")).toContain("javascript");
+    expect(spaContentType("/x/index-abc.css")).toContain("css");
+    expect(spaContentType("/x/logo.svg")).toBe("image/svg+xml");
+    expect(spaContentType("/x/unknown.bin")).toBe("application/octet-stream");
+  });
+});
+
+describe("spaDistDir", () => {
+  test("anchors to <installDir>/web/ui/dist", () => {
+    expect(spaDistDir("/opt/agent")).toBe("/opt/agent/web/ui/dist");
+  });
+});
+
+describe("serveSpa — missing bundle", () => {
+  test("503s with a build hint when dist/ is absent", async () => {
+    const res = serveSpa("/nonexistent/dist", "/app/");
+    expect(res.status).toBe(503);
+    expect(await res.text()).toContain("run `bun run build`");
+  });
+});
+
+describe("serveSpa — with a fixture bundle", () => {
+  let dist: string;
+
+  beforeAll(() => {
+    dist = mkdtempSync(join(tmpdir(), "agent-spa-test-"));
+    mkdirSync(join(dist, "assets"), { recursive: true });
+    writeFileSync(join(dist, "index.html"), "<!doctype html><div id=root></div>");
+    writeFileSync(join(dist, "assets", "index-abc.js"), "console.log('spa')");
+    writeFileSync(join(dist, "assets", "index-abc.css"), ".x{color:red}");
+  });
+
+  afterAll(() => {
+    rmSync(dist, { recursive: true, force: true });
+  });
+
+  test("serves the SPA shell at the mount root", async () => {
+    const res = serveSpa(dist, SPA_MOUNT);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    expect(await res.text()).toContain("id=root");
+  });
+
+  test("serves the SPA shell for a client-routed path (no extension)", async () => {
+    const res = serveSpa(dist, "/app/agents");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    expect(await res.text()).toContain("id=root");
+  });
+
+  test("serves a real JS asset with the right content-type", async () => {
+    const res = serveSpa(dist, "/app/assets/index-abc.js");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("javascript");
+    expect(await res.text()).toContain("spa");
+  });
+
+  test("serves a real CSS asset", async () => {
+    const res = serveSpa(dist, "/app/assets/index-abc.css");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("css");
+  });
+
+  test("an asset-shaped path that doesn't exist falls back to the SPA shell", async () => {
+    const res = serveSpa(dist, "/app/assets/missing.js");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+  });
+
+  test("blocks path traversal out of dist/", async () => {
+    // A `..`-containing path never enters the asset branch → SPA shell (not the
+    // escaped file). The 404 belt-and-braces guards the loosened case.
+    const res = serveSpa(dist, "/app/../../etc/passwd");
+    // Either the shell (traversal filtered) or a 404 — never the escaped file.
+    expect([200, 404]).toContain(res.status);
+    if (res.status === 200) {
+      expect(res.headers.get("content-type")).toContain("text/html");
+    }
+  });
+});

--- a/src/spa-serve.ts
+++ b/src/spa-serve.ts
@@ -1,0 +1,116 @@
+/**
+ * Serve the built v2 agent SPA bundle (`web/ui/dist/`) at the daemon's `/app`
+ * mount — reachable at `<hub>/agent/app/` over the hub proxy (the hub strips the
+ * `/agent` prefix, so the daemon sees `/app/*`).
+ *
+ * This is ADDITIVE: it sits alongside the existing daemon-rendered HTML pages
+ * (`/agents`, `/home`, `/admin`, `/jobs`, `/terminal`, `/ui`), which stay mounted
+ * untouched. The design's incremental migration — operators compare the SPA with
+ * the HTML until the HTML retires in a later phase.
+ *
+ * Mirrors the hub's `serveSpa` (parachute-hub/src/hub-server.ts): asset URLs are
+ * origin-absolute (`/agent/app/assets/...`) per the Vite `base`, so the HTML
+ * loads correctly under the proxied mount; any non-asset path falls back to the
+ * SPA shell (react-router takes it from there). A missing `dist/` → 503 with a
+ * "run build" hint (the dev-checkout case).
+ */
+import { existsSync } from "fs";
+import { join, resolve } from "path";
+
+/** The SPA mount the daemon serves the bundle under (post-stripPrefix). */
+export const SPA_MOUNT = "/app";
+
+/**
+ * Resolve the SPA bundle dir from the install root. Anchored to the package so a
+ * `bun src/daemon.ts` from any cwd finds `<repo>/web/ui/dist/`.
+ */
+export function spaDistDir(installDir: string): string {
+  return join(installDir, "web", "ui", "dist");
+}
+
+/**
+ * True when `pathname` falls under the SPA mount (`/app`, `/app/`, `/app/...`).
+ * Asset requests (`/app/assets/...`) match too — they're served from `dist/`.
+ */
+export function isSpaPath(pathname: string): boolean {
+  return pathname === SPA_MOUNT || pathname.startsWith(`${SPA_MOUNT}/`);
+}
+
+/**
+ * Pick a content type for the static assets Vite produces. Mismatches show up
+ * loud (a `.js` served as `text/html` is unmistakable); the list is trivially
+ * extensible.
+ */
+export function spaContentType(pathname: string): string {
+  const ext = pathname.slice(pathname.lastIndexOf(".") + 1).toLowerCase();
+  switch (ext) {
+    case "html":
+      return "text/html; charset=utf-8";
+    case "js":
+    case "mjs":
+      return "application/javascript; charset=utf-8";
+    case "css":
+      return "text/css; charset=utf-8";
+    case "svg":
+      return "image/svg+xml";
+    case "png":
+      return "image/png";
+    case "ico":
+      return "image/x-icon";
+    case "woff2":
+      return "font/woff2";
+    case "woff":
+      return "font/woff";
+    case "json":
+    case "map":
+      return "application/json";
+    case "txt":
+      return "text/plain; charset=utf-8";
+    default:
+      return "application/octet-stream";
+  }
+}
+
+/**
+ * Serve a single file under the SPA mount, falling back to `index.html` for
+ * client-side-routed paths (anything that doesn't resolve to a real file under
+ * `dist/`). Path traversal is blocked twice: the asset-shape filter rejects
+ * sub-paths containing "..", and the resolved absolute path is checked to start
+ * with `dist/` before any read.
+ */
+export function serveSpa(distDir: string, pathname: string): Response {
+  if (!existsSync(distDir)) {
+    return new Response(
+      "agent SPA bundle not found — run `bun run build` in web/ui/ to produce dist/",
+      { status: 503, headers: { "content-type": "text/plain; charset=utf-8" } },
+    );
+  }
+  // Strip the mount prefix: "/app" → "", "/app/" → "/", "/app/x" → "/x".
+  const sub = pathname === SPA_MOUNT ? "" : pathname.slice(SPA_MOUNT.length);
+  const indexPath = join(distDir, "index.html");
+
+  // Empty / mount-root / any non-asset request → the SPA shell. First defense
+  // against traversal: bare paths and anything containing ".." never enter the
+  // asset branch.
+  const looksLikeAsset = sub.length > 0 && /\.[a-z0-9]+$/i.test(sub) && !sub.includes("..");
+  if (!looksLikeAsset) {
+    return new Response(Bun.file(indexPath), {
+      headers: { "content-type": "text/html; charset=utf-8" },
+    });
+  }
+
+  const filePath = resolve(distDir, `.${sub}`);
+  // Second defense: refuse any resolved path that escapes dist/.
+  if (!filePath.startsWith(`${distDir}/`)) {
+    return new Response("not found", { status: 404 });
+  }
+  if (!existsSync(filePath)) {
+    // Asset request that doesn't resolve to a real file → the SPA shell.
+    return new Response(Bun.file(indexPath), {
+      headers: { "content-type": "text/html; charset=utf-8" },
+    });
+  }
+  return new Response(Bun.file(filePath), {
+    headers: { "content-type": spaContentType(filePath) },
+  });
+}

--- a/web/ui/.gitignore
+++ b/web/ui/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.tsbuildinfo

--- a/web/ui/bun.lock
+++ b/web/ui/bun.lock
@@ -1,0 +1,503 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@openparachute/agent-web-ui",
+      "dependencies": {
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "react-router-dom": "^7.0.0",
+      },
+      "devDependencies": {
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/node": "^22.19.17",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "@vitejs/plugin-react": "^4.3.0",
+        "@vitest/ui": "^4.1.5",
+        "jsdom": "^25.0.1",
+        "typescript": "^5.6.0",
+        "vite": "^6.0.0",
+        "vitest": "^4.1.5",
+      },
+    },
+  },
+  "packages": {
+    "@adobe/css-tools": ["@adobe/css-tools@4.5.0", "", {}, "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q=="],
+
+    "@asamuzakjp/css-color": ["@asamuzakjp/css-color@3.2.0", "", { "dependencies": { "@csstools/css-calc": "^2.1.3", "@csstools/css-color-parser": "^3.0.9", "@csstools/css-parser-algorithms": "^3.0.4", "@csstools/css-tokenizer": "^3.0.3", "lru-cache": "^10.4.3" } }, "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw=="],
+
+    "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
+
+    "@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
+
+    "@babel/core": ["@babel/core@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-compilation-targets": "^7.29.7", "@babel/helper-module-transforms": "^7.29.7", "@babel/helpers": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA=="],
+
+    "@babel/generator": ["@babel/generator@7.29.7", "", { "dependencies": { "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ=="],
+
+    "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.29.7", "", { "dependencies": { "@babel/compat-data": "^7.29.7", "@babel/helper-validator-option": "^7.29.7", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g=="],
+
+    "@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
+
+    "@babel/helper-module-imports": ["@babel/helper-module-imports@7.29.7", "", { "dependencies": { "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g=="],
+
+    "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.29.7", "", { "dependencies": { "@babel/helper-module-imports": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7", "@babel/traverse": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg=="],
+
+    "@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.29.7", "", {}, "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/helper-validator-option": ["@babel/helper-validator-option@7.29.7", "", {}, "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw=="],
+
+    "@babel/helpers": ["@babel/helpers@7.29.7", "", { "dependencies": { "@babel/template": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg=="],
+
+    "@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
+
+    "@babel/plugin-transform-react-jsx-self": ["@babel/plugin-transform-react-jsx-self@7.29.7", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw=="],
+
+    "@babel/plugin-transform-react-jsx-source": ["@babel/plugin-transform-react-jsx-source@7.29.7", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
+    "@babel/template": ["@babel/template@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg=="],
+
+    "@babel/traverse": ["@babel/traverse@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-globals": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/types": "^7.29.7", "debug": "^4.3.1" } }, "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw=="],
+
+    "@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
+
+    "@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
+
+    "@csstools/css-calc": ["@csstools/css-calc@2.1.4", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ=="],
+
+    "@csstools/css-color-parser": ["@csstools/css-color-parser@3.1.0", "", { "dependencies": { "@csstools/color-helpers": "^5.1.0", "@csstools/css-calc": "^2.1.4" }, "peerDependencies": { "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA=="],
+
+    "@csstools/css-parser-algorithms": ["@csstools/css-parser-algorithms@3.0.5", "", { "peerDependencies": { "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ=="],
+
+    "@csstools/css-tokenizer": ["@csstools/css-tokenizer@3.0.4", "", {}, "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.62.0", "", { "os": "android", "cpu": "arm" }, "sha512-IPIQ55ythEHkfEd9jMEi32OQ7SxURsGA43JI22lj01OLZNt2NUbJX8YUHxkVWyQ6daHPNn0truF5nSj3DQp6YQ=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.62.0", "", { "os": "android", "cpu": "arm64" }, "sha512-M6s9cr10MibETyo8JsOkq+Lo1+lU6hcvb1MApnUql5qte/5hMEgzlN8/ReIKNfRV8rrqX50W1BX9zoUhC192RA=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.62.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BqCoMoIbn0keKys+dEAdBa70EtOwV1bEsQCUgU9FdiZmmMge/Zk7LlkYGqbrdHR+Frnt0E1FOanly+rlwvvQzw=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.62.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-SIMzST3VFNXDAbeIWDWiFCNM5qncUBDWaEV7NfE7oZbDt2mgfW4MvbKdbYiGOLoM32gbTv608UMd0XktEYSD7w=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.62.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-ezjfSQMP7ArdUsbBwbQIfwAlhE84I2iVnzQNCFSveqV42q+BmKlzVpf7mxv5EchLcoWU4y6/heFzVg1F+hodUQ=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.62.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-9+qTWGW9AZRhnUgwtTwzNwcPlL87ngkeN0LA+q1bADvmY9aNvWaF2TFW8BZgnQPYxpDI7+rMVLivcd4V737TAQ=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.62.0", "", { "os": "linux", "cpu": "arm" }, "sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.62.0", "", { "os": "linux", "cpu": "arm" }, "sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.62.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-bVURMg+6eNN9C/yc0aVjooZcwTTtYF4YW3xta5pP0//r3o1V8gXEHXWCndj47w/HhwsFroZrFhR+6uQP5T0n0g=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.62.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.62.0", "", { "os": "linux", "cpu": "none" }, "sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.62.0", "", { "os": "linux", "cpu": "none" }, "sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.62.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.62.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.62.0", "", { "os": "linux", "cpu": "none" }, "sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.62.0", "", { "os": "linux", "cpu": "none" }, "sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.62.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.62.0", "", { "os": "linux", "cpu": "x64" }, "sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.62.0", "", { "os": "linux", "cpu": "x64" }, "sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.62.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-3oVS7FLGa4U1qcvao9ylGxrjXZyUQqR8UwxEcnUEyPX53O/C/mKDZegNXTdHCP+h3e6ta/f1EN38Yif1mmZHYg=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.62.0", "", { "os": "none", "cpu": "arm64" }, "sha512-yTB9TgfWj5wHe5QgktAgXTLLot1gvEjl1NiPPAUiCs4oPrIWFl5V4nC3GrkNdj9LaAU4s94nVrGbGOCqUpyWsg=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.62.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-5LOhoaesY3doG1c+ac/2JtgREpKoJr5bUHH8tKY0V8di7+uSV6BwLs2PlR0/yzefGOkR+wE7ZolZphHCsyG5Rw=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.62.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-yYkWHhmbhRTWTnWos5HC4GcPQfjlzzCNbM9e/+GXrLuaBXYA3qSDR9f0Vgufd5S8yX81U8jPKp7ZnAjZFMtRnw=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.62.0", "", { "os": "win32", "cpu": "x64" }, "sha512-SoTb6lPg25xZlA2ibwQ++ahCCnH+FP0qmEuafMJ4gznZKOlXioKEAeJLgCrqjM98ACziXM9V1amFjICVL4IFoA=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.62.0", "", { "os": "win32", "cpu": "x64" }, "sha512-5L+T1fMX4RIEBoZzT0+sQ0PhTS36NULFmMXtl1TZo44TMAROIMHbZufSOjVWt/Y622BtxgxtaNOokbTDvfsrZA=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
+
+    "@testing-library/jest-dom": ["@testing-library/jest-dom@6.9.1", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" } }, "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA=="],
+
+    "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
+
+    "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
+
+    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
+
+    "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
+
+    "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
+
+    "@types/babel__template": ["@types/babel__template@7.4.4", "", { "dependencies": { "@babel/parser": "^7.1.0", "@babel/types": "^7.0.0" } }, "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A=="],
+
+    "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@types/node": ["@types/node@22.19.21", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA=="],
+
+    "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
+
+    "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
+
+    "@vitest/expect": ["@vitest/expect@4.1.9", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.9", "@vitest/utils": "4.1.9", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.9", "", { "dependencies": { "@vitest/spy": "4.1.9", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.9", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.9", "", { "dependencies": { "@vitest/utils": "4.1.9", "pathe": "^2.0.3" } }, "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.9", "", { "dependencies": { "@vitest/pretty-format": "4.1.9", "@vitest/utils": "4.1.9", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.9", "", {}, "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA=="],
+
+    "@vitest/ui": ["@vitest/ui@4.1.9", "", { "dependencies": { "@vitest/utils": "4.1.9", "fflate": "^0.8.2", "flatted": "^3.4.2", "pathe": "^2.0.3", "sirv": "^3.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0" }, "peerDependencies": { "vitest": "4.1.9" } }, "sha512-U/cRvtqfEPj27FI1n9cyUvi4vXXdcLhjJiI+InYKdk8hP4VrS6RXOjGL7rfFaeBc37iRKANsR6eEzIoC7lmgBQ=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.9", "", { "dependencies": { "@vitest/pretty-format": "4.1.9", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA=="],
+
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+
+    "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.38", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw=="],
+
+    "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "caniuse-lite": ["caniuse-lite@1.0.30001799", "", {}, "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw=="],
+
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
+    "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
+
+    "cssstyle": ["cssstyle@4.6.0", "", { "dependencies": { "@asamuzakjp/css-color": "^3.2.0", "rrweb-cssom": "^0.8.0" } }, "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg=="],
+
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "data-urls": ["data-urls@5.0.0", "", { "dependencies": { "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.0.0" } }, "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
+
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
+    "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "electron-to-chromium": ["electron-to-chromium@1.5.375", "", {}, "sha512-ZWP5eB4BVPW/ZYo9252hQZHZ5XavtsTgpbhcmMmRwymavC5AsLWQWBPaKMeNd2LW0KGby5HPXvj7+sr4ta5j/Q=="],
+
+    "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-module-lexer": ["es-module-lexer@2.1.0", "", {}, "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
+
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
+
+    "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fflate": ["fflate@0.8.3", "", {}, "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="],
+
+    "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
+
+    "form-data": ["form-data@4.0.6", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.4", "mime-types": "^2.1.35" } }, "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
+
+    "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
+
+    "html-encoding-sniffer": ["html-encoding-sniffer@4.0.0", "", { "dependencies": { "whatwg-encoding": "^3.1.1" } }, "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ=="],
+
+    "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
+
+    "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "jsdom": ["jsdom@25.0.1", "", { "dependencies": { "cssstyle": "^4.1.0", "data-urls": "^5.0.0", "decimal.js": "^10.4.3", "form-data": "^4.0.0", "html-encoding-sniffer": "^4.0.0", "http-proxy-agent": "^7.0.2", "https-proxy-agent": "^7.0.5", "is-potential-custom-element-name": "^1.0.1", "nwsapi": "^2.2.12", "parse5": "^7.1.2", "rrweb-cssom": "^0.7.1", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^5.0.0", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^7.0.0", "whatwg-encoding": "^3.1.1", "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.0.0", "ws": "^8.18.0", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^2.11.2" }, "optionalPeers": ["canvas"] }, "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw=="],
+
+    "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
+    "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
+    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
+
+    "mrmime": ["mrmime@2.0.1", "", {}, "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "nanoid": ["nanoid@3.3.13", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q=="],
+
+    "node-releases": ["node-releases@2.0.48", "", {}, "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA=="],
+
+    "nwsapi": ["nwsapi@2.2.24", "", {}, "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A=="],
+
+    "obug": ["obug@2.1.3", "", {}, "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg=="],
+
+    "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
+
+    "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
+
+    "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
+
+    "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
+
+    "react-router": ["react-router@7.18.0", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-pTTGt8J+ji1NOmYnjzT+bAJy/1zD+Jp4ziO6cL7T3ZLvXKtusO7BpFqlRXitqpcPVqllsIXFHRMt+2/k3Xn6HQ=="],
+
+    "react-router-dom": ["react-router-dom@7.18.0", "", { "dependencies": { "react-router": "7.18.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-Fi0yY6kgtKae/Th2xibdWK0KSdYZ4B53Gyf6wRtomOKWgpNm7H7+DyfDhncdz9FKbpS+1jmDhg3F4WoGJ+yFOA=="],
+
+    "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
+
+    "rollup": ["rollup@4.62.0", "", { "dependencies": { "@types/estree": "1.0.9" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.62.0", "@rollup/rollup-android-arm64": "4.62.0", "@rollup/rollup-darwin-arm64": "4.62.0", "@rollup/rollup-darwin-x64": "4.62.0", "@rollup/rollup-freebsd-arm64": "4.62.0", "@rollup/rollup-freebsd-x64": "4.62.0", "@rollup/rollup-linux-arm-gnueabihf": "4.62.0", "@rollup/rollup-linux-arm-musleabihf": "4.62.0", "@rollup/rollup-linux-arm64-gnu": "4.62.0", "@rollup/rollup-linux-arm64-musl": "4.62.0", "@rollup/rollup-linux-loong64-gnu": "4.62.0", "@rollup/rollup-linux-loong64-musl": "4.62.0", "@rollup/rollup-linux-ppc64-gnu": "4.62.0", "@rollup/rollup-linux-ppc64-musl": "4.62.0", "@rollup/rollup-linux-riscv64-gnu": "4.62.0", "@rollup/rollup-linux-riscv64-musl": "4.62.0", "@rollup/rollup-linux-s390x-gnu": "4.62.0", "@rollup/rollup-linux-x64-gnu": "4.62.0", "@rollup/rollup-linux-x64-musl": "4.62.0", "@rollup/rollup-openbsd-x64": "4.62.0", "@rollup/rollup-openharmony-arm64": "4.62.0", "@rollup/rollup-win32-arm64-msvc": "4.62.0", "@rollup/rollup-win32-ia32-msvc": "4.62.0", "@rollup/rollup-win32-x64-gnu": "4.62.0", "@rollup/rollup-win32-x64-msvc": "4.62.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA=="],
+
+    "rrweb-cssom": ["rrweb-cssom@0.7.1", "", {}, "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
+
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
+
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
+
+    "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
+
+    "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
+
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
+
+    "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
+
+    "tldts": ["tldts@6.1.86", "", { "dependencies": { "tldts-core": "^6.1.86" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ=="],
+
+    "tldts-core": ["tldts-core@6.1.86", "", {}, "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA=="],
+
+    "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
+
+    "tough-cookie": ["tough-cookie@5.1.2", "", { "dependencies": { "tldts": "^6.1.32" } }, "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A=="],
+
+    "tr46": ["tr46@5.1.1", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
+
+    "vite": ["vite@6.4.3", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A=="],
+
+    "vitest": ["vitest@4.1.9", "", { "dependencies": { "@vitest/expect": "4.1.9", "@vitest/mocker": "4.1.9", "@vitest/pretty-format": "4.1.9", "@vitest/runner": "4.1.9", "@vitest/snapshot": "4.1.9", "@vitest/spy": "4.1.9", "@vitest/utils": "4.1.9", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.9", "@vitest/browser-preview": "4.1.9", "@vitest/browser-webdriverio": "4.1.9", "@vitest/coverage-istanbul": "4.1.9", "@vitest/coverage-v8": "4.1.9", "@vitest/ui": "4.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ=="],
+
+    "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
+
+    "webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
+
+    "whatwg-encoding": ["whatwg-encoding@3.1.1", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
+
+    "whatwg-url": ["whatwg-url@14.2.0", "", { "dependencies": { "tr46": "^5.1.0", "webidl-conversions": "^7.0.0" } }, "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+
+    "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
+
+    "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
+
+    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "@asamuzakjp/css-color/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
+
+    "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
+
+    "cssstyle/rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
+  }
+}

--- a/web/ui/index.html
+++ b/web/ui/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="referrer" content="no-referrer" />
+    <title>Parachute Agent</title>
+    <meta name="description" content="Manage Parachute agents — every backend, one surface." />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/web/ui/package.json
+++ b/web/ui/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@openparachute/agent-web-ui",
+  "version": "0.0.1-rc.1",
+  "private": true,
+  "description": "Agent web UI — Vite + React + TypeScript. The v2 agent-centric SPA, mounted at /app (reachable at <hub>/agent/app/).",
+  "license": "AGPL-3.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build && node scripts/verify-base.mjs",
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-router-dom": "^7.0.0"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/node": "^22.19.17",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.3.0",
+    "@vitest/ui": "^4.1.5",
+    "jsdom": "^25.0.1",
+    "typescript": "^5.6.0",
+    "vite": "^6.0.0",
+    "vitest": "^4.1.5"
+  }
+}

--- a/web/ui/scripts/verify-base.mjs
+++ b/web/ui/scripts/verify-base.mjs
@@ -1,0 +1,30 @@
+// Regression check mirroring the hub's verify-base: the canonical-mount default
+// build must produce asset URLs prefixed with `/agent/app/`. If
+// `vite.config.ts`'s `base` ever drifts back to `/` or to a different mount, the
+// bundle HTML loses the right prefix and assets 404 under the SPA mount — the
+// same silent failure the hub/paraclaw mount-path convention codifies.
+//
+// Skipped when VITE_BASE_PATH is set explicitly (legitimate override).
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const override = process.env.VITE_BASE_PATH;
+if (override && override !== "/agent/app/") {
+  console.log(`verify-base: VITE_BASE_PATH=${override} (override) — skipping default-mount check.`);
+  process.exit(0);
+}
+
+const html = readFileSync(resolve("dist/index.html"), "utf8");
+const wantPrefix = "/agent/app/assets/";
+const hasMounted = html.includes(`src="${wantPrefix}`) || html.includes(`href="${wantPrefix}`);
+if (!hasMounted) {
+  console.error(
+    "x verify-base: dist/index.html is missing /agent/app/-prefixed asset URLs.\n" +
+      "  This means vite's `base` resolved to something other than `/agent/app/`.\n" +
+      "  Check web/ui/vite.config.ts (default should be `/agent/app/`) and any\n" +
+      "  VITE_BASE_PATH env var leaking into the build environment.",
+  );
+  process.exit(1);
+}
+console.log("verify-base: ok — dist/index.html references /agent/app/-prefixed assets.");

--- a/web/ui/src/App.test.tsx
+++ b/web/ui/src/App.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * App shell smoke test — nav renders, Home routes to the Agents view, and the
+ * basename detection picks the right mount prefix.
+ */
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as api from "./lib/api.ts";
+import { App } from "./App.tsx";
+import { detectBasename } from "./lib/basename.ts";
+
+vi.mock("./lib/api.ts", async (orig) => {
+  const actual = (await orig()) as typeof api;
+  return {
+    ...actual,
+    listAgents: vi.fn(async () => ({ agents: [] })),
+    listAgentDefs: vi.fn(async () => ({ defs: [] })),
+    listAgentVaults: vi.fn(async () => ({ vaults: [] })),
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("App shell", () => {
+  it("renders the brand wordmark + the Agents nav link", () => {
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <App />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText("Parachute Agent")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Agents" })).toBeInTheDocument();
+  });
+
+  it("routes Home to the Agents view", async () => {
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <App />
+      </MemoryRouter>,
+    );
+    expect(await screen.findByRole("heading", { name: "Agents", level: 1 })).toBeInTheDocument();
+  });
+
+  it("renders a 404 for an unknown route", () => {
+    render(
+      <MemoryRouter initialEntries={["/nope"]}>
+        <App />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText(/404/)).toBeInTheDocument();
+  });
+});
+
+describe("detectBasename", () => {
+  it("maps the hub-proxied /agent/app mount", () => {
+    expect(detectBasename("/agent/app/")).toBe("/agent/app");
+    expect(detectBasename("/agent/app/agents")).toBe("/agent/app");
+  });
+
+  it("maps the daemon-direct /app mount", () => {
+    expect(detectBasename("/app")).toBe("/app");
+    expect(detectBasename("/app/agents")).toBe("/app");
+  });
+
+  it("returns empty for the dev origin root", () => {
+    expect(detectBasename("/")).toBe("");
+  });
+});

--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -21,14 +21,12 @@ import { Agents } from "./routes/Agents.tsx";
 
 const WORDMARK = "Parachute Agent";
 
-function subtitleFor(pathname: string): string {
-  if (pathname === "/agents" || pathname.startsWith("/agents/")) return "agents";
-  return "agents";
-}
+// Single view today (the Agents list). When create/config views land (Phase 3-4),
+// derive the subtitle from the route then.
+const SUBTITLE = "agents";
 
 export function App() {
-  const { pathname } = useLocation();
-  const subtitle = subtitleFor(pathname);
+  const subtitle = SUBTITLE;
 
   return (
     <div className="page">

--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -1,0 +1,80 @@
+/**
+ * Parachute Agent SPA (v2).
+ *
+ * The one agent-centric surface the Agent UI v2 design calls for
+ * (`design/2026-06-18-agent-ui-v2-and-reactivity.md`, Part 2). This is Phase 2:
+ * the SPA shell + a unified, READ-ONLY Agents view. It mounts at the agent
+ * module's NEW `/app` sub-path (reachable at `<hub>/agent/app/`) so it coexists
+ * with the existing daemon-rendered HTML pages — operators compare the two
+ * during the incremental migration; the HTML retires in Phase 4.
+ *
+ * Home IS the Agents list (the design's "Home becomes the Agents list"). Later
+ * phases add the unified create flow (Phase 3) and the def-vault editor +
+ * schedules fold-in (Phase 4); this shell leaves room for those nav entries.
+ *
+ * Auth: the SPA loads OPEN, then mints a hub `agent:admin` Bearer from
+ * `<origin>/admin/agent-token` (the operator's hub session cookie) — see
+ * `lib/auth.ts`. All `/agent/api/*` calls carry that Bearer.
+ */
+import { Link, Route, Routes, useLocation } from "react-router-dom";
+import { Agents } from "./routes/Agents.tsx";
+
+const WORDMARK = "Parachute Agent";
+
+function subtitleFor(pathname: string): string {
+  if (pathname === "/agents" || pathname.startsWith("/agents/")) return "agents";
+  return "agents";
+}
+
+export function App() {
+  const { pathname } = useLocation();
+  const subtitle = subtitleFor(pathname);
+
+  return (
+    <div className="page">
+      <nav className="nav">
+        <Link to="/" className="brand">
+          <span className="brand-wordmark">{WORDMARK}</span>
+          <span className="sub">{subtitle}</span>
+        </Link>
+        <NavSection to="/" label="Agents" exact />
+        {/* Boundary: everything past here is the older daemon-rendered HTML,
+            kept mounted during the migration so the operator can compare. */}
+        <span className="nav-divider" aria-hidden="true" />
+        <a href="/agent/agents" title="The legacy create/list HTML page">
+          Classic UI
+        </a>
+      </nav>
+
+      <Routes>
+        {/* Home is the Agents list (design: "Home becomes the Agents list"). */}
+        <Route path="/" element={<Agents />} />
+        <Route path="/agents" element={<Agents />} />
+        <Route
+          path="*"
+          element={
+            <div className="empty">
+              404 — back to <Link to="/">Agents</Link>.
+            </div>
+          }
+        />
+      </Routes>
+    </div>
+  );
+}
+
+function NavSection({ to, label, exact }: { to: string; label: string; exact?: boolean }) {
+  const { pathname } = useLocation();
+  const active = exact
+    ? pathname === to || pathname === "/agents"
+    : pathname === to || pathname.startsWith(`${to}/`);
+  return (
+    <Link
+      to={to}
+      className={active ? "nav-link nav-link-active" : "nav-link"}
+      aria-current={active ? "page" : undefined}
+    >
+      {label}
+    </Link>
+  );
+}

--- a/web/ui/src/lib/api.test.ts
+++ b/web/ui/src/lib/api.test.ts
@@ -1,0 +1,157 @@
+/**
+ * api.ts unit tests — the API base derivation, the Bearer-attaching authed
+ * fetch with a single 401 re-mint-and-retry, and the three typed list helpers.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./auth.ts", () => ({
+  getAgentToken: vi.fn(),
+  clearCachedToken: vi.fn(),
+}));
+
+import * as auth from "./auth.ts";
+import {
+  apiBase,
+  HttpError,
+  listAgentDefs,
+  listAgentVaults,
+  listAgents,
+} from "./api.ts";
+
+const getAgentToken = vi.mocked(auth.getAgentToken);
+const clearCachedToken = vi.mocked(auth.clearCachedToken);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getAgentToken.mockResolvedValue("jwt-tok");
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/** A `fetch`-shaped mock so `mock.calls` carries [input, init?] tuples. */
+function fetchFn(impl: (input: string, init?: RequestInit) => Promise<Response>) {
+  return vi.fn<(input: string, init?: RequestInit) => Promise<Response>>(impl);
+}
+
+describe("apiBase", () => {
+  it("falls back to /agent/api when the mount isn't an /app sub-path (dev origin root)", () => {
+    // In vitest BASE_URL is "/", so the /app match fails → canonical fallback.
+    expect(apiBase()).toBe("/agent/api");
+  });
+});
+
+describe("listAgents / listAgentDefs / listAgentVaults", () => {
+  it("attaches the Bearer and hits the right endpoint", async () => {
+    const fetchMock = fetchFn(async () => jsonResponse(200, { agents: [] }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await listAgents();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("/agent/api/agents");
+    const headers = new Headers(init?.headers);
+    expect(headers.get("authorization")).toBe("Bearer jwt-tok");
+    expect(headers.get("accept")).toBe("application/json");
+  });
+
+  it("listAgentDefs hits /agent/api/agent-defs and parses defs", async () => {
+    const defs = [
+      {
+        noteId: "n1",
+        name: "eng",
+        backend: "channel",
+        vault: "default",
+        status: "enabled",
+        pending: [],
+        systemPromptPreview: "You are…",
+        wants: ["vault:default"],
+        channel: "eng",
+      },
+    ];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse(200, { defs })),
+    );
+    const res = await listAgentDefs();
+    expect(res.defs).toHaveLength(1);
+    expect(res.defs[0]!.name).toBe("eng");
+  });
+
+  it("listAgentVaults hits /agent/api/agent-vaults and parses vaults", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse(200, {
+          vaults: [{ vault: "default", url: "http://127.0.0.1:1940", tokenPresent: true }],
+        }),
+      ),
+    );
+    const res = await listAgentVaults();
+    expect(res.vaults[0]!.tokenPresent).toBe(true);
+  });
+
+  it("omits the Authorization header when no token is available", async () => {
+    getAgentToken.mockResolvedValue(null);
+    const fetchMock = fetchFn(async () => jsonResponse(200, { agents: [] }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await listAgents();
+
+    const [, init] = fetchMock.mock.calls[0]!;
+    const headers = new Headers(init?.headers);
+    expect(headers.get("authorization")).toBeNull();
+  });
+
+  it("re-mints and retries once on a 401, then succeeds", async () => {
+    getAgentToken.mockResolvedValueOnce("stale").mockResolvedValueOnce("fresh");
+    const fetchMock = fetchFn(async () => new Response("", { status: 401 }));
+    fetchMock
+      .mockResolvedValueOnce(new Response("", { status: 401 }))
+      .mockResolvedValueOnce(jsonResponse(200, { agents: [{ name: "a" }] }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await listAgents();
+
+    expect(clearCachedToken).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // First with the stale token, second with the freshly minted one.
+    expect(new Headers(fetchMock.mock.calls[0]![1]?.headers).get("authorization")).toBe(
+      "Bearer stale",
+    );
+    expect(new Headers(fetchMock.mock.calls[1]![1]?.headers).get("authorization")).toBe(
+      "Bearer fresh",
+    );
+    expect(res.agents).toHaveLength(1);
+  });
+
+  it("throws HttpError carrying the status + server error message on a non-2xx", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse(500, { error: "boom" })),
+    );
+    await expect(listAgents()).rejects.toMatchObject({
+      name: "HttpError",
+      status: 500,
+      message: "boom",
+    });
+  });
+
+  it("surfaces a persistent 401 as an HttpError when no fresh token mints", async () => {
+    getAgentToken.mockResolvedValueOnce("stale").mockResolvedValueOnce(null);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("", { status: 401 })),
+    );
+    await expect(listAgents()).rejects.toBeInstanceOf(HttpError);
+  });
+});

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -1,0 +1,182 @@
+/**
+ * HTTP client for the agent SPA. All calls hit the daemon's JSON API, gated by
+ * the hub-minted `agent:admin` Bearer (`lib/auth.ts:getAgentToken`).
+ *
+ * This phase (Agent UI v2 — Phase 2) is READ-ONLY: it surfaces the three
+ * Phase-1 list endpoints and merges them into one agent-centric view. No create
+ * / edit / delete (those are Phases 3–4).
+ *
+ *   - `GET /agent/api/agents`        — every agent across ALL backends
+ *     (interactive / programmatic / channel), with live status.
+ *   - `GET /agent/api/agent-defs`    — the vault-native `#agent/definition`
+ *     records (the durable defs that instantiate agents).
+ *   - `GET /agent/api/agent-vaults`  — the module-level def-vault list
+ *     (`agent-vaults.json` — which vaults the module reads defs from).
+ *
+ * ## API base path
+ *
+ * The daemon's API lives at the `/agent/api/*` proxied path (the hub strips the
+ * `/agent` prefix; the daemon sees `/api/*`). The SPA serves under
+ * `import.meta.env.BASE_URL` = `/agent/app/`, so its sibling API is `/agent/api`
+ * — derived by swapping the trailing `app/` segment for `api`. In stand-alone
+ * dev (`BASE_URL=/`), we fall back to `/agent/api`, which the dev proxy in
+ * vite.config.ts forwards to the loopback daemon.
+ */
+import { clearCachedToken, getAgentToken } from "./auth.ts";
+
+/** Status code carried alongside the message so callers can branch numerically. */
+export class HttpError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "HttpError";
+  }
+}
+
+/**
+ * Resolve the daemon API base from the SPA mount. `/agent/app/` → `/agent/api`;
+ * anything else (dev at origin root) → `/agent/api`, which the vite dev proxy
+ * forwards. Origin-absolute, so it resolves correctly regardless of the
+ * react-router basename.
+ */
+export function apiBase(): string {
+  const base = import.meta.env.BASE_URL || "/";
+  // `/agent/app/` → `/agent/api`. Strip a trailing `app/` (or `app`) and append
+  // `api`; if the mount doesn't end in `app`, fall back to the canonical path.
+  const m = base.match(/^(.*\/)app\/?$/);
+  if (m) return `${m[1]}api`;
+  return "/agent/api";
+}
+
+/**
+ * `fetch` with the agent Bearer attached + a single re-mint-and-retry on 401 —
+ * the SPA mirror of `src/ui-kit.ts:authedFetch`. On a clean 401 we drop the
+ * cached token, re-mint once, and retry; a persistent 401 surfaces as an
+ * `HttpError`.
+ */
+async function authedFetch(path: string, init: RequestInit = {}): Promise<Response> {
+  const token = await getAgentToken();
+  const headers = new Headers(init.headers);
+  headers.set("accept", "application/json");
+  if (token) headers.set("authorization", `Bearer ${token}`);
+  const res = await fetch(path, { ...init, headers });
+  if (res.status !== 401) return res;
+  // Re-mint once and retry. The first mint may have been stale/absent.
+  clearCachedToken();
+  const fresh = await getAgentToken();
+  if (!fresh) return res; // no session — let the caller surface the 401
+  const retryHeaders = new Headers(init.headers);
+  retryHeaders.set("accept", "application/json");
+  retryHeaders.set("authorization", `Bearer ${fresh}`);
+  return fetch(path, { ...init, headers: retryHeaders });
+}
+
+/** GET a JSON endpoint with the Bearer, throwing HttpError on a non-2xx. */
+async function getJson<T>(suffix: string): Promise<T> {
+  const res = await authedFetch(`${apiBase()}${suffix}`);
+  if (!res.ok) {
+    let detail = "";
+    try {
+      const body = (await res.json()) as { error?: string };
+      detail = body.error ?? "";
+    } catch {
+      detail = await res.text().catch(() => "");
+    }
+    throw new HttpError(res.status, detail || `${suffix} failed: ${res.status}`);
+  }
+  return (await res.json()) as T;
+}
+
+// ---------------------------------------------------------------------------
+// Wire types — mirror the daemon's Phase-1 JSON shapes (snake/camel as the
+// daemon emits them; the daemon uses camelCase for these endpoints).
+// ---------------------------------------------------------------------------
+
+/** The backend that drives an agent. The primary axis of the v2 view. */
+export type AgentBackend = "interactive" | "programmatic" | "channel";
+
+/**
+ * One entry from `GET /agent/api/agents` — the merged all-backends list.
+ * Mirrors `AgentInfo` in `src/agents.ts`. Interactive agents carry
+ * `attached`/`hasWorkspace`; programmatic/channel agents carry a live `status`
+ * and (when vault-native) a `channel` + `vault`.
+ */
+export interface AgentRow {
+  name: string;
+  session: string;
+  attached: boolean;
+  workspace: string;
+  hasWorkspace: boolean;
+  backend: AgentBackend;
+  /** Live status — `idle` | `working` | `queued:N`. Absent for interactive. */
+  status?: string;
+  /** The wake channel this agent serves (channel-backend; agent == channel). */
+  channel?: string;
+  /** The def-vault backing this agent's conversation, when known. */
+  vault?: string;
+  systemPromptMode?: "append" | "replace";
+  workingDir?: string;
+}
+
+export interface AgentsResponse {
+  agents: AgentRow[];
+}
+
+/** The resolved liveness of a vault-native def. Mirrors `AgentDefStatus`. */
+export type AgentDefStatus = "enabled" | "pending" | "error" | string;
+
+/**
+ * One entry from `GET /agent/api/agent-defs` — a vault-native
+ * `#agent/definition` record. Mirrors `AgentDefDetail` in `src/agent-defs.ts`.
+ */
+export interface AgentDefRow {
+  /** The vault note id (the create/edit/delete key — not used read-only). */
+  noteId: string;
+  name: string;
+  backend: "programmatic" | "channel";
+  vault: string;
+  status: AgentDefStatus;
+  /** Declared connections still pending approval (empty when none). */
+  pending: string[];
+  /** First ~200 chars of the system prompt — a preview, NOT the full text. */
+  systemPromptPreview: string;
+  /** Structured `wants:` connection keys (empty when own-vault only). */
+  wants: string[];
+  /** The wake channel inbound routes to this agent on (== name). */
+  channel: string;
+}
+
+export interface AgentDefsResponse {
+  defs: AgentDefRow[];
+}
+
+/**
+ * One entry from `GET /agent/api/agent-vaults` — a def-vault binding.
+ * `tokenPresent` is a boolean, NEVER the token value.
+ */
+export interface AgentVaultRow {
+  vault: string;
+  url: string;
+  tokenPresent: boolean;
+}
+
+export interface AgentVaultsResponse {
+  vaults: AgentVaultRow[];
+}
+
+/** List every agent across all backends. */
+export function listAgents(): Promise<AgentsResponse> {
+  return getJson<AgentsResponse>("/agents");
+}
+
+/** List the vault-native agent definitions. */
+export function listAgentDefs(): Promise<AgentDefsResponse> {
+  return getJson<AgentDefsResponse>("/agent-defs");
+}
+
+/** List the module's def-vaults (read-only display). */
+export function listAgentVaults(): Promise<AgentVaultsResponse> {
+  return getJson<AgentVaultsResponse>("/agent-vaults");
+}

--- a/web/ui/src/lib/auth.test.ts
+++ b/web/ui/src/lib/auth.test.ts
@@ -1,0 +1,138 @@
+/**
+ * auth.ts unit tests — the agent:admin mint, token cache, and 401 re-mint.
+ *
+ * The module holds module-scoped state (cached token, in-flight promise). Each
+ * test does a dynamic import after `vi.resetModules()` so the cache starts empty.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.stubGlobal("window", {
+    location: { origin: "https://hub.example", pathname: "/agent/app/" },
+  } as unknown as Window & typeof globalThis);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+});
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("getAgentToken", () => {
+  it("mints from <origin>/admin/agent-token with credentials:include and caches it", async () => {
+    const expiresAt = new Date(Date.now() + 10 * 60 * 1000).toISOString();
+    const fetchMock = vi.fn(async () =>
+      jsonResponse(200, { token: "jwt-1", expires_at: expiresAt, scopes: ["agent:admin"] }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const auth = await import("./auth.ts");
+    expect(await auth.getAgentToken()).toBe("jwt-1");
+    // Second call hits the cache, not the wire.
+    expect(await auth.getAgentToken()).toBe("jwt-1");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://hub.example/admin/agent-token",
+      expect.objectContaining({ credentials: "include" }),
+    );
+  });
+
+  it("returns null on a 401 (no session) and drops the cache", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("", { status: 401 })),
+    );
+    const auth = await import("./auth.ts");
+    expect(await auth.getAgentToken()).toBeNull();
+  });
+
+  it("returns null on a network error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("offline");
+      }),
+    );
+    const auth = await import("./auth.ts");
+    expect(await auth.getAgentToken()).toBeNull();
+  });
+
+  it("dedupes concurrent in-flight mint requests", async () => {
+    let resolveFetch: (r: Response) => void = () => {};
+    const fetchMock = vi.fn(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveFetch = resolve;
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const auth = await import("./auth.ts");
+    const a = auth.getAgentToken();
+    const b = auth.getAgentToken();
+    resolveFetch(
+      jsonResponse(200, {
+        token: "jwt-shared",
+        expires_at: new Date(Date.now() + 60_000).toISOString(),
+      }),
+    );
+    expect(await a).toBe("jwt-shared");
+    expect(await b).toBe("jwt-shared");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("refetches when the cached token is within the refresh buffer of expiry", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          token: "jwt-near-expiry",
+          // 10s out — well inside the 30s refresh buffer.
+          expires_at: new Date(Date.now() + 10_000).toISOString(),
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          token: "jwt-fresh",
+          expires_at: new Date(Date.now() + 600_000).toISOString(),
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const auth = await import("./auth.ts");
+    expect(await auth.getAgentToken()).toBe("jwt-near-expiry");
+    expect(await auth.getAgentToken()).toBe("jwt-fresh");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("clearCachedToken forces a re-mint on the next call", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          token: "jwt-a",
+          expires_at: new Date(Date.now() + 600_000).toISOString(),
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          token: "jwt-b",
+          expires_at: new Date(Date.now() + 600_000).toISOString(),
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const auth = await import("./auth.ts");
+    expect(await auth.getAgentToken()).toBe("jwt-a");
+    auth.clearCachedToken();
+    expect(await auth.getAgentToken()).toBe("jwt-b");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/web/ui/src/lib/auth.ts
+++ b/web/ui/src/lib/auth.ts
@@ -1,0 +1,114 @@
+/**
+ * Auth helper for the agent SPA. The SPA is served BY the agent daemon (under
+ * the hub-proxied `/agent/app/` mount), so it leans on the operator's existing
+ * hub SESSION COOKIE rather than running its own OAuth dance — exactly as the
+ * daemon-rendered HTML pages already do (`src/ui-kit.ts:fetchToken`, the
+ * `/admin/channel-token` → `/admin/agent-token` rename).
+ *
+ * Flow:
+ *   1. SPA bootstrap (or any `/agent/api/*` call) calls `getAgentToken()`.
+ *   2. That hits `GET <origin>/admin/agent-token` with `credentials:"include"`.
+ *      The hub endpoint reads the `parachute_hub_session` cookie (set by the
+ *      hub's /login) and trades it for a short-lived (~10 min) JWT carrying
+ *      `aud:agent` + the `agent:admin` scope, returned as JSON.
+ *   3. The token is held in module-scoped state — NEVER localStorage. Page
+ *      snapshots can't carry it past a refresh, and the XSS surface is the
+ *      narrowest possible.
+ *   4. On 401, the cached token is dropped and the next call re-mints. The
+ *      caller (`lib/api.ts:authedFetch`) re-mints once and retries — matching
+ *      the HTML pages' single-retry-on-401 behavior.
+ *
+ * Note: the mint endpoint lives at the HUB origin root (`/admin/agent-token`),
+ * NOT under the `/agent` proxy prefix — the hub serves it directly, cookie-gated
+ * to the logged-in portal operator. We therefore hit `origin + "/admin/..."`,
+ * never a BASE_URL-prefixed path.
+ */
+
+interface MintedToken {
+  token: string;
+  expiresAt: number; // epoch ms
+}
+
+let cached: MintedToken | null = null;
+let inFlight: Promise<string | null> | null = null;
+
+/** Minimum slack we keep on the cached token before refetching. */
+const REFRESH_BUFFER_MS = 30_000;
+
+/** Default TTL assumed when the mint response omits `expires_at`. */
+const DEFAULT_TTL_MS = 10 * 60 * 1000;
+
+function tokenEndpoint(): string {
+  // The mint sits at the hub origin root, cookie-gated. Same origin in every
+  // mode (dev, daemon-direct, hub-proxied) — we never prefix with BASE_URL.
+  const origin = typeof window !== "undefined" ? window.location.origin : "";
+  return `${origin}/admin/agent-token`;
+}
+
+/**
+ * Returns the cached agent:admin JWT, refreshing it if it's about to expire (or
+ * if we don't have one yet). Concurrent callers share the in-flight fetch so a
+ * burst of API calls doesn't mint a token each.
+ *
+ * Returns `null` when the mint fails (no session, network error, malformed
+ * body). The SPA renders OPEN, so a failed mint surfaces as an API 401 the
+ * caller handles (re-mint + retry, then an error state) — it does NOT hard-
+ * redirect, mirroring the daemon HTML pages which tolerate a failed mint.
+ */
+export async function getAgentToken(): Promise<string | null> {
+  const now = Date.now();
+  if (cached && cached.expiresAt - now > REFRESH_BUFFER_MS) {
+    return cached.token;
+  }
+  if (inFlight) return inFlight;
+  inFlight = fetchToken().finally(() => {
+    inFlight = null;
+  });
+  return inFlight;
+}
+
+async function fetchToken(): Promise<string | null> {
+  let res: Response;
+  try {
+    res = await fetch(tokenEndpoint(), {
+      method: "GET",
+      headers: { accept: "application/json" },
+      credentials: "include",
+    });
+  } catch {
+    cached = null;
+    return null;
+  }
+  if (!res.ok) {
+    // 401 (no session) / 403 (non-admin) / 5xx — drop the cache and report no
+    // token. The API layer surfaces the resulting failure to the operator.
+    cached = null;
+    return null;
+  }
+  let body: { token?: string; expires_at?: string };
+  try {
+    body = (await res.json()) as typeof body;
+  } catch {
+    cached = null;
+    return null;
+  }
+  if (!body.token) {
+    cached = null;
+    return null;
+  }
+  const expiresAt = body.expires_at
+    ? new Date(body.expires_at).getTime()
+    : Date.now() + DEFAULT_TTL_MS;
+  cached = { token: body.token, expiresAt };
+  return body.token;
+}
+
+/** Drop the cached token. Useful after an explicit invalidation (e.g. a 401). */
+export function clearCachedToken(): void {
+  cached = null;
+}
+
+/** Test seam: replace the cached token directly. */
+export function _setCachedTokenForTest(token: string, expiresAt: number): void {
+  cached = { token, expiresAt };
+}

--- a/web/ui/src/lib/basename.ts
+++ b/web/ui/src/lib/basename.ts
@@ -1,0 +1,22 @@
+/**
+ * Mount-aware react-router basename detection, extracted from `main.tsx` so it's
+ * importable in tests without triggering `main.tsx`'s `createRoot().render()`
+ * side effect.
+ *
+ * The v2 agent SPA serves at the agent module's `/app` sub-path, reachable three
+ * ways:
+ *
+ *   - `<hub>/agent/app/…`  (the real, hub-proxied operator path)
+ *   - `<daemon>/app/…`     (daemon-direct, no hub — e.g. local 1941)
+ *   - `/…`                 (stand-alone dev, VITE_BASE_PATH=/)
+ *
+ * react-router needs the *runtime* basename so `<Link to="/agents">` resolves to
+ * the right absolute path; without it the SPA would navigate to `/agents` at the
+ * origin root and 404. We detect the longest matching prefix.
+ */
+export function detectBasename(pathname: string): string {
+  if (pathname === "/agent/app" || pathname.startsWith("/agent/app/")) return "/agent/app";
+  if (pathname === "/app" || pathname.startsWith("/app/")) return "/app";
+  // Stand-alone dev served at origin root (VITE_BASE_PATH=/).
+  return "";
+}

--- a/web/ui/src/main.tsx
+++ b/web/ui/src/main.tsx
@@ -1,0 +1,17 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
+import { App } from "./App.tsx";
+import { detectBasename } from "./lib/basename.ts";
+import "./styles.css";
+
+const root = document.getElementById("root");
+if (!root) throw new Error("#root not found");
+
+createRoot(root).render(
+  <StrictMode>
+    <BrowserRouter basename={detectBasename(window.location.pathname)}>
+      <App />
+    </BrowserRouter>
+  </StrictMode>,
+);

--- a/web/ui/src/routes/Agents.test.tsx
+++ b/web/ui/src/routes/Agents.test.tsx
@@ -1,0 +1,204 @@
+/**
+ * Agents route tests — the all-backends merge (unit), and the read-only view's
+ * loading / empty / populated / error states + the detail panel.
+ */
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as api from "../lib/api.ts";
+import { Agents, mergeAgents } from "./Agents.tsx";
+
+vi.mock("../lib/api.ts", async (orig) => {
+  const actual = (await orig()) as typeof api;
+  return {
+    ...actual,
+    listAgents: vi.fn(),
+    listAgentDefs: vi.fn(),
+    listAgentVaults: vi.fn(),
+  };
+});
+
+const listAgents = vi.mocked(api.listAgents);
+const listAgentDefs = vi.mocked(api.listAgentDefs);
+const listAgentVaults = vi.mocked(api.listAgentVaults);
+
+function agentRow(over: Partial<api.AgentRow> = {}): api.AgentRow {
+  return {
+    name: "alpha",
+    session: "alpha-agent",
+    attached: false,
+    workspace: "/w/alpha",
+    hasWorkspace: true,
+    backend: "programmatic",
+    ...over,
+  };
+}
+
+function defRow(over: Partial<api.AgentDefRow> = {}): api.AgentDefRow {
+  return {
+    noteId: "note-1",
+    name: "alpha",
+    backend: "programmatic",
+    vault: "default",
+    status: "enabled",
+    pending: [],
+    systemPromptPreview: "You are a helpful agent.",
+    wants: [],
+    channel: "alpha",
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  listAgents.mockResolvedValue({ agents: [] });
+  listAgentDefs.mockResolvedValue({ defs: [] });
+  listAgentVaults.mockResolvedValue({ vaults: [] });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function renderRoute() {
+  return render(
+    <MemoryRouter>
+      <Agents />
+    </MemoryRouter>,
+  );
+}
+
+describe("mergeAgents (all-backends merge)", () => {
+  it("merges live agents across backends and dedupes by name", () => {
+    const merged = mergeAgents(
+      [
+        agentRow({ name: "prog", backend: "programmatic", status: "idle" }),
+        agentRow({ name: "chan", backend: "channel", channel: "chan", vault: "default", status: "queued:2" }),
+        agentRow({ name: "tmux", backend: "interactive", attached: true }),
+      ],
+      [],
+    );
+    expect(merged.map((m) => m.name)).toEqual(["chan", "prog", "tmux"]); // sorted
+    const chan = merged.find((m) => m.name === "chan")!;
+    expect(chan.backend).toBe("channel");
+    expect(chan.status).toBe("queued:2");
+    expect(chan.live).toBe(true);
+  });
+
+  it("attaches the def to a live agent of the same name and fills gaps", () => {
+    const merged = mergeAgents(
+      [agentRow({ name: "alpha", backend: "channel" })],
+      [defRow({ name: "alpha", vault: "default", channel: "alpha", wants: ["vault:other"] })],
+    );
+    expect(merged).toHaveLength(1);
+    expect(merged[0]!.def?.wants).toEqual(["vault:other"]);
+    // The live row carried no vault; the def filled it.
+    expect(merged[0]!.vault).toBe("default");
+  });
+
+  it("surfaces a def with no live agent as a def-only (not-running) row", () => {
+    const merged = mergeAgents([], [defRow({ name: "ghost" })]);
+    expect(merged).toHaveLength(1);
+    expect(merged[0]!.live).toBe(false);
+    expect(merged[0]!.name).toBe("ghost");
+  });
+});
+
+describe("Agents view states", () => {
+  it("renders the loading state first", () => {
+    renderRoute();
+    expect(screen.getByText(/loading agents/i)).toBeInTheDocument();
+  });
+
+  it("renders the empty state when there are no agents", async () => {
+    renderRoute();
+    expect(await screen.findByText(/no agents yet/i)).toBeInTheDocument();
+    expect(screen.getByTestId("agents-count")).toHaveTextContent("0 agents");
+  });
+
+  it("renders a populated table merging all backends", async () => {
+    listAgents.mockResolvedValue({
+      agents: [
+        agentRow({ name: "prog", backend: "programmatic", status: "idle" }),
+        agentRow({ name: "chan", backend: "channel", channel: "chan", vault: "default", status: "queued:1" }),
+      ],
+    });
+    listAgentDefs.mockResolvedValue({ defs: [defRow({ name: "prog" })] });
+    renderRoute();
+
+    expect(await screen.findByTestId("agent-row-prog")).toBeInTheDocument();
+    expect(screen.getByTestId("agent-row-chan")).toBeInTheDocument();
+    expect(screen.getByTestId("agents-count")).toHaveTextContent("2 agents");
+
+    const chanRow = screen.getByTestId("agent-row-chan");
+    expect(within(chanRow).getByText("channel")).toBeInTheDocument();
+    expect(within(chanRow).getByText("queued:1")).toBeInTheDocument();
+    expect(within(chanRow).getByText("default")).toBeInTheDocument();
+  });
+
+  it("renders the error state with a retry that re-fetches", async () => {
+    listAgents.mockRejectedValueOnce(new api.HttpError(500, "kaboom"));
+    renderRoute();
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/kaboom/i);
+
+    // Retry — this time everything resolves.
+    listAgents.mockResolvedValue({ agents: [agentRow({ name: "alpha" })] });
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+    expect(await screen.findByTestId("agent-row-alpha")).toBeInTheDocument();
+  });
+
+  it("shows a friendlier message on a 401", async () => {
+    listAgents.mockRejectedValueOnce(new api.HttpError(401, "unauthorized"));
+    renderRoute();
+    expect(await screen.findByRole("alert")).toHaveTextContent(/not signed in to the hub/i);
+  });
+
+  it("opens a detail panel on row click, showing the def's system prompt + wants", async () => {
+    listAgents.mockResolvedValue({ agents: [agentRow({ name: "alpha", backend: "channel" })] });
+    listAgentDefs.mockResolvedValue({
+      defs: [defRow({ name: "alpha", systemPromptPreview: "Persona text", wants: ["vault:x"] })],
+    });
+    renderRoute();
+
+    fireEvent.click(await screen.findByTestId("agent-row-alpha"));
+
+    const detail = await screen.findByTestId("agent-detail");
+    expect(within(detail).getByTestId("detail-prompt")).toHaveTextContent("Persona text");
+    expect(within(detail).getByText("vault:x")).toBeInTheDocument();
+    // Channel-backend note about the deferred connect affordance.
+    expect(within(detail).getByTestId("detail-channel-note")).toBeInTheDocument();
+  });
+
+  it("detail panel notes when an agent has no backing def", async () => {
+    listAgents.mockResolvedValue({ agents: [agentRow({ name: "tmux", backend: "interactive" })] });
+    listAgentDefs.mockResolvedValue({ defs: [] });
+    renderRoute();
+
+    fireEvent.click(await screen.findByTestId("agent-row-tmux"));
+    const detail = await screen.findByTestId("agent-detail");
+    expect(within(detail).getByTestId("detail-no-def")).toBeInTheDocument();
+  });
+
+  it("renders the read-only Def-vaults section", async () => {
+    listAgentVaults.mockResolvedValue({
+      vaults: [
+        { vault: "default", url: "http://127.0.0.1:1940", tokenPresent: true },
+        { vault: "stale", url: "http://127.0.0.1:1950", tokenPresent: false },
+      ],
+    });
+    renderRoute();
+
+    await waitFor(() => expect(screen.getByTestId("def-vault-default")).toBeInTheDocument());
+    const ok = screen.getByTestId("def-vault-default");
+    expect(within(ok).getByText("present")).toBeInTheDocument();
+    const stale = screen.getByTestId("def-vault-stale");
+    expect(within(stale).getByText("missing")).toBeInTheDocument();
+  });
+
+  it("shows the def-vaults empty state when none configured", async () => {
+    renderRoute();
+    expect(await screen.findByTestId("def-vaults-empty")).toBeInTheDocument();
+  });
+});

--- a/web/ui/src/routes/Agents.tsx
+++ b/web/ui/src/routes/Agents.tsx
@@ -1,0 +1,378 @@
+/**
+ * `/agents` — the unified, READ-ONLY Agents view (Agent UI v2, Phase 2).
+ *
+ * The one agent-centric surface the v2 design calls for: a single list of
+ * EVERY agent across ALL backends (interactive / programmatic / channel) with a
+ * detail panel, plus a read-only "Def-vaults" section showing which vaults the
+ * module reads `#agent/definition` notes from.
+ *
+ * This phase is strictly read-only — no create flow (Phase 3) and no def-vault
+ * editor (Phase 4). It composes the three Phase-1 list endpoints:
+ *
+ *   - `GET /agent/api/agents`       → the live agents (all backends merged)
+ *   - `GET /agent/api/agent-defs`   → the vault-native defs (system-prompt
+ *                                     preview, wants, status) the detail panel
+ *                                     enriches a row with
+ *   - `GET /agent/api/agent-vaults` → the def-vault list (read-only display)
+ *
+ * The "all-backends merge" is the load-bearing v2 move (#102): the list shows
+ * channel/programmatic/interactive agents in one table instead of separate
+ * pages. We dedupe defs that have no corresponding live agent so a def authored
+ * but not yet instantiated still appears (as a def-only row), giving the
+ * operator the full picture.
+ */
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  type AgentDefRow,
+  type AgentRow,
+  type AgentVaultRow,
+  HttpError,
+  listAgentDefs,
+  listAgentVaults,
+  listAgents,
+} from "../lib/api.ts";
+
+type LoadState =
+  | { kind: "loading" }
+  | { kind: "error"; message: string }
+  | { kind: "ok"; agents: AgentRow[]; defs: AgentDefRow[]; vaults: AgentVaultRow[] };
+
+/**
+ * A merged view-model row. Every live agent is one row; a def with no matching
+ * live agent surfaces as a def-only row (it's been authored but isn't running).
+ * Keyed by name (an agent's name == its def name == its wake channel in the v2
+ * 1:1 model).
+ */
+export interface MergedAgent {
+  name: string;
+  backend: string;
+  channel?: string;
+  vault?: string;
+  status?: string;
+  /** True when a live agent (interactive/programmatic/channel) exists. */
+  live: boolean;
+  /** The vault-native def, when one defines this agent. */
+  def?: AgentDefRow;
+}
+
+/** Merge the live agent list with the vault-native defs into one keyed set. */
+export function mergeAgents(agents: AgentRow[], defs: AgentDefRow[]): MergedAgent[] {
+  const byName = new Map<string, MergedAgent>();
+  for (const a of agents) {
+    byName.set(a.name, {
+      name: a.name,
+      backend: a.backend,
+      ...(a.channel ? { channel: a.channel } : {}),
+      ...(a.vault ? { vault: a.vault } : {}),
+      ...(a.status ? { status: a.status } : {}),
+      live: true,
+    });
+  }
+  for (const d of defs) {
+    const existing = byName.get(d.name);
+    if (existing) {
+      existing.def = d;
+      // Fill gaps the live row didn't carry from the durable def.
+      if (!existing.channel && d.channel) existing.channel = d.channel;
+      if (!existing.vault && d.vault) existing.vault = d.vault;
+    } else {
+      byName.set(d.name, {
+        name: d.name,
+        backend: d.backend,
+        channel: d.channel,
+        vault: d.vault,
+        status: d.status,
+        live: false,
+        def: d,
+      });
+    }
+  }
+  return [...byName.values()].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function backendPillClass(backend: string): string {
+  if (backend === "programmatic") return "pill backend-programmatic";
+  if (backend === "channel") return "pill backend-channel";
+  return "pill backend-interactive";
+}
+
+function statusPillClass(status: string): string {
+  if (status === "enabled" || status === "idle") return "pill status-enabled";
+  if (status === "working") return "pill status-working";
+  if (status === "pending" || status.startsWith("queued")) return "pill status-queued";
+  if (status === "error") return "pill status-error";
+  return "pill";
+}
+
+export function Agents() {
+  const [state, setState] = useState<LoadState>({ kind: "loading" });
+  const [selected, setSelected] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setState({ kind: "loading" });
+    try {
+      // Fetch all three in parallel — the merge needs agents + defs; vaults is
+      // an independent read-only section. A failure in any surfaces as one error.
+      const [agentsRes, defsRes, vaultsRes] = await Promise.all([
+        listAgents(),
+        listAgentDefs(),
+        listAgentVaults(),
+      ]);
+      setState({
+        kind: "ok",
+        agents: agentsRes.agents,
+        defs: defsRes.defs,
+        vaults: vaultsRes.vaults,
+      });
+    } catch (err) {
+      const message =
+        err instanceof HttpError
+          ? err.status === 401
+            ? "Not signed in to the hub — sign in to the portal, then reload."
+            : `Failed to load agents: ${err.message}`
+          : `Failed to load agents: ${(err as Error).message}`;
+      setState({ kind: "error", message });
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const merged = useMemo(
+    () => (state.kind === "ok" ? mergeAgents(state.agents, state.defs) : []),
+    [state],
+  );
+
+  const selectedAgent = useMemo(
+    () => merged.find((m) => m.name === selected) ?? null,
+    [merged, selected],
+  );
+
+  return (
+    <div>
+      <h1>Agents</h1>
+      <p className="lede">
+        Every agent across all backends, in one place — programmatic, channel, and
+        interactive. Read-only for now; the create flow and def-vault editor land in
+        later phases.
+      </p>
+
+      {state.kind === "error" ? (
+        <div className="error-banner" role="alert">
+          {state.message}{" "}
+          <button type="button" className="secondary" onClick={() => void load()}>
+            Retry
+          </button>
+        </div>
+      ) : null}
+
+      {state.kind === "loading" ? <div className="loading">Loading agents…</div> : null}
+
+      {state.kind === "ok" ? (
+        <>
+          {selectedAgent ? (
+            <AgentDetail agent={selectedAgent} onClose={() => setSelected(null)} />
+          ) : null}
+
+          <section className="card" aria-label="Agents">
+            <div className="section-head">
+              <h2>All agents</h2>
+              <span className="count" data-testid="agents-count">
+                {merged.length} {merged.length === 1 ? "agent" : "agents"}
+              </span>
+            </div>
+            {merged.length === 0 ? (
+              <div className="empty">
+                No agents yet. Define one in a vault as an{" "}
+                <code>#agent/definition</code> note, or spawn one from the create flow
+                (coming in a later phase).
+              </div>
+            ) : (
+              <table>
+                <thead>
+                  <tr>
+                    <th>Name</th>
+                    <th>Backend</th>
+                    <th>Channel</th>
+                    <th>Status</th>
+                    <th>Vault</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {merged.map((m) => (
+                    <tr
+                      key={m.name}
+                      className={`agent-row${selected === m.name ? " selected" : ""}`}
+                      data-testid={`agent-row-${m.name}`}
+                      onClick={() => setSelected(selected === m.name ? null : m.name)}
+                    >
+                      <td className="cell-name">{m.name}</td>
+                      <td>
+                        <span className={backendPillClass(m.backend)}>{m.backend}</span>
+                      </td>
+                      <td className={m.channel ? "" : "cell-dim"}>{m.channel ?? "—"}</td>
+                      <td>
+                        {m.status ? (
+                          <span className={statusPillClass(m.status)}>{m.status}</span>
+                        ) : m.live ? (
+                          <span className="cell-dim">live</span>
+                        ) : (
+                          <span className="cell-dim">not running</span>
+                        )}
+                      </td>
+                      <td className={m.vault ? "" : "cell-dim"}>{m.vault ?? "—"}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </section>
+
+          <DefVaultsSection vaults={state.vaults} />
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * The per-agent detail panel. Surfaces the def's system-prompt preview, wants,
+ * vault, and status. For a channel-backend agent it notes that the queue / MCP
+ * connect affordance arrives in a later phase (this view is read-only).
+ */
+export function AgentDetail({ agent, onClose }: { agent: MergedAgent; onClose: () => void }) {
+  const def = agent.def;
+  return (
+    <div className="detail" data-testid="agent-detail">
+      <div className="detail-head">
+        <h2>{agent.name}</h2>
+        <span className={backendPillClass(agent.backend)}>{agent.backend}</span>
+        {agent.status ? (
+          <span className={statusPillClass(agent.status)}>{agent.status}</span>
+        ) : null}
+        <button type="button" className="detail-close" onClick={onClose}>
+          Close
+        </button>
+      </div>
+
+      <dl className="detail-grid">
+        <dt>Backend</dt>
+        <dd>{agent.backend}</dd>
+        <dt>Channel</dt>
+        <dd>{agent.channel ?? "—"}</dd>
+        <dt>Vault</dt>
+        <dd>{agent.vault ?? "—"}</dd>
+        <dt>Running</dt>
+        <dd>{agent.live ? "yes" : "no (defined, not instantiated)"}</dd>
+        {def ? (
+          <>
+            <dt>Def status</dt>
+            <dd>{def.status}</dd>
+          </>
+        ) : null}
+      </dl>
+
+      {def ? (
+        <>
+          <h3>System prompt</h3>
+          {def.systemPromptPreview ? (
+            <p className="detail-prompt" data-testid="detail-prompt">
+              {def.systemPromptPreview}
+            </p>
+          ) : (
+            <p className="dim">No system prompt set (Claude Code's default).</p>
+          )}
+
+          <h3>Wants</h3>
+          {def.wants.length > 0 ? (
+            <div className="tag-list">
+              {def.wants.map((w) => (
+                <span key={w} className="tag">
+                  {w}
+                </span>
+              ))}
+            </div>
+          ) : (
+            <p className="dim">Own-vault only — no extra connections requested.</p>
+          )}
+
+          {def.pending.length > 0 ? (
+            <>
+              <h3>Pending approval</h3>
+              <div className="tag-list">
+                {def.pending.map((p) => (
+                  <span key={p} className="tag">
+                    {p}
+                  </span>
+                ))}
+              </div>
+            </>
+          ) : null}
+        </>
+      ) : (
+        <p className="dim" data-testid="detail-no-def">
+          This agent isn't backed by a vault-native <code>#agent/definition</code> note,
+          so there's no system prompt or wants to show.
+        </p>
+      )}
+
+      {agent.backend === "channel" ? (
+        <p className="detail-note" data-testid="detail-channel-note">
+          Channel backend — the queue depth and the "connect your Claude Code session"
+          affordance arrive in a later phase.
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * Read-only "Def-vaults" section: which vaults the module reads agent
+ * definitions from (`agent-vaults.json`). `tokenPresent` shows binding health
+ * without ever surfacing the token value. The add/remove editor is Phase 4.
+ */
+export function DefVaultsSection({ vaults }: { vaults: AgentVaultRow[] }) {
+  return (
+    <section className="card" aria-label="Def-vaults">
+      <div className="section-head">
+        <h2>Def-vaults</h2>
+        <span className="count">{vaults.length}</span>
+      </div>
+      <p className="muted">
+        Vaults this module reads <code>#agent/definition</code> notes from. Editing the
+        list (add / remove) comes in a later phase.
+      </p>
+      {vaults.length === 0 ? (
+        <div className="empty" data-testid="def-vaults-empty">
+          No def-vaults configured yet.
+        </div>
+      ) : (
+        <table>
+          <thead>
+            <tr>
+              <th>Vault</th>
+              <th>URL</th>
+              <th>Token</th>
+            </tr>
+          </thead>
+          <tbody>
+            {vaults.map((v) => (
+              <tr key={v.vault} data-testid={`def-vault-${v.vault}`}>
+                <td className="cell-name">{v.vault}</td>
+                <td className="cell-dim">{v.url}</td>
+                <td>
+                  {v.tokenPresent ? (
+                    <span className="pill status-enabled">present</span>
+                  ) : (
+                    <span className="pill status-error">missing</span>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </section>
+  );
+}

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -1,0 +1,395 @@
+/*
+ * Brand tokens kept in sync with the agent daemon's server-rendered surfaces
+ * (src/ui-kit.ts THEME_CSS) and the hub SPA (parachute-hub/web/ui/src/styles.css)
+ * so the v2 SPA is visually continuous with the hub portal the operator just
+ * came from and the daemon HTML pages it sits alongside during the migration.
+ * Don't drift these without updating the server-rendered surfaces too.
+ */
+:root {
+  --bg: #faf8f4;
+  --bg-soft: #f3f0ea;
+  --fg: #2c2a26;
+  --fg-muted: #6b6860;
+  --fg-dim: #9a9690;
+  --accent: #4a7c59;
+  --accent-soft: rgba(74, 124, 89, 0.08);
+  --accent-hover: #3d6849;
+  --border: #e4e0d8;
+  --border-light: #ece9e2;
+  --card-bg: #ffffff;
+  --error: #a3392b;
+  --error-soft: rgba(163, 57, 43, 0.08);
+  --warn: #b08023;
+  --warn-soft: rgba(176, 128, 35, 0.08);
+  --success: #3d6849;
+  --success-soft: rgba(61, 104, 73, 0.08);
+  --font-serif: Georgia, "Times New Roman", serif;
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  --font-mono: ui-monospace, "SF Mono", Menlo, Monaco, "Cascadia Mono", monospace;
+  font-family: var(--font-sans);
+}
+
+* {
+  box-sizing: border-box;
+}
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--fg);
+}
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+a:hover {
+  text-decoration: underline;
+}
+
+button {
+  font: inherit;
+  background: var(--accent);
+  color: white;
+  border: 0;
+  border-radius: 6px;
+  padding: 0.45rem 0.9rem;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+button:hover {
+  background: var(--accent-hover);
+}
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+button.secondary {
+  background: white;
+  color: var(--fg);
+  border: 1px solid var(--border);
+}
+button.secondary:hover {
+  background: var(--bg-soft);
+}
+
+code {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  background: var(--bg-soft);
+  padding: 0.1em 0.3em;
+  border-radius: 3px;
+}
+
+.page {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 1.5rem 1.5rem 6rem;
+}
+
+/* ---- Nav ---- */
+.nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem 1rem;
+  align-items: center;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 2rem;
+}
+.nav .brand {
+  font-weight: 600;
+  font-family: var(--font-serif);
+  font-size: 1.15rem;
+  margin-right: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: var(--accent);
+  text-decoration: none;
+}
+.nav .brand:hover {
+  color: var(--accent-hover);
+  text-decoration: none;
+}
+.nav .brand-wordmark {
+  color: var(--fg);
+  letter-spacing: -0.005em;
+}
+.nav .brand .sub {
+  color: var(--fg-dim);
+  font-size: 0.78rem;
+  font-weight: 400;
+  margin-left: 0.4rem;
+  font-family: var(--font-sans);
+}
+.nav a {
+  color: var(--fg-muted);
+  font-size: 0.95rem;
+}
+.nav a:hover {
+  text-decoration: none;
+  color: var(--fg);
+}
+.nav a.nav-link-active {
+  color: var(--accent);
+  font-weight: 500;
+  text-decoration: underline;
+  text-underline-offset: 0.3em;
+  text-decoration-thickness: 2px;
+}
+.nav .nav-divider {
+  display: inline-block;
+  width: 1px;
+  height: 1.1em;
+  background: var(--border);
+  align-self: center;
+}
+
+/* ---- Headings ---- */
+h1 {
+  margin: 0 0 0.5rem;
+  font-family: var(--font-serif);
+  font-size: 1.85rem;
+  font-weight: 400;
+  letter-spacing: -0.01em;
+  line-height: 1.2;
+  color: var(--fg);
+}
+h2 {
+  margin: 0 0 1rem;
+  font-size: 1.4rem;
+  font-weight: 500;
+}
+h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.muted {
+  color: var(--fg-muted);
+  font-size: 0.92rem;
+}
+.dim {
+  color: var(--fg-dim);
+  font-size: 0.85rem;
+}
+
+.lede {
+  color: var(--fg-muted);
+  font-size: 0.95rem;
+  margin: 0 0 1.5rem;
+  max-width: 60ch;
+}
+
+/* ---- Banners / states ---- */
+.error-banner {
+  background: var(--error-soft);
+  border: 1px solid var(--error);
+  color: var(--error);
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+  font-size: 0.9rem;
+}
+.empty {
+  border: 1px dashed var(--border);
+  border-radius: 10px;
+  padding: 2rem 1.5rem;
+  text-align: center;
+  color: var(--fg-muted);
+  background: var(--card-bg);
+}
+.loading {
+  color: var(--fg-muted);
+  padding: 1rem 0;
+  font-size: 0.92rem;
+}
+
+/* ---- Cards / sections ---- */
+.card {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.1rem 1.25rem;
+  box-shadow: 0 1px 2px rgba(44, 42, 38, 0.04), 0 8px 24px rgba(44, 42, 38, 0.05);
+  margin-bottom: 1.5rem;
+}
+.section-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+}
+.section-head .count {
+  color: var(--fg-dim);
+  font-size: 0.85rem;
+}
+
+/* ---- Tables ---- */
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.88rem;
+}
+th,
+td {
+  text-align: left;
+  padding: 0.6rem 0.7rem;
+  border-bottom: 1px solid var(--border);
+  vertical-align: middle;
+}
+th {
+  color: var(--fg-muted);
+  font-weight: 500;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+tr.agent-row {
+  cursor: pointer;
+}
+tr.agent-row:hover {
+  background: var(--bg-soft);
+}
+tr.agent-row.selected {
+  background: var(--accent-soft);
+}
+.cell-name {
+  font-weight: 600;
+  color: var(--fg);
+}
+.cell-dim {
+  color: var(--fg-dim);
+}
+
+/* ---- Pills / badges ---- */
+.pill {
+  display: inline-block;
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  border: 1px solid var(--border);
+  color: var(--fg-muted);
+  background: var(--bg-soft);
+}
+.pill.backend-programmatic {
+  color: var(--accent);
+  background: var(--accent-soft);
+  border-color: transparent;
+}
+.pill.backend-channel {
+  color: var(--warn);
+  background: var(--warn-soft);
+  border-color: transparent;
+}
+.pill.backend-interactive {
+  color: var(--fg-muted);
+  background: var(--bg-soft);
+}
+.pill.status-enabled,
+.pill.status-idle {
+  color: var(--success);
+  background: var(--success-soft);
+  border-color: transparent;
+}
+.pill.status-working {
+  color: var(--accent);
+  background: var(--accent-soft);
+  border-color: transparent;
+}
+.pill.status-pending,
+.pill.status-queued {
+  color: var(--warn);
+  background: var(--warn-soft);
+  border-color: transparent;
+}
+.pill.status-error {
+  color: var(--error);
+  background: var(--error-soft);
+  border-color: transparent;
+}
+
+/* ---- Detail panel ---- */
+.detail {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.25rem 1.4rem;
+  margin-bottom: 1.5rem;
+  box-shadow: 0 1px 2px rgba(44, 42, 38, 0.04), 0 8px 24px rgba(44, 42, 38, 0.05);
+}
+.detail-head {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.9rem;
+}
+.detail-head h2 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+.detail-grid {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.45rem 1.2rem;
+  font-size: 0.9rem;
+  margin-bottom: 1rem;
+}
+.detail-grid dt {
+  color: var(--fg-muted);
+  font-weight: 500;
+}
+.detail-grid dd {
+  margin: 0;
+  color: var(--fg);
+  word-break: break-word;
+}
+.detail-prompt {
+  background: var(--bg-soft);
+  border: 1px solid var(--border-light);
+  border-radius: 8px;
+  padding: 0.75rem 0.9rem;
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  white-space: pre-wrap;
+  color: var(--fg);
+  margin: 0.3rem 0 1rem;
+}
+.detail-note {
+  font-size: 0.82rem;
+  color: var(--fg-dim);
+  margin: 0.5rem 0 0;
+}
+.detail-close {
+  margin-left: auto;
+  background: white;
+  color: var(--fg-muted);
+  border: 1px solid var(--border);
+  padding: 0.3rem 0.7rem;
+  font-size: 0.82rem;
+}
+.detail-close:hover {
+  background: var(--bg-soft);
+  color: var(--fg);
+}
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+.tag {
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
+  background: var(--bg-soft);
+  border: 1px solid var(--border-light);
+  border-radius: 4px;
+  padding: 0.05rem 0.35rem;
+  color: var(--fg-muted);
+}

--- a/web/ui/src/test/setup.ts
+++ b/web/ui/src/test/setup.ts
@@ -1,0 +1,8 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup } from "@testing-library/react";
+import { afterEach, vi } from "vitest";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});

--- a/web/ui/tsconfig.json
+++ b/web/ui/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/web/ui/vite.config.ts
+++ b/web/ui/vite.config.ts
@@ -1,0 +1,43 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+// The v2 agent SPA mounts at the agent module's proxied `/app` sub-path —
+// reachable at `<hub>/agent/app/`. The hub reverse-proxies `<expose>/agent/*`
+// to the loopback daemon with `stripPrefix:true`, so the daemon sees `/app/*`;
+// asset URLs are origin-absolute and resolve under `/agent/app/assets/...` over
+// the expose. We pick a NEW sub-path (`/app`) deliberately so this SPA coexists
+// with the existing daemon-rendered HTML pages (`/agents`, `/home`, `/admin`,
+// …) — the design's incremental migration: operators compare the two until the
+// HTML pages retire in Phase 4.
+//
+// Override with `VITE_BASE_PATH=/` for stand-alone dev served at the origin root.
+const basePath = normalizeBase(process.env.VITE_BASE_PATH ?? "/agent/app/");
+
+function normalizeBase(input: string): string {
+  let b = input.startsWith("/") ? input : `/${input}`;
+  if (!b.endsWith("/")) b += "/";
+  return b;
+}
+
+export default defineConfig({
+  base: basePath,
+  plugins: [react()],
+  server: {
+    port: 5175,
+    proxy: {
+      // Dev server runs under `/agent/app/` to mirror the production mount. The
+      // agent daemon serves the token mint at `<origin>/admin/agent-token` and
+      // the JSON API at `/agent/api/*` (proxied) — but in a stand-alone daemon
+      // (no hub) those live at `/admin/agent-token` + `/api/*`. Proxy both
+      // shapes to the running daemon so the dev SPA hits real auth + data.
+      "/admin/agent-token": {
+        target: process.env.AGENT_ORIGIN ?? "http://127.0.0.1:1941",
+        changeOrigin: true,
+      },
+      "/agent/api": {
+        target: process.env.AGENT_ORIGIN ?? "http://127.0.0.1:1941",
+        changeOrigin: true,
+      },
+    },
+  },
+});

--- a/web/ui/vitest.config.ts
+++ b/web/ui/vitest.config.ts
@@ -1,0 +1,19 @@
+/**
+ * Vitest config for the agent web UI. Mirrors the hub's setup — separate from
+ * vite.config.ts so the production-bundle base path doesn't co-mingle with test
+ * concerns. jsdom is the rendering target; setupFiles extends `expect` with
+ * @testing-library/jest-dom matchers and resets fetch / storage mocks per test.
+ */
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "jsdom",
+    setupFiles: ["./src/test/setup.ts"],
+    css: false,
+    restoreMocks: true,
+    clearMocks: true,
+  },
+});


### PR DESCRIPTION
Phase 2 of the agent UI v2 (`design/2026-06-18-agent-ui-v2-and-reactivity.md`): the SPA shell + a unified, **read-only** Agents view, mounted at **`/agent/app/`** so it coexists with the existing daemon-HTML pages (retired in Phase 4).

- **New Vite+React+TS SPA** (`web/ui/`, scaffolded from `parachute-hub/web/ui` — same theme, `verify-base`, in-memory auth). Daemon serves the bundle via `src/spa-serve.ts` (double path-traversal guard: `..` filter + `startsWith(distDir+"/")`).
- **Auth**: mints `agent:admin` from `<origin>/admin/agent-token` (session cookie), cached in module memory (never localStorage), re-mint on 401 — matches the existing pattern.
- **Agents view**: one table of EVERY agent (all backends, merged `GET /api/agents` + `GET /api/agent-defs`; a def with no live agent shows "not running") — name · backend · channel · status · vault, with a detail panel (system-prompt preview, wants, vault, status) + a read-only def-vaults list (`tokenPresent`, never the token). Loading/empty/error states.
- Existing HTML pages (`/agents`, `/home`, `/admin`, …) untouched + still mounted.

## Verified
Daemon `bun test ./src/` **1030 pass / 0 fail**; SPA vitest **32 pass**; both typecheck clean (pre-existing bridge.ts only); `bun run build` + verify-base pass. **Reviewed LGTM** (no blockers; security clean — traversal guard, auth, no secrets). Nits folded: dead subtitle stub inlined; added `test:spa`/`test:all` root scripts so the SPA tests are runnable from root. Phase-3 notes (basename via import.meta.env, apiBase daemon-direct) carried forward.

Next: Phase 3 (unified create flow + channel-backend connect UX) — **pending Aaron's look at the shell**. No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)