### PR TITLE
feat(agent): execution model — single/multi-threaded + #agent/thread record

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,13 +240,18 @@ Bearer `vault:<name>:write`).
 The unified model is `definition -> thread -> message`: **everything is a thread**, and
 EVERY completed turn materializes a `#agent/thread` note (a "run" was always a thread with
 one turn — the older `#agent/run` tag retired into this). The note is the durable,
-queryable record of one thread: its BODY is a rolling SUMMARY (the `## Summary` section is
-a slot a future summarizer agent may own/enrich — module-owned in v1; the `## Latest turn`
-section + the metadata roll-up are always module-owned), and its metadata carries the
-thread state — `channel`, `definition`, `mode`, `status`, `started_at`, `last_turn_at`,
-`turn_count`, and cumulative `usage`. The INDEXED `status`/`definition`/`mode` fields make
-threads operator-queryable ("all failed threads", "all threads of agent X", "all
-multi-threaded threads").
+queryable record of one thread: its BODY is a rolling SUMMARY (`## Summary` /
+`## Latest turn`), and its metadata carries the thread state — `channel`, `definition`,
+`mode`, `status`, `started_at`, `last_turn_at`, `turn_count`, and cumulative `usage`. The
+INDEXED `status`/`definition`/`mode` fields make threads operator-queryable ("all failed
+threads", "all threads of agent X", "all multi-threaded threads").
+
+**v1 OVERWRITES the `## Summary` section every turn.** The module regenerates the whole
+body from the rolled-up metadata each turn (it never reads the prior note's content), so
+`## Summary` is a module-owned default, not a preserved slot. It is EARMARKED for a future
+summarizer agent, but summarizer-agent enrichment needs a read-prior-content → merge path
+(to preserve a summarizer-owned section across the regenerate), which is DEFERRED. "May
+own" means earmarked, not preserved.
 
 **Both execution modes materialize a thread note** — the mode governs the thread's
 IDENTITY (its path leaf) + whether it upserts:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,7 +165,8 @@ vault: the note's `channel` metadata routes it.
 `design/2026-06-17-vault-native-agents.md`). Every vault object this module manages
 hangs off the `#agent` prefix: `#agent/definition` (a vault-native agent def — body
 is the system prompt, metadata is the config), `#agent/message{,/inbound,/outbound}`
-(a conversation turn), `#agent/job` (a scheduled trigger). The tag schema declares
+(a conversation turn), `#agent/job` (a scheduled trigger), `#agent/thread` (the durable
+record of one thread — see the `#agent/thread` subsection below). The tag schema declares
 `parent_names` so a human `tag:#agent` query rolls up to everything the module owns.
 The module always queries the EXACT leaf tag (never relies on prefix magic), and
 keeps the "tag both queryable parent + directional child literally" floor so loop
@@ -233,6 +234,38 @@ Bearer `vault:<name>:write`).
    auth block on the trigger is a follow-up. The daemon defends in depth too:
    `ingestInbound` drops any note tagged `#agent/message/outbound`, so a reply can
    never wake its own session.
+
+### `#agent/thread` — the thread record (the unified model)
+
+The unified model is `definition -> thread -> message`: **everything is a thread**, and
+EVERY completed turn materializes a `#agent/thread` note (a "run" was always a thread with
+one turn — the older `#agent/run` tag retired into this). The note is the durable,
+queryable record of one thread: its BODY is a rolling SUMMARY (the `## Summary` section is
+a slot a future summarizer agent may own/enrich — module-owned in v1; the `## Latest turn`
+section + the metadata roll-up are always module-owned), and its metadata carries the
+thread state — `channel`, `definition`, `mode`, `status`, `started_at`, `last_turn_at`,
+`turn_count`, and cumulative `usage`. The INDEXED `status`/`definition`/`mode` fields make
+threads operator-queryable ("all failed threads", "all threads of agent X", "all
+multi-threaded threads").
+
+**Both execution modes materialize a thread note** — the mode governs the thread's
+IDENTITY (its path leaf) + whether it upserts:
+
+- **`single-threaded`** — exactly ONE thread note per channel at the DETERMINISTIC path
+  `Threads/<safeChannel>/<safeName>` (named after the definition). It UPSERTS in place
+  across turns: the transport READs the existing note, then writes the rolled-up
+  aggregates (`turn_count` incremented, `usage` summed, original `started_at` preserved,
+  `last_turn_at` advanced). Safe today because the drain is serial per channel and
+  single-threaded is one-thread-per-channel; concurrent-threads-per-channel (the deferred
+  continuation increment) will re-derive aggregates from the `#agent/message` children or
+  a vault atomic-merge instead.
+- **`multi-threaded`** — one thread note PER FIRE at `Threads/<safeChannel>/<uuid>`
+  (`turn_count` 1; usage = this fire's). No upsert.
+
+**Loop safety:** the thread note carries `['#agent/thread']` EXACTLY — never a message tag,
+never the inbound child — so it can never wake a session. It is also the PRIMARY record of
+the turn, written BEFORE the additive outbound transcript write, so a turn's record
+survives an outbound failure.
 
 ## Environment variables
 

--- a/design/2026-06-18-agent-ui-v2-and-reactivity.md
+++ b/design/2026-06-18-agent-ui-v2-and-reactivity.md
@@ -90,6 +90,37 @@ save looks broken (the ch-verify confusion, in the operator's face). **Connector
 hard prerequisite for the def-authoring UI** (cheap → do first). Connector 2 (delete) is
 *not* a blocker (ship with a ≤60s delete-convergence note). Connector 3 optional.
 
+## Execution lifecycle: single-threaded vs multi-threaded
+
+A `#agent/definition`'s `metadata.mode` declares its EXECUTION-LIFECYCLE shape — how a
+turn relates to the agent's conversation thread + what record it leaves. An agent is one
+of exactly two kinds (the canonical model; defined by `claude -p` session-id semantics):
+
+- **`single-threaded`** (DEFAULT; = today's behavior) — ONE persistent session per
+  channel. Each turn `--resume`s the stored session id and persists the returned id; the
+  **channel transcript IS the record**, so NO separate run note is written. A scheduled
+  job for a single-threaded def is a synthetic inbound that resumes that one thread
+  (continuing the chat).
+- **`multi-threaded`** — turns are THREAD-KEYED. Every fire mints a fresh thread, runs an
+  independent turn, and writes ONE `#agent/run` note as its per-fire observability record
+  (input + reply + status + timing; the indexed `status`/`definition`/`mode` fields make
+  runs operator-queryable).
+
+**The retired term.** "one-shot" was never its own mode — it was only ever the
+**degenerate first turn of a multi-threaded agent**, so the name retires. The parser
+DUAL-ACCEPTS the legacy values (`resident`→`single-threaded`, `one-shot`→`multi-threaded`,
+`per-thread`→`multi-threaded`), mapping silently, so already-authored def notes keep
+working with no migration.
+
+**Ships now in its degenerate form.** TODAY no inbound carries a thread id, so a
+multi-threaded agent mints a FRESH thread on every fire (no `--resume` read; the returned
+session id is NOT persisted to the channel store). The **deferred increment** is
+thread-id routing: route inbound by a thread id, add a thread-keyed session store, and
+record the minted session/thread id into the run note so a specific prior thread becomes
+resumable. When that lands, the SAME mode gains continuation **with no operator-facing
+change and no migration** — the fresh-per-fire shape that ships now is simply its
+degenerate case.
+
 ## Phased build order
 - **Phase 0 — Connector 1** (def create+edit reactive): manifest `definition.reload`
   action + `created`+`updated` template; provision; verify a def edit reflects live.

--- a/design/2026-06-18-agent-ui-v2-and-reactivity.md
+++ b/design/2026-06-18-agent-ui-v2-and-reactivity.md
@@ -90,21 +90,40 @@ save looks broken (the ch-verify confusion, in the operator's face). **Connector
 hard prerequisite for the def-authoring UI** (cheap → do first). Connector 2 (delete) is
 *not* a blocker (ship with a ≤60s delete-convergence note). Connector 3 optional.
 
-## Execution lifecycle: single-threaded vs multi-threaded
+## Execution lifecycle: everything is a thread
+
+**The unified model: `definition -> thread -> message`.** EVERYTHING is a thread. A
+`#agent/definition` instantiates an agent; each agent runs THREADS; each thread holds
+MESSAGES (the conversation turns). A "run" was always just a thread with one turn — so the
+term retires, the `#agent/run` note becomes the `#agent/thread` note, and **BOTH execution
+modes materialize a thread note** (the structural unification). A `#agent/thread` note is
+the durable, queryable record of one thread; its BODY holds a rolling SUMMARY of the
+thread (a future summarizer agent may own/enrich the `## Summary` slot — module-owned in
+v1), and its metadata carries the thread state (`channel`, `definition`, `mode`, `status`,
+`started_at`, `last_turn_at`, `turn_count`, cumulative `usage`). The indexed
+`status`/`definition`/`mode` fields make threads operator-queryable.
 
 A `#agent/definition`'s `metadata.mode` declares its EXECUTION-LIFECYCLE shape — how a
-turn relates to the agent's conversation thread + what record it leaves. An agent is one
-of exactly two kinds (the canonical model; defined by `claude -p` session-id semantics):
+turn relates to the agent's thread, and the thread note's IDENTITY. An agent is one of
+exactly two kinds (defined by `claude -p` session-id semantics):
 
 - **`single-threaded`** (DEFAULT; = today's behavior) — ONE persistent session per
   channel. Each turn `--resume`s the stored session id and persists the returned id; the
-  **channel transcript IS the record**, so NO separate run note is written. A scheduled
-  job for a single-threaded def is a synthetic inbound that resumes that one thread
-  (continuing the chat).
+  **channel transcript IS the conversation**. It materializes exactly ONE `#agent/thread`
+  note per channel, **named after the definition** (the deterministic stable path
+  `Threads/<channel>/<name>`), UPSERTED in place across turns — the body holds a rolling
+  summary, and `turn_count` + cumulative `usage` roll up each turn. A scheduled job for a
+  single-threaded def is a synthetic inbound that resumes that one thread (continuing the
+  chat) + upserts its one thread note.
 - **`multi-threaded`** — turns are THREAD-KEYED. Every fire mints a fresh thread, runs an
-  independent turn, and writes ONE `#agent/run` note as its per-fire observability record
-  (input + reply + status + timing; the indexed `status`/`definition`/`mode` fields make
-  runs operator-queryable).
+  independent turn, and materializes ONE `#agent/thread` note **per fire**
+  (`Threads/<channel>/<uuid>`; `turn_count` 1; usage = this fire's). Its per-fire
+  observability record (input + reply + status + timing).
+
+The thread note is the PRIMARY record of the turn, written BEFORE the additive outbound
+transcript write (the c34db03 ordering, now applied UNIFORMLY to both modes) so the turn's
+record survives an outbound failure. It carries `['#agent/thread']` EXACTLY — never a
+message tag — so it can never wake a session (loop safety).
 
 **The retired term.** "one-shot" was never its own mode — it was only ever the
 **degenerate first turn of a multi-threaded agent**, so the name retires. The parser
@@ -114,12 +133,16 @@ working with no migration.
 
 **Ships now in its degenerate form.** TODAY no inbound carries a thread id, so a
 multi-threaded agent mints a FRESH thread on every fire (no `--resume` read; the returned
-session id is NOT persisted to the channel store). The **deferred increment** is
-thread-id routing: route inbound by a thread id, add a thread-keyed session store, and
-record the minted session/thread id into the run note so a specific prior thread becomes
-resumable. When that lands, the SAME mode gains continuation **with no operator-facing
-change and no migration** — the fresh-per-fire shape that ships now is simply its
-degenerate case.
+session id is NOT persisted to the channel store), and the single-threaded thread-note
+aggregates are computed by READING the existing note then writing — SAFE because the drain
+is serial per channel and single-threaded is one-thread-per-channel today. The **deferred
+continuation increment**: thread-id routing on the inbound, a thread-keyed session store,
+per-thread drain serialization, message-level per-turn usage, and recording the minted
+session/thread id into the thread note so a specific prior thread becomes resumable (at
+which point single-threaded's read-modify-write aggregation switches to re-deriving from
+the `#agent/message` children or a vault atomic-merge, to avoid lost-update). When that
+lands, the SAME mode gains continuation **with no operator-facing change and no
+migration** — the fresh-per-fire shape that ships now is simply its degenerate case.
 
 ## Phased build order
 - **Phase 0 — Connector 1** (def create+edit reactive): manifest `definition.reload`

--- a/src/agent-defs.test.ts
+++ b/src/agent-defs.test.ts
@@ -230,6 +230,47 @@ describe("parseAgentDef", () => {
     expect(def.spec.channels).toEqual(["laptop"]);
   });
 
+  // --- execution-lifecycle mode (the Phase-3 prerequisite) ---
+
+  test("mode defaults to resident when omitted (= today's behavior)", () => {
+    const def = parseAgentDef(
+      { id: "Agents/uni-dev", content: "role", metadata: { name: "uni-dev" } },
+      { vault: "default" },
+    );
+    expect(def.spec.mode).toBe("resident");
+    // The def note id is threaded onto the spec as provenance (for a one-shot run note).
+    expect(def.spec.definition).toBe("Agents/uni-dev");
+  });
+
+  test("accepts mode:resident explicitly", () => {
+    const def = parseAgentDef(
+      { id: "n1", content: "role", metadata: { name: "a", mode: "resident" } },
+      { vault: "v" },
+    );
+    expect(def.spec.mode).toBe("resident");
+  });
+
+  test("accepts mode:one-shot, threads it onto the spec", () => {
+    const def = parseAgentDef(
+      { id: "Agents/digest", content: "Run the daily digest.", metadata: { name: "digest", mode: "one-shot" } },
+      { vault: "default" },
+    );
+    expect(def.spec.mode).toBe("one-shot");
+    expect(def.spec.definition).toBe("Agents/digest");
+  });
+
+  test("REJECTS mode:per-thread with a clear, actionable error (deferred — needs thread routing)", () => {
+    expect(() =>
+      parseAgentDef({ id: "n", content: "x", metadata: { name: "a", mode: "per-thread" } }, { vault: "v" }),
+    ).toThrow(/per-thread mode is not yet supported.*resident or one-shot/);
+  });
+
+  test("rejects an unrecognized mode value", () => {
+    expect(() =>
+      parseAgentDef({ id: "n", content: "x", metadata: { name: "a", mode: "weird" } }, { vault: "v" }),
+    ).toThrow(/mode must be "resident" or "one-shot"/);
+  });
+
   test("rejects a relative workspace path", () => {
     expect(() =>
       parseAgentDef({ id: "n", content: "x", metadata: { name: "a", workspace: "rel/path" } }, { vault: "v" }),

--- a/src/agent-defs.test.ts
+++ b/src/agent-defs.test.ts
@@ -232,43 +232,57 @@ describe("parseAgentDef", () => {
 
   // --- execution-lifecycle mode (the Phase-3 prerequisite) ---
 
-  test("mode defaults to resident when omitted (= today's behavior)", () => {
+  test("mode defaults to single-threaded when omitted (= today's behavior)", () => {
     const def = parseAgentDef(
       { id: "Agents/uni-dev", content: "role", metadata: { name: "uni-dev" } },
       { vault: "default" },
     );
-    expect(def.spec.mode).toBe("resident");
-    // The def note id is threaded onto the spec as provenance (for a one-shot run note).
+    expect(def.spec.mode).toBe("single-threaded");
+    // The def note id is threaded onto the spec as provenance (for a multi-threaded run note).
     expect(def.spec.definition).toBe("Agents/uni-dev");
   });
 
-  test("accepts mode:resident explicitly", () => {
+  test("accepts mode:single-threaded explicitly", () => {
     const def = parseAgentDef(
-      { id: "n1", content: "role", metadata: { name: "a", mode: "resident" } },
+      { id: "n1", content: "role", metadata: { name: "a", mode: "single-threaded" } },
       { vault: "v" },
     );
-    expect(def.spec.mode).toBe("resident");
+    expect(def.spec.mode).toBe("single-threaded");
   });
 
-  test("accepts mode:one-shot, threads it onto the spec", () => {
+  test("accepts mode:multi-threaded, threads it onto the spec", () => {
     const def = parseAgentDef(
-      { id: "Agents/digest", content: "Run the daily digest.", metadata: { name: "digest", mode: "one-shot" } },
+      { id: "Agents/digest", content: "Run the daily digest.", metadata: { name: "digest", mode: "multi-threaded" } },
       { vault: "default" },
     );
-    expect(def.spec.mode).toBe("one-shot");
+    expect(def.spec.mode).toBe("multi-threaded");
     expect(def.spec.definition).toBe("Agents/digest");
   });
 
-  test("REJECTS mode:per-thread with a clear, actionable error (deferred — needs thread routing)", () => {
-    expect(() =>
-      parseAgentDef({ id: "n", content: "x", metadata: { name: "a", mode: "per-thread" } }, { vault: "v" }),
-    ).toThrow(/per-thread mode is not yet supported.*resident or one-shot/);
-  });
-
-  test("rejects an unrecognized mode value", () => {
+  test("rejects an UNKNOWN mode value with AgentDefParseError", () => {
     expect(() =>
       parseAgentDef({ id: "n", content: "x", metadata: { name: "a", mode: "weird" } }, { vault: "v" }),
-    ).toThrow(/mode must be "resident" or "one-shot"/);
+    ).toThrow(/mode must be "single-threaded" or "multi-threaded"/);
+  });
+
+  test("DUAL-ACCEPTs the legacy aliases (resident→single, one-shot/per-thread→multi)", () => {
+    const resident = parseAgentDef(
+      { id: "n1", content: "x", metadata: { name: "a", mode: "resident" } },
+      { vault: "v" },
+    );
+    expect(resident.spec.mode).toBe("single-threaded");
+
+    const oneShot = parseAgentDef(
+      { id: "n2", content: "x", metadata: { name: "b", mode: "one-shot" } },
+      { vault: "v" },
+    );
+    expect(oneShot.spec.mode).toBe("multi-threaded");
+
+    const perThread = parseAgentDef(
+      { id: "n3", content: "x", metadata: { name: "c", mode: "per-thread" } },
+      { vault: "v" },
+    );
+    expect(perThread.spec.mode).toBe("multi-threaded");
   });
 
   test("rejects a relative workspace path", () => {

--- a/src/agent-defs.test.ts
+++ b/src/agent-defs.test.ts
@@ -238,7 +238,7 @@ describe("parseAgentDef", () => {
       { vault: "default" },
     );
     expect(def.spec.mode).toBe("single-threaded");
-    // The def note id is threaded onto the spec as provenance (for a multi-threaded run note).
+    // The def note id is threaded onto the spec as provenance (for the `#agent/thread` note).
     expect(def.spec.definition).toBe("Agents/uni-dev");
   });
 

--- a/src/agent-defs.ts
+++ b/src/agent-defs.ts
@@ -42,6 +42,7 @@
 import {
   type AgentSpec,
   type AgentBackendKind,
+  type AgentMode,
   type SystemPromptMode,
   type AgentMount,
 } from "./sandbox/types.ts";
@@ -180,6 +181,8 @@ function nameOfDefNote(note: { metadata?: Record<string, unknown> }): string | u
  *   - note BODY (`content`)  → `spec.systemPrompt` (the agent's role, in prose).
  *   - `metadata.name`        → `spec.name` (REQUIRED, slug) = the wake channel.
  *   - `metadata.backend`     → `spec.backend` (default `programmatic`).
+ *   - `metadata.mode`        → `spec.mode` (default `resident`; `one-shot` ok;
+ *     `per-thread` REJECTED — deferred). The note id → `spec.definition` (provenance).
  *   - `metadata.systemPromptMode` → `spec.systemPromptMode` (default `append`).
  *   - `metadata.workspace`   → `spec.workspace` (optional absolute host cwd).
  *   - `metadata.filesystem`  → `spec.filesystem` (`workspace` | `full`).
@@ -245,10 +248,37 @@ export function parseAgentDef(note: {
     backend = rawBackend;
   }
 
+  // Execution-lifecycle mode (the Phase-3 prerequisite). Default `resident` (= today:
+  // one persistent session per channel, resumed + persisted each turn). `one-shot` is
+  // an ephemeral turn (no resume, no persist, writes an `#agent/run` note). `per-thread`
+  // is DEFERRED — it needs inbound thread-routing that doesn't exist yet, so REJECT it
+  // with a clear, actionable error (→ status:error on the note) rather than silently
+  // demoting to resident (which would hide the operator's intent).
+  let mode: AgentMode = "resident";
+  const rawMode = metaStr(meta.mode);
+  if (rawMode !== undefined) {
+    if (rawMode === "per-thread") {
+      throw new AgentDefParseError(
+        `#agent/definition note ${noteId}: per-thread mode is not yet supported — ` +
+          `needs thread routing; use resident or one-shot.`,
+      );
+    }
+    if (rawMode !== "resident" && rawMode !== "one-shot") {
+      throw new AgentDefParseError(
+        `#agent/definition note ${noteId}: mode must be "resident" or "one-shot"`,
+      );
+    }
+    mode = rawMode;
+  }
+
   const spec: AgentSpec = {
     name,
     channels: [name], // wake channel = the agent name (agent ≡ channel)
     backend,
+    mode,
+    // The def note id — provenance carried into a one-shot run note (interim plain id
+    // string; typed link fields are a future vault feature).
+    definition: noteId,
     // Own-vault binding (4a): the def-vault, write-scoped. NOT sourced from the note
     // — it's the vault the note LIVES in (passed in by the caller).
     vault: { name: binding.vault, access: "write" },

--- a/src/agent-defs.ts
+++ b/src/agent-defs.ts
@@ -181,8 +181,9 @@ function nameOfDefNote(note: { metadata?: Record<string, unknown> }): string | u
  *   - note BODY (`content`)  → `spec.systemPrompt` (the agent's role, in prose).
  *   - `metadata.name`        → `spec.name` (REQUIRED, slug) = the wake channel.
  *   - `metadata.backend`     → `spec.backend` (default `programmatic`).
- *   - `metadata.mode`        → `spec.mode` (default `resident`; `one-shot` ok;
- *     `per-thread` REJECTED — deferred). The note id → `spec.definition` (provenance).
+ *   - `metadata.mode`        → `spec.mode` (default `single-threaded`; `multi-threaded`
+ *     ok; the legacy aliases `resident`/`one-shot`/`per-thread` are DUAL-ACCEPTED and
+ *     mapped silently). The note id → `spec.definition` (provenance).
  *   - `metadata.systemPromptMode` → `spec.systemPromptMode` (default `append`).
  *   - `metadata.workspace`   → `spec.workspace` (optional absolute host cwd).
  *   - `metadata.filesystem`  → `spec.filesystem` (`workspace` | `full`).
@@ -248,27 +249,40 @@ export function parseAgentDef(note: {
     backend = rawBackend;
   }
 
-  // Execution-lifecycle mode (the Phase-3 prerequisite). Default `resident` (= today:
-  // one persistent session per channel, resumed + persisted each turn). `one-shot` is
-  // an ephemeral turn (no resume, no persist, writes an `#agent/run` note). `per-thread`
-  // is DEFERRED — it needs inbound thread-routing that doesn't exist yet, so REJECT it
-  // with a clear, actionable error (→ status:error on the note) rather than silently
-  // demoting to resident (which would hide the operator's intent).
-  let mode: AgentMode = "resident";
+  // Execution-lifecycle mode (the Phase-3 prerequisite). An agent is SINGLE-THREADED
+  // or MULTI-THREADED. Default `single-threaded` (= today: one persistent session per
+  // channel, resumed + persisted each turn). `multi-threaded` is thread-keyed — today
+  // (no inbound thread id yet) every fire mints a fresh thread (no resume, no persist,
+  // writes an `#agent/run` note).
+  //
+  // DUAL-ACCEPT the legacy aliases, mapping silently (no operator-facing break, no
+  // migration of already-authored notes):
+  //   legacy value   → canonical value
+  //   ─────────────────────────────────
+  //   resident       → single-threaded
+  //   one-shot       → multi-threaded   (one-shot was just multi-threaded's degenerate
+  //                                       first turn — the term retires)
+  //   per-thread     → multi-threaded   (per-thread continuation is the DEFERRED
+  //                                       increment of multi-threaded, not its own mode)
+  //
+  // Any OTHER value is rejected with a clear, actionable error (→ status:error on the
+  // note) rather than silently demoting (which would hide the operator's intent).
+  let mode: AgentMode = "single-threaded";
   const rawMode = metaStr(meta.mode);
   if (rawMode !== undefined) {
-    if (rawMode === "per-thread") {
+    if (rawMode === "single-threaded" || rawMode === "resident") {
+      mode = "single-threaded";
+    } else if (
+      rawMode === "multi-threaded" ||
+      rawMode === "one-shot" ||
+      rawMode === "per-thread"
+    ) {
+      mode = "multi-threaded";
+    } else {
       throw new AgentDefParseError(
-        `#agent/definition note ${noteId}: per-thread mode is not yet supported — ` +
-          `needs thread routing; use resident or one-shot.`,
+        `#agent/definition note ${noteId}: mode must be "single-threaded" or "multi-threaded"`,
       );
     }
-    if (rawMode !== "resident" && rawMode !== "one-shot") {
-      throw new AgentDefParseError(
-        `#agent/definition note ${noteId}: mode must be "resident" or "one-shot"`,
-      );
-    }
-    mode = rawMode;
   }
 
   const spec: AgentSpec = {
@@ -276,8 +290,8 @@ export function parseAgentDef(note: {
     channels: [name], // wake channel = the agent name (agent ≡ channel)
     backend,
     mode,
-    // The def note id — provenance carried into a one-shot run note (interim plain id
-    // string; typed link fields are a future vault feature).
+    // The def note id — provenance carried into a multi-threaded run note (interim plain
+    // id string; typed link fields are a future vault feature).
     definition: noteId,
     // Own-vault binding (4a): the def-vault, write-scoped. NOT sourced from the note
     // — it's the vault the note LIVES in (passed in by the caller).

--- a/src/agent-defs.ts
+++ b/src/agent-defs.ts
@@ -252,8 +252,11 @@ export function parseAgentDef(note: {
   // Execution-lifecycle mode (the Phase-3 prerequisite). An agent is SINGLE-THREADED
   // or MULTI-THREADED. Default `single-threaded` (= today: one persistent session per
   // channel, resumed + persisted each turn). `multi-threaded` is thread-keyed — today
-  // (no inbound thread id yet) every fire mints a fresh thread (no resume, no persist,
-  // writes an `#agent/run` note).
+  // (no inbound thread id yet) every fire mints a fresh thread (no resume, no persist).
+  // BOTH modes now materialize an `#agent/thread` note (the unified model
+  // `definition -> thread -> message`): single-threaded upserts ONE thread note per
+  // channel (named after the def, rolling summary + turn_count); multi-threaded writes
+  // one thread note per fire.
   //
   // DUAL-ACCEPT the legacy aliases, mapping silently (no operator-facing break, no
   // migration of already-authored notes):
@@ -290,8 +293,8 @@ export function parseAgentDef(note: {
     channels: [name], // wake channel = the agent name (agent ≡ channel)
     backend,
     mode,
-    // The def note id — provenance carried into a multi-threaded run note (interim plain
-    // id string; typed link fields are a future vault feature).
+    // The def note id — provenance carried into the `#agent/thread` note (BOTH modes;
+    // interim plain id string; typed link fields are a future vault feature).
     definition: noteId,
     // Own-vault binding (4a): the def-vault, write-scoped. NOT sourced from the note
     // — it's the vault the note LIVES in (passed in by the caller).

--- a/src/backends/programmatic.test.ts
+++ b/src/backends/programmatic.test.ts
@@ -197,6 +197,16 @@ function specWithSystemPrompt(
   };
 }
 
+/** A one-shot spec — the ephemeral execution-lifecycle mode (no resume, no persist). */
+function specOneShot(name = "eng"): AgentSpec {
+  return {
+    name,
+    channels: [name],
+    mode: "one-shot",
+    vault: { name: "default", access: "read", tags: ["#agent/message"] },
+  };
+}
+
 function mkDirs(tag: string): void {
   sessionsDir = mkdtempSync(join(tmpdir(), `prog-sessions-${tag}-`));
   stateDir = mkdtempSync(join(tmpdir(), `prog-state-${tag}-`));
@@ -331,6 +341,65 @@ describe("ProgrammaticBackend.deliver — second turn (sid stored)", () => {
     expect(cmd2).toContain("--resume sess-RESUME");
     // The sid is stable (same conversation continued, not forked).
     expect(state.get("eng")).toBe("sess-RESUME");
+  });
+});
+
+describe("ProgrammaticBackend.deliver — mode: one-shot (ephemeral, no resume/persist)", () => {
+  test("one-shot turn does NOT --resume even with a stored sid, and does NOT persist the returned id", async () => {
+    mkDirs("oneshot");
+    const state = new AgentSessionState({ stateDir });
+    // Plant a prior session id for the channel — a resident turn WOULD resume it; a
+    // one-shot turn must IGNORE it (no --resume) and must NOT overwrite it.
+    state.set("eng", "sess-PRIOR");
+
+    const { fn, calls } = recordingSpawn({ stdout: successTurn("sess-NEW", "ephemeral reply") });
+    const backend = new ProgrammaticBackend(baseDeps(fn, { sessionState: state }));
+    const handle = await backend.start(specOneShot("eng"));
+
+    const result = await backend.deliver(handle, "fire the one-shot");
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.reply).toBe("ephemeral reply");
+
+    // The argv carries NO --resume (the prior id was deliberately not read).
+    const cmd = calls[0]!.argv[2]!;
+    expect(cmd).toContain("SBX claude -p");
+    expect(cmd).not.toContain("--resume");
+
+    // The returned id is NOT persisted: the store still holds the PRIOR id, untouched
+    // (a one-shot fire leaves no continuity handle behind).
+    expect(state.get("eng")).toBe("sess-PRIOR");
+    // …and a fresh store instance ("restart") confirms it was never written.
+    expect(new AgentSessionState({ stateDir }).get("eng")).toBe("sess-PRIOR");
+  });
+
+  test("a one-shot turn with NO prior id still omits --resume and persists nothing", async () => {
+    mkDirs("oneshot-fresh");
+    const state = new AgentSessionState({ stateDir });
+    const { fn, calls } = recordingSpawn({ stdout: successTurn("sess-X", "reply") });
+    const backend = new ProgrammaticBackend(baseDeps(fn, { sessionState: state }));
+    const handle = await backend.start(specOneShot("eng"));
+
+    await backend.deliver(handle, "go");
+    expect(calls[0]!.argv[2]!).not.toContain("--resume");
+    // Nothing persisted — the channel has no stored id after a one-shot fire.
+    expect(state.get("eng")).toBeUndefined();
+  });
+
+  test("REGRESSION: resident (default mode) still resumes + persists exactly as before", async () => {
+    mkDirs("resident-regress");
+    const state = new AgentSessionState({ stateDir });
+    state.set("eng", "sess-PRIOR");
+    const { fn, calls } = recordingSpawn({ stdout: successTurn("sess-PRIOR", "continued") });
+    // specWithVault has NO mode → resident (the default).
+    const backend = new ProgrammaticBackend(baseDeps(fn, { sessionState: state }));
+    const handle = await backend.start(specWithVault("eng"));
+
+    const result = await backend.deliver(handle, "continue the thread");
+    expect(result.ok).toBe(true);
+    // A resident turn DOES resume the stored id…
+    expect(calls[0]!.argv[2]!).toContain("--resume sess-PRIOR");
+    // …and persists the (same, stable) id.
+    expect(state.get("eng")).toBe("sess-PRIOR");
   });
 });
 

--- a/src/backends/programmatic.test.ts
+++ b/src/backends/programmatic.test.ts
@@ -197,12 +197,12 @@ function specWithSystemPrompt(
   };
 }
 
-/** A one-shot spec — the ephemeral execution-lifecycle mode (no resume, no persist). */
-function specOneShot(name = "eng"): AgentSpec {
+/** A multi-threaded spec — fresh-per-fire today (no resume, no persist). */
+function specMultiThreaded(name = "eng"): AgentSpec {
   return {
     name,
     channels: [name],
-    mode: "one-shot",
+    mode: "multi-threaded",
     vault: { name: "default", access: "read", tags: ["#agent/message"] },
   };
 }
@@ -344,19 +344,19 @@ describe("ProgrammaticBackend.deliver — second turn (sid stored)", () => {
   });
 });
 
-describe("ProgrammaticBackend.deliver — mode: one-shot (ephemeral, no resume/persist)", () => {
-  test("one-shot turn does NOT --resume even with a stored sid, and does NOT persist the returned id", async () => {
-    mkDirs("oneshot");
+describe("ProgrammaticBackend.deliver — mode: multi-threaded (fresh-per-fire, no resume/persist)", () => {
+  test("multi-threaded turn does NOT --resume even with a stored sid, and does NOT persist the returned id", async () => {
+    mkDirs("multithreaded");
     const state = new AgentSessionState({ stateDir });
-    // Plant a prior session id for the channel — a resident turn WOULD resume it; a
-    // one-shot turn must IGNORE it (no --resume) and must NOT overwrite it.
+    // Plant a prior session id for the channel — a single-threaded turn WOULD resume it; a
+    // multi-threaded turn must IGNORE it (no --resume) and must NOT overwrite it.
     state.set("eng", "sess-PRIOR");
 
     const { fn, calls } = recordingSpawn({ stdout: successTurn("sess-NEW", "ephemeral reply") });
     const backend = new ProgrammaticBackend(baseDeps(fn, { sessionState: state }));
-    const handle = await backend.start(specOneShot("eng"));
+    const handle = await backend.start(specMultiThreaded("eng"));
 
-    const result = await backend.deliver(handle, "fire the one-shot");
+    const result = await backend.deliver(handle, "fire the turn");
     expect(result.ok).toBe(true);
     if (result.ok) expect(result.reply).toBe("ephemeral reply");
 
@@ -366,37 +366,37 @@ describe("ProgrammaticBackend.deliver — mode: one-shot (ephemeral, no resume/p
     expect(cmd).not.toContain("--resume");
 
     // The returned id is NOT persisted: the store still holds the PRIOR id, untouched
-    // (a one-shot fire leaves no continuity handle behind).
+    // (a multi-threaded fire leaves no continuity handle behind in its fresh-per-fire form).
     expect(state.get("eng")).toBe("sess-PRIOR");
     // …and a fresh store instance ("restart") confirms it was never written.
     expect(new AgentSessionState({ stateDir }).get("eng")).toBe("sess-PRIOR");
   });
 
-  test("a one-shot turn with NO prior id still omits --resume and persists nothing", async () => {
-    mkDirs("oneshot-fresh");
+  test("a multi-threaded turn with NO prior id still omits --resume and persists nothing", async () => {
+    mkDirs("multithreaded-fresh");
     const state = new AgentSessionState({ stateDir });
     const { fn, calls } = recordingSpawn({ stdout: successTurn("sess-X", "reply") });
     const backend = new ProgrammaticBackend(baseDeps(fn, { sessionState: state }));
-    const handle = await backend.start(specOneShot("eng"));
+    const handle = await backend.start(specMultiThreaded("eng"));
 
     await backend.deliver(handle, "go");
     expect(calls[0]!.argv[2]!).not.toContain("--resume");
-    // Nothing persisted — the channel has no stored id after a one-shot fire.
+    // Nothing persisted — the channel has no stored id after a multi-threaded fire.
     expect(state.get("eng")).toBeUndefined();
   });
 
-  test("REGRESSION: resident (default mode) still resumes + persists exactly as before", async () => {
-    mkDirs("resident-regress");
+  test("REGRESSION: single-threaded (default mode) still resumes + persists exactly as before", async () => {
+    mkDirs("single-threaded-regress");
     const state = new AgentSessionState({ stateDir });
     state.set("eng", "sess-PRIOR");
     const { fn, calls } = recordingSpawn({ stdout: successTurn("sess-PRIOR", "continued") });
-    // specWithVault has NO mode → resident (the default).
+    // specWithVault has NO mode → single-threaded (the default).
     const backend = new ProgrammaticBackend(baseDeps(fn, { sessionState: state }));
     const handle = await backend.start(specWithVault("eng"));
 
     const result = await backend.deliver(handle, "continue the thread");
     expect(result.ok).toBe(true);
-    // A resident turn DOES resume the stored id…
+    // A single-threaded turn DOES resume the stored id…
     expect(calls[0]!.argv[2]!).toContain("--resume sess-PRIOR");
     // …and persists the (same, stable) id.
     expect(state.get("eng")).toBe("sess-PRIOR");

--- a/src/backends/programmatic.ts
+++ b/src/backends/programmatic.ts
@@ -393,8 +393,16 @@ export class ProgrammaticBackend implements AgentBackend {
       writeFileSync(systemPromptFile, spec.systemPrompt, { mode: 0o600 });
     }
 
-    // Build the -p argv with --resume when a session id is stored for this channel.
-    const resumeSessionId = this.deps.sessionState.get(channel);
+    // Mode-aware session handling (the architecture-synthesis chokepoint). A
+    // `one-shot` agent runs an EPHEMERAL turn: do NOT read a prior session id (no
+    // `--resume`) and do NOT persist the returned id below — each fire is a clean,
+    // independent invocation with no conversation continuity. `resident` (the default,
+    // = today) reads + persists exactly as before. Branch ONCE here on `spec.mode`.
+    const oneShot = spec.mode === "one-shot";
+
+    // Build the -p argv with --resume when a session id is stored for this channel —
+    // skipped entirely for one-shot (no continuity to restore).
+    const resumeSessionId = oneShot ? undefined : this.deps.sessionState.get(channel);
     const argv = buildProgrammaticClaudeArgs({
       message,
       mcpConfigPath,
@@ -489,8 +497,10 @@ export class ProgrammaticBackend implements AgentBackend {
 
     // Persist the captured session id so the NEXT turn resumes it — even on a
     // failed turn (a turn can fail AFTER establishing a session; the id is still
-    // the continuation handle). A blank id is a no-op in the store.
-    if (parsed.sessionId) this.deps.sessionState.set(channel, parsed.sessionId);
+    // the continuation handle). A blank id is a no-op in the store. SKIPPED for
+    // one-shot: the turn is ephemeral, so its session id is never stored (the next
+    // fire must start fresh — no resume, no persist).
+    if (!oneShot && parsed.sessionId) this.deps.sessionState.set(channel, parsed.sessionId);
 
     const usage: DeliverUsage | undefined = parsed.usage
       ? {

--- a/src/backends/programmatic.ts
+++ b/src/backends/programmatic.ts
@@ -394,15 +394,20 @@ export class ProgrammaticBackend implements AgentBackend {
     }
 
     // Mode-aware session handling (the architecture-synthesis chokepoint). A
-    // `one-shot` agent runs an EPHEMERAL turn: do NOT read a prior session id (no
-    // `--resume`) and do NOT persist the returned id below — each fire is a clean,
-    // independent invocation with no conversation continuity. `resident` (the default,
-    // = today) reads + persists exactly as before. Branch ONCE here on `spec.mode`.
-    const oneShot = spec.mode === "one-shot";
+    // `multi-threaded` agent is thread-keyed; TODAY (no inbound thread id yet) every
+    // fire mints a FRESH thread: do NOT read a prior session id (no `--resume`) and do
+    // NOT persist the returned id below — each fire is a clean, independent invocation
+    // with no conversation continuity. (The per-thread persist+resume — keying the
+    // session store by thread id so a specific prior thread can be resumed — is the
+    // DEFERRED increment of this mode; until then multi-threaded ships in its degenerate
+    // fresh-per-fire form.) `single-threaded` (the default, = today) reads + persists
+    // exactly as before. Branch ONCE here on `spec.mode`.
+    const multiThreaded = spec.mode === "multi-threaded";
 
     // Build the -p argv with --resume when a session id is stored for this channel —
-    // skipped entirely for one-shot (no continuity to restore).
-    const resumeSessionId = oneShot ? undefined : this.deps.sessionState.get(channel);
+    // skipped entirely for multi-threaded (no continuity to restore in its fresh-per-
+    // fire form).
+    const resumeSessionId = multiThreaded ? undefined : this.deps.sessionState.get(channel);
     const argv = buildProgrammaticClaudeArgs({
       message,
       mcpConfigPath,
@@ -498,9 +503,10 @@ export class ProgrammaticBackend implements AgentBackend {
     // Persist the captured session id so the NEXT turn resumes it — even on a
     // failed turn (a turn can fail AFTER establishing a session; the id is still
     // the continuation handle). A blank id is a no-op in the store. SKIPPED for
-    // one-shot: the turn is ephemeral, so its session id is never stored (the next
-    // fire must start fresh — no resume, no persist).
-    if (!oneShot && parsed.sessionId) this.deps.sessionState.set(channel, parsed.sessionId);
+    // multi-threaded: in its fresh-per-fire form the returned session id is never
+    // persisted to the channel store (the next fire must start fresh — no resume, no
+    // persist; recording the minted id per thread is the deferred continuation increment).
+    if (!multiThreaded && parsed.sessionId) this.deps.sessionState.set(channel, parsed.sessionId);
 
     const usage: DeliverUsage | undefined = parsed.usage
       ? {

--- a/src/backends/registry.test.ts
+++ b/src/backends/registry.test.ts
@@ -341,7 +341,7 @@ describe("ProgrammaticAgentRegistry — #agent/thread notes (unified lifecycle, 
     expect(threads.threads.every((t) => t.mode === "multi-threaded")).toBe(true);
   });
 
-  test("a FAILED turn (BOTH modes) still materializes an #agent/thread note with status:error + the reason", async () => {
+  test("a FAILED MULTI-THREADED turn still materializes an #agent/thread note with status:error + the reason", async () => {
     const backend = new FakeBackend();
     backend.resultFor = () => ({ ok: false, error: "mint refused" });
     const rec = recorder();
@@ -353,6 +353,28 @@ describe("ProgrammaticAgentRegistry — #agent/thread notes (unified lifecycle, 
     await until(() => threads.threads.length === 1);
 
     expect(threads.threads).toHaveLength(1);
+    expect(threads.threads[0]!.mode).toBe("multi-threaded");
+    expect(threads.threads[0]!.status).toBe("error");
+    expect(threads.threads[0]!.output).toBe("mint refused");
+    // No outbound note for a failed turn (unchanged behavior).
+    expect(rec.calls).toHaveLength(0);
+  });
+
+  test("a FAILED SINGLE-THREADED turn ALSO materializes an #agent/thread note with status:error (substantiates BOTH modes)", async () => {
+    const backend = new FakeBackend();
+    backend.resultFor = () => ({ ok: false, error: "mint refused" });
+    const rec = recorder();
+    const threads = threadRecorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn, writeThread: threads.fn });
+    // specFor → no mode → single-threaded (the default).
+    await reg.register(specFor("eng"));
+
+    reg.enqueue("eng", { content: "do it" });
+    await until(() => threads.threads.length === 1);
+
+    expect(threads.threads).toHaveLength(1);
+    expect(threads.threads[0]!.mode).toBe("single-threaded");
+    expect(threads.threads[0]!.name).toBe("eng");
     expect(threads.threads[0]!.status).toBe("error");
     expect(threads.threads[0]!.output).toBe("mint refused");
     // No outbound note for a failed turn (unchanged behavior).

--- a/src/backends/registry.test.ts
+++ b/src/backends/registry.test.ts
@@ -13,6 +13,8 @@ import { describe, test, expect } from "bun:test";
 import {
   ProgrammaticAgentRegistry,
   type WriteOutbound,
+  type WriteRun,
+  type RunNote,
   type TurnEventSink,
   type TurnLifecycleEvent,
 } from "./registry.ts";
@@ -92,6 +94,23 @@ function recorder(): { calls: { channel: string; reply: string; inReplyTo?: stri
   };
   return { calls, fn };
 }
+
+/** A recorder WriteRun — captures every `#agent/run` note the registry writes. */
+function runRecorder(): { runs: RunNote[]; fn: WriteRun } {
+  const runs: RunNote[] = [];
+  const fn: WriteRun = async (run) => {
+    runs.push(run);
+  };
+  return { runs, fn };
+}
+
+/** A one-shot spec (writes an `#agent/run` note per fire). */
+const specOneShot = (name: string, channel = name, definition?: string): AgentSpec => ({
+  name,
+  channels: [channel],
+  mode: "one-shot",
+  ...(definition ? { definition } : {}),
+});
 
 /** A recorder TurnEventSink — captures every (channel, event) the registry emits. */
 function turnRecorder(): { events: { channel: string; event: TurnLifecycleEvent }[]; fn: TurnEventSink } {
@@ -219,6 +238,81 @@ describe("ProgrammaticAgentRegistry — inbound enqueue + outbound", () => {
     // Both turns ran; the throw on the first didn't strand the second.
     expect(backend.calls.map((c) => c.message)).toEqual(["first (throws)", "second (ok)"]);
     expect(rec.calls).toEqual([{ channel: "eng", reply: "reply:second (ok)" }]);
+  });
+});
+
+describe("ProgrammaticAgentRegistry — #agent/run notes (one-shot lifecycle)", () => {
+  test("a completed ONE-SHOT turn writes an #agent/run note (status ok) carrying input/output/definition/mode", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const runs = runRecorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn, writeRun: runs.fn });
+    await reg.register(specOneShot("digest", "digest", "Agents/digest"));
+
+    reg.enqueue("digest", { content: "run the digest" });
+    await until(() => runs.runs.length === 1);
+
+    expect(runs.runs).toHaveLength(1);
+    const run = runs.runs[0]!;
+    expect(run.channel).toBe("digest");
+    expect(run.status).toBe("ok");
+    expect(run.mode).toBe("one-shot");
+    expect(run.definition).toBe("Agents/digest");
+    expect(run.input).toBe("run the digest");
+    expect(run.output).toBe("reply:run the digest");
+    expect(typeof run.started_at).toBe("string");
+    expect(typeof run.ended_at).toBe("string");
+  });
+
+  test("a RESIDENT turn writes NO #agent/run note (the channel transcript is its record)", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const runs = runRecorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn, writeRun: runs.fn });
+    // specFor → no mode → resident (the default).
+    await reg.register(specFor("eng"));
+
+    reg.enqueue("eng", { content: "hello" });
+    await until(() => rec.calls.length === 1);
+    // Let any erroneous run-note write land, then assert none did.
+    await new Promise<void>((r) => setTimeout(r, 5));
+    expect(runs.runs).toHaveLength(0);
+    // The resident outbound reply was still written (no regression).
+    expect(rec.calls).toHaveLength(1);
+  });
+
+  test("a FAILED one-shot turn still writes an #agent/run note with status:error + the reason", async () => {
+    const backend = new FakeBackend();
+    backend.resultFor = () => ({ ok: false, error: "mint refused" });
+    const rec = recorder();
+    const runs = runRecorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn, writeRun: runs.fn });
+    await reg.register(specOneShot("digest"));
+
+    reg.enqueue("digest", { content: "do it" });
+    await until(() => runs.runs.length === 1);
+
+    expect(runs.runs).toHaveLength(1);
+    expect(runs.runs[0]!.status).toBe("error");
+    expect(runs.runs[0]!.output).toBe("mint refused");
+    // No outbound note for a failed turn (unchanged behavior).
+    expect(rec.calls).toHaveLength(0);
+  });
+
+  test("a one-shot turn with an empty reply STILL writes a run note (status ok, empty output)", async () => {
+    const backend = new FakeBackend();
+    backend.resultFor = () => ({ ok: true, reply: "" });
+    const rec = recorder();
+    const runs = runRecorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn, writeRun: runs.fn });
+    await reg.register(specOneShot("digest"));
+
+    reg.enqueue("digest", { content: "tool-only run" });
+    await until(() => runs.runs.length === 1);
+    expect(runs.runs[0]!.status).toBe("ok");
+    expect(runs.runs[0]!.output).toBe("");
+    // Empty reply → no outbound message note (the run note IS the record).
+    expect(rec.calls).toHaveLength(0);
   });
 });
 

--- a/src/backends/registry.test.ts
+++ b/src/backends/registry.test.ts
@@ -13,8 +13,8 @@ import { describe, test, expect } from "bun:test";
 import {
   ProgrammaticAgentRegistry,
   type WriteOutbound,
-  type WriteRun,
-  type RunNote,
+  type WriteThread,
+  type ThreadNote,
   type TurnEventSink,
   type TurnLifecycleEvent,
 } from "./registry.ts";
@@ -95,16 +95,16 @@ function recorder(): { calls: { channel: string; reply: string; inReplyTo?: stri
   return { calls, fn };
 }
 
-/** A recorder WriteRun — captures every `#agent/run` note the registry writes. */
-function runRecorder(): { runs: RunNote[]; fn: WriteRun } {
-  const runs: RunNote[] = [];
-  const fn: WriteRun = async (run) => {
-    runs.push(run);
+/** A recorder WriteThread — captures every `#agent/thread` note the registry writes. */
+function threadRecorder(): { threads: ThreadNote[]; fn: WriteThread } {
+  const threads: ThreadNote[] = [];
+  const fn: WriteThread = async (thread) => {
+    threads.push(thread);
   };
-  return { runs, fn };
+  return { threads, fn };
 }
 
-/** A multi-threaded spec (writes an `#agent/run` note per fire). */
+/** A multi-threaded spec (materializes one `#agent/thread` note per fire). */
 const specMultiThreaded = (name: string, channel = name, definition?: string): AgentSpec => ({
   name,
   channels: [channel],
@@ -241,91 +241,147 @@ describe("ProgrammaticAgentRegistry — inbound enqueue + outbound", () => {
   });
 });
 
-describe("ProgrammaticAgentRegistry — #agent/run notes (multi-threaded lifecycle)", () => {
-  test("a completed MULTI-THREADED turn writes an #agent/run note (status ok) carrying input/output/definition/mode", async () => {
+describe("ProgrammaticAgentRegistry — #agent/thread notes (unified lifecycle, BOTH modes)", () => {
+  test("a completed MULTI-THREADED turn materializes an #agent/thread note (status ok) carrying input/output/definition/mode/name", async () => {
     const backend = new FakeBackend();
     const rec = recorder();
-    const runs = runRecorder();
-    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn, writeRun: runs.fn });
+    const threads = threadRecorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn, writeThread: threads.fn });
     await reg.register(specMultiThreaded("digest", "digest", "Agents/digest"));
 
     reg.enqueue("digest", { content: "run the digest" });
-    await until(() => runs.runs.length === 1);
+    await until(() => threads.threads.length === 1);
 
-    expect(runs.runs).toHaveLength(1);
-    const run = runs.runs[0]!;
-    expect(run.channel).toBe("digest");
-    expect(run.status).toBe("ok");
-    expect(run.mode).toBe("multi-threaded");
-    expect(run.definition).toBe("Agents/digest");
-    expect(run.input).toBe("run the digest");
-    expect(run.output).toBe("reply:run the digest");
-    expect(typeof run.started_at).toBe("string");
-    expect(typeof run.ended_at).toBe("string");
+    expect(threads.threads).toHaveLength(1);
+    const thread = threads.threads[0]!;
+    expect(thread.channel).toBe("digest");
+    expect(thread.name).toBe("digest");
+    expect(thread.status).toBe("ok");
+    expect(thread.mode).toBe("multi-threaded");
+    expect(thread.definition).toBe("Agents/digest");
+    expect(thread.input).toBe("run the digest");
+    expect(thread.output).toBe("reply:run the digest");
+    expect(typeof thread.started_at).toBe("string");
+    expect(typeof thread.ended_at).toBe("string");
     // The dual-write is ADDITIVE: a non-empty reply writes EXACTLY one outbound
-    // (the chat delivery) AND exactly one run note (the primary record).
+    // (the chat delivery) AND exactly one thread note (the primary record).
     await until(() => rec.calls.length === 1);
     expect(rec.calls.length).toBe(1);
-    expect(runs.runs.length).toBe(1);
+    expect(threads.threads.length).toBe(1);
   });
 
-  test("a SINGLE-THREADED turn writes NO #agent/run note (the channel transcript is its record)", async () => {
+  test("a SINGLE-THREADED turn ALSO materializes ONE #agent/thread note (the unified model — named after the def)", async () => {
     const backend = new FakeBackend();
     const rec = recorder();
-    const runs = runRecorder();
-    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn, writeRun: runs.fn });
+    const threads = threadRecorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn, writeThread: threads.fn });
     // specFor → no mode → single-threaded (the default).
     await reg.register(specFor("eng"));
 
     reg.enqueue("eng", { content: "hello" });
-    await until(() => rec.calls.length === 1);
-    // Let any erroneous run-note write land, then assert none did.
-    await new Promise<void>((r) => setTimeout(r, 5));
-    expect(runs.runs).toHaveLength(0);
+    await until(() => threads.threads.length === 1);
+
+    // BOTH modes materialize a thread note now (the structural unification): a
+    // single-threaded turn writes ONE, mode single-threaded, NAMED AFTER THE DEF (the
+    // deterministic upsert key the transport derives the stable path from).
+    expect(threads.threads).toHaveLength(1);
+    expect(threads.threads[0]!.mode).toBe("single-threaded");
+    expect(threads.threads[0]!.name).toBe("eng");
+    expect(threads.threads[0]!.channel).toBe("eng");
+    expect(threads.threads[0]!.input).toBe("hello");
+    expect(threads.threads[0]!.output).toBe("reply:hello");
     // The single-threaded outbound reply was still written (no regression).
     expect(rec.calls).toHaveLength(1);
   });
 
-  test("a FAILED multi-threaded turn still writes an #agent/run note with status:error + the reason", async () => {
+  test("a single-threaded agent over TWO turns records ONE thread (same name/channel — the upsert key) both turns, status carries forward", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const threads = threadRecorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn, writeThread: threads.fn });
+    await reg.register(specFor("eng")); // single-threaded (default).
+
+    // Two turns on the same channel — drained serially, FIFO.
+    reg.enqueue("eng", { content: "turn one" });
+    reg.enqueue("eng", { content: "turn two" });
+    await until(() => threads.threads.length === 2);
+
+    // recordThread is called for BOTH turns (the registry seam can't simulate the
+    // transport's read-existing upsert, so we assert the UPSERT KEY is stable across
+    // turns — same channel + same name + same mode — which the transport maps to the
+    // SAME deterministic path `Threads/<channel>/<name>`, overwriting in place. The
+    // per-turn turn_count/usage aggregation is covered at the vault-transport layer).
+    expect(threads.threads).toHaveLength(2);
+    const [t1, t2] = threads.threads;
+    expect(t1!.mode).toBe("single-threaded");
+    expect(t2!.mode).toBe("single-threaded");
+    expect(t1!.name).toBe("eng");
+    expect(t2!.name).toBe("eng"); // SAME upsert key → same note, upserted.
+    expect(t1!.channel).toBe("eng");
+    expect(t2!.channel).toBe("eng");
+    expect(t1!.input).toBe("turn one");
+    expect(t2!.input).toBe("turn two");
+  });
+
+  test("a multi-threaded fire writes a thread note per fire (each carries this fire's turn — distinct records)", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const threads = threadRecorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn, writeThread: threads.fn });
+    await reg.register(specMultiThreaded("digest"));
+
+    reg.enqueue("digest", { content: "fire A" });
+    reg.enqueue("digest", { content: "fire B" });
+    await until(() => threads.threads.length === 2);
+
+    // One thread note PER FIRE (today one fire = one thread = one note; the transport
+    // assigns each a fresh uuid path, so they're distinct records).
+    expect(threads.threads).toHaveLength(2);
+    expect(threads.threads.map((t) => t.input)).toEqual(["fire A", "fire B"]);
+    expect(threads.threads.every((t) => t.mode === "multi-threaded")).toBe(true);
+  });
+
+  test("a FAILED turn (BOTH modes) still materializes an #agent/thread note with status:error + the reason", async () => {
     const backend = new FakeBackend();
     backend.resultFor = () => ({ ok: false, error: "mint refused" });
     const rec = recorder();
-    const runs = runRecorder();
-    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn, writeRun: runs.fn });
+    const threads = threadRecorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn, writeThread: threads.fn });
     await reg.register(specMultiThreaded("digest"));
 
     reg.enqueue("digest", { content: "do it" });
-    await until(() => runs.runs.length === 1);
+    await until(() => threads.threads.length === 1);
 
-    expect(runs.runs).toHaveLength(1);
-    expect(runs.runs[0]!.status).toBe("error");
-    expect(runs.runs[0]!.output).toBe("mint refused");
+    expect(threads.threads).toHaveLength(1);
+    expect(threads.threads[0]!.status).toBe("error");
+    expect(threads.threads[0]!.output).toBe("mint refused");
     // No outbound note for a failed turn (unchanged behavior).
     expect(rec.calls).toHaveLength(0);
   });
 
-  test("a multi-threaded turn with an empty reply STILL writes a run note (status ok, empty output)", async () => {
+  test("a turn with an empty reply STILL materializes a thread note (status ok, empty output)", async () => {
     const backend = new FakeBackend();
     backend.resultFor = () => ({ ok: true, reply: "" });
     const rec = recorder();
-    const runs = runRecorder();
-    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn, writeRun: runs.fn });
+    const threads = threadRecorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn, writeThread: threads.fn });
     await reg.register(specMultiThreaded("digest"));
 
     reg.enqueue("digest", { content: "tool-only run" });
-    await until(() => runs.runs.length === 1);
-    expect(runs.runs[0]!.status).toBe("ok");
-    expect(runs.runs[0]!.output).toBe("");
-    // Empty reply → no outbound message note (the run note IS the record).
+    await until(() => threads.threads.length === 1);
+    expect(threads.threads[0]!.status).toBe("ok");
+    expect(threads.threads[0]!.output).toBe("");
+    // Empty reply → no outbound message note (the thread note IS the record).
     expect(rec.calls).toHaveLength(0);
   });
 
-  test("REGRESSION (c34db03): a multi-threaded turn whose outbound write THROWS still leaves exactly one #agent/run note", async () => {
+  test("REGRESSION (c34db03, now BOTH modes): a turn whose outbound write THROWS still leaves exactly one #agent/thread note", async () => {
     const backend = new FakeBackend();
-    const runs = runRecorder();
-    // A THROWING WriteOutbound — the run note is written BEFORE the additive outbound
-    // (c34db03), so the failed transcript write must NOT cost us the primary record.
-    // (`recorder()` can't throw; a small inline throwing variant.)
+    const threads = threadRecorder();
+    // A THROWING WriteOutbound — the thread note is written BEFORE the additive outbound
+    // (c34db03, now applied uniformly to BOTH modes), so the failed transcript write must
+    // NOT cost us the primary record. Use a SINGLE-THREADED spec to prove the c34db03
+    // ordering now protects single-threaded too. (`recorder()` can't throw; inline variant.)
     let outboundAttempts = 0;
     const throwingWriteOutbound: WriteOutbound = async () => {
       outboundAttempts++;
@@ -334,20 +390,21 @@ describe("ProgrammaticAgentRegistry — #agent/run notes (multi-threaded lifecyc
     const reg = new ProgrammaticAgentRegistry({
       backend,
       writeOutbound: throwingWriteOutbound,
-      writeRun: runs.fn,
+      writeThread: threads.fn,
     });
-    await reg.register(specMultiThreaded("digest", "digest", "Agents/digest"));
+    await reg.register(specFor("eng")); // single-threaded (default) — the ordering applies here now.
 
-    reg.enqueue("digest", { content: "fire it" });
-    await until(() => runs.runs.length === 1);
+    reg.enqueue("eng", { content: "fire it" });
+    await until(() => threads.threads.length === 1);
     // Let the (throwing) outbound attempt settle.
     await new Promise<void>((r) => setTimeout(r, 5));
 
-    // The run note survived the outbound failure: exactly ONE, status ok, output = the reply.
-    expect(runs.runs).toHaveLength(1);
-    expect(runs.runs[0]!.status).toBe("ok");
-    expect(runs.runs[0]!.output).toBe("reply:fire it");
-    // The outbound WAS attempted (and threw) — proving the run note was written first.
+    // The thread note survived the outbound failure: exactly ONE, status ok, output = the reply.
+    expect(threads.threads).toHaveLength(1);
+    expect(threads.threads[0]!.status).toBe("ok");
+    expect(threads.threads[0]!.mode).toBe("single-threaded");
+    expect(threads.threads[0]!.output).toBe("reply:fire it");
+    // The outbound WAS attempted (and threw) — proving the thread note was written first.
     expect(outboundAttempts).toBe(1);
   });
 });

--- a/src/backends/registry.test.ts
+++ b/src/backends/registry.test.ts
@@ -104,11 +104,11 @@ function runRecorder(): { runs: RunNote[]; fn: WriteRun } {
   return { runs, fn };
 }
 
-/** A one-shot spec (writes an `#agent/run` note per fire). */
-const specOneShot = (name: string, channel = name, definition?: string): AgentSpec => ({
+/** A multi-threaded spec (writes an `#agent/run` note per fire). */
+const specMultiThreaded = (name: string, channel = name, definition?: string): AgentSpec => ({
   name,
   channels: [channel],
-  mode: "one-shot",
+  mode: "multi-threaded",
   ...(definition ? { definition } : {}),
 });
 
@@ -241,13 +241,13 @@ describe("ProgrammaticAgentRegistry — inbound enqueue + outbound", () => {
   });
 });
 
-describe("ProgrammaticAgentRegistry — #agent/run notes (one-shot lifecycle)", () => {
-  test("a completed ONE-SHOT turn writes an #agent/run note (status ok) carrying input/output/definition/mode", async () => {
+describe("ProgrammaticAgentRegistry — #agent/run notes (multi-threaded lifecycle)", () => {
+  test("a completed MULTI-THREADED turn writes an #agent/run note (status ok) carrying input/output/definition/mode", async () => {
     const backend = new FakeBackend();
     const rec = recorder();
     const runs = runRecorder();
     const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn, writeRun: runs.fn });
-    await reg.register(specOneShot("digest", "digest", "Agents/digest"));
+    await reg.register(specMultiThreaded("digest", "digest", "Agents/digest"));
 
     reg.enqueue("digest", { content: "run the digest" });
     await until(() => runs.runs.length === 1);
@@ -256,20 +256,25 @@ describe("ProgrammaticAgentRegistry — #agent/run notes (one-shot lifecycle)", 
     const run = runs.runs[0]!;
     expect(run.channel).toBe("digest");
     expect(run.status).toBe("ok");
-    expect(run.mode).toBe("one-shot");
+    expect(run.mode).toBe("multi-threaded");
     expect(run.definition).toBe("Agents/digest");
     expect(run.input).toBe("run the digest");
     expect(run.output).toBe("reply:run the digest");
     expect(typeof run.started_at).toBe("string");
     expect(typeof run.ended_at).toBe("string");
+    // The dual-write is ADDITIVE: a non-empty reply writes EXACTLY one outbound
+    // (the chat delivery) AND exactly one run note (the primary record).
+    await until(() => rec.calls.length === 1);
+    expect(rec.calls.length).toBe(1);
+    expect(runs.runs.length).toBe(1);
   });
 
-  test("a RESIDENT turn writes NO #agent/run note (the channel transcript is its record)", async () => {
+  test("a SINGLE-THREADED turn writes NO #agent/run note (the channel transcript is its record)", async () => {
     const backend = new FakeBackend();
     const rec = recorder();
     const runs = runRecorder();
     const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn, writeRun: runs.fn });
-    // specFor → no mode → resident (the default).
+    // specFor → no mode → single-threaded (the default).
     await reg.register(specFor("eng"));
 
     reg.enqueue("eng", { content: "hello" });
@@ -277,17 +282,17 @@ describe("ProgrammaticAgentRegistry — #agent/run notes (one-shot lifecycle)", 
     // Let any erroneous run-note write land, then assert none did.
     await new Promise<void>((r) => setTimeout(r, 5));
     expect(runs.runs).toHaveLength(0);
-    // The resident outbound reply was still written (no regression).
+    // The single-threaded outbound reply was still written (no regression).
     expect(rec.calls).toHaveLength(1);
   });
 
-  test("a FAILED one-shot turn still writes an #agent/run note with status:error + the reason", async () => {
+  test("a FAILED multi-threaded turn still writes an #agent/run note with status:error + the reason", async () => {
     const backend = new FakeBackend();
     backend.resultFor = () => ({ ok: false, error: "mint refused" });
     const rec = recorder();
     const runs = runRecorder();
     const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn, writeRun: runs.fn });
-    await reg.register(specOneShot("digest"));
+    await reg.register(specMultiThreaded("digest"));
 
     reg.enqueue("digest", { content: "do it" });
     await until(() => runs.runs.length === 1);
@@ -299,13 +304,13 @@ describe("ProgrammaticAgentRegistry — #agent/run notes (one-shot lifecycle)", 
     expect(rec.calls).toHaveLength(0);
   });
 
-  test("a one-shot turn with an empty reply STILL writes a run note (status ok, empty output)", async () => {
+  test("a multi-threaded turn with an empty reply STILL writes a run note (status ok, empty output)", async () => {
     const backend = new FakeBackend();
     backend.resultFor = () => ({ ok: true, reply: "" });
     const rec = recorder();
     const runs = runRecorder();
     const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn, writeRun: runs.fn });
-    await reg.register(specOneShot("digest"));
+    await reg.register(specMultiThreaded("digest"));
 
     reg.enqueue("digest", { content: "tool-only run" });
     await until(() => runs.runs.length === 1);
@@ -313,6 +318,37 @@ describe("ProgrammaticAgentRegistry — #agent/run notes (one-shot lifecycle)", 
     expect(runs.runs[0]!.output).toBe("");
     // Empty reply → no outbound message note (the run note IS the record).
     expect(rec.calls).toHaveLength(0);
+  });
+
+  test("REGRESSION (c34db03): a multi-threaded turn whose outbound write THROWS still leaves exactly one #agent/run note", async () => {
+    const backend = new FakeBackend();
+    const runs = runRecorder();
+    // A THROWING WriteOutbound — the run note is written BEFORE the additive outbound
+    // (c34db03), so the failed transcript write must NOT cost us the primary record.
+    // (`recorder()` can't throw; a small inline throwing variant.)
+    let outboundAttempts = 0;
+    const throwingWriteOutbound: WriteOutbound = async () => {
+      outboundAttempts++;
+      throw new Error("vault write boom");
+    };
+    const reg = new ProgrammaticAgentRegistry({
+      backend,
+      writeOutbound: throwingWriteOutbound,
+      writeRun: runs.fn,
+    });
+    await reg.register(specMultiThreaded("digest", "digest", "Agents/digest"));
+
+    reg.enqueue("digest", { content: "fire it" });
+    await until(() => runs.runs.length === 1);
+    // Let the (throwing) outbound attempt settle.
+    await new Promise<void>((r) => setTimeout(r, 5));
+
+    // The run note survived the outbound failure: exactly ONE, status ok, output = the reply.
+    expect(runs.runs).toHaveLength(1);
+    expect(runs.runs[0]!.status).toBe("ok");
+    expect(runs.runs[0]!.output).toBe("reply:fire it");
+    // The outbound WAS attempted (and threw) — proving the run note was written first.
+    expect(outboundAttempts).toBe(1);
   });
 });
 

--- a/src/backends/registry.ts
+++ b/src/backends/registry.ts
@@ -73,6 +73,42 @@ export type WriteOutbound = (
   inReplyTo?: string,
 ) => Promise<void>;
 
+/**
+ * The run record one `one-shot` turn produces — the data the registry hands {@link
+ * WriteRun} to persist as an `#agent/run` note. A `resident` turn produces NONE (its
+ * record is the channel transcript). Mirrors {@link RunRecord} in transport.ts; kept
+ * local here so the registry doesn't import the transport layer.
+ */
+export interface RunNote {
+  channel: string;
+  /** The `#agent/definition` note id (provenance; plain id string). */
+  definition?: string;
+  /** The mode the turn ran under (always `one-shot` for a run note). */
+  mode: string;
+  /** Outcome — `ok` (success) or `error` (the turn failed). */
+  status: "ok" | "error";
+  /** The inbound text handed to the turn (the `-p` prompt). */
+  input: string;
+  /** The reply on success, or the failure reason on error. */
+  output: string;
+  /** ISO start/end of the turn. */
+  started_at: string;
+  ended_at: string;
+  /** Optional token/cost usage for observability. */
+  usage?: { inputTokens?: number; outputTokens?: number; totalCostUsd?: number };
+}
+
+/**
+ * Write the run record for a completed `one-shot` turn — the seam the registry posts a
+ * run note through. The daemon wires this to the channel transport's `writeRun()` (a
+ * VaultTransport writes an `#agent/run` note). Called ONLY for one-shot turns; a
+ * resident turn writes NO run note (its record is the transcript). A write failure is
+ * the implementation's to surface (the registry logs whatever it throws); it never
+ * re-runs the turn. Optional on the registry — when unwired (no vault-backed channel),
+ * a one-shot turn still runs, it just leaves no run note.
+ */
+export type WriteRun = (run: RunNote) => Promise<void>;
+
 /** A queued inbound message awaiting its serial turn. */
 interface QueuedMessage {
   /** The inbound text handed to the `claude -p` turn as the prompt. */
@@ -120,12 +156,20 @@ export class ProgrammaticAgentRegistry {
 
   private readonly backend: AgentBackend;
   private readonly writeOutbound: WriteOutbound;
+  /** Optional run-note sink — write an `#agent/run` note for a one-shot turn. */
+  private readonly writeRun?: WriteRun;
   /** Optional streaming-view sink — push interim + lifecycle turn events per channel. */
   private readonly onTurnEvent?: TurnEventSink;
 
-  constructor(deps: { backend: AgentBackend; writeOutbound: WriteOutbound; onTurnEvent?: TurnEventSink }) {
+  constructor(deps: {
+    backend: AgentBackend;
+    writeOutbound: WriteOutbound;
+    writeRun?: WriteRun;
+    onTurnEvent?: TurnEventSink;
+  }) {
     this.backend = deps.backend;
     this.writeOutbound = deps.writeOutbound;
+    if (deps.writeRun) this.writeRun = deps.writeRun;
     if (deps.onTurnEvent) this.onTurnEvent = deps.onTurnEvent;
   }
 
@@ -326,6 +370,12 @@ export class ProgrammaticAgentRegistry {
       if (!handle) return; // deregistered mid-drain — stop.
       const msg = queue.shift()!;
 
+      // Mode governs the run record: a `one-shot` turn writes an `#agent/run` note (it
+      // has no resumed transcript to be its record); a `resident` turn writes NONE
+      // (the channel transcript IS its record — don't double-write). Read off the spec.
+      const oneShot = handle.spec.mode === "one-shot";
+      const startedAt = new Date().toISOString();
+
       let result;
       try {
         // Forward each interim event to the streaming-view sink (keyed by channel)
@@ -343,6 +393,11 @@ export class ProgrammaticAgentRegistry {
           `parachute-agent: programmatic turn for channel "${channel}" threw ` +
             `(should be a value): ${reason}`,
         );
+        // A one-shot turn records its run even on a (defensive-catch) failure — the
+        // run note is the record, so a failed run is still a queryable `status:error`.
+        if (oneShot) {
+          await this.recordRun(handle, msg, "error", reason, startedAt, undefined);
+        }
         this.emitTurnEvent(channel, { kind: "error", error: reason });
         continue;
       }
@@ -354,6 +409,11 @@ export class ProgrammaticAgentRegistry {
         console.warn(
           `parachute-agent: programmatic turn for channel "${channel}" failed: ${result.error}`,
         );
+        // A one-shot turn records the failed run (status:error) — its record is the run
+        // note, not the transcript, so a failure must still leave a queryable trace.
+        if (oneShot) {
+          await this.recordRun(handle, msg, "error", result.error, startedAt, undefined);
+        }
         this.emitTurnEvent(channel, { kind: "error", error: result.error });
         continue;
       }
@@ -377,12 +437,60 @@ export class ProgrammaticAgentRegistry {
         }
       }
 
+      // A one-shot turn's RUN RECORD: write the `#agent/run` note (status:ok) now that
+      // the turn succeeded. The run note is the one-shot's record — `resident` writes
+      // NONE (its record is the channel transcript, written via `reply()` above). The
+      // outbound reply (above) is unchanged for both modes; this is ADDITIVE for
+      // one-shot. Best-effort: a run-note failure is logged + the turn still resolves
+      // (we never re-run a `claude -p` turn — that would burn quota for a duplicate).
+      if (oneShot) {
+        await this.recordRun(handle, msg, "ok", result.reply ?? "", startedAt, result.usage);
+      }
+
       // Resolve the live view: `done` carries the final reply text (empty when the
       // turn produced none) so the UI finalizes the in-progress bubble — the durable
       // note (written above) is what actually persists; this just ends the spinner.
       // Reached only when the outbound write SUCCEEDED, or there was no reply to write
       // (empty/tool-only turn → clean resolve, no note expected).
       this.emitTurnEvent(channel, { kind: "done", reply: result.reply ?? "" });
+    }
+  }
+
+  /**
+   * Write the `#agent/run` note for a completed one-shot turn — the run record. A
+   * no-op when no {@link WriteRun} sink is wired (a channel with no durable store). The
+   * timing is captured by the caller (`startedAt` before the turn; `ended_at` is now).
+   * Best-effort: a write failure is LOGGED, never thrown out — a missing run note must
+   * not strand the queue, and the turn is never re-run (it would burn quota for a
+   * duplicate `claude -p`).
+   */
+  private async recordRun(
+    handle: ProgrammaticAgentHandle,
+    msg: QueuedMessage,
+    status: "ok" | "error",
+    output: string,
+    startedAt: string,
+    usage: RunNote["usage"],
+  ): Promise<void> {
+    if (!this.writeRun) return;
+    const run: RunNote = {
+      channel: handle.channel,
+      ...(handle.spec.definition ? { definition: handle.spec.definition } : {}),
+      mode: handle.spec.mode ?? "one-shot",
+      status,
+      input: msg.content,
+      output,
+      started_at: startedAt,
+      ended_at: new Date().toISOString(),
+      ...(usage ? { usage } : {}),
+    };
+    try {
+      await this.writeRun(run);
+    } catch (err) {
+      console.error(
+        `parachute-agent: writing #agent/run note for channel "${handle.channel}" failed ` +
+          `(continuing): ${(err as Error).message}`,
+      );
     }
   }
 }

--- a/src/backends/registry.ts
+++ b/src/backends/registry.ts
@@ -74,16 +74,16 @@ export type WriteOutbound = (
 ) => Promise<void>;
 
 /**
- * The run record one `one-shot` turn produces — the data the registry hands {@link
- * WriteRun} to persist as an `#agent/run` note. A `resident` turn produces NONE (its
- * record is the channel transcript). Mirrors {@link RunRecord} in transport.ts; kept
+ * The run record one `multi-threaded` turn produces — the data the registry hands {@link
+ * WriteRun} to persist as an `#agent/run` note. A `single-threaded` turn produces NONE
+ * (its record is the channel transcript). Mirrors {@link RunRecord} in transport.ts; kept
  * local here so the registry doesn't import the transport layer.
  */
 export interface RunNote {
   channel: string;
   /** The `#agent/definition` note id (provenance; plain id string). */
   definition?: string;
-  /** The mode the turn ran under (always `one-shot` for a run note today). */
+  /** The mode the turn ran under (always `multi-threaded` for a run note today). */
   mode: AgentMode;
   /** Outcome — `ok` (success) or `error` (the turn failed). */
   status: "ok" | "error";
@@ -99,13 +99,13 @@ export interface RunNote {
 }
 
 /**
- * Write the run record for a completed `one-shot` turn — the seam the registry posts a
- * run note through. The daemon wires this to the channel transport's `writeRun()` (a
- * VaultTransport writes an `#agent/run` note). Called ONLY for one-shot turns; a
- * resident turn writes NO run note (its record is the transcript). A write failure is
- * the implementation's to surface (the registry logs whatever it throws); it never
+ * Write the run record for a completed `multi-threaded` turn — the seam the registry
+ * posts a run note through. The daemon wires this to the channel transport's `writeRun()`
+ * (a VaultTransport writes an `#agent/run` note). Called ONLY for multi-threaded turns; a
+ * single-threaded turn writes NO run note (its record is the transcript). A write failure
+ * is the implementation's to surface (the registry logs whatever it throws); it never
  * re-runs the turn. Optional on the registry — when unwired (no vault-backed channel),
- * a one-shot turn still runs, it just leaves no run note.
+ * a multi-threaded turn still runs, it just leaves no run note.
  */
 export type WriteRun = (run: RunNote) => Promise<void>;
 
@@ -156,7 +156,7 @@ export class ProgrammaticAgentRegistry {
 
   private readonly backend: AgentBackend;
   private readonly writeOutbound: WriteOutbound;
-  /** Optional run-note sink — write an `#agent/run` note for a one-shot turn. */
+  /** Optional run-note sink — write an `#agent/run` note for a multi-threaded turn. */
   private readonly writeRun?: WriteRun;
   /** Optional streaming-view sink — push interim + lifecycle turn events per channel. */
   private readonly onTurnEvent?: TurnEventSink;
@@ -370,10 +370,10 @@ export class ProgrammaticAgentRegistry {
       if (!handle) return; // deregistered mid-drain — stop.
       const msg = queue.shift()!;
 
-      // Mode governs the run record: a `one-shot` turn writes an `#agent/run` note (it
-      // has no resumed transcript to be its record); a `resident` turn writes NONE
-      // (the channel transcript IS its record — don't double-write). Read off the spec.
-      const oneShot = handle.spec.mode === "one-shot";
+      // Mode governs the run record: a `multi-threaded` turn writes an `#agent/run` note
+      // (it has no resumed transcript to be its record); a `single-threaded` turn writes
+      // NONE (the channel transcript IS its record — don't double-write). Read off the spec.
+      const multiThreaded = handle.spec.mode === "multi-threaded";
       const startedAt = new Date().toISOString();
 
       let result;
@@ -393,9 +393,9 @@ export class ProgrammaticAgentRegistry {
           `parachute-agent: programmatic turn for channel "${channel}" threw ` +
             `(should be a value): ${reason}`,
         );
-        // A one-shot turn records its run even on a (defensive-catch) failure — the
+        // A multi-threaded turn records its run even on a (defensive-catch) failure — the
         // run note is the record, so a failed run is still a queryable `status:error`.
-        if (oneShot) {
+        if (multiThreaded) {
           await this.recordRun(handle, msg, "error", reason, startedAt, undefined);
         }
         this.emitTurnEvent(channel, { kind: "error", error: reason });
@@ -409,31 +409,31 @@ export class ProgrammaticAgentRegistry {
         console.warn(
           `parachute-agent: programmatic turn for channel "${channel}" failed: ${result.error}`,
         );
-        // A one-shot turn records the failed run (status:error) — its record is the run
-        // note, not the transcript, so a failure must still leave a queryable trace.
-        if (oneShot) {
+        // A multi-threaded turn records the failed run (status:error) — its record is the
+        // run note, not the transcript, so a failure must still leave a queryable trace.
+        if (multiThreaded) {
           await this.recordRun(handle, msg, "error", result.error, startedAt, undefined);
         }
         this.emitTurnEvent(channel, { kind: "error", error: result.error });
         continue;
       }
 
-      // A one-shot turn's RUN RECORD comes FIRST — it is the PRIMARY record of the turn
-      // (status:ok now that the turn succeeded), so it must survive even if the ADDITIVE
-      // outbound transcript write below fails (that path `continue`s past here). Writing
-      // it before the outbound is what guarantees the invariant "a completed one-shot
-      // turn always leaves exactly one run note." `resident` writes NONE here — its
-      // record IS the channel transcript, written via the outbound below. Best-effort: a
-      // run-note failure is logged + the turn still resolves (we never re-run a
-      // `claude -p` turn — that would burn quota for a duplicate).
-      if (oneShot) {
+      // A multi-threaded turn's RUN RECORD comes FIRST — it is the PRIMARY record of the
+      // turn (status:ok now that the turn succeeded), so it must survive even if the
+      // ADDITIVE outbound transcript write below fails (that path `continue`s past here).
+      // Writing it before the outbound is what guarantees the invariant "a completed
+      // multi-threaded turn always leaves exactly one run note." `single-threaded` writes
+      // NONE here — its record IS the channel transcript, written via the outbound below.
+      // Best-effort: a run-note failure is logged + the turn still resolves (we never
+      // re-run a `claude -p` turn — that would burn quota for a duplicate).
+      if (multiThreaded) {
         await this.recordRun(handle, msg, "ok", result.reply ?? "", startedAt, result.usage);
       }
 
-      // The outbound reply — the channel-transcript record for `resident`, and an
-      // ADDITIVE delivery for `one-shot` (whose primary record, the run note, is already
-      // written above). Empty reply → NO note (reviewer contract — `reply` can be ""): a
-      // turn that produced no text (e.g. tool-only work) leaves the chat clean.
+      // The outbound reply — the channel-transcript record for `single-threaded`, and an
+      // ADDITIVE delivery for `multi-threaded` (whose primary record, the run note, is
+      // already written above). Empty reply → NO note (reviewer contract — `reply` can be
+      // ""): a turn that produced no text (e.g. tool-only work) leaves the chat clean.
       if (result.reply && result.reply.length > 0) {
         try {
           await this.writeOutbound(channel, result.reply, msg.inReplyTo);
@@ -445,7 +445,7 @@ export class ProgrammaticAgentRegistry {
           // The reply was produced but NOT persisted to the transcript. Resolve the live
           // view to ERROR, not `done` — a `done` would drop the in-progress bubble and
           // trigger a poll that finds no note, leaving the user with a silently vanished
-          // reply. (reviewer nit, PR #83.) For one-shot the run note above already
+          // reply. (reviewer nit, PR #83.) For multi-threaded the run note above already
           // captured the reply durably, so the run record is not lost.
           this.emitTurnEvent(channel, { kind: "error", error: `reply produced but not saved: ${reason}` });
           continue;
@@ -462,7 +462,7 @@ export class ProgrammaticAgentRegistry {
   }
 
   /**
-   * Write the `#agent/run` note for a completed one-shot turn — the run record. A
+   * Write the `#agent/run` note for a completed multi-threaded turn — the run record. A
    * no-op when no {@link WriteRun} sink is wired (a channel with no durable store). The
    * timing is captured by the caller (`startedAt` before the turn; `ended_at` is now).
    * Best-effort: a write failure is LOGGED, never thrown out — a missing run note must
@@ -481,7 +481,7 @@ export class ProgrammaticAgentRegistry {
     const run: RunNote = {
       channel: handle.channel,
       ...(handle.spec.definition ? { definition: handle.spec.definition } : {}),
-      mode: handle.spec.mode ?? "one-shot",
+      mode: handle.spec.mode ?? "multi-threaded",
       status,
       input: msg.content,
       output,

--- a/src/backends/registry.ts
+++ b/src/backends/registry.ts
@@ -32,7 +32,7 @@
  * webhook (no loop).
  */
 
-import type { AgentSpec } from "../sandbox/types.ts";
+import type { AgentSpec, AgentMode } from "../sandbox/types.ts";
 import { normalizeChannel } from "../sandbox/types.ts";
 import type { AgentBackend, AgentHandle, InterimTurnEvent } from "./types.ts";
 
@@ -83,8 +83,8 @@ export interface RunNote {
   channel: string;
   /** The `#agent/definition` note id (provenance; plain id string). */
   definition?: string;
-  /** The mode the turn ran under (always `one-shot` for a run note). */
-  mode: string;
+  /** The mode the turn ran under (always `one-shot` for a run note today). */
+  mode: AgentMode;
   /** Outcome — `ok` (success) or `error` (the turn failed). */
   status: "ok" | "error";
   /** The inbound text handed to the turn (the `-p` prompt). */
@@ -418,8 +418,22 @@ export class ProgrammaticAgentRegistry {
         continue;
       }
 
-      // Empty reply → NO note (reviewer contract — `reply` can be ""). A turn that
-      // legitimately produced no text (e.g. tool-only work) leaves the chat clean.
+      // A one-shot turn's RUN RECORD comes FIRST — it is the PRIMARY record of the turn
+      // (status:ok now that the turn succeeded), so it must survive even if the ADDITIVE
+      // outbound transcript write below fails (that path `continue`s past here). Writing
+      // it before the outbound is what guarantees the invariant "a completed one-shot
+      // turn always leaves exactly one run note." `resident` writes NONE here — its
+      // record IS the channel transcript, written via the outbound below. Best-effort: a
+      // run-note failure is logged + the turn still resolves (we never re-run a
+      // `claude -p` turn — that would burn quota for a duplicate).
+      if (oneShot) {
+        await this.recordRun(handle, msg, "ok", result.reply ?? "", startedAt, result.usage);
+      }
+
+      // The outbound reply — the channel-transcript record for `resident`, and an
+      // ADDITIVE delivery for `one-shot` (whose primary record, the run note, is already
+      // written above). Empty reply → NO note (reviewer contract — `reply` can be ""): a
+      // turn that produced no text (e.g. tool-only work) leaves the chat clean.
       if (result.reply && result.reply.length > 0) {
         try {
           await this.writeOutbound(channel, result.reply, msg.inReplyTo);
@@ -428,23 +442,14 @@ export class ProgrammaticAgentRegistry {
           console.error(
             `parachute-agent: programmatic outbound write for channel "${channel}" failed: ${reason}`,
           );
-          // The reply was produced but NOT persisted. Resolve the live view to ERROR,
-          // not `done` — a `done` would drop the in-progress bubble and trigger a poll
-          // that finds no note, leaving the user with a silently vanished reply.
-          // (reviewer nit, PR #83)
+          // The reply was produced but NOT persisted to the transcript. Resolve the live
+          // view to ERROR, not `done` — a `done` would drop the in-progress bubble and
+          // trigger a poll that finds no note, leaving the user with a silently vanished
+          // reply. (reviewer nit, PR #83.) For one-shot the run note above already
+          // captured the reply durably, so the run record is not lost.
           this.emitTurnEvent(channel, { kind: "error", error: `reply produced but not saved: ${reason}` });
           continue;
         }
-      }
-
-      // A one-shot turn's RUN RECORD: write the `#agent/run` note (status:ok) now that
-      // the turn succeeded. The run note is the one-shot's record — `resident` writes
-      // NONE (its record is the channel transcript, written via `reply()` above). The
-      // outbound reply (above) is unchanged for both modes; this is ADDITIVE for
-      // one-shot. Best-effort: a run-note failure is logged + the turn still resolves
-      // (we never re-run a `claude -p` turn — that would burn quota for a duplicate).
-      if (oneShot) {
-        await this.recordRun(handle, msg, "ok", result.reply ?? "", startedAt, result.usage);
       }
 
       // Resolve the live view: `done` carries the final reply text (empty when the

--- a/src/backends/registry.ts
+++ b/src/backends/registry.ts
@@ -30,6 +30,16 @@
  * which tags the note `#agent/message/outbound` — the vault inbound trigger keys on
  * `#agent/message/inbound` only, so writing the reply CANNOT re-trigger the inbound
  * webhook (no loop).
+ *
+ * ── Thread note (the UNIFIED model: definition -> thread -> message) ───────────────
+ * BOTH execution-lifecycle modes now MATERIALIZE a `#agent/thread` note (the structural
+ * unification — everything is a thread; a "run" was always a thread with one turn). It is
+ * the PRIMARY record of the turn, written BEFORE the additive outbound (the c34db03
+ * ordering, now uniform) so the record survives an outbound failure. The MODE governs the
+ * thread's identity (resolved transport-side): `single-threaded` upserts ONE thread note
+ * per channel (named after the def, rolling turn_count + cumulative usage),
+ * `multi-threaded` writes one thread note per fire. The thread note carries
+ * `['#agent/thread']` EXACTLY — never a message tag — so it can never wake a session.
  */
 
 import type { AgentSpec, AgentMode } from "../sandbox/types.ts";
@@ -74,16 +84,23 @@ export type WriteOutbound = (
 ) => Promise<void>;
 
 /**
- * The run record one `multi-threaded` turn produces — the data the registry hands {@link
- * WriteRun} to persist as an `#agent/run` note. A `single-threaded` turn produces NONE
- * (its record is the channel transcript). Mirrors {@link RunRecord} in transport.ts; kept
- * local here so the registry doesn't import the transport layer.
+ * One turn's input to materializing a `#agent/thread` note (the UNIFIED model
+ * `definition -> thread -> message`) — the data the registry hands {@link WriteThread}.
+ * BOTH execution-lifecycle modes materialize a thread note (the structural unification:
+ * everything is a thread; a "run" was always a thread with one turn). Mirrors {@link
+ * ThreadRecord} in transport.ts; kept local here so the registry doesn't import the
+ * transport layer.
  */
-export interface RunNote {
+export interface ThreadNote {
   channel: string;
+  /**
+   * The agent/def name — single-threaded's thread is "named after the definition" (the
+   * transport sanitizes it into the deterministic upsert path). Falls back to the channel.
+   */
+  name?: string;
   /** The `#agent/definition` note id (provenance; plain id string). */
   definition?: string;
-  /** The mode the turn ran under (always `multi-threaded` for a run note today). */
+  /** The mode the turn ran under — governs thread identity + whether the note upserts. */
   mode: AgentMode;
   /** Outcome — `ok` (success) or `error` (the turn failed). */
   status: "ok" | "error";
@@ -99,15 +116,15 @@ export interface RunNote {
 }
 
 /**
- * Write the run record for a completed `multi-threaded` turn — the seam the registry
- * posts a run note through. The daemon wires this to the channel transport's `writeRun()`
- * (a VaultTransport writes an `#agent/run` note). Called ONLY for multi-threaded turns; a
- * single-threaded turn writes NO run note (its record is the transcript). A write failure
- * is the implementation's to surface (the registry logs whatever it throws); it never
- * re-runs the turn. Optional on the registry — when unwired (no vault-backed channel),
- * a multi-threaded turn still runs, it just leaves no run note.
+ * Materialize a `#agent/thread` note for a completed turn — the seam the registry posts a
+ * thread note through. The daemon wires this to the channel transport's `writeThread()` (a
+ * VaultTransport writes a `#agent/thread` note). Called for BOTH modes now (the structural
+ * unification — every turn materializes a thread note): single-threaded upserts one note
+ * per channel, multi-threaded writes one per fire. A write failure is the implementation's
+ * to surface (the registry logs whatever it throws); it never re-runs the turn. Optional on
+ * the registry — when unwired (no vault-backed channel), a turn still runs, just no note.
  */
-export type WriteRun = (run: RunNote) => Promise<void>;
+export type WriteThread = (thread: ThreadNote) => Promise<void>;
 
 /** A queued inbound message awaiting its serial turn. */
 interface QueuedMessage {
@@ -156,20 +173,20 @@ export class ProgrammaticAgentRegistry {
 
   private readonly backend: AgentBackend;
   private readonly writeOutbound: WriteOutbound;
-  /** Optional run-note sink — write an `#agent/run` note for a multi-threaded turn. */
-  private readonly writeRun?: WriteRun;
+  /** Optional thread-note sink — materialize an `#agent/thread` note (BOTH modes). */
+  private readonly writeThread?: WriteThread;
   /** Optional streaming-view sink — push interim + lifecycle turn events per channel. */
   private readonly onTurnEvent?: TurnEventSink;
 
   constructor(deps: {
     backend: AgentBackend;
     writeOutbound: WriteOutbound;
-    writeRun?: WriteRun;
+    writeThread?: WriteThread;
     onTurnEvent?: TurnEventSink;
   }) {
     this.backend = deps.backend;
     this.writeOutbound = deps.writeOutbound;
-    if (deps.writeRun) this.writeRun = deps.writeRun;
+    if (deps.writeThread) this.writeThread = deps.writeThread;
     if (deps.onTurnEvent) this.onTurnEvent = deps.onTurnEvent;
   }
 
@@ -370,10 +387,12 @@ export class ProgrammaticAgentRegistry {
       if (!handle) return; // deregistered mid-drain — stop.
       const msg = queue.shift()!;
 
-      // Mode governs the run record: a `multi-threaded` turn writes an `#agent/run` note
-      // (it has no resumed transcript to be its record); a `single-threaded` turn writes
-      // NONE (the channel transcript IS its record — don't double-write). Read off the spec.
-      const multiThreaded = handle.spec.mode === "multi-threaded";
+      // The UNIFIED model (the structural unification): BOTH modes materialize a
+      // `#agent/thread` note — everything is a thread; a "run" was always a thread with one
+      // turn. The MODE difference is the thread's identity (resolved transport-side):
+      // single-threaded upserts ONE note per channel (rolling turn_count + usage),
+      // multi-threaded writes one note per fire. Read the mode off the spec so the
+      // thread note carries it (it's the indexed query axis + governs the upsert).
       const startedAt = new Date().toISOString();
 
       let result;
@@ -393,11 +412,11 @@ export class ProgrammaticAgentRegistry {
           `parachute-agent: programmatic turn for channel "${channel}" threw ` +
             `(should be a value): ${reason}`,
         );
-        // A multi-threaded turn records its run even on a (defensive-catch) failure — the
-        // run note is the record, so a failed run is still a queryable `status:error`.
-        if (multiThreaded) {
-          await this.recordRun(handle, msg, "error", reason, startedAt, undefined);
-        }
+        // BOTH modes materialize a thread note even on a (defensive-catch) failure — the
+        // thread note captures the turn outcome, so a failed turn is still a queryable
+        // `status:error` (single-threaded upserts the rolling thread; multi-threaded writes
+        // a per-fire note).
+        await this.recordThread(handle, msg, "error", reason, startedAt, undefined);
         this.emitTurnEvent(channel, { kind: "error", error: reason });
         continue;
       }
@@ -409,31 +428,28 @@ export class ProgrammaticAgentRegistry {
         console.warn(
           `parachute-agent: programmatic turn for channel "${channel}" failed: ${result.error}`,
         );
-        // A multi-threaded turn records the failed run (status:error) — its record is the
-        // run note, not the transcript, so a failure must still leave a queryable trace.
-        if (multiThreaded) {
-          await this.recordRun(handle, msg, "error", result.error, startedAt, undefined);
-        }
+        // BOTH modes record the failed turn (status:error) on the thread note so a failure
+        // always leaves a queryable trace (single-threaded upserts the rolling thread,
+        // marking it errored; multi-threaded writes a per-fire status:error note).
+        await this.recordThread(handle, msg, "error", result.error, startedAt, undefined);
         this.emitTurnEvent(channel, { kind: "error", error: result.error });
         continue;
       }
 
-      // A multi-threaded turn's RUN RECORD comes FIRST — it is the PRIMARY record of the
-      // turn (status:ok now that the turn succeeded), so it must survive even if the
-      // ADDITIVE outbound transcript write below fails (that path `continue`s past here).
-      // Writing it before the outbound is what guarantees the invariant "a completed
-      // multi-threaded turn always leaves exactly one run note." `single-threaded` writes
-      // NONE here — its record IS the channel transcript, written via the outbound below.
-      // Best-effort: a run-note failure is logged + the turn still resolves (we never
-      // re-run a `claude -p` turn — that would burn quota for a duplicate).
-      if (multiThreaded) {
-        await this.recordRun(handle, msg, "ok", result.reply ?? "", startedAt, result.usage);
-      }
+      // The THREAD NOTE comes FIRST — it is the PRIMARY record of the turn (status:ok now
+      // that the turn succeeded), so it must survive even if the ADDITIVE outbound transcript
+      // write below fails (that path `continue`s past here). Writing it before the outbound
+      // (the c34db03 ordering — now applied UNIFORMLY to both modes) guarantees the turn's
+      // record survives an outbound failure: single-threaded upserts the rolling thread,
+      // multi-threaded writes the per-fire note. Best-effort: a thread-note failure is
+      // logged + the turn still resolves (we never re-run a `claude -p` turn — that would
+      // burn quota for a duplicate).
+      await this.recordThread(handle, msg, "ok", result.reply ?? "", startedAt, result.usage);
 
-      // The outbound reply — the channel-transcript record for `single-threaded`, and an
-      // ADDITIVE delivery for `multi-threaded` (whose primary record, the run note, is
-      // already written above). Empty reply → NO note (reviewer contract — `reply` can be
-      // ""): a turn that produced no text (e.g. tool-only work) leaves the chat clean.
+      // The outbound reply — the channel-transcript delivery (the chat bubble). It is
+      // ADDITIVE to the primary thread-note record already written above (for BOTH modes).
+      // Empty reply → NO note (reviewer contract — `reply` can be ""): a turn that produced
+      // no text (e.g. tool-only work) leaves the chat clean.
       if (result.reply && result.reply.length > 0) {
         try {
           await this.writeOutbound(channel, result.reply, msg.inReplyTo);
@@ -445,8 +461,8 @@ export class ProgrammaticAgentRegistry {
           // The reply was produced but NOT persisted to the transcript. Resolve the live
           // view to ERROR, not `done` — a `done` would drop the in-progress bubble and
           // trigger a poll that finds no note, leaving the user with a silently vanished
-          // reply. (reviewer nit, PR #83.) For multi-threaded the run note above already
-          // captured the reply durably, so the run record is not lost.
+          // reply. (reviewer nit, PR #83.) The thread note above already captured the reply
+          // durably (BOTH modes), so the turn's record is not lost.
           this.emitTurnEvent(channel, { kind: "error", error: `reply produced but not saved: ${reason}` });
           continue;
         }
@@ -462,26 +478,30 @@ export class ProgrammaticAgentRegistry {
   }
 
   /**
-   * Write the `#agent/run` note for a completed multi-threaded turn — the run record. A
-   * no-op when no {@link WriteRun} sink is wired (a channel with no durable store). The
-   * timing is captured by the caller (`startedAt` before the turn; `ended_at` is now).
-   * Best-effort: a write failure is LOGGED, never thrown out — a missing run note must
-   * not strand the queue, and the turn is never re-run (it would burn quota for a
-   * duplicate `claude -p`).
+   * Materialize the `#agent/thread` note for a completed turn — the UNIFIED model, written
+   * for BOTH modes (the structural unification). A no-op when no {@link WriteThread} sink is
+   * wired (a channel with no durable store). The timing is captured by the caller
+   * (`startedAt` before the turn; `ended_at` is now). The MODE rides on the note so the
+   * transport resolves the thread identity (single-threaded upserts one note per channel,
+   * multi-threaded writes one per fire) + the upsert aggregation. The thread `name` is the
+   * agent name (single-threaded's thread is "named after the definition"). Best-effort: a
+   * write failure is LOGGED, never thrown out — a missing thread note must not strand the
+   * queue, and the turn is never re-run (it would burn quota for a duplicate `claude -p`).
    */
-  private async recordRun(
+  private async recordThread(
     handle: ProgrammaticAgentHandle,
     msg: QueuedMessage,
     status: "ok" | "error",
     output: string,
     startedAt: string,
-    usage: RunNote["usage"],
+    usage: ThreadNote["usage"],
   ): Promise<void> {
-    if (!this.writeRun) return;
-    const run: RunNote = {
+    if (!this.writeThread) return;
+    const thread: ThreadNote = {
       channel: handle.channel,
+      name: handle.spec.name,
       ...(handle.spec.definition ? { definition: handle.spec.definition } : {}),
-      mode: handle.spec.mode ?? "multi-threaded",
+      mode: handle.spec.mode ?? "single-threaded",
       status,
       input: msg.content,
       output,
@@ -490,10 +510,10 @@ export class ProgrammaticAgentRegistry {
       ...(usage ? { usage } : {}),
     };
     try {
-      await this.writeRun(run);
+      await this.writeThread(thread);
     } catch (err) {
       console.error(
-        `parachute-agent: writing #agent/run note for channel "${handle.channel}" failed ` +
+        `parachute-agent: writing #agent/thread note for channel "${handle.channel}" failed ` +
           `(continuing): ${(err as Error).message}`,
       );
     }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -121,6 +121,7 @@ import {
 import {
   ProgrammaticAgentRegistry,
   type WriteOutbound,
+  type WriteRun,
   type TurnEventSink,
 } from "./backends/registry.ts";
 import {
@@ -724,6 +725,37 @@ export function buildWriteOutbound(channels: Map<string, Channel>): WriteOutboun
 }
 
 /**
+ * Build the {@link WriteRun} the programmatic registry posts a one-shot turn's run
+ * record through — resolve the channel's transport from the live `channels` map and
+ * call its `writeRun()` (a VaultTransport writes an `#agent/run` note). A transport
+ * without a durable store (telegram) has no `writeRun`; we no-op there (a one-shot on a
+ * non-vault channel still runs — it just leaves no run note). A missing transport
+ * (channel deregistered between the turn + its run record) throws; the registry logs it
+ * and moves on (it never re-runs the turn).
+ */
+export function buildWriteRun(channels: Map<string, Channel>): WriteRun {
+  return async (run) => {
+    const ch = channels.get(run.channel);
+    if (!ch) {
+      throw new Error(`no live transport for channel "${run.channel}" — cannot write the run note`);
+    }
+    // Only a transport with a durable store implements writeRun (the VaultTransport).
+    if (!ch.transport.writeRun) return;
+    await ch.transport.writeRun({
+      channel: run.channel,
+      ...(run.definition ? { definition: run.definition } : {}),
+      mode: run.mode,
+      status: run.status,
+      input: run.input,
+      output: run.output,
+      started_at: run.started_at,
+      ended_at: run.ended_at,
+      ...(run.usage ? { usage: run.usage } : {}),
+    });
+  };
+}
+
+/**
  * Build the REAL programmatic-agent registry — the {@link ProgrammaticBackend}
  * wired to the env-resolved spawn deps + the per-channel session-id store, plus the
  * outbound-write callback over the live `channels`. Lazily defaulted by
@@ -779,6 +811,7 @@ export function createDefaultProgrammaticRegistry(
   return new ProgrammaticAgentRegistry({
     backend,
     writeOutbound: buildWriteOutbound(channels),
+    writeRun: buildWriteRun(channels),
     ...(onTurnEvent ? { onTurnEvent } : {}),
   });
 }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -725,11 +725,11 @@ export function buildWriteOutbound(channels: Map<string, Channel>): WriteOutboun
 }
 
 /**
- * Build the {@link WriteRun} the programmatic registry posts a one-shot turn's run
+ * Build the {@link WriteRun} the programmatic registry posts a multi-threaded turn's run
  * record through — resolve the channel's transport from the live `channels` map and
  * call its `writeRun()` (a VaultTransport writes an `#agent/run` note). A transport
- * without a durable store (telegram) has no `writeRun`; we no-op there (a one-shot on a
- * non-vault channel still runs — it just leaves no run note). A missing transport
+ * without a durable store (telegram) has no `writeRun`; we no-op there (a multi-threaded
+ * turn on a non-vault channel still runs — it just leaves no run note). A missing transport
  * (channel deregistered between the turn + its run record) throws; the registry logs it
  * and moves on (it never re-runs the turn).
  */

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -121,7 +121,7 @@ import {
 import {
   ProgrammaticAgentRegistry,
   type WriteOutbound,
-  type WriteRun,
+  type WriteThread,
   type TurnEventSink,
 } from "./backends/registry.ts";
 import {
@@ -725,32 +725,37 @@ export function buildWriteOutbound(channels: Map<string, Channel>): WriteOutboun
 }
 
 /**
- * Build the {@link WriteRun} the programmatic registry posts a multi-threaded turn's run
- * record through — resolve the channel's transport from the live `channels` map and
- * call its `writeRun()` (a VaultTransport writes an `#agent/run` note). A transport
- * without a durable store (telegram) has no `writeRun`; we no-op there (a multi-threaded
- * turn on a non-vault channel still runs — it just leaves no run note). A missing transport
- * (channel deregistered between the turn + its run record) throws; the registry logs it
- * and moves on (it never re-runs the turn).
+ * Build the {@link WriteThread} the programmatic registry posts each turn's thread note
+ * through — the UNIFIED model, called for BOTH modes (the structural unification: every
+ * turn materializes a thread note). Resolve the channel's transport from the live
+ * `channels` map and call its `writeThread()` (a VaultTransport writes a `#agent/thread`
+ * note; single-threaded upserts one note per channel, multi-threaded writes one per fire).
+ * A transport without a durable store (telegram) has no `writeThread`; we no-op there (the
+ * turn still runs — it just leaves no thread note). A missing transport (channel
+ * deregistered between the turn + its thread record) throws; the registry logs it and moves
+ * on (it never re-runs the turn).
  */
-export function buildWriteRun(channels: Map<string, Channel>): WriteRun {
-  return async (run) => {
-    const ch = channels.get(run.channel);
+export function buildWriteThread(channels: Map<string, Channel>): WriteThread {
+  return async (thread) => {
+    const ch = channels.get(thread.channel);
     if (!ch) {
-      throw new Error(`no live transport for channel "${run.channel}" — cannot write the run note`);
+      throw new Error(
+        `no live transport for channel "${thread.channel}" — cannot write the thread note`,
+      );
     }
-    // Only a transport with a durable store implements writeRun (the VaultTransport).
-    if (!ch.transport.writeRun) return;
-    await ch.transport.writeRun({
-      channel: run.channel,
-      ...(run.definition ? { definition: run.definition } : {}),
-      mode: run.mode,
-      status: run.status,
-      input: run.input,
-      output: run.output,
-      started_at: run.started_at,
-      ended_at: run.ended_at,
-      ...(run.usage ? { usage: run.usage } : {}),
+    // Only a transport with a durable store implements writeThread (the VaultTransport).
+    if (!ch.transport.writeThread) return;
+    await ch.transport.writeThread({
+      channel: thread.channel,
+      ...(thread.name ? { name: thread.name } : {}),
+      ...(thread.definition ? { definition: thread.definition } : {}),
+      mode: thread.mode,
+      status: thread.status,
+      input: thread.input,
+      output: thread.output,
+      started_at: thread.started_at,
+      ended_at: thread.ended_at,
+      ...(thread.usage ? { usage: thread.usage } : {}),
     });
   };
 }
@@ -811,7 +816,7 @@ export function createDefaultProgrammaticRegistry(
   return new ProgrammaticAgentRegistry({
     backend,
     writeOutbound: buildWriteOutbound(channels),
-    writeRun: buildWriteRun(channels),
+    writeThread: buildWriteThread(channels),
     ...(onTurnEvent ? { onTurnEvent } : {}),
   });
 }

--- a/src/runner.test.ts
+++ b/src/runner.test.ts
@@ -1,6 +1,20 @@
 import { describe, test, expect } from "bun:test";
 import { Runner, type TickDriver } from "./runner.ts";
 import type { Job } from "./jobs.ts";
+import {
+  ProgrammaticAgentRegistry,
+  type WriteOutbound,
+  type WriteRun,
+  type RunNote,
+} from "./backends/registry.ts";
+import type {
+  AgentBackend,
+  AgentHandle,
+  AgentStatus,
+  DeliverResult,
+  InterimSink,
+} from "./backends/types.ts";
+import type { AgentSpec } from "./sandbox/types.ts";
 
 /** A controllable clock — tests step time by setting `current`. */
 function fakeClock(startIso: string) {
@@ -345,5 +359,112 @@ describe("Runner — driver wiring (start/stop)", () => {
     r.start();
     r.start();
     expect(scheduleCalls).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Runner ↔ mode-aware deliver — a scheduled fire honors the DEF's mode.
+//
+// The runner is mode-AGNOSTIC: `fire(job)` just authors a synthetic inbound onto the
+// job's channel. The def's `mode` governs downstream at the deliver chokepoint. This
+// is what fixes "a scheduled job silently resumes the chat thread" — the operator
+// expresses ephemerality via `mode: one-shot` on the DEF, and the runner's fire then
+// runs an ephemeral turn + leaves a run note (a resident def's fire resumes the
+// thread as today). We wire the runner's `fire` to the REAL registry enqueue path
+// (fire → enqueue → mode-aware deliver) so the end-to-end behavior is asserted, not
+// just the runner-in-isolation contract.
+// ---------------------------------------------------------------------------
+
+/** A fake backend that records whether each turn resumed, keyed off the spec's mode. */
+class ModeFakeBackend implements AgentBackend {
+  readonly kind = "programmatic";
+  readonly resumed = new Map<string, boolean>(); // channel → did this turn resume?
+  private readonly sessionId = new Map<string, string>(); // channel → persisted id
+
+  async start(spec: AgentSpec): Promise<AgentHandle> {
+    return { backend: this.kind, channel: spec.channels[0] as string, name: spec.name, spec };
+  }
+  async deliver(handle: AgentHandle, message: string, _onInterim?: InterimSink): Promise<DeliverResult> {
+    // Mirror the real backend's mode semantics so the runner-path assertion is faithful.
+    const oneShot = handle.spec?.mode === "one-shot";
+    const prior = oneShot ? undefined : this.sessionId.get(handle.channel);
+    this.resumed.set(handle.channel, prior !== undefined);
+    if (!oneShot) this.sessionId.set(handle.channel, "sess-" + handle.channel);
+    return { ok: true, reply: "did: " + message };
+  }
+  async stop(_handle: AgentHandle): Promise<void> {}
+  async status(_handle: AgentHandle): Promise<AgentStatus> {
+    return { live: true };
+  }
+  /** Seed a prior session id (as if a previous turn established one). */
+  seed(channel: string, id: string): void {
+    this.sessionId.set(channel, id);
+  }
+}
+
+const noopOutbound: WriteOutbound = async () => {};
+function runRec(): { runs: RunNote[]; fn: WriteRun } {
+  const runs: RunNote[] = [];
+  return { runs, fn: async (r) => void runs.push(r) };
+}
+async function flushTurns(pred: () => boolean, tries = 200): Promise<void> {
+  for (let i = 0; i < tries && !pred(); i++) await new Promise<void>((r) => setTimeout(r, 1));
+}
+
+/** Wire a runner whose `fire` enqueues onto the registry (the real fire→deliver path). */
+function wireRunner(reg: ProgrammaticAgentRegistry, clock = fakeClock("2026-06-17T10:30:00Z")) {
+  return new Runner({
+    loadJobs: async () => [],
+    fire: async (j: Job) => {
+      reg.enqueue(j.channel, { content: j.message });
+    },
+    persistFire: async () => {},
+    now: clock.now,
+    log: silent,
+  });
+}
+
+describe("Runner — a scheduled fire honors the def's mode", () => {
+  test("a ONE-SHOT def's scheduled fire is ephemeral (no resume) + writes a run note", async () => {
+    const backend = new ModeFakeBackend();
+    const runs = runRec();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: noopOutbound, writeRun: runs.fn });
+    await reg.register({ name: "digest", channels: ["digest"], mode: "one-shot", definition: "Agents/digest" });
+    // Even with a prior session id seeded, a one-shot fire must NOT resume.
+    backend.seed("digest", "sess-OLD");
+
+    const r = wireRunner(reg);
+    // runNow needs the job in the store; drive `fire` directly (the runner's fire is
+    // what we're testing routes through the mode-aware deliver).
+    await r["fire"](job({ id: "digest-job", channel: "digest", message: "run the digest" }));
+    await flushTurns(() => runs.runs.length === 1);
+
+    // Ephemeral: the scheduled fire did NOT resume the chat thread.
+    expect(backend.resumed.get("digest")).toBe(false);
+    // …and it left a run record (the one-shot's record, since there's no resumed transcript).
+    expect(runs.runs).toHaveLength(1);
+    expect(runs.runs[0]!.mode).toBe("one-shot");
+    expect(runs.runs[0]!.status).toBe("ok");
+    expect(runs.runs[0]!.input).toBe("run the digest");
+  });
+
+  test("REGRESSION: a RESIDENT def's scheduled fire RESUMES the thread + writes NO run note", async () => {
+    const backend = new ModeFakeBackend();
+    const runs = runRec();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: noopOutbound, writeRun: runs.fn });
+    // No mode → resident (the default = today's behavior).
+    await reg.register({ name: "uni-dev", channels: ["uni-dev"] });
+    backend.seed("uni-dev", "sess-EXISTING"); // a prior turn established the thread.
+
+    const r = wireRunner(reg);
+    await r["fire"](job({ id: "uni-job", channel: "uni-dev", message: "daily check-in" }));
+    await flushTurns(() => backend.resumed.has("uni-dev"));
+    // Let any erroneous run-note write land, then assert none did.
+    await new Promise<void>((r2) => setTimeout(r2, 5));
+
+    // A resident def's scheduled fire RESUMES the existing chat thread (today's behavior).
+    expect(backend.resumed.get("uni-dev")).toBe(true);
+    // …and writes NO run note — the channel transcript is its record.
+    expect(runs.runs).toHaveLength(0);
   });
 });

--- a/src/runner.test.ts
+++ b/src/runner.test.ts
@@ -4,8 +4,8 @@ import type { Job } from "./jobs.ts";
 import {
   ProgrammaticAgentRegistry,
   type WriteOutbound,
-  type WriteRun,
-  type RunNote,
+  type WriteThread,
+  type ThreadNote,
 } from "./backends/registry.ts";
 import type {
   AgentBackend,
@@ -369,8 +369,9 @@ describe("Runner — driver wiring (start/stop)", () => {
 // job's channel. The def's `mode` governs downstream at the deliver chokepoint. This
 // is what fixes "a scheduled job silently resumes the chat thread" — the operator
 // expresses ephemerality via `mode: multi-threaded` on the DEF, and the runner's fire
-// then runs a fresh turn + leaves a run note (a single-threaded def's fire resumes the
-// thread as today). We wire the runner's `fire` to the REAL registry enqueue path
+// then runs a fresh turn + materializes a per-fire thread note (a single-threaded def's
+// fire resumes the thread as today + upserts its one thread note). We wire the runner's
+// `fire` to the REAL registry enqueue path
 // (fire → enqueue → mode-aware deliver) so the end-to-end behavior is asserted, not
 // just the runner-in-isolation contract.
 // ---------------------------------------------------------------------------
@@ -403,9 +404,9 @@ class ModeFakeBackend implements AgentBackend {
 }
 
 const noopOutbound: WriteOutbound = async () => {};
-function runRec(): { runs: RunNote[]; fn: WriteRun } {
-  const runs: RunNote[] = [];
-  return { runs, fn: async (r) => void runs.push(r) };
+function threadRec(): { threads: ThreadNote[]; fn: WriteThread } {
+  const threads: ThreadNote[] = [];
+  return { threads, fn: async (t) => void threads.push(t) };
 }
 async function flushTurns(pred: () => boolean, tries = 200): Promise<void> {
   for (let i = 0; i < tries && !pred(); i++) await new Promise<void>((r) => setTimeout(r, 1));
@@ -425,10 +426,10 @@ function wireRunner(reg: ProgrammaticAgentRegistry, clock = fakeClock("2026-06-1
 }
 
 describe("Runner — a scheduled fire honors the def's mode", () => {
-  test("a MULTI-THREADED def's scheduled fire is fresh (no resume) + writes a run note", async () => {
+  test("a MULTI-THREADED def's scheduled fire is fresh (no resume) + materializes a thread note", async () => {
     const backend = new ModeFakeBackend();
-    const runs = runRec();
-    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: noopOutbound, writeRun: runs.fn });
+    const threads = threadRec();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: noopOutbound, writeThread: threads.fn });
     await reg.register({ name: "digest", channels: ["digest"], mode: "multi-threaded", definition: "Agents/digest" });
     // Even with a prior session id seeded, a multi-threaded fire must NOT resume.
     backend.seed("digest", "sess-OLD");
@@ -437,34 +438,35 @@ describe("Runner — a scheduled fire honors the def's mode", () => {
     // runNow needs the job in the store; drive `fire` directly (the runner's fire is
     // what we're testing routes through the mode-aware deliver).
     await r["fire"](job({ id: "digest-job", channel: "digest", message: "run the digest" }));
-    await flushTurns(() => runs.runs.length === 1);
+    await flushTurns(() => threads.threads.length === 1);
 
     // Fresh-per-fire: the scheduled fire did NOT resume the chat thread.
     expect(backend.resumed.get("digest")).toBe(false);
-    // …and it left a run record (the multi-threaded record, since there's no resumed transcript).
-    expect(runs.runs).toHaveLength(1);
-    expect(runs.runs[0]!.mode).toBe("multi-threaded");
-    expect(runs.runs[0]!.status).toBe("ok");
-    expect(runs.runs[0]!.input).toBe("run the digest");
+    // …and it materialized one thread note per fire (the multi-threaded record).
+    expect(threads.threads).toHaveLength(1);
+    expect(threads.threads[0]!.mode).toBe("multi-threaded");
+    expect(threads.threads[0]!.status).toBe("ok");
+    expect(threads.threads[0]!.input).toBe("run the digest");
   });
 
-  test("REGRESSION: a SINGLE-THREADED def's scheduled fire RESUMES the thread + writes NO run note", async () => {
+  test("REGRESSION: a SINGLE-THREADED def's scheduled fire RESUMES the thread + materializes ONE thread note", async () => {
     const backend = new ModeFakeBackend();
-    const runs = runRec();
-    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: noopOutbound, writeRun: runs.fn });
+    const threads = threadRec();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: noopOutbound, writeThread: threads.fn });
     // No mode → single-threaded (the default = today's behavior).
     await reg.register({ name: "uni-dev", channels: ["uni-dev"] });
     backend.seed("uni-dev", "sess-EXISTING"); // a prior turn established the thread.
 
     const r = wireRunner(reg);
     await r["fire"](job({ id: "uni-job", channel: "uni-dev", message: "daily check-in" }));
-    await flushTurns(() => backend.resumed.has("uni-dev"));
-    // Let any erroneous run-note write land, then assert none did.
-    await new Promise<void>((r2) => setTimeout(r2, 5));
+    await flushTurns(() => threads.threads.length === 1);
 
     // A single-threaded def's scheduled fire RESUMES the existing chat thread (today's behavior).
     expect(backend.resumed.get("uni-dev")).toBe(true);
-    // …and writes NO run note — the channel transcript is its record.
-    expect(runs.runs).toHaveLength(0);
+    // …and materializes ONE thread note (the unified model — single-threaded now writes a
+    // thread note too, named after the def, holding a rolling summary).
+    expect(threads.threads).toHaveLength(1);
+    expect(threads.threads[0]!.mode).toBe("single-threaded");
+    expect(threads.threads[0]!.name).toBe("uni-dev");
   });
 });

--- a/src/runner.test.ts
+++ b/src/runner.test.ts
@@ -368,8 +368,8 @@ describe("Runner — driver wiring (start/stop)", () => {
 // The runner is mode-AGNOSTIC: `fire(job)` just authors a synthetic inbound onto the
 // job's channel. The def's `mode` governs downstream at the deliver chokepoint. This
 // is what fixes "a scheduled job silently resumes the chat thread" — the operator
-// expresses ephemerality via `mode: one-shot` on the DEF, and the runner's fire then
-// runs an ephemeral turn + leaves a run note (a resident def's fire resumes the
+// expresses ephemerality via `mode: multi-threaded` on the DEF, and the runner's fire
+// then runs a fresh turn + leaves a run note (a single-threaded def's fire resumes the
 // thread as today). We wire the runner's `fire` to the REAL registry enqueue path
 // (fire → enqueue → mode-aware deliver) so the end-to-end behavior is asserted, not
 // just the runner-in-isolation contract.
@@ -386,10 +386,10 @@ class ModeFakeBackend implements AgentBackend {
   }
   async deliver(handle: AgentHandle, message: string, _onInterim?: InterimSink): Promise<DeliverResult> {
     // Mirror the real backend's mode semantics so the runner-path assertion is faithful.
-    const oneShot = handle.spec?.mode === "one-shot";
-    const prior = oneShot ? undefined : this.sessionId.get(handle.channel);
+    const multiThreaded = handle.spec?.mode === "multi-threaded";
+    const prior = multiThreaded ? undefined : this.sessionId.get(handle.channel);
     this.resumed.set(handle.channel, prior !== undefined);
-    if (!oneShot) this.sessionId.set(handle.channel, "sess-" + handle.channel);
+    if (!multiThreaded) this.sessionId.set(handle.channel, "sess-" + handle.channel);
     return { ok: true, reply: "did: " + message };
   }
   async stop(_handle: AgentHandle): Promise<void> {}
@@ -425,12 +425,12 @@ function wireRunner(reg: ProgrammaticAgentRegistry, clock = fakeClock("2026-06-1
 }
 
 describe("Runner — a scheduled fire honors the def's mode", () => {
-  test("a ONE-SHOT def's scheduled fire is ephemeral (no resume) + writes a run note", async () => {
+  test("a MULTI-THREADED def's scheduled fire is fresh (no resume) + writes a run note", async () => {
     const backend = new ModeFakeBackend();
     const runs = runRec();
     const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: noopOutbound, writeRun: runs.fn });
-    await reg.register({ name: "digest", channels: ["digest"], mode: "one-shot", definition: "Agents/digest" });
-    // Even with a prior session id seeded, a one-shot fire must NOT resume.
+    await reg.register({ name: "digest", channels: ["digest"], mode: "multi-threaded", definition: "Agents/digest" });
+    // Even with a prior session id seeded, a multi-threaded fire must NOT resume.
     backend.seed("digest", "sess-OLD");
 
     const r = wireRunner(reg);
@@ -439,20 +439,20 @@ describe("Runner — a scheduled fire honors the def's mode", () => {
     await r["fire"](job({ id: "digest-job", channel: "digest", message: "run the digest" }));
     await flushTurns(() => runs.runs.length === 1);
 
-    // Ephemeral: the scheduled fire did NOT resume the chat thread.
+    // Fresh-per-fire: the scheduled fire did NOT resume the chat thread.
     expect(backend.resumed.get("digest")).toBe(false);
-    // …and it left a run record (the one-shot's record, since there's no resumed transcript).
+    // …and it left a run record (the multi-threaded record, since there's no resumed transcript).
     expect(runs.runs).toHaveLength(1);
-    expect(runs.runs[0]!.mode).toBe("one-shot");
+    expect(runs.runs[0]!.mode).toBe("multi-threaded");
     expect(runs.runs[0]!.status).toBe("ok");
     expect(runs.runs[0]!.input).toBe("run the digest");
   });
 
-  test("REGRESSION: a RESIDENT def's scheduled fire RESUMES the thread + writes NO run note", async () => {
+  test("REGRESSION: a SINGLE-THREADED def's scheduled fire RESUMES the thread + writes NO run note", async () => {
     const backend = new ModeFakeBackend();
     const runs = runRec();
     const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: noopOutbound, writeRun: runs.fn });
-    // No mode → resident (the default = today's behavior).
+    // No mode → single-threaded (the default = today's behavior).
     await reg.register({ name: "uni-dev", channels: ["uni-dev"] });
     backend.seed("uni-dev", "sess-EXISTING"); // a prior turn established the thread.
 
@@ -462,7 +462,7 @@ describe("Runner — a scheduled fire honors the def's mode", () => {
     // Let any erroneous run-note write land, then assert none did.
     await new Promise<void>((r2) => setTimeout(r2, 5));
 
-    // A resident def's scheduled fire RESUMES the existing chat thread (today's behavior).
+    // A single-threaded def's scheduled fire RESUMES the existing chat thread (today's behavior).
     expect(backend.resumed.get("uni-dev")).toBe(true);
     // …and writes NO run note — the channel transcript is its record.
     expect(runs.runs).toHaveLength(0);

--- a/src/sandbox/types.ts
+++ b/src/sandbox/types.ts
@@ -154,6 +154,31 @@ export type AgentBackendKind = "interactive" | "programmatic" | "channel";
  */
 export type SystemPromptMode = "append" | "replace";
 
+/**
+ * The agent's EXECUTION-LIFECYCLE mode — how a turn relates to the agent's
+ * conversation thread + what run record it leaves (the architecture synthesis,
+ * Phase 3 prerequisite). Defined entirely by `claude -p` session-id semantics:
+ *
+ *  - `"resident"` (DEFAULT; = today's behavior): ONE persistent session id per
+ *    channel. Each turn `--resume`s the stored id and persists the returned id after
+ *    — the channel transcript IS the thread, so there is NO separate run record. A
+ *    scheduled runner job for a resident def is a synthetic inbound that RESUMES that
+ *    one thread (continuing the chat). This is exactly what every agent does today.
+ *
+ *  - `"one-shot"`: an EPHEMERAL turn. Do NOT read the prior session id (no
+ *    `--resume`) and do NOT persist the returned id — each fire is a clean,
+ *    independent invocation with no conversation continuity. Because there's no
+ *    resumed transcript to be the record, a completed one-shot turn writes ONE
+ *    `#agent/run` note (the run record: input + reply + status + timing). This is
+ *    what an operator reaches for when a scheduled job should be a clean task run,
+ *    NOT a silent continuation of the chat thread.
+ *
+ *  - `"per-thread"` (DEFERRED — not yet supported): one session id per inbound
+ *    THREAD. Needs inbound thread-routing that doesn't exist yet; {@link
+ *    parseAgentDef} REJECTS it with a clear error rather than silently demoting.
+ */
+export type AgentMode = "resident" | "one-shot" | "per-thread";
+
 export interface AgentSpec {
   /** Human-readable arm name; used as the tmux session + workspace slug. */
   name: string;
@@ -277,6 +302,26 @@ export interface AgentSpec {
    * {@link SystemPromptMode}.
    */
   systemPromptMode?: SystemPromptMode;
+  /**
+   * The execution-lifecycle mode (the Phase-3 prerequisite). `"resident"`
+   * (DEFAULT, = today): one persistent session per channel, `--resume`d + persisted
+   * each turn, the channel transcript is the thread (no run note). `"one-shot"`: an
+   * ephemeral turn — no `--resume`, the returned session id is NOT persisted, and a
+   * completed turn writes one `#agent/run` note. `"per-thread"` is deferred (parse
+   * rejects it). Read at the session-handling chokepoint (the programmatic backend's
+   * `deliver` resume block) + governs whether the registry writes a run note.
+   * Persisted in spec.json (set from the def's `metadata.mode`). See {@link AgentMode}.
+   */
+  mode?: AgentMode;
+  /**
+   * The `#agent/definition` note id this agent was instantiated from — the
+   * provenance carried into the `#agent/run` note a one-shot turn writes (so a run
+   * record links back to its def). A plain id STRING for now (interim — typed link
+   * fields are a future vault feature). Set by {@link parseAgentDef} from the note
+   * id; unset for a spec not sourced from a def note (then a one-shot run note
+   * carries no definition link).
+   */
+  definition?: string;
 }
 
 /**

--- a/src/sandbox/types.ts
+++ b/src/sandbox/types.ts
@@ -156,33 +156,38 @@ export type SystemPromptMode = "append" | "replace";
 
 /**
  * The agent's EXECUTION-LIFECYCLE mode — how a turn relates to the agent's
- * conversation thread + what run record it leaves (the architecture synthesis,
- * Phase 3 prerequisite). An agent is either SINGLE-THREADED or MULTI-THREADED;
- * the distinction is defined entirely by `claude -p` session-id semantics:
+ * conversation thread (the architecture synthesis, Phase 3 prerequisite). The UNIFIED
+ * model is `definition -> thread -> message`: EVERYTHING is a thread, and BOTH modes
+ * materialize a `#agent/thread` note (the structural unification — a "run" was always a
+ * thread with one turn). An agent is either SINGLE-THREADED or MULTI-THREADED; the
+ * distinction is defined entirely by `claude -p` session-id semantics + the thread's
+ * identity:
  *
  *  - `"single-threaded"` (DEFAULT; = today's behavior): ONE persistent session id
  *    per channel. Each turn `--resume`s the stored id and persists the returned id
- *    after — the channel transcript IS the thread, so there is NO separate run
- *    record. A scheduled runner job for a single-threaded def is a synthetic inbound
- *    that RESUMES that one thread (continuing the chat). This is exactly what every
- *    agent does today.
+ *    after — the channel transcript IS the thread. It materializes exactly ONE
+ *    `#agent/thread` note per channel, named after the definition, UPSERTED in place
+ *    each turn; the note body holds a rolling SUMMARY of the conversation (turn_count +
+ *    cumulative usage roll up). A scheduled runner job for a single-threaded def is a
+ *    synthetic inbound that RESUMES that one thread (continuing the chat). This is
+ *    exactly what every agent does today (plus the now-materialized thread note).
  *
  *  - `"multi-threaded"`: turns are THREAD-KEYED. TODAY — because no inbound carries
  *    a thread id yet — every fire mints a FRESH thread: do NOT read the prior session
  *    id (no `--resume`) and do NOT persist the returned id to the channel store, so
- *    each fire is a clean, independent invocation with no conversation continuity.
- *    Because there's no resumed transcript to be the record, a completed turn writes
- *    ONE `#agent/run` note (the run record: input + reply + status + timing). This is
- *    what an operator reaches for when a scheduled job should be a clean task run,
- *    NOT a silent continuation of the chat thread.
+ *    each fire is a clean, independent invocation with no conversation continuity. It
+ *    materializes ONE `#agent/thread` note per FIRE (the per-fire record: input + reply
+ *    + status + timing). This is what an operator reaches for when a scheduled job
+ *    should be a clean task run, NOT a silent continuation of the chat thread.
  *
  *    ("one-shot" was the prior name for this mode — it was only ever the DEGENERATE
  *    FIRST-TURN of a multi-threaded agent, so the term retires. Continuation-by-
  *    thread-id — resuming a SPECIFIC prior thread — is a DEFERRED increment: it needs
- *    thread-id routing on the inbound, a thread-keyed session store, and recording the
- *    minted session/thread id into the run note so a thread becomes resumable. When it
- *    lands, the SAME mode simply gains continuation with NO operator-facing change and
- *    NO migration; the fresh-per-fire shape that ships now is its degenerate case.)
+ *    thread-id routing on the inbound, a thread-keyed session store, per-thread drain
+ *    serialization, and recording the minted session/thread id into the thread note so
+ *    a thread becomes resumable. When it lands, the SAME mode simply gains continuation
+ *    with NO operator-facing change and NO migration; the fresh-per-fire shape that ships
+ *    now is its degenerate case.)
  */
 export type AgentMode = "single-threaded" | "multi-threaded";
 
@@ -312,22 +317,24 @@ export interface AgentSpec {
   /**
    * The execution-lifecycle mode (the Phase-3 prerequisite). `"single-threaded"`
    * (DEFAULT, = today): one persistent session per channel, `--resume`d + persisted
-   * each turn, the channel transcript is the thread (no run note). `"multi-threaded"`:
-   * thread-keyed — today (no inbound thread id yet) every fire mints a fresh thread
-   * (no `--resume`, the returned session id is NOT persisted to the channel store) and
-   * a completed turn writes one `#agent/run` note. Read at the session-handling
-   * chokepoint (the programmatic backend's `deliver` resume block) + governs whether
-   * the registry writes a run note. Persisted in spec.json (set from the def's
-   * `metadata.mode`). See {@link AgentMode}.
+   * each turn, the channel transcript is the thread. `"multi-threaded"`: thread-keyed —
+   * today (no inbound thread id yet) every fire mints a fresh thread (no `--resume`, the
+   * returned session id is NOT persisted to the channel store). BOTH modes now materialize
+   * an `#agent/thread` note (the unified model `definition -> thread -> message`): a
+   * single-threaded agent upserts ONE thread note per channel (named after the def, rolling
+   * summary); a multi-threaded agent writes one thread note per fire. Read at the
+   * session-handling chokepoint (the programmatic backend's `deliver` resume block) +
+   * governs the thread note's identity (one-per-channel upsert vs one-per-fire). Persisted
+   * in spec.json (set from the def's `metadata.mode`). See {@link AgentMode}.
    */
   mode?: AgentMode;
   /**
    * The `#agent/definition` note id this agent was instantiated from — the
-   * provenance carried into the `#agent/run` note a multi-threaded turn writes (so a
-   * run record links back to its def). A plain id STRING for now (interim — typed link
-   * fields are a future vault feature). Set by {@link parseAgentDef} from the note
-   * id; unset for a spec not sourced from a def note (then a multi-threaded run note
-   * carries no definition link).
+   * provenance carried into the `#agent/thread` note a turn materializes (so a thread
+   * record links back to its def; BOTH modes). A plain id STRING for now (interim — typed
+   * link fields are a future vault feature). Set by {@link parseAgentDef} from the note
+   * id; unset for a spec not sourced from a def note (then the thread note carries no
+   * definition link).
    */
   definition?: string;
 }

--- a/src/sandbox/types.ts
+++ b/src/sandbox/types.ts
@@ -79,7 +79,7 @@ export interface OtherMcpSpec {
  */
 /**
  * A channel binding for an arm. A bare string is shorthand for `{ name, access:
- * "write" }` (back-compat — the common read+write resident session); the object
+ * "write" }` (back-compat — the common read+write single-threaded session); the object
  * form scopes a channel read-only so an arm that only *watches* a channel mints
  * `agent:read` and never `agent:write` (the "scope an arm to channel X
  * read-only" use case).
@@ -157,27 +157,34 @@ export type SystemPromptMode = "append" | "replace";
 /**
  * The agent's EXECUTION-LIFECYCLE mode — how a turn relates to the agent's
  * conversation thread + what run record it leaves (the architecture synthesis,
- * Phase 3 prerequisite). Defined entirely by `claude -p` session-id semantics:
+ * Phase 3 prerequisite). An agent is either SINGLE-THREADED or MULTI-THREADED;
+ * the distinction is defined entirely by `claude -p` session-id semantics:
  *
- *  - `"resident"` (DEFAULT; = today's behavior): ONE persistent session id per
- *    channel. Each turn `--resume`s the stored id and persists the returned id after
- *    — the channel transcript IS the thread, so there is NO separate run record. A
- *    scheduled runner job for a resident def is a synthetic inbound that RESUMES that
- *    one thread (continuing the chat). This is exactly what every agent does today.
+ *  - `"single-threaded"` (DEFAULT; = today's behavior): ONE persistent session id
+ *    per channel. Each turn `--resume`s the stored id and persists the returned id
+ *    after — the channel transcript IS the thread, so there is NO separate run
+ *    record. A scheduled runner job for a single-threaded def is a synthetic inbound
+ *    that RESUMES that one thread (continuing the chat). This is exactly what every
+ *    agent does today.
  *
- *  - `"one-shot"`: an EPHEMERAL turn. Do NOT read the prior session id (no
- *    `--resume`) and do NOT persist the returned id — each fire is a clean,
- *    independent invocation with no conversation continuity. Because there's no
- *    resumed transcript to be the record, a completed one-shot turn writes ONE
- *    `#agent/run` note (the run record: input + reply + status + timing). This is
+ *  - `"multi-threaded"`: turns are THREAD-KEYED. TODAY — because no inbound carries
+ *    a thread id yet — every fire mints a FRESH thread: do NOT read the prior session
+ *    id (no `--resume`) and do NOT persist the returned id to the channel store, so
+ *    each fire is a clean, independent invocation with no conversation continuity.
+ *    Because there's no resumed transcript to be the record, a completed turn writes
+ *    ONE `#agent/run` note (the run record: input + reply + status + timing). This is
  *    what an operator reaches for when a scheduled job should be a clean task run,
  *    NOT a silent continuation of the chat thread.
  *
- *  - `"per-thread"` (DEFERRED — not yet supported): one session id per inbound
- *    THREAD. Needs inbound thread-routing that doesn't exist yet; {@link
- *    parseAgentDef} REJECTS it with a clear error rather than silently demoting.
+ *    ("one-shot" was the prior name for this mode — it was only ever the DEGENERATE
+ *    FIRST-TURN of a multi-threaded agent, so the term retires. Continuation-by-
+ *    thread-id — resuming a SPECIFIC prior thread — is a DEFERRED increment: it needs
+ *    thread-id routing on the inbound, a thread-keyed session store, and recording the
+ *    minted session/thread id into the run note so a thread becomes resumable. When it
+ *    lands, the SAME mode simply gains continuation with NO operator-facing change and
+ *    NO migration; the fresh-per-fire shape that ships now is its degenerate case.)
  */
-export type AgentMode = "resident" | "one-shot" | "per-thread";
+export type AgentMode = "single-threaded" | "multi-threaded";
 
 export interface AgentSpec {
   /** Human-readable arm name; used as the tmux session + workspace slug. */
@@ -303,22 +310,23 @@ export interface AgentSpec {
    */
   systemPromptMode?: SystemPromptMode;
   /**
-   * The execution-lifecycle mode (the Phase-3 prerequisite). `"resident"`
+   * The execution-lifecycle mode (the Phase-3 prerequisite). `"single-threaded"`
    * (DEFAULT, = today): one persistent session per channel, `--resume`d + persisted
-   * each turn, the channel transcript is the thread (no run note). `"one-shot"`: an
-   * ephemeral turn — no `--resume`, the returned session id is NOT persisted, and a
-   * completed turn writes one `#agent/run` note. `"per-thread"` is deferred (parse
-   * rejects it). Read at the session-handling chokepoint (the programmatic backend's
-   * `deliver` resume block) + governs whether the registry writes a run note.
-   * Persisted in spec.json (set from the def's `metadata.mode`). See {@link AgentMode}.
+   * each turn, the channel transcript is the thread (no run note). `"multi-threaded"`:
+   * thread-keyed — today (no inbound thread id yet) every fire mints a fresh thread
+   * (no `--resume`, the returned session id is NOT persisted to the channel store) and
+   * a completed turn writes one `#agent/run` note. Read at the session-handling
+   * chokepoint (the programmatic backend's `deliver` resume block) + governs whether
+   * the registry writes a run note. Persisted in spec.json (set from the def's
+   * `metadata.mode`). See {@link AgentMode}.
    */
   mode?: AgentMode;
   /**
    * The `#agent/definition` note id this agent was instantiated from — the
-   * provenance carried into the `#agent/run` note a one-shot turn writes (so a run
-   * record links back to its def). A plain id STRING for now (interim — typed link
+   * provenance carried into the `#agent/run` note a multi-threaded turn writes (so a
+   * run record links back to its def). A plain id STRING for now (interim — typed link
    * fields are a future vault feature). Set by {@link parseAgentDef} from the note
-   * id; unset for a spec not sourced from a def note (then a one-shot run note
+   * id; unset for a spec not sourced from a def note (then a multi-threaded run note
    * carries no definition link).
    */
   definition?: string;

--- a/src/spawn-agent-cli.test.ts
+++ b/src/spawn-agent-cli.test.ts
@@ -51,7 +51,7 @@ describe("parseArgs — name + channels + vault + egress + mounts → the right 
     ]);
   });
 
-  test("a bare --channel defaults to write (back-compat resident session)", () => {
+  test("a bare --channel defaults to write (back-compat single-threaded session)", () => {
     const { spec } = parseArgs(["a", "--channel", "c"]);
     expect(spec!.channels).toEqual([{ name: "c" }]);
   });

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -30,6 +30,34 @@ export interface ReplyArgs {
   meta?: Record<string, string>;
 }
 
+/**
+ * The durable record of ONE `one-shot` agent turn (the execution-lifecycle taxonomy).
+ * A one-shot turn has no resumed transcript to be its record, so the daemon writes a
+ * run note instead. (A `resident` turn writes NONE — the channel transcript is its
+ * record.) The transport that backs the channel persists this; only the VaultTransport
+ * implements it (a `#agent/run` note) — other transports omit the optional method.
+ */
+export interface RunRecord {
+  /** The channel the turn ran on. */
+  channel: string;
+  /** The `#agent/definition` note id this run came from (provenance; plain id string). */
+  definition?: string;
+  /** The mode the turn ran under (always `one-shot` for a run note today). */
+  mode: string;
+  /** Outcome — `ok` (success) or `error` (the turn failed). */
+  status: "ok" | "error";
+  /** The inbound text the turn was handed (the `-p` prompt). */
+  input: string;
+  /** The reply text on success, or the failure reason on error. */
+  output: string;
+  /** ISO timestamp the turn started. */
+  started_at: string;
+  /** ISO timestamp the turn ended. */
+  ended_at: string;
+  /** Optional token/cost usage for observability (serialized into the note metadata). */
+  usage?: { inputTokens?: number; outputTokens?: number; totalCostUsd?: number };
+}
+
 export interface ReactArgs {
   channel: string;
   message_id: string;
@@ -95,6 +123,14 @@ export interface Transport {
   sendPermission?(args: PermissionArgs): Promise<{ sent: string[] }>;
   /** Optional: fetch an attachment, returning a local path. */
   download?(args: DownloadArgs): Promise<{ path: string }>;
+  /**
+   * Optional: write the durable record of a completed `one-shot` turn (an
+   * `#agent/run` note for the VaultTransport). Only meaningful for a vault-backed
+   * channel; transports without a durable store omit it. The daemon calls it ONLY for
+   * one-shot turns (a resident turn's record is its channel transcript). Returns the
+   * written record's id(s).
+   */
+  writeRun?(run: RunRecord): Promise<{ sent: string[] }>;
   /**
    * Optional: handle an HTTP request the daemon didn't handle itself. The
    * daemon owns `Bun.serve`; a transport that needs to contribute routes (e.g.

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -10,6 +10,8 @@
  * so a non-Telegram transport never has to invent Telegram fields.
  */
 
+import type { AgentMode } from "./sandbox/types.ts";
+
 /** An inbound message, routed by the daemon to the bridges subscribed to `channel`. */
 export interface InboundMessage {
   /** The named channel this message arrived on. */
@@ -43,7 +45,7 @@ export interface RunRecord {
   /** The `#agent/definition` note id this run came from (provenance; plain id string). */
   definition?: string;
   /** The mode the turn ran under (always `one-shot` for a run note today). */
-  mode: string;
+  mode: AgentMode;
   /** Outcome — `ok` (success) or `error` (the turn failed). */
   status: "ok" | "error";
   /** The inbound text the turn was handed (the `-p` prompt). */

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -33,31 +33,41 @@ export interface ReplyArgs {
 }
 
 /**
- * The durable record of ONE `multi-threaded` agent turn (the execution-lifecycle
- * taxonomy). A multi-threaded turn has no resumed transcript to be its record, so the
- * daemon writes a run note instead. (A `single-threaded` turn writes NONE — the channel
- * transcript is its record.) The transport that backs the channel persists this; only the
- * VaultTransport implements it (a `#agent/run` note) — other transports omit the optional
- * method.
+ * One turn's input to materializing a `#agent/thread` note — the UNIFIED model
+ * (`definition -> thread -> message`). BOTH execution-lifecycle modes materialize a thread
+ * note (the structural unification: everything is a thread; a "run" was always a thread
+ * with one turn). The transport that backs the channel persists this; only the
+ * VaultTransport implements it (a `#agent/thread` note) — other transports omit the
+ * optional method.
+ *
+ * MODE difference (resolved transport-side): `single-threaded` upserts ONE thread note per
+ * channel at a deterministic path named after the def and rolls up turn_count + usage;
+ * `multi-threaded` writes one thread note PER FIRE. The carrier shape is the same.
  */
-export interface RunRecord {
+export interface ThreadRecord {
   /** The channel the turn ran on. */
   channel: string;
-  /** The `#agent/definition` note id this run came from (provenance; plain id string). */
+  /**
+   * The agent/def name — the single-threaded thread is "named after the definition": this
+   * sanitizes to the deterministic path leaf so the one-per-channel note upserts in place.
+   * Omitted falls back to the channel (the 1:1 default, where channel == name).
+   */
+  name?: string;
+  /** The `#agent/definition` note id this thread came from (provenance; plain id string). */
   definition?: string;
-  /** The mode the turn ran under (always `multi-threaded` for a run note today). */
+  /** The mode the turn ran under — governs thread identity + whether the note upserts. */
   mode: AgentMode;
-  /** Outcome — `ok` (success) or `error` (the turn failed). */
+  /** Outcome of THIS turn — `ok` (success) or `error` (the turn failed). */
   status: "ok" | "error";
   /** The inbound text the turn was handed (the `-p` prompt). */
   input: string;
   /** The reply text on success, or the failure reason on error. */
   output: string;
-  /** ISO timestamp the turn started. */
+  /** ISO timestamp the turn started (single-threaded preserves the FIRST turn's). */
   started_at: string;
-  /** ISO timestamp the turn ended. */
+  /** ISO timestamp the turn ended (becomes the thread's `last_turn_at`). */
   ended_at: string;
-  /** Optional token/cost usage for observability (serialized into the note metadata). */
+  /** Optional token/cost usage for this turn (single-threaded accumulates into the note). */
   usage?: { inputTokens?: number; outputTokens?: number; totalCostUsd?: number };
 }
 
@@ -127,13 +137,13 @@ export interface Transport {
   /** Optional: fetch an attachment, returning a local path. */
   download?(args: DownloadArgs): Promise<{ path: string }>;
   /**
-   * Optional: write the durable record of a completed `multi-threaded` turn (an
-   * `#agent/run` note for the VaultTransport). Only meaningful for a vault-backed
-   * channel; transports without a durable store omit it. The daemon calls it ONLY for
-   * multi-threaded turns (a single-threaded turn's record is its channel transcript).
-   * Returns the written record's id(s).
+   * Optional: materialize a `#agent/thread` note for a completed turn (the VaultTransport's
+   * `#agent/thread` note). Only meaningful for a vault-backed channel; transports without a
+   * durable store omit it. The daemon calls it for BOTH execution-lifecycle modes (the
+   * structural unification — every turn materializes a thread note): single-threaded upserts
+   * one note per channel, multi-threaded writes one per fire. Returns the written note id(s).
    */
-  writeRun?(run: RunRecord): Promise<{ sent: string[] }>;
+  writeThread?(thread: ThreadRecord): Promise<{ sent: string[] }>;
   /**
    * Optional: handle an HTTP request the daemon didn't handle itself. The
    * daemon owns `Bun.serve`; a transport that needs to contribute routes (e.g.

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -33,18 +33,19 @@ export interface ReplyArgs {
 }
 
 /**
- * The durable record of ONE `one-shot` agent turn (the execution-lifecycle taxonomy).
- * A one-shot turn has no resumed transcript to be its record, so the daemon writes a
- * run note instead. (A `resident` turn writes NONE — the channel transcript is its
- * record.) The transport that backs the channel persists this; only the VaultTransport
- * implements it (a `#agent/run` note) — other transports omit the optional method.
+ * The durable record of ONE `multi-threaded` agent turn (the execution-lifecycle
+ * taxonomy). A multi-threaded turn has no resumed transcript to be its record, so the
+ * daemon writes a run note instead. (A `single-threaded` turn writes NONE — the channel
+ * transcript is its record.) The transport that backs the channel persists this; only the
+ * VaultTransport implements it (a `#agent/run` note) — other transports omit the optional
+ * method.
  */
 export interface RunRecord {
   /** The channel the turn ran on. */
   channel: string;
   /** The `#agent/definition` note id this run came from (provenance; plain id string). */
   definition?: string;
-  /** The mode the turn ran under (always `one-shot` for a run note today). */
+  /** The mode the turn ran under (always `multi-threaded` for a run note today). */
   mode: AgentMode;
   /** Outcome — `ok` (success) or `error` (the turn failed). */
   status: "ok" | "error";
@@ -126,11 +127,11 @@ export interface Transport {
   /** Optional: fetch an attachment, returning a local path. */
   download?(args: DownloadArgs): Promise<{ path: string }>;
   /**
-   * Optional: write the durable record of a completed `one-shot` turn (an
+   * Optional: write the durable record of a completed `multi-threaded` turn (an
    * `#agent/run` note for the VaultTransport). Only meaningful for a vault-backed
    * channel; transports without a durable store omit it. The daemon calls it ONLY for
-   * one-shot turns (a resident turn's record is its channel transcript). Returns the
-   * written record's id(s).
+   * multi-threaded turns (a single-threaded turn's record is its channel transcript).
+   * Returns the written record's id(s).
    */
   writeRun?(run: RunRecord): Promise<{ sent: string[] }>;
   /**

--- a/src/transports/vault.test.ts
+++ b/src/transports/vault.test.ts
@@ -349,9 +349,144 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
     expect(stored!.content).toContain("reply two");
   });
 
-  test("writeThread() on an error turn records status:error + the failure reason in the body", async () => {
+  test("SINGLE-THREADED error on turn 2: turn_count==2, status:error, started_at preserved, last_turn_at advanced", async () => {
+    // Same stored-note simulation as the two-turn test: turn 2 reads back turn 1's note.
+    let stored: { metadata: Record<string, string>; content: string } | undefined;
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const u = String(url);
+      const method = init?.method ?? "GET";
+      if (u.includes("/api/notes/") && method === "GET") {
+        if (!stored) return new Response("not found", { status: 404 });
+        return new Response(JSON.stringify(stored), { status: 200 });
+      }
+      if (u.includes("/api/notes/") && method === "PATCH") {
+        const body = JSON.parse(String(init?.body)) as { metadata: Record<string, string>; content: string };
+        stored = { metadata: body.metadata, content: body.content };
+        return new Response(JSON.stringify({ id: "thread-eng" }), { status: 200 });
+      }
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+
+    // Turn 1 — ok.
+    await t.writeThread({
+      channel: "eng",
+      name: "eng",
+      mode: "single-threaded",
+      status: "ok",
+      input: "turn one",
+      output: "reply one",
+      started_at: "2026-06-18T07:00:00.000Z",
+      ended_at: "2026-06-18T07:00:05.000Z",
+    });
+    expect(stored!.metadata.status).toBe("ok");
+
+    // Turn 2 — ERROR. The single-threaded thread keeps upserting (the failure is part of
+    // the rolling thread record); the status reflects this latest turn.
+    await t.writeThread({
+      channel: "eng",
+      name: "eng",
+      mode: "single-threaded",
+      status: "error",
+      input: "turn two",
+      output: "claude -p exited 1: boom",
+      started_at: "2026-06-18T08:00:00.000Z", // later — must NOT overwrite the first.
+      ended_at: "2026-06-18T08:00:09.000Z",
+    });
+
+    expect(stored!.metadata.turn_count).toBe("2"); // incremented despite the error.
+    expect(stored!.metadata.status).toBe("error"); // the latest turn's outcome.
+    expect(stored!.metadata.started_at).toBe("2026-06-18T07:00:00.000Z"); // preserved.
+    expect(stored!.metadata.last_turn_at).toBe("2026-06-18T08:00:09.000Z"); // advanced.
+    // The body's latest-turn section is the Error block.
+    expect(stored!.content).toContain("**Error:**");
+    expect(stored!.content).toContain("claude -p exited 1: boom");
+  });
+
+  test("SINGLE-THREADED: a 500 on the read-back GET rejects (not a silent aggregate reset)", async () => {
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const u = String(url);
+      const method = init?.method ?? "GET";
+      // The single-threaded read-back GET returns a 500 (an UNEXPECTED non-404 error) →
+      // readThreadNote throws → writeThread rejects, surfacing the misconfig rather than
+      // silently resetting the thread's aggregates.
+      if (u.includes("/api/notes/") && method === "GET") {
+        return new Response("boom", { status: 500 });
+      }
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+    await expect(
+      t.writeThread({
+        channel: "eng",
+        name: "eng",
+        mode: "single-threaded",
+        status: "ok",
+        input: "x",
+        output: "y",
+        started_at: "2026-06-18T07:00:00.000Z",
+        ended_at: "2026-06-18T07:00:01.000Z",
+      }),
+    ).rejects.toThrow(/read thread note failed/);
+  });
+
+  test("SINGLE-THREADED cost rounding: 0.1 + 0.2 serializes as \"0.3\" (no IEEE-754 drift)", async () => {
+    let stored: { metadata: Record<string, string>; content: string } | undefined;
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const u = String(url);
+      const method = init?.method ?? "GET";
+      if (u.includes("/api/notes/") && method === "GET") {
+        if (!stored) return new Response("not found", { status: 404 });
+        return new Response(JSON.stringify(stored), { status: 200 });
+      }
+      if (u.includes("/api/notes/") && method === "PATCH") {
+        const body = JSON.parse(String(init?.body)) as { metadata: Record<string, string>; content: string };
+        stored = { metadata: body.metadata, content: body.content };
+        return new Response(JSON.stringify({ id: "thread-eng" }), { status: 200 });
+      }
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+
+    await t.writeThread({
+      channel: "eng",
+      name: "eng",
+      mode: "single-threaded",
+      status: "ok",
+      input: "one",
+      output: "r1",
+      started_at: "2026-06-18T07:00:00.000Z",
+      ended_at: "2026-06-18T07:00:05.000Z",
+      usage: { totalCostUsd: 0.1 },
+    });
+    await t.writeThread({
+      channel: "eng",
+      name: "eng",
+      mode: "single-threaded",
+      status: "ok",
+      input: "two",
+      output: "r2",
+      started_at: "2026-06-18T08:00:00.000Z",
+      ended_at: "2026-06-18T08:00:09.000Z",
+      usage: { totalCostUsd: 0.2 },
+    });
+
+    // The naive sum 0.1 + 0.2 === 0.30000000000000004; the round-to-9-decimals guard
+    // serializes it cleanly as "0.3".
+    expect(stored!.metadata.total_cost_usd).toBe("0.3");
+  });
+
+  test("writeThread() on a MULTI-THREADED error turn records status:error + the failure reason in the body (NO read-back)", async () => {
+    const calls: { url: string; init: RequestInit }[] = [];
     let captured: { tags: string[]; metadata: Record<string, string>; content: string } | undefined;
     globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      calls.push({ url: String(url), init: init ?? {} });
       if (String(url).includes("/api/notes/") && (init?.method ?? "GET") === "PATCH") {
         captured = JSON.parse(String(init?.body));
       }
@@ -376,6 +511,10 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
     // The body's latest-turn section is the Error block on a failure.
     expect(captured!.content).toContain("**Error:**");
     expect(captured!.content).toContain("claude -p exited 1: boom");
+    // Multi-threaded does NO read-back even on the error path (fresh per fire).
+    expect(
+      calls.filter((c) => c.url.includes("/api/notes/") && (c.init.method ?? "GET") === "GET"),
+    ).toHaveLength(0);
   });
 
   test("writeThread() throws on a non-ok vault response (PATCH)", async () => {

--- a/src/transports/vault.test.ts
+++ b/src/transports/vault.test.ts
@@ -26,7 +26,7 @@
  */
 
 import { describe, test, expect, afterEach } from "bun:test";
-import { VaultTransport, AGENT_VAULT_TAG_SCHEMA } from "./vault.ts";
+import { VaultTransport, AGENT_VAULT_TAG_SCHEMA, AGENT_RUN_TAG } from "./vault.ts";
 import type { TransportContext, InboundMessage } from "../transport.ts";
 import { instantiateTransport } from "../registry.ts";
 
@@ -147,6 +147,114 @@ describe("VaultTransport — reply (outbound note write)", () => {
     const t = new VaultTransport(baseConfig());
     await t.start(fakeCtx("eng"));
     await expect(t.reply({ channel: "eng", text: "x" })).rejects.toThrow(/write reply failed/);
+  });
+});
+
+describe("VaultTransport — writeRun (#agent/run record for a one-shot turn)", () => {
+  test("writeRun() POSTs an #agent/run note with indexed status/definition/mode + timing + Bearer", async () => {
+    const calls: { url: string; init: RequestInit }[] = [];
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      calls.push({ url: String(url), init: init ?? {} });
+      return new Response(JSON.stringify({ id: "run-note-1" }), {
+        status: 201,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+    const result = await t.writeRun({
+      channel: "eng",
+      definition: "Agents/digest",
+      mode: "one-shot",
+      status: "ok",
+      input: "run the daily digest",
+      output: "digest complete: 3 items",
+      started_at: "2026-06-18T07:00:00.000Z",
+      ended_at: "2026-06-18T07:00:12.000Z",
+      usage: { inputTokens: 100, outputTokens: 40, totalCostUsd: 0.002 },
+    });
+
+    expect(result.sent).toEqual(["run-note-1"]);
+    // start() also fires ensureSchema() (PUT .../api/tags/*); isolate the run-note POST.
+    const noteCalls = calls.filter((c) => c.url.endsWith("/api/notes"));
+    expect(noteCalls).toHaveLength(1);
+    const call = noteCalls[0]!;
+    expect(call.url).toBe("http://127.0.0.1:1940/vault/default/api/notes");
+    expect(call.init.method).toBe("POST");
+    expect((call.init.headers as Record<string, string>).authorization).toBe("Bearer write-token-xyz");
+
+    const sent = JSON.parse(String(call.init.body)) as {
+      content: string;
+      path: string;
+      tags: string[];
+      metadata: Record<string, string>;
+    };
+    // The run note carries the run tag ONLY — NOT a message tag + NOT the inbound
+    // child, so it can never wake a session (no loop).
+    expect(sent.tags).toEqual([AGENT_RUN_TAG]);
+    expect(sent.tags).not.toContain("#agent/message");
+    expect(sent.tags).not.toContain("#agent/message/inbound");
+    // Indexed/queryable fields.
+    expect(sent.metadata.status).toBe("ok");
+    expect(sent.metadata.definition).toBe("Agents/digest");
+    expect(sent.metadata.mode).toBe("one-shot");
+    // Timing + channel + usage (stringified for the vault).
+    expect(sent.metadata.channel).toBe("eng");
+    expect(sent.metadata.started_at).toBe("2026-06-18T07:00:00.000Z");
+    expect(sent.metadata.ended_at).toBe("2026-06-18T07:00:12.000Z");
+    expect(sent.metadata.input_tokens).toBe("100");
+    expect(sent.metadata.output_tokens).toBe("40");
+    expect(sent.metadata.total_cost_usd).toBe("0.002");
+    // The body carries the input + reply (the human-readable run record).
+    expect(sent.content).toContain("run the daily digest");
+    expect(sent.content).toContain("digest complete: 3 items");
+    expect(sent.path.startsWith("Runs/eng/")).toBe(true);
+  });
+
+  test("writeRun() on an error run records status:error + the failure reason in the body", async () => {
+    let captured: { tags: string[]; metadata: Record<string, string>; content: string } | undefined;
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      if (String(url).endsWith("/api/notes")) {
+        captured = JSON.parse(String(init?.body));
+      }
+      return new Response(JSON.stringify({ id: "run-err-1" }), { status: 201 });
+    }) as typeof fetch;
+
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+    await t.writeRun({
+      channel: "eng",
+      mode: "one-shot",
+      status: "error",
+      input: "do the thing",
+      output: "claude -p exited 1: boom",
+      started_at: "2026-06-18T07:00:00.000Z",
+      ended_at: "2026-06-18T07:00:01.000Z",
+    });
+
+    expect(captured!.metadata.status).toBe("error");
+    // No definition → the field is absent (not an empty string).
+    expect("definition" in captured!.metadata).toBe(false);
+    expect(captured!.content).toContain("claude -p exited 1: boom");
+  });
+
+  test("writeRun() throws on a non-ok vault response", async () => {
+    globalThis.fetch = (async () =>
+      new Response("boom", { status: 500 })) as unknown as typeof fetch;
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+    await expect(
+      t.writeRun({
+        channel: "eng",
+        mode: "one-shot",
+        status: "ok",
+        input: "x",
+        output: "y",
+        started_at: "2026-06-18T07:00:00.000Z",
+        ended_at: "2026-06-18T07:00:01.000Z",
+      }),
+    ).rejects.toThrow(/write run note failed/);
   });
 });
 
@@ -626,12 +734,13 @@ describe("VaultTransport — ensureSchema (tag-schema declaration on connect)", 
     expect(jobBody.parent_names).toEqual(["#agent"]);
   });
 
-  test("schema declares the #agent/* namespace rollup PLUS the interim + legacy families (dual-read, 12 entries)", async () => {
+  test("schema declares the #agent/* namespace rollup PLUS the interim + legacy families (dual-read, 13 entries)", async () => {
     // The `#agent/*` namespace (design 2026-06-17-vault-native-agents) rolls up
-    // definitions, messages, and jobs to the `#agent` root. DUAL-READ: the schema
+    // definitions, messages, jobs, AND runs to the `#agent` root. DUAL-READ: the schema
     // ALSO keeps declaring the interim flat `#agent-message*` AND legacy
     // `#channel-message*` inheritance so pre-namespace history keeps its parent/child
-    // expansion until the one-time re-tag run lands. Exactly 12 entries.
+    // expansion until the one-time re-tag run lands. Exactly 13 entries (12 + the
+    // execution-lifecycle `#agent/run` record tag).
     const names = AGENT_VAULT_TAG_SCHEMA.map((e) => e.name);
     expect(names).toEqual([
       "#agent",
@@ -640,6 +749,7 @@ describe("VaultTransport — ensureSchema (tag-schema declaration on connect)", 
       "#agent/message/inbound",
       "#agent/message/outbound",
       "#agent/job",
+      "#agent/run",
       "#agent-message",
       "#agent-message/inbound",
       "#agent-message/outbound",
@@ -652,6 +762,7 @@ describe("VaultTransport — ensureSchema (tag-schema declaration on connect)", 
     expect(byName("#agent/definition").parent_names).toEqual(["#agent"]);
     expect(byName("#agent/message").parent_names).toEqual(["#agent"]);
     expect(byName("#agent/job").parent_names).toEqual(["#agent"]);
+    expect(byName("#agent/run").parent_names).toEqual(["#agent"]);
     expect(byName("#agent/message/inbound").parent_names).toEqual(["#agent/message"]);
     expect(byName("#agent/message/outbound").parent_names).toEqual(["#agent/message"]);
     // The interim + legacy children still declare their own parents (inheritance preserved).
@@ -659,6 +770,14 @@ describe("VaultTransport — ensureSchema (tag-schema declaration on connect)", 
     expect(byName("#agent-message/outbound").parent_names).toEqual(["#agent-message"]);
     expect(byName("#channel-message/inbound").parent_names).toEqual(["#channel-message"]);
     expect(byName("#channel-message/outbound").parent_names).toEqual(["#channel-message"]);
+    // `#agent/run` declares INDEXED string fields so runs are operator-queryable —
+    // "all failed runs" (status), "all runs of agent X" (definition), "all one-shot
+    // runs" (mode).
+    expect(byName("#agent/run").fields).toEqual({
+      status: { type: "string", indexed: true },
+      definition: { type: "string", indexed: true },
+      mode: { type: "string", indexed: true },
+    });
   });
 
   test("schema is sourced from AGENT_VAULT_TAG_SCHEMA — declares exactly its entries", async () => {
@@ -672,6 +791,24 @@ describe("VaultTransport — ensureSchema (tag-schema declaration on connect)", 
     await t.ensureSchema();
 
     expect(declared).toEqual(AGENT_VAULT_TAG_SCHEMA.map((e) => e.name));
+  });
+
+  test("ensureSchema sends the indexed `fields` body for #agent/run", async () => {
+    let runBody: { fields?: Record<string, unknown> } | undefined;
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const name = decodeURIComponent(String(url).split("/api/tags/")[1]!);
+      if (name === AGENT_RUN_TAG) runBody = JSON.parse(String(init?.body));
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+
+    const t = new VaultTransport(baseConfig());
+    await t.ensureSchema();
+
+    expect(runBody?.fields).toEqual({
+      status: { type: "string", indexed: true },
+      definition: { type: "string", indexed: true },
+      mode: { type: "string", indexed: true },
+    });
   });
 
   test("best-effort: a rejecting fetch does NOT throw out of ensureSchema", async () => {

--- a/src/transports/vault.test.ts
+++ b/src/transports/vault.test.ts
@@ -151,7 +151,7 @@ describe("VaultTransport — reply (outbound note write)", () => {
 });
 
 describe("VaultTransport — writeThread (#agent/thread note, the unified model)", () => {
-  test("MULTI-THREADED: writeThread() POSTs a fresh-per-fire #agent/thread note with indexed status/definition/mode + timing + Bearer (NO read-back)", async () => {
+  test("MULTI-THREADED: writeThread() PATCH-upserts (if_missing:create) a fresh-per-fire #agent/thread note with indexed status/definition/mode + timing + Bearer (NO read-back)", async () => {
     const calls: { url: string; init: RequestInit }[] = [];
     globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
       calls.push({ url: String(url), init: init ?? {} });
@@ -177,15 +177,17 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
     });
 
     expect(result.sent).toEqual(["thread-note-1"]);
-    // start() also fires ensureSchema() (PUT .../api/tags/*); isolate the thread-note POST.
-    const noteCalls = calls.filter((c) => c.url.endsWith("/api/notes") && c.init.method === "POST");
+    // start() also fires ensureSchema() (PUT .../api/tags/*); isolate the thread-note
+    // write. The write is a PATCH-by-path upsert (NOT POST — POST 409s on an existing
+    // path), so it targets /api/notes/<encoded-path>, discriminated by method.
+    const noteCalls = calls.filter((c) => c.url.includes("/api/notes/") && c.init.method === "PATCH");
     expect(noteCalls).toHaveLength(1);
     // Multi-threaded does NO read-back (no GET to /api/notes/<path>) — fresh per fire.
     const getCalls = calls.filter((c) => c.url.includes("/api/notes/") && (c.init.method ?? "GET") === "GET");
     expect(getCalls).toHaveLength(0);
     const call = noteCalls[0]!;
-    expect(call.url).toBe("http://127.0.0.1:1940/vault/default/api/notes");
-    expect(call.init.method).toBe("POST");
+    expect(decodeURIComponent(call.url)).toContain("/vault/default/api/notes/Threads/eng/");
+    expect(call.init.method).toBe("PATCH");
     expect((call.init.headers as Record<string, string>).authorization).toBe("Bearer write-token-xyz");
 
     const sent = JSON.parse(String(call.init.body)) as {
@@ -193,7 +195,13 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
       path: string;
       tags: string[];
       metadata: Record<string, string>;
+      if_missing: string;
+      force: boolean;
     };
+    // The upsert verb: PATCH + `if_missing: "create"` (creates when missing — every
+    // multi-threaded fire — updates when present) + `force: true` (the 428 precondition).
+    expect(sent.if_missing).toBe("create");
+    expect(sent.force).toBe(true);
     // LOOP SAFETY (HARD CONSTRAINT 4): the thread note carries the thread tag EXACTLY —
     // NOT a message tag + NOT the inbound child — so it can never wake a session.
     expect(sent.tags).toEqual([AGENT_THREAD_TAG]);
@@ -231,9 +239,10 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
         // First turn: the note doesn't exist yet (404 → turn_count starts at 0).
         return new Response("not found", { status: 404 });
       }
-      if (u.endsWith("/api/notes") && method === "POST") {
+      // The write is a PATCH-by-path upsert (if_missing:create), NOT POST.
+      if (u.includes("/api/notes/") && method === "PATCH") {
         posts.push({ url: u, init: init ?? {} });
-        return new Response(JSON.stringify({ id: "thread-eng" }), { status: 201 });
+        return new Response(JSON.stringify({ id: "thread-eng" }), { status: 200 });
       }
       return new Response("{}", { status: 200 }); // ensureSchema PUTs
     }) as typeof fetch;
@@ -255,14 +264,20 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
     // It READ the existing note first (the upsert read-back), by the DETERMINISTIC path.
     expect(gets).toHaveLength(1);
     expect(decodeURIComponent(gets[0]!)).toContain("/api/notes/Threads/eng/eng");
-    // Then UPSERTED by POSTing to the same deterministic path (named after the def).
+    // Then UPSERTED via PATCH (if_missing:create) to the same deterministic path.
     expect(posts).toHaveLength(1);
+    expect(posts[0]!.init.method).toBe("PATCH");
+    expect(decodeURIComponent(posts[0]!.url)).toContain("/api/notes/Threads/eng/eng");
     const sent = JSON.parse(String(posts[0]!.init.body)) as {
       path: string;
       tags: string[];
       metadata: Record<string, string>;
       content: string;
+      if_missing: string;
+      force: boolean;
     };
+    expect(sent.if_missing).toBe("create"); // upsert verb (not POST — POST 409s).
+    expect(sent.force).toBe(true);
     expect(sent.tags).toEqual([AGENT_THREAD_TAG]); // loop safety.
     expect(sent.path).toBe("Threads/eng/eng"); // deterministic, named after the def.
     expect(sent.metadata.mode).toBe("single-threaded");
@@ -283,10 +298,11 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
         if (!stored) return new Response("not found", { status: 404 });
         return new Response(JSON.stringify(stored), { status: 200 });
       }
-      if (u.endsWith("/api/notes") && method === "POST") {
+      // PATCH-by-path with if_missing:create is the upsert (turn 1 creates, turn 2 updates).
+      if (u.includes("/api/notes/") && method === "PATCH") {
         const body = JSON.parse(String(init?.body)) as { metadata: Record<string, string>; content: string };
         stored = { metadata: body.metadata, content: body.content }; // the vault upserts it.
-        return new Response(JSON.stringify({ id: "thread-eng" }), { status: 201 });
+        return new Response(JSON.stringify({ id: "thread-eng" }), { status: 200 });
       }
       return new Response("{}", { status: 200 });
     }) as typeof fetch;
@@ -336,10 +352,10 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
   test("writeThread() on an error turn records status:error + the failure reason in the body", async () => {
     let captured: { tags: string[]; metadata: Record<string, string>; content: string } | undefined;
     globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
-      if (String(url).endsWith("/api/notes") && (init?.method ?? "GET") === "POST") {
+      if (String(url).includes("/api/notes/") && (init?.method ?? "GET") === "PATCH") {
         captured = JSON.parse(String(init?.body));
       }
-      return new Response(JSON.stringify({ id: "thread-err-1" }), { status: 201 });
+      return new Response(JSON.stringify({ id: "thread-err-1" }), { status: 200 });
     }) as typeof fetch;
 
     const t = new VaultTransport(baseConfig());
@@ -362,10 +378,10 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
     expect(captured!.content).toContain("claude -p exited 1: boom");
   });
 
-  test("writeThread() throws on a non-ok vault response (POST)", async () => {
+  test("writeThread() throws on a non-ok vault response (PATCH)", async () => {
     globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
-      // multi-threaded → no GET; the POST fails.
-      if (String(url).endsWith("/api/notes") && (init?.method ?? "GET") === "POST") {
+      // multi-threaded → no GET; the PATCH upsert fails.
+      if (String(url).includes("/api/notes/") && (init?.method ?? "GET") === "PATCH") {
         return new Response("boom", { status: 500 });
       }
       return new Response("{}", { status: 200 });

--- a/src/transports/vault.test.ts
+++ b/src/transports/vault.test.ts
@@ -150,7 +150,7 @@ describe("VaultTransport — reply (outbound note write)", () => {
   });
 });
 
-describe("VaultTransport — writeRun (#agent/run record for a one-shot turn)", () => {
+describe("VaultTransport — writeRun (#agent/run record for a multi-threaded turn)", () => {
   test("writeRun() POSTs an #agent/run note with indexed status/definition/mode + timing + Bearer", async () => {
     const calls: { url: string; init: RequestInit }[] = [];
     globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
@@ -166,7 +166,7 @@ describe("VaultTransport — writeRun (#agent/run record for a one-shot turn)", 
     const result = await t.writeRun({
       channel: "eng",
       definition: "Agents/digest",
-      mode: "one-shot",
+      mode: "multi-threaded",
       status: "ok",
       input: "run the daily digest",
       output: "digest complete: 3 items",
@@ -198,7 +198,7 @@ describe("VaultTransport — writeRun (#agent/run record for a one-shot turn)", 
     // Indexed/queryable fields.
     expect(sent.metadata.status).toBe("ok");
     expect(sent.metadata.definition).toBe("Agents/digest");
-    expect(sent.metadata.mode).toBe("one-shot");
+    expect(sent.metadata.mode).toBe("multi-threaded");
     // Timing + channel + usage (stringified for the vault).
     expect(sent.metadata.channel).toBe("eng");
     expect(sent.metadata.started_at).toBe("2026-06-18T07:00:00.000Z");
@@ -225,7 +225,7 @@ describe("VaultTransport — writeRun (#agent/run record for a one-shot turn)", 
     await t.start(fakeCtx("eng"));
     await t.writeRun({
       channel: "eng",
-      mode: "one-shot",
+      mode: "multi-threaded",
       status: "error",
       input: "do the thing",
       output: "claude -p exited 1: boom",
@@ -247,7 +247,7 @@ describe("VaultTransport — writeRun (#agent/run record for a one-shot turn)", 
     await expect(
       t.writeRun({
         channel: "eng",
-        mode: "one-shot",
+        mode: "multi-threaded",
         status: "ok",
         input: "x",
         output: "y",
@@ -771,7 +771,7 @@ describe("VaultTransport — ensureSchema (tag-schema declaration on connect)", 
     expect(byName("#channel-message/inbound").parent_names).toEqual(["#channel-message"]);
     expect(byName("#channel-message/outbound").parent_names).toEqual(["#channel-message"]);
     // `#agent/run` declares INDEXED string fields so runs are operator-queryable —
-    // "all failed runs" (status), "all runs of agent X" (definition), "all one-shot
+    // "all failed runs" (status), "all runs of agent X" (definition), "all multi-threaded
     // runs" (mode).
     expect(byName("#agent/run").fields).toEqual({
       status: { type: "string", indexed: true },

--- a/src/transports/vault.test.ts
+++ b/src/transports/vault.test.ts
@@ -26,7 +26,7 @@
  */
 
 import { describe, test, expect, afterEach } from "bun:test";
-import { VaultTransport, AGENT_VAULT_TAG_SCHEMA, AGENT_RUN_TAG } from "./vault.ts";
+import { VaultTransport, AGENT_VAULT_TAG_SCHEMA, AGENT_THREAD_TAG } from "./vault.ts";
 import type { TransportContext, InboundMessage } from "../transport.ts";
 import { instantiateTransport } from "../registry.ts";
 
@@ -150,12 +150,12 @@ describe("VaultTransport — reply (outbound note write)", () => {
   });
 });
 
-describe("VaultTransport — writeRun (#agent/run record for a multi-threaded turn)", () => {
-  test("writeRun() POSTs an #agent/run note with indexed status/definition/mode + timing + Bearer", async () => {
+describe("VaultTransport — writeThread (#agent/thread note, the unified model)", () => {
+  test("MULTI-THREADED: writeThread() POSTs a fresh-per-fire #agent/thread note with indexed status/definition/mode + timing + Bearer (NO read-back)", async () => {
     const calls: { url: string; init: RequestInit }[] = [];
     globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
       calls.push({ url: String(url), init: init ?? {} });
-      return new Response(JSON.stringify({ id: "run-note-1" }), {
+      return new Response(JSON.stringify({ id: "thread-note-1" }), {
         status: 201,
         headers: { "content-type": "application/json" },
       });
@@ -163,8 +163,9 @@ describe("VaultTransport — writeRun (#agent/run record for a multi-threaded tu
 
     const t = new VaultTransport(baseConfig());
     await t.start(fakeCtx("eng"));
-    const result = await t.writeRun({
+    const result = await t.writeThread({
       channel: "eng",
+      name: "digest",
       definition: "Agents/digest",
       mode: "multi-threaded",
       status: "ok",
@@ -175,10 +176,13 @@ describe("VaultTransport — writeRun (#agent/run record for a multi-threaded tu
       usage: { inputTokens: 100, outputTokens: 40, totalCostUsd: 0.002 },
     });
 
-    expect(result.sent).toEqual(["run-note-1"]);
-    // start() also fires ensureSchema() (PUT .../api/tags/*); isolate the run-note POST.
-    const noteCalls = calls.filter((c) => c.url.endsWith("/api/notes"));
+    expect(result.sent).toEqual(["thread-note-1"]);
+    // start() also fires ensureSchema() (PUT .../api/tags/*); isolate the thread-note POST.
+    const noteCalls = calls.filter((c) => c.url.endsWith("/api/notes") && c.init.method === "POST");
     expect(noteCalls).toHaveLength(1);
+    // Multi-threaded does NO read-back (no GET to /api/notes/<path>) — fresh per fire.
+    const getCalls = calls.filter((c) => c.url.includes("/api/notes/") && (c.init.method ?? "GET") === "GET");
+    expect(getCalls).toHaveLength(0);
     const call = noteCalls[0]!;
     expect(call.url).toBe("http://127.0.0.1:1940/vault/default/api/notes");
     expect(call.init.method).toBe("POST");
@@ -190,40 +194,157 @@ describe("VaultTransport — writeRun (#agent/run record for a multi-threaded tu
       tags: string[];
       metadata: Record<string, string>;
     };
-    // The run note carries the run tag ONLY — NOT a message tag + NOT the inbound
-    // child, so it can never wake a session (no loop).
-    expect(sent.tags).toEqual([AGENT_RUN_TAG]);
+    // LOOP SAFETY (HARD CONSTRAINT 4): the thread note carries the thread tag EXACTLY —
+    // NOT a message tag + NOT the inbound child — so it can never wake a session.
+    expect(sent.tags).toEqual([AGENT_THREAD_TAG]);
     expect(sent.tags).not.toContain("#agent/message");
     expect(sent.tags).not.toContain("#agent/message/inbound");
     // Indexed/queryable fields.
     expect(sent.metadata.status).toBe("ok");
     expect(sent.metadata.definition).toBe("Agents/digest");
     expect(sent.metadata.mode).toBe("multi-threaded");
-    // Timing + channel + usage (stringified for the vault).
+    // Thread-state + channel + usage (stringified for the vault).
     expect(sent.metadata.channel).toBe("eng");
     expect(sent.metadata.started_at).toBe("2026-06-18T07:00:00.000Z");
-    expect(sent.metadata.ended_at).toBe("2026-06-18T07:00:12.000Z");
+    expect(sent.metadata.last_turn_at).toBe("2026-06-18T07:00:12.000Z");
+    expect(sent.metadata.turn_count).toBe("1");
     expect(sent.metadata.input_tokens).toBe("100");
     expect(sent.metadata.output_tokens).toBe("40");
     expect(sent.metadata.total_cost_usd).toBe("0.002");
-    // The body carries the input + reply (the human-readable run record).
+    // The body is a rolling SUMMARY with the two documented sections.
+    expect(sent.content).toContain("## Summary");
+    expect(sent.content).toContain("## Latest turn");
     expect(sent.content).toContain("run the daily digest");
     expect(sent.content).toContain("digest complete: 3 items");
-    expect(sent.path.startsWith("Runs/eng/")).toBe(true);
+    // Multi-threaded path leaf is a fresh uuid under Threads/<channel>/.
+    expect(sent.path.startsWith("Threads/eng/")).toBe(true);
   });
 
-  test("writeRun() on an error run records status:error + the failure reason in the body", async () => {
-    let captured: { tags: string[]; metadata: Record<string, string>; content: string } | undefined;
+  test("SINGLE-THREADED: writeThread() upserts ONE deterministic-path note named after the def (reads existing first)", async () => {
+    const posts: { url: string; init: RequestInit }[] = [];
+    const gets: string[] = [];
     globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
-      if (String(url).endsWith("/api/notes")) {
-        captured = JSON.parse(String(init?.body));
+      const u = String(url);
+      const method = init?.method ?? "GET";
+      if (u.includes("/api/notes/") && method === "GET") {
+        gets.push(u);
+        // First turn: the note doesn't exist yet (404 → turn_count starts at 0).
+        return new Response("not found", { status: 404 });
       }
-      return new Response(JSON.stringify({ id: "run-err-1" }), { status: 201 });
+      if (u.endsWith("/api/notes") && method === "POST") {
+        posts.push({ url: u, init: init ?? {} });
+        return new Response(JSON.stringify({ id: "thread-eng" }), { status: 201 });
+      }
+      return new Response("{}", { status: 200 }); // ensureSchema PUTs
     }) as typeof fetch;
 
     const t = new VaultTransport(baseConfig());
     await t.start(fakeCtx("eng"));
-    await t.writeRun({
+    await t.writeThread({
+      channel: "eng",
+      name: "eng",
+      mode: "single-threaded",
+      status: "ok",
+      input: "hello",
+      output: "hi there",
+      started_at: "2026-06-18T07:00:00.000Z",
+      ended_at: "2026-06-18T07:00:05.000Z",
+      usage: { inputTokens: 10, outputTokens: 5 },
+    });
+
+    // It READ the existing note first (the upsert read-back), by the DETERMINISTIC path.
+    expect(gets).toHaveLength(1);
+    expect(decodeURIComponent(gets[0]!)).toContain("/api/notes/Threads/eng/eng");
+    // Then UPSERTED by POSTing to the same deterministic path (named after the def).
+    expect(posts).toHaveLength(1);
+    const sent = JSON.parse(String(posts[0]!.init.body)) as {
+      path: string;
+      tags: string[];
+      metadata: Record<string, string>;
+      content: string;
+    };
+    expect(sent.tags).toEqual([AGENT_THREAD_TAG]); // loop safety.
+    expect(sent.path).toBe("Threads/eng/eng"); // deterministic, named after the def.
+    expect(sent.metadata.mode).toBe("single-threaded");
+    expect(sent.metadata.turn_count).toBe("1"); // first turn (no prior).
+    expect(sent.metadata.started_at).toBe("2026-06-18T07:00:00.000Z");
+    expect(sent.metadata.last_turn_at).toBe("2026-06-18T07:00:05.000Z");
+    expect(sent.content).toContain("## Summary");
+    expect(sent.content).toContain("single-threaded thread for eng");
+  });
+
+  test("SINGLE-THREADED over TWO turns: same deterministic path, turn_count==2, summed usage, preserved started_at", async () => {
+    // Simulate a vault: the second turn reads back the note the FIRST turn wrote.
+    let stored: { metadata: Record<string, string>; content: string } | undefined;
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const u = String(url);
+      const method = init?.method ?? "GET";
+      if (u.includes("/api/notes/") && method === "GET") {
+        if (!stored) return new Response("not found", { status: 404 });
+        return new Response(JSON.stringify(stored), { status: 200 });
+      }
+      if (u.endsWith("/api/notes") && method === "POST") {
+        const body = JSON.parse(String(init?.body)) as { metadata: Record<string, string>; content: string };
+        stored = { metadata: body.metadata, content: body.content }; // the vault upserts it.
+        return new Response(JSON.stringify({ id: "thread-eng" }), { status: 201 });
+      }
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+
+    await t.writeThread({
+      channel: "eng",
+      name: "eng",
+      mode: "single-threaded",
+      status: "ok",
+      input: "turn one",
+      output: "reply one",
+      started_at: "2026-06-18T07:00:00.000Z",
+      ended_at: "2026-06-18T07:00:05.000Z",
+      usage: { inputTokens: 10, outputTokens: 5, totalCostUsd: 0.001 },
+    });
+    expect(stored!.metadata.turn_count).toBe("1");
+
+    await t.writeThread({
+      channel: "eng",
+      name: "eng",
+      mode: "single-threaded",
+      status: "ok",
+      input: "turn two",
+      output: "reply two",
+      started_at: "2026-06-18T08:00:00.000Z", // a LATER start — must NOT overwrite the first.
+      ended_at: "2026-06-18T08:00:09.000Z",
+      usage: { inputTokens: 20, outputTokens: 8, totalCostUsd: 0.002 },
+    });
+
+    // ONE note, upserted: turn_count incremented, usage SUMMED, started_at PRESERVED,
+    // last_turn_at advanced.
+    expect(stored!.metadata.turn_count).toBe("2");
+    expect(stored!.metadata.input_tokens).toBe("30"); // 10 + 20
+    expect(stored!.metadata.output_tokens).toBe("13"); // 5 + 8
+    expect(stored!.metadata.total_cost_usd).toBe("0.003"); // 0.001 + 0.002
+    expect(stored!.metadata.started_at).toBe("2026-06-18T07:00:00.000Z"); // first turn's, preserved.
+    expect(stored!.metadata.last_turn_at).toBe("2026-06-18T08:00:09.000Z"); // latest turn.
+    // The body's summary reflects 2 turns + the latest turn's content.
+    expect(stored!.content).toContain("2 turns");
+    expect(stored!.content).toContain("turn two");
+    expect(stored!.content).toContain("reply two");
+  });
+
+  test("writeThread() on an error turn records status:error + the failure reason in the body", async () => {
+    let captured: { tags: string[]; metadata: Record<string, string>; content: string } | undefined;
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      if (String(url).endsWith("/api/notes") && (init?.method ?? "GET") === "POST") {
+        captured = JSON.parse(String(init?.body));
+      }
+      return new Response(JSON.stringify({ id: "thread-err-1" }), { status: 201 });
+    }) as typeof fetch;
+
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+    await t.writeThread({
       channel: "eng",
       mode: "multi-threaded",
       status: "error",
@@ -236,16 +357,23 @@ describe("VaultTransport — writeRun (#agent/run record for a multi-threaded tu
     expect(captured!.metadata.status).toBe("error");
     // No definition → the field is absent (not an empty string).
     expect("definition" in captured!.metadata).toBe(false);
+    // The body's latest-turn section is the Error block on a failure.
+    expect(captured!.content).toContain("**Error:**");
     expect(captured!.content).toContain("claude -p exited 1: boom");
   });
 
-  test("writeRun() throws on a non-ok vault response", async () => {
-    globalThis.fetch = (async () =>
-      new Response("boom", { status: 500 })) as unknown as typeof fetch;
+  test("writeThread() throws on a non-ok vault response (POST)", async () => {
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      // multi-threaded → no GET; the POST fails.
+      if (String(url).endsWith("/api/notes") && (init?.method ?? "GET") === "POST") {
+        return new Response("boom", { status: 500 });
+      }
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
     const t = new VaultTransport(baseConfig());
     await t.start(fakeCtx("eng"));
     await expect(
-      t.writeRun({
+      t.writeThread({
         channel: "eng",
         mode: "multi-threaded",
         status: "ok",
@@ -254,7 +382,7 @@ describe("VaultTransport — writeRun (#agent/run record for a multi-threaded tu
         started_at: "2026-06-18T07:00:00.000Z",
         ended_at: "2026-06-18T07:00:01.000Z",
       }),
-    ).rejects.toThrow(/write run note failed/);
+    ).rejects.toThrow(/write thread note failed/);
   });
 });
 
@@ -736,11 +864,11 @@ describe("VaultTransport — ensureSchema (tag-schema declaration on connect)", 
 
   test("schema declares the #agent/* namespace rollup PLUS the interim + legacy families (dual-read, 13 entries)", async () => {
     // The `#agent/*` namespace (design 2026-06-17-vault-native-agents) rolls up
-    // definitions, messages, jobs, AND runs to the `#agent` root. DUAL-READ: the schema
+    // definitions, messages, jobs, AND threads to the `#agent` root. DUAL-READ: the schema
     // ALSO keeps declaring the interim flat `#agent-message*` AND legacy
     // `#channel-message*` inheritance so pre-namespace history keeps its parent/child
     // expansion until the one-time re-tag run lands. Exactly 13 entries (12 + the
-    // execution-lifecycle `#agent/run` record tag).
+    // execution-lifecycle `#agent/thread` record tag).
     const names = AGENT_VAULT_TAG_SCHEMA.map((e) => e.name);
     expect(names).toEqual([
       "#agent",
@@ -749,7 +877,7 @@ describe("VaultTransport — ensureSchema (tag-schema declaration on connect)", 
       "#agent/message/inbound",
       "#agent/message/outbound",
       "#agent/job",
-      "#agent/run",
+      "#agent/thread",
       "#agent-message",
       "#agent-message/inbound",
       "#agent-message/outbound",
@@ -762,7 +890,7 @@ describe("VaultTransport — ensureSchema (tag-schema declaration on connect)", 
     expect(byName("#agent/definition").parent_names).toEqual(["#agent"]);
     expect(byName("#agent/message").parent_names).toEqual(["#agent"]);
     expect(byName("#agent/job").parent_names).toEqual(["#agent"]);
-    expect(byName("#agent/run").parent_names).toEqual(["#agent"]);
+    expect(byName("#agent/thread").parent_names).toEqual(["#agent"]);
     expect(byName("#agent/message/inbound").parent_names).toEqual(["#agent/message"]);
     expect(byName("#agent/message/outbound").parent_names).toEqual(["#agent/message"]);
     // The interim + legacy children still declare their own parents (inheritance preserved).
@@ -770,10 +898,10 @@ describe("VaultTransport — ensureSchema (tag-schema declaration on connect)", 
     expect(byName("#agent-message/outbound").parent_names).toEqual(["#agent-message"]);
     expect(byName("#channel-message/inbound").parent_names).toEqual(["#channel-message"]);
     expect(byName("#channel-message/outbound").parent_names).toEqual(["#channel-message"]);
-    // `#agent/run` declares INDEXED string fields so runs are operator-queryable —
-    // "all failed runs" (status), "all runs of agent X" (definition), "all multi-threaded
-    // runs" (mode).
-    expect(byName("#agent/run").fields).toEqual({
+    // `#agent/thread` declares INDEXED string fields so threads are operator-queryable —
+    // "all failed threads" (status), "all threads of agent X" (definition), "all
+    // multi-threaded threads" (mode). The three axes carry over from the run record VERBATIM.
+    expect(byName("#agent/thread").fields).toEqual({
       status: { type: "string", indexed: true },
       definition: { type: "string", indexed: true },
       mode: { type: "string", indexed: true },
@@ -793,18 +921,18 @@ describe("VaultTransport — ensureSchema (tag-schema declaration on connect)", 
     expect(declared).toEqual(AGENT_VAULT_TAG_SCHEMA.map((e) => e.name));
   });
 
-  test("ensureSchema sends the indexed `fields` body for #agent/run", async () => {
-    let runBody: { fields?: Record<string, unknown> } | undefined;
+  test("ensureSchema sends the indexed `fields` body for #agent/thread", async () => {
+    let threadBody: { fields?: Record<string, unknown> } | undefined;
     globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
       const name = decodeURIComponent(String(url).split("/api/tags/")[1]!);
-      if (name === AGENT_RUN_TAG) runBody = JSON.parse(String(init?.body));
+      if (name === AGENT_THREAD_TAG) threadBody = JSON.parse(String(init?.body));
       return new Response("{}", { status: 200 });
     }) as typeof fetch;
 
     const t = new VaultTransport(baseConfig());
     await t.ensureSchema();
 
-    expect(runBody?.fields).toEqual({
+    expect(threadBody?.fields).toEqual({
       status: { type: "string", indexed: true },
       definition: { type: "string", indexed: true },
       mode: { type: "string", indexed: true },

--- a/src/transports/vault.ts
+++ b/src/transports/vault.ts
@@ -64,6 +64,7 @@ import type {
   Transport,
   TransportContext,
   ReplyArgs,
+  RunRecord,
 } from "../transport.ts";
 
 /** Config for a vault transport instance (from the channel registry entry). */
@@ -294,6 +295,20 @@ const AGENT_JOB_TAG = "#agent/job";
 const JOB_PATH_PREFIX = "Channels";
 
 /**
+ * Run-record tag — a `#agent/run` note is the durable record of ONE `one-shot`
+ * agent turn (the execution-lifecycle taxonomy; the Phase-3 prerequisite). A
+ * `resident` turn leaves no run note — the channel transcript IS its record — so this
+ * is written ONLY for one-shot fires. Body = the input + reply; metadata =
+ * `{ definition, mode, status, started_at, ended_at, usage? }`. The INDEXED string
+ * fields (`status`, `definition`, `mode`) make "all failed runs" / "all runs of agent
+ * X" / "all one-shot runs" operator-queryable. `definition` is a plain note-id string
+ * for now (interim — typed link fields are a future vault feature).
+ */
+export const AGENT_RUN_TAG = "#agent/run";
+/** Default path prefix under which run notes are written: `Runs/<ch>/<id>`. */
+const RUN_PATH_PREFIX = "Runs";
+
+/**
  * The tag schema this module manages in any vault it's connected to.
  *
  * This is the declarative complement to the "tag both parent + child" fail-safe
@@ -329,6 +344,14 @@ export const AGENT_VAULT_TAG_SCHEMA: ReadonlyArray<{
   name: string;
   description?: string;
   parent_names?: string[];
+  /**
+   * Indexed metadata field declarations (the vault's `update-tag` `fields` shape) —
+   * `{ <field>: { type, indexed } }`. Declared so the field gets a generated column +
+   * index, making it queryable via metadata operator objects. Used by `#agent/run`
+   * (status/definition/mode) so an operator can query "all failed runs" / "all runs of
+   * agent X" / "all one-shot runs".
+   */
+  fields?: Record<string, { type: "string" | "boolean" | "integer"; indexed?: boolean }>;
 }> = [
   {
     name: AGENT_ROOT_TAG,
@@ -358,6 +381,21 @@ export const AGENT_VAULT_TAG_SCHEMA: ReadonlyArray<{
     name: AGENT_JOB_TAG,
     parent_names: [AGENT_ROOT_TAG],
     description: "A scheduled job — the runner injects this note's message on its cron schedule.",
+  },
+  {
+    name: AGENT_RUN_TAG,
+    parent_names: [AGENT_ROOT_TAG],
+    description:
+      "A run record for ONE one-shot agent turn — body is the input + reply, metadata is the run outcome.",
+    // Indexed so an operator can query runs by outcome / agent / mode:
+    //  - status     → "all failed runs" (status:error)
+    //  - definition → "all runs of agent X" (the def note id)
+    //  - mode       → "all one-shot runs"
+    fields: {
+      status: { type: "string", indexed: true },
+      definition: { type: "string", indexed: true },
+      mode: { type: "string", indexed: true },
+    },
   },
   // --- Interim (dual-read) — the flat `#agent-message*` tags that preceded the
   //     `#agent/*` namespace. Declared so pre-namespace history keeps its
@@ -525,9 +563,14 @@ export class VaultTransport implements Transport {
         // Single-segment, percent-encoded name: `#agent/message/inbound` →
         // `%23agent%2Fmessage%2Finbound`. The vault decodes it back to the literal.
         const url = `${this.vaultUrl}/vault/${this.vault}/api/tags/${encodeURIComponent(entry.name)}`;
-        const body: { description?: string; parent_names?: string[] } = {};
+        const body: {
+          description?: string;
+          parent_names?: string[];
+          fields?: Record<string, { type: "string" | "boolean" | "integer"; indexed?: boolean }>;
+        } = {};
         if (entry.description !== undefined) body.description = entry.description;
         if (entry.parent_names !== undefined) body.parent_names = entry.parent_names;
+        if (entry.fields !== undefined) body.fields = entry.fields;
 
         const res = await fetch(url, {
           method: "PUT",
@@ -615,6 +658,64 @@ export class VaultTransport implements Transport {
 
     // The vault returns the created note; surface its id. Fall back to the id we
     // proposed in the path if the response shape is unexpected.
+    let noteId: string = id;
+    try {
+      const created = (await res.json()) as { id?: string; note?: { id?: string } };
+      noteId = created?.id ?? created?.note?.id ?? id;
+    } catch {
+      // Non-JSON / empty body — keep the proposed id.
+    }
+    return { sent: [noteId] };
+  }
+
+  /**
+   * Write the durable record of ONE completed `one-shot` turn — an `#agent/run` note
+   * (the execution-lifecycle taxonomy; the Phase-3 prerequisite). The body is the
+   * input + reply; the metadata is the run outcome. The INDEXED fields
+   * (`status`/`definition`/`mode`) make runs operator-queryable. This note is NOT a
+   * `#agent/message` and carries NO inbound child tag, so it can never wake a session
+   * (no loop). Best-effort caller-side: a throw is surfaced to the registry, which
+   * logs it (a missing run note never re-runs the turn — that would fork nothing here,
+   * but it's the same "don't retry" posture as outbound).
+   */
+  async writeRun(run: RunRecord): Promise<{ sent: string[] }> {
+    const id = crypto.randomUUID();
+    const safeChannel = run.channel.replace(/[^a-zA-Z0-9_-]/g, "-");
+    const path = `${RUN_PATH_PREFIX}/${safeChannel}/${id}`;
+
+    // Indexed string fields (queryable) + the timing/usage observability fields. The
+    // vault stores metadata as strings; usage numbers are stringified.
+    const metadata: Record<string, string> = {
+      channel: run.channel,
+      mode: run.mode,
+      status: run.status,
+      started_at: run.started_at,
+      ended_at: run.ended_at,
+    };
+    if (run.definition) metadata.definition = run.definition;
+    if (run.usage) {
+      if (typeof run.usage.inputTokens === "number") metadata.input_tokens = String(run.usage.inputTokens);
+      if (typeof run.usage.outputTokens === "number") metadata.output_tokens = String(run.usage.outputTokens);
+      if (typeof run.usage.totalCostUsd === "number") metadata.total_cost_usd = String(run.usage.totalCostUsd);
+    }
+
+    // Body = the input + the reply (or the error) — the human-readable run record.
+    const body = `## Input\n\n${run.input}\n\n## ${run.status === "ok" ? "Reply" : "Error"}\n\n${run.output}\n`;
+
+    const res = await fetch(`${this.vaultUrl}/vault/${this.vault}/api/notes`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${this.token}`,
+      },
+      body: JSON.stringify({ content: body, path, tags: [AGENT_RUN_TAG], metadata }),
+    });
+
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "");
+      throw new Error(`vault transport: write run note failed (${res.status}) ${detail}`.trim());
+    }
+
     let noteId: string = id;
     try {
       const created = (await res.json()) as { id?: string; note?: { id?: string } };

--- a/src/transports/vault.ts
+++ b/src/transports/vault.ts
@@ -251,10 +251,18 @@ function numFromMeta(v: unknown): number {
 /**
  * Build the `#agent/thread` note BODY — the rolling SUMMARY of the thread (design
  * 2026-06-18: "hold a summary of this thread in the content; maybe another agent
- * facilitates that"). v1 the MODULE writes a useful default, STRUCTURED so a future
- * summarizer agent can own/enrich the `## Summary` section: that section is the slot a
- * summarizer may later own; the `## Latest turn` section + the metadata roll-up are
- * always MODULE-OWNED. The same shape serves both modes (multi-threaded = one turn).
+ * facilitates that"). The MODULE writes a useful default, STRUCTURED (`## Summary` /
+ * `## Latest turn`) so the `## Summary` section is the slot a future summarizer agent is
+ * EARMARKED to own/enrich; the `## Latest turn` block + the metadata roll-up are always
+ * module-owned. The same shape serves both modes (multi-threaded = one turn).
+ *
+ * v1 LIMITATION — the module OVERWRITES the `## Summary` section every turn. This function
+ * REGENERATES the whole body from scratch using only the rolled-up aggregates (passed in
+ * from `prior.metadata`); it NEVER reads `prior.content`. So a summarizer agent's
+ * enrichment of `## Summary` would be CLOBBERED on the next turn. Summarizer-agent
+ * enrichment needs a read-prior-content → merge path (preserve a summarizer-owned section
+ * across the regenerate), which is DEFERRED. Until then, "may own" means EARMARKED, not
+ * PRESERVED.
  */
 function buildThreadSummaryBody(t: {
   name: string;
@@ -268,8 +276,10 @@ function buildThreadSummaryBody(t: {
   const turns = t.turnCount === 1 ? "1 turn" : `${t.turnCount} turns`;
   const auto = `${t.mode} thread for ${t.name} — ${turns}, last ${t.status} at ${t.lastTurnAt}.`;
   const turnHeading = t.status === "ok" ? "Reply" : "Error";
-  // `## Summary` is the SUMMARIZER-OWNABLE slot (module writes a default in v1); the
-  // `## Latest turn` block + the metadata roll-up are always module-owned.
+  // `## Summary` is EARMARKED for a future summarizer agent — but v1 OVERWRITES it every
+  // turn (this body is fully regenerated from metadata; `prior.content` is never read), so
+  // it's a module-owned default for now, NOT a preserved slot (see the function doc).
+  // The `## Latest turn` block + the metadata roll-up are always module-owned.
   return (
     `## Summary\n\n${auto}\n\n` +
     `## Latest turn\n\n` +
@@ -755,6 +765,10 @@ export class VaultTransport implements Transport {
     // ambiguous `thread_id` metadata field). single-threaded: a DETERMINISTIC leaf named
     // after the def (the agent/spec name, sanitized) so the SAME note upserts across turns.
     // multi-threaded: a fresh uuid per fire (one fire = one thread = one note today).
+    // COLLISION NOTE: two single-threaded agents whose names collapse to the SAME safeName
+    // on the same channel would upsert each other's thread note. Acceptable because the
+    // registry enforces ONE agent per channel (byChannel index), so the collision can't
+    // arise in practice.
     const safeName = (thread.name ?? thread.channel).replace(/[^a-zA-Z0-9_-]/g, "-");
     const leaf = singleThreaded ? safeName : crypto.randomUUID();
     const path = `${THREAD_PATH_PREFIX}/${safeChannel}/${leaf}`;
@@ -814,7 +828,10 @@ export class VaultTransport implements Transport {
     if (singleThreaded || thread.usage) {
       if (inputTokens) metadata.input_tokens = String(inputTokens);
       if (outputTokens) metadata.output_tokens = String(outputTokens);
-      if (costUsd) metadata.total_cost_usd = String(costUsd);
+      // Round the accumulated cost to 9 decimals before serializing — summing floats
+      // (e.g. 0.1 + 0.2) accrues IEEE-754 drift, so a naive String() yields
+      // "0.30000000000000004". 9 decimals covers sub-cent costs without losing precision.
+      if (costUsd) metadata.total_cost_usd = String(Math.round(costUsd * 1e9) / 1e9);
     }
 
     const body = buildThreadSummaryBody({
@@ -835,8 +852,12 @@ export class VaultTransport implements Transport {
     // it when missing (turn 1, and every multi-threaded fresh-uuid fire). `force: true`
     // satisfies the vault's 428 mutation precondition (mirrors `setInboundStatus`). The
     // path is one URL segment (percent-encoded `/`); the route `decodeURIComponent`s it.
-    // The `tags` array is consumed by the create branch and is a no-op on update (the
-    // update branch reads `tags.add`/`tags.remove`), so the tag is set once and preserved.
+    // The `tags` array is consumed ONLY by the create branch. VERIFIED against the vault
+    // (`routes.ts`): the PATCH UPDATE branch reads `tags.add` / `tags.remove` (the delta
+    // shape), NOT a plain `tags` array — so sending `tags: [AGENT_THREAD_TAG]` here is
+    // INERT on update (the note's existing tag is preserved untouched) and only takes
+    // effect on the if_missing:create branch. So the single tag is set once at create and
+    // preserved across every subsequent upsert (HARD CONSTRAINT 4 — loop-safe single tag).
     const url = `${this.vaultUrl}/vault/${this.vault}/api/notes/${encodeURIComponent(path)}`;
     const res = await fetch(url, {
       method: "PATCH",
@@ -884,8 +905,14 @@ export class VaultTransport implements Transport {
     let res: Response;
     try {
       res = await fetch(url, { headers: { authorization: `Bearer ${this.token}` } });
-    } catch {
+    } catch (err) {
       // Vault unreachable — treat as "no prior" (we'll create fresh; aggregates reset).
+      // SURFACE it: a flaky vault silently resetting a thread's turn_count/usage is a
+      // data-quality bug we want visible in logs. Still return undefined so the upsert
+      // proceeds (don't strand the queue on a transient network blip).
+      console.warn(
+        `parachute-agent: readThreadNote network error — thread aggregates reset for ${path}: ${(err as Error).message}`,
+      );
       return undefined;
     }
     if (res.status === 404) return undefined; // first turn — note doesn't exist yet.

--- a/src/transports/vault.ts
+++ b/src/transports/vault.ts
@@ -827,16 +827,31 @@ export class VaultTransport implements Transport {
       output: thread.output,
     });
 
-    // Upsert by path (the vault upserts on POST-by-path) — mirrors `upsertJobNote`. The
-    // deterministic single-threaded path overwrites in place; the multi-threaded uuid path
-    // is fresh per fire.
-    const res = await fetch(`${this.vaultUrl}/vault/${this.vault}/api/notes`, {
-      method: "POST",
+    // Upsert by path via PATCH + `if_missing: "create"` (vault#309) — NOT POST. POST
+    // /api/notes 409s `path_conflict` on an existing path (it does not upsert), so a
+    // single-threaded thread note would create on turn 1 and 409 on every turn after.
+    // PATCH-by-path is the real upsert: the vault resolves the (decoded) path, UPDATES it
+    // when present (single-threaded turn 2+: content replaced, metadata merged) or CREATES
+    // it when missing (turn 1, and every multi-threaded fresh-uuid fire). `force: true`
+    // satisfies the vault's 428 mutation precondition (mirrors `setInboundStatus`). The
+    // path is one URL segment (percent-encoded `/`); the route `decodeURIComponent`s it.
+    // The `tags` array is consumed by the create branch and is a no-op on update (the
+    // update branch reads `tags.add`/`tags.remove`), so the tag is set once and preserved.
+    const url = `${this.vaultUrl}/vault/${this.vault}/api/notes/${encodeURIComponent(path)}`;
+    const res = await fetch(url, {
+      method: "PATCH",
       headers: {
         "content-type": "application/json",
         authorization: `Bearer ${this.token}`,
       },
-      body: JSON.stringify({ content: body, path, tags: [AGENT_THREAD_TAG], metadata }),
+      body: JSON.stringify({
+        content: body,
+        path,
+        tags: [AGENT_THREAD_TAG],
+        metadata,
+        if_missing: "create",
+        force: true,
+      }),
     });
 
     if (!res.ok) {

--- a/src/transports/vault.ts
+++ b/src/transports/vault.ts
@@ -64,7 +64,7 @@ import type {
   Transport,
   TransportContext,
   ReplyArgs,
-  RunRecord,
+  ThreadRecord,
 } from "../transport.ts";
 
 /** Config for a vault transport instance (from the channel registry entry). */
@@ -238,6 +238,46 @@ function coerceInboundStatus(v: unknown): InboundStatus {
   return "pending";
 }
 
+/**
+ * Coerce a raw metadata value (the vault stores metadata as STRINGS) to a finite number,
+ * defaulting to 0. Used to roll up a single-threaded thread's cumulative aggregates
+ * (`turn_count`, token/cost usage) read back from the prior note.
+ */
+function numFromMeta(v: unknown): number {
+  const n = typeof v === "number" ? v : typeof v === "string" ? Number(v) : NaN;
+  return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * Build the `#agent/thread` note BODY — the rolling SUMMARY of the thread (design
+ * 2026-06-18: "hold a summary of this thread in the content; maybe another agent
+ * facilitates that"). v1 the MODULE writes a useful default, STRUCTURED so a future
+ * summarizer agent can own/enrich the `## Summary` section: that section is the slot a
+ * summarizer may later own; the `## Latest turn` section + the metadata roll-up are
+ * always MODULE-OWNED. The same shape serves both modes (multi-threaded = one turn).
+ */
+function buildThreadSummaryBody(t: {
+  name: string;
+  mode: string;
+  turnCount: number;
+  status: "ok" | "error";
+  lastTurnAt: string;
+  input: string;
+  output: string;
+}): string {
+  const turns = t.turnCount === 1 ? "1 turn" : `${t.turnCount} turns`;
+  const auto = `${t.mode} thread for ${t.name} — ${turns}, last ${t.status} at ${t.lastTurnAt}.`;
+  const turnHeading = t.status === "ok" ? "Reply" : "Error";
+  // `## Summary` is the SUMMARIZER-OWNABLE slot (module writes a default in v1); the
+  // `## Latest turn` block + the metadata roll-up are always module-owned.
+  return (
+    `## Summary\n\n${auto}\n\n` +
+    `## Latest turn\n\n` +
+    `**Input:** ${t.input}\n\n` +
+    `**${turnHeading}:** ${t.output}\n`
+  );
+}
+
 // ---------------------------------------------------------------------------
 // PRIOR tags (pre-namespace) — DUAL-READ only. We never WRITE these going forward,
 // but we recognize them on READ so pre-namespace history loads + a still-live prior
@@ -295,18 +335,30 @@ const AGENT_JOB_TAG = "#agent/job";
 const JOB_PATH_PREFIX = "Channels";
 
 /**
- * Run-record tag — a `#agent/run` note is the durable record of ONE `multi-threaded`
- * agent turn (the execution-lifecycle taxonomy; the Phase-3 prerequisite). A
- * `single-threaded` turn leaves no run note — the channel transcript IS its record — so
- * this is written ONLY for multi-threaded fires. Body = the input + reply; metadata =
- * `{ definition, mode, status, started_at, ended_at, usage? }`. The INDEXED string
- * fields (`status`, `definition`, `mode`) make "all failed runs" / "all runs of agent
- * X" / "all multi-threaded runs" operator-queryable. `definition` is a plain note-id
- * string for now (interim — typed link fields are a future vault feature).
+ * Thread tag — the UNIFIED model: `definition -> thread -> message`. EVERYTHING is a
+ * thread; a `#agent/thread` note is the durable, queryable record of one conversation
+ * thread, written for BOTH execution-lifecycle modes (the structural unification —
+ * "a run was always a thread with one turn"). The note BODY is a rolling SUMMARY of the
+ * thread (a future summarizer agent may own/enrich the `## Summary` slot — module-owned
+ * in v1); metadata = `{ channel, definition, mode, status, started_at, last_turn_at,
+ * turn_count, usage }`. The INDEXED string fields (`status`, `definition`, `mode`) make
+ * "all failed threads" / "all threads of agent X" / "all multi-threaded threads"
+ * operator-queryable. `definition` is a plain note-id string for now (interim — typed
+ * link fields are a future vault feature).
+ *
+ * The MODE difference is the thread's IDENTITY (path leaf) + whether it upserts:
+ *  - `single-threaded` — exactly ONE thread note per channel, at the DETERMINISTIC stable
+ *    path `Threads/<safeChannel>/<safeName>` ("named after the definition"), UPSERTED in
+ *    place across turns (turn_count increments, usage accumulates).
+ *  - `multi-threaded` — one thread note per fire, at `Threads/<safeChannel>/<uuid>` (today
+ *    one fire = one thread = one note; turn_count = 1; usage = this turn's). No upsert.
+ *
+ * The note carries `['#agent/thread']` EXACTLY — NOT a message tag, NOT the inbound
+ * child — so it can never wake a session (no loop).
  */
-export const AGENT_RUN_TAG = "#agent/run";
-/** Default path prefix under which run notes are written: `Runs/<ch>/<id>`. */
-const RUN_PATH_PREFIX = "Runs";
+export const AGENT_THREAD_TAG = "#agent/thread";
+/** Default path prefix under which thread notes are written: `Threads/<ch>/<leaf>`. */
+const THREAD_PATH_PREFIX = "Threads";
 
 /**
  * The tag schema this module manages in any vault it's connected to.
@@ -347,9 +399,9 @@ export const AGENT_VAULT_TAG_SCHEMA: ReadonlyArray<{
   /**
    * Indexed metadata field declarations (the vault's `update-tag` `fields` shape) —
    * `{ <field>: { type, indexed } }`. Declared so the field gets a generated column +
-   * index, making it queryable via metadata operator objects. Used by `#agent/run`
-   * (status/definition/mode) so an operator can query "all failed runs" / "all runs of
-   * agent X" / "all multi-threaded runs".
+   * index, making it queryable via metadata operator objects. Used by `#agent/thread`
+   * (status/definition/mode) so an operator can query "all failed threads" / "all threads
+   * of agent X" / "all multi-threaded threads".
    */
   fields?: Record<string, { type: "string" | "boolean" | "integer"; indexed?: boolean }>;
 }> = [
@@ -383,14 +435,15 @@ export const AGENT_VAULT_TAG_SCHEMA: ReadonlyArray<{
     description: "A scheduled job — the runner injects this note's message on its cron schedule.",
   },
   {
-    name: AGENT_RUN_TAG,
+    name: AGENT_THREAD_TAG,
     parent_names: [AGENT_ROOT_TAG],
     description:
-      "A run record for ONE multi-threaded agent turn — body is the input + reply, metadata is the run outcome.",
-    // Indexed so an operator can query runs by outcome / agent / mode:
-    //  - status     → "all failed runs" (status:error)
-    //  - definition → "all runs of agent X" (the def note id)
-    //  - mode       → "all multi-threaded runs"
+      "A thread record (definition -> thread -> message) — body is a rolling summary, metadata is the thread state. Written for BOTH modes.",
+    // The three indexed query axes carry over from the run record VERBATIM — an operator
+    // can query threads by outcome / agent / mode:
+    //  - status     → "all failed threads" (status:error)
+    //  - definition → "all threads of agent X" (the def note id)
+    //  - mode       → "all multi-threaded threads"
     fields: {
       status: { type: "string", indexed: true },
       definition: { type: "string", indexed: true },
@@ -669,61 +722,177 @@ export class VaultTransport implements Transport {
   }
 
   /**
-   * Write the durable record of ONE completed `multi-threaded` turn — an `#agent/run` note
-   * (the execution-lifecycle taxonomy; the Phase-3 prerequisite). The body is the
-   * input + reply; the metadata is the run outcome. The INDEXED fields
-   * (`status`/`definition`/`mode`) make runs operator-queryable. This note is NOT a
-   * `#agent/message` and carries NO inbound child tag, so it can never wake a session
-   * (no loop). Best-effort caller-side: a throw is surfaced to the registry, which
-   * logs it (a missing run note never re-runs the turn — that would fork nothing here,
-   * but it's the same "don't retry" posture as outbound).
+   * Materialize a `#agent/thread` note for ONE completed turn — the UNIFIED model
+   * (`definition -> thread -> message`). Written for BOTH execution-lifecycle modes
+   * (the structural unification): EVERYTHING is a thread, a "run" was always a thread
+   * with one turn. The note BODY is a rolling SUMMARY of the thread; the metadata is the
+   * thread state. The INDEXED fields (`status`/`definition`/`mode`) make threads
+   * operator-queryable. This note carries `['#agent/thread']` EXACTLY — NOT a
+   * `#agent/message`, NO inbound child — so it can never wake a session (no loop).
+   *
+   * The MODE governs the thread's IDENTITY + whether it upserts:
+   *  - `single-threaded` — ONE thread note per channel at the DETERMINISTIC stable path
+   *    `Threads/<safeChannel>/<safeName>` (named after the definition). It UPSERTS in
+   *    place across turns: we READ the existing note first, then write the rolled-up
+   *    aggregates (`turn_count` incremented, cumulative `usage`, original `started_at`).
+   *  - `multi-threaded` — one thread note PER FIRE at `Threads/<safeChannel>/<uuid>`
+   *    (today one fire = one thread; turn_count = 1; usage = this turn's). NO upsert.
+   *
+   * SAFETY of the read-modify-write for single-threaded: the drain is SERIAL per channel
+   * AND single-threaded is one-thread-per-channel today, so there's no concurrent writer
+   * to lose an update against. WHEN CONTINUATION brings concurrent threads per channel,
+   * switch to re-deriving aggregates from the `#agent/message` children or a vault
+   * atomic-merge, to avoid lost-update.
+   *
+   * Best-effort caller-side: a throw is surfaced to the registry, which logs it (a missing
+   * thread note never re-runs the turn — same "don't retry" posture as outbound).
    */
-  async writeRun(run: RunRecord): Promise<{ sent: string[] }> {
-    const id = crypto.randomUUID();
-    const safeChannel = run.channel.replace(/[^a-zA-Z0-9_-]/g, "-");
-    const path = `${RUN_PATH_PREFIX}/${safeChannel}/${id}`;
+  async writeThread(thread: ThreadRecord): Promise<{ sent: string[] }> {
+    const safeChannel = thread.channel.replace(/[^a-zA-Z0-9_-]/g, "-");
+    const singleThreaded = thread.mode === "single-threaded";
 
-    // Indexed string fields (queryable) + the timing/usage observability fields. The
-    // vault stores metadata as strings; usage numbers are stringified.
-    const metadata: Record<string, string> = {
-      channel: run.channel,
-      mode: run.mode,
-      status: run.status,
-      started_at: run.started_at,
-      ended_at: run.ended_at,
-    };
-    if (run.definition) metadata.definition = run.definition;
-    if (run.usage) {
-      if (typeof run.usage.inputTokens === "number") metadata.input_tokens = String(run.usage.inputTokens);
-      if (typeof run.usage.outputTokens === "number") metadata.output_tokens = String(run.usage.outputTokens);
-      if (typeof run.usage.totalCostUsd === "number") metadata.total_cost_usd = String(run.usage.totalCostUsd);
+    // IDENTITY by mode (HARD CONSTRAINT 3 — the path leaf IS the thread's identity; no
+    // ambiguous `thread_id` metadata field). single-threaded: a DETERMINISTIC leaf named
+    // after the def (the agent/spec name, sanitized) so the SAME note upserts across turns.
+    // multi-threaded: a fresh uuid per fire (one fire = one thread = one note today).
+    const safeName = (thread.name ?? thread.channel).replace(/[^a-zA-Z0-9_-]/g, "-");
+    const leaf = singleThreaded ? safeName : crypto.randomUUID();
+    const path = `${THREAD_PATH_PREFIX}/${safeChannel}/${leaf}`;
+
+    // For single-threaded UPSERT, read the existing thread note (by its deterministic
+    // path) to roll up the aggregates. SAFE because the drain is serial per channel and
+    // single-threaded is one-thread-per-channel today (see the method doc) — there's no
+    // concurrent writer to lose an update against.
+    //   WHEN CONTINUATION brings concurrent threads per channel, switch to re-deriving
+    //   aggregates from the #agent/message children or a vault atomic-merge, to avoid
+    //   lost-update.
+    let priorTurnCount = 0;
+    let priorInputTokens = 0;
+    let priorOutputTokens = 0;
+    let priorCostUsd = 0;
+    let priorStartedAt: string | undefined;
+    if (singleThreaded) {
+      const prior = await this.readThreadNote(path);
+      if (prior) {
+        priorTurnCount = numFromMeta(prior.metadata?.turn_count);
+        priorInputTokens = numFromMeta(prior.metadata?.input_tokens);
+        priorOutputTokens = numFromMeta(prior.metadata?.output_tokens);
+        priorCostUsd = numFromMeta(prior.metadata?.total_cost_usd);
+        if (typeof prior.metadata?.started_at === "string" && prior.metadata.started_at) {
+          priorStartedAt = prior.metadata.started_at;
+        }
+      }
     }
 
-    // Body = the input + the reply (or the error) — the human-readable run record.
-    const body = `## Input\n\n${run.input}\n\n## ${run.status === "ok" ? "Reply" : "Error"}\n\n${run.output}\n`;
+    const turnCount = singleThreaded ? priorTurnCount + 1 : 1;
+    // `started_at` is set ONCE on create (preserve the prior on upsert); `last_turn_at`
+    // advances every turn.
+    const startedAt = priorStartedAt ?? thread.started_at;
+    const lastTurnAt = thread.ended_at;
 
+    // Cumulative usage: single-threaded SUMS this turn into the prior totals; multi-threaded
+    // carries just this turn's (one fire = one thread).
+    const inputTokens =
+      (singleThreaded ? priorInputTokens : 0) + (thread.usage?.inputTokens ?? 0);
+    const outputTokens =
+      (singleThreaded ? priorOutputTokens : 0) + (thread.usage?.outputTokens ?? 0);
+    const costUsd = (singleThreaded ? priorCostUsd : 0) + (thread.usage?.totalCostUsd ?? 0);
+
+    // Indexed string fields (queryable) + the thread-state observability fields. The
+    // vault stores metadata as strings; numbers are stringified.
+    const metadata: Record<string, string> = {
+      channel: thread.channel,
+      mode: thread.mode,
+      status: thread.status,
+      started_at: startedAt,
+      last_turn_at: lastTurnAt,
+      turn_count: String(turnCount),
+    };
+    if (thread.definition) metadata.definition = thread.definition;
+    // Usage is always present once a turn carried it OR we accumulated any — emit the
+    // running totals so a query sees cumulative cost for the thread.
+    if (singleThreaded || thread.usage) {
+      if (inputTokens) metadata.input_tokens = String(inputTokens);
+      if (outputTokens) metadata.output_tokens = String(outputTokens);
+      if (costUsd) metadata.total_cost_usd = String(costUsd);
+    }
+
+    const body = buildThreadSummaryBody({
+      name: thread.name ?? thread.channel,
+      mode: thread.mode,
+      turnCount,
+      status: thread.status,
+      lastTurnAt,
+      input: thread.input,
+      output: thread.output,
+    });
+
+    // Upsert by path (the vault upserts on POST-by-path) — mirrors `upsertJobNote`. The
+    // deterministic single-threaded path overwrites in place; the multi-threaded uuid path
+    // is fresh per fire.
     const res = await fetch(`${this.vaultUrl}/vault/${this.vault}/api/notes`, {
       method: "POST",
       headers: {
         "content-type": "application/json",
         authorization: `Bearer ${this.token}`,
       },
-      body: JSON.stringify({ content: body, path, tags: [AGENT_RUN_TAG], metadata }),
+      body: JSON.stringify({ content: body, path, tags: [AGENT_THREAD_TAG], metadata }),
     });
 
     if (!res.ok) {
       const detail = await res.text().catch(() => "");
-      throw new Error(`vault transport: write run note failed (${res.status}) ${detail}`.trim());
+      throw new Error(`vault transport: write thread note failed (${res.status}) ${detail}`.trim());
     }
 
-    let noteId: string = id;
+    let noteId: string = path;
     try {
       const created = (await res.json()) as { id?: string; note?: { id?: string } };
-      noteId = created?.id ?? created?.note?.id ?? id;
+      noteId = created?.id ?? created?.note?.id ?? path;
     } catch {
-      // Non-JSON / empty body — keep the proposed id.
+      // Non-JSON / empty body — keep the path as the addressable id.
     }
     return { sent: [noteId] };
+  }
+
+  /**
+   * Read a single thread note by its deterministic PATH (the single-threaded upsert
+   * read-back). The vault's `GET .../api/notes/<id-or-path>` resolves a note by id OR
+   * path; we percent-encode the path's `/` so it's one URL segment. Returns the note
+   * (metadata + content) or undefined when it doesn't exist yet (a 404 on the first
+   * turn) or the vault is unreachable — the caller treats "no prior" as turn_count 0.
+   * Throws on an UNEXPECTED non-ok response (not 404) so a misconfig surfaces.
+   */
+  private async readThreadNote(
+    path: string,
+  ): Promise<{ metadata?: Record<string, unknown>; content?: string } | undefined> {
+    const url = `${this.vaultUrl}/vault/${this.vault}/api/notes/${encodeURIComponent(path)}`;
+    let res: Response;
+    try {
+      res = await fetch(url, { headers: { authorization: `Bearer ${this.token}` } });
+    } catch {
+      // Vault unreachable — treat as "no prior" (we'll create fresh; aggregates reset).
+      return undefined;
+    }
+    if (res.status === 404) return undefined; // first turn — note doesn't exist yet.
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "");
+      throw new Error(`vault transport: read thread note failed (${res.status}) ${detail}`.trim());
+    }
+    try {
+      const parsed = (await res.json()) as unknown;
+      // Tolerate a bare note object OR a `{ note: {...} }` envelope OR a 1-element array.
+      if (Array.isArray(parsed)) {
+        return parsed[0] as { metadata?: Record<string, unknown>; content?: string } | undefined;
+      }
+      const obj = parsed as { note?: unknown; metadata?: unknown; content?: unknown };
+      if (obj.note && typeof obj.note === "object") {
+        return obj.note as { metadata?: Record<string, unknown>; content?: string };
+      }
+      return obj as { metadata?: Record<string, unknown>; content?: string };
+    } catch {
+      // Bad JSON — treat as no prior (don't strand the write on a parse hiccup).
+      return undefined;
+    }
   }
 
   // react / edit / download: vault has no reactions; v1 is reply-only. Omitted.

--- a/src/transports/vault.ts
+++ b/src/transports/vault.ts
@@ -295,14 +295,14 @@ const AGENT_JOB_TAG = "#agent/job";
 const JOB_PATH_PREFIX = "Channels";
 
 /**
- * Run-record tag — a `#agent/run` note is the durable record of ONE `one-shot`
+ * Run-record tag — a `#agent/run` note is the durable record of ONE `multi-threaded`
  * agent turn (the execution-lifecycle taxonomy; the Phase-3 prerequisite). A
- * `resident` turn leaves no run note — the channel transcript IS its record — so this
- * is written ONLY for one-shot fires. Body = the input + reply; metadata =
+ * `single-threaded` turn leaves no run note — the channel transcript IS its record — so
+ * this is written ONLY for multi-threaded fires. Body = the input + reply; metadata =
  * `{ definition, mode, status, started_at, ended_at, usage? }`. The INDEXED string
  * fields (`status`, `definition`, `mode`) make "all failed runs" / "all runs of agent
- * X" / "all one-shot runs" operator-queryable. `definition` is a plain note-id string
- * for now (interim — typed link fields are a future vault feature).
+ * X" / "all multi-threaded runs" operator-queryable. `definition` is a plain note-id
+ * string for now (interim — typed link fields are a future vault feature).
  */
 export const AGENT_RUN_TAG = "#agent/run";
 /** Default path prefix under which run notes are written: `Runs/<ch>/<id>`. */
@@ -349,7 +349,7 @@ export const AGENT_VAULT_TAG_SCHEMA: ReadonlyArray<{
    * `{ <field>: { type, indexed } }`. Declared so the field gets a generated column +
    * index, making it queryable via metadata operator objects. Used by `#agent/run`
    * (status/definition/mode) so an operator can query "all failed runs" / "all runs of
-   * agent X" / "all one-shot runs".
+   * agent X" / "all multi-threaded runs".
    */
   fields?: Record<string, { type: "string" | "boolean" | "integer"; indexed?: boolean }>;
 }> = [
@@ -386,11 +386,11 @@ export const AGENT_VAULT_TAG_SCHEMA: ReadonlyArray<{
     name: AGENT_RUN_TAG,
     parent_names: [AGENT_ROOT_TAG],
     description:
-      "A run record for ONE one-shot agent turn — body is the input + reply, metadata is the run outcome.",
+      "A run record for ONE multi-threaded agent turn — body is the input + reply, metadata is the run outcome.",
     // Indexed so an operator can query runs by outcome / agent / mode:
     //  - status     → "all failed runs" (status:error)
     //  - definition → "all runs of agent X" (the def note id)
-    //  - mode       → "all one-shot runs"
+    //  - mode       → "all multi-threaded runs"
     fields: {
       status: { type: "string", indexed: true },
       definition: { type: "string", indexed: true },
@@ -669,7 +669,7 @@ export class VaultTransport implements Transport {
   }
 
   /**
-   * Write the durable record of ONE completed `one-shot` turn — an `#agent/run` note
+   * Write the durable record of ONE completed `multi-threaded` turn — an `#agent/run` note
    * (the execution-lifecycle taxonomy; the Phase-3 prerequisite). The body is the
    * input + reply; the metadata is the run outcome. The INDEXED fields
    * (`status`/`definition`/`mode`) make runs operator-queryable. This note is NOT a


### PR DESCRIPTION
## Agent execution model: single-threaded vs multi-threaded, and `#agent/thread`

The Phase-3 prerequisite for the Agent UI v2 create flow. Establishes the agent execution model and its durable record. **No version bump** (RC rule). `#agent/run` never shipped (this PR is unmerged), so `#agent/thread` is the only tag that ever reaches a vault — **zero migration**.

### The model — everything is a thread
An agent (`#agent/definition`) is one of two kinds, and **every completed turn materializes an `#agent/thread` note**. The graph is `definition → thread → message`.

- **`single-threaded`** (default) — ONE persistent `claude -p` session per channel (`--resume`d + persisted each turn). Its **one thread** is a deterministic note named after the def (`Threads/<channel>/<name>`), **upserted** across turns: `turn_count++`, usage summed, `started_at` preserved, `last_turn_at` advanced.
- **`multi-threaded`** — thread-keyed. Today every fire mints a fresh thread (no resume/persist) and writes one thread note per fire. Thread-id *continuation* (resume a specific prior thread) is the documented deferred increment — the same mode gains it with no operator change.

"one-shot" / "resident" / "per-thread" / "run" all retired as terms (a run was always a thread with one turn). The parser **dual-accepts** the legacy `mode` values (`resident`→single, `one-shot`/`per-thread`→multi) so nothing already authored breaks.

### The thread note
- Tags: `['#agent/thread']` **exactly** — never a message/inbound tag, so it can never wake a session (loop-safe).
- Metadata: indexed `status`/`definition`/`mode` (operator-queryable: "all failed threads of agent X, with cost") + `channel`/`started_at`/`last_turn_at`/`turn_count`/cumulative `usage`.
- Body: a **rolling summary** — a `## Summary` section (v1 the module regenerates it each turn; earmarked for a future summarizer agent once a read-prior→merge path lands) + `## Latest turn`.
- Written **before** the additive outbound, so a turn's record survives an outbound-write failure (uniform across both modes).

### Two correctness traps caught during verification
1. **POST 409s on an existing path** — the upsert had to be **PATCH + `if_missing:create` + `force`** (the real vault upsert verb), or single-threaded would've frozen at `turn_count: 1`. The `%2F`-encoded-slash-path round-trip (read-back + update) is verified against the real vault `route()` — see vault PR #490, which also syncs the typed-link edge vocabulary `run`→`thread`.
2. **Session store NOT re-keyed** — re-keying channel→thread would've silently reset every resident agent's memory; it stays channel-keyed (thread-keying is deferred continuation work). Session id stays in the local 0600 store, never the vault note (sensitive + machine-local).

### Commits
`b229b33` taxonomy · `c34db03` record-before-outbound fix · `c2f2316` single/multi rename · `6d7e1aa` `#agent/run`→`#agent/thread` + both-modes materialization · `d0ec51d` PATCH-upsert fix · `a519781` review punch-list (cost rounding, read-back observability, doc accuracy, +coverage).

### Review + gates
- Independent reviews: the lifecycle commits (LGTM-with-nits, folded), then a **3-lens adversarial review** of the structural change — all ship-with-nits, every nit folded into `a519781`. Loop-safety, write-ordering, unchanged session-resume, and correct aggregates all confirmed.
- `bun run typecheck` clean (except 2 pre-existing `bridge.ts` TS2589); `bun test ./src/` = **1057 pass / 0 fail**.

### Deferred (documented, not in this PR)
Thread-id routing + a thread-keyed session store + recording the session id (continuation); per-thread (not per-channel) drain serialization; message-level per-turn usage for multi-turn threads; summarizer-agent ownership of the `## Summary` slot; the typed-link upgrade of `definition`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
