### PR TITLE
feat(agent-ui): Phase 3 — unified create-agent flow (mode + backend + channel-connect)

### DIFF
--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -8,9 +8,9 @@
  * with the existing daemon-rendered HTML pages — operators compare the two
  * during the incremental migration; the HTML retires in Phase 4.
  *
- * Home IS the Agents list (the design's "Home becomes the Agents list"). Later
- * phases add the unified create flow (Phase 3) and the def-vault editor +
- * schedules fold-in (Phase 4); this shell leaves room for those nav entries.
+ * Home IS the Agents list (the design's "Home becomes the Agents list"). Phase 3
+ * adds the unified create flow (`/create`); the def-vault editor + schedules
+ * fold-in are Phase 4; this shell leaves room for those nav entries.
  *
  * Auth: the SPA loads OPEN, then mints a hub `agent:admin` Bearer from
  * `<origin>/admin/agent-token` (the operator's hub session cookie) — see
@@ -18,15 +18,18 @@
  */
 import { Link, Route, Routes, useLocation } from "react-router-dom";
 import { Agents } from "./routes/Agents.tsx";
+import { CreateAgentRoute } from "./routes/CreateAgent.tsx";
 
 const WORDMARK = "Parachute Agent";
 
-// Single view today (the Agents list). When create/config views land (Phase 3-4),
-// derive the subtitle from the route then.
-const SUBTITLE = "agents";
+function subtitleFor(pathname: string): string {
+  if (pathname === "/create" || pathname.startsWith("/create/")) return "new agent";
+  return "agents";
+}
 
 export function App() {
-  const subtitle = SUBTITLE;
+  const { pathname } = useLocation();
+  const subtitle = subtitleFor(pathname);
 
   return (
     <div className="page">
@@ -36,6 +39,7 @@ export function App() {
           <span className="sub">{subtitle}</span>
         </Link>
         <NavSection to="/" label="Agents" exact />
+        <NavSection to="/create" label="New agent" />
         {/* Boundary: everything past here is the older daemon-rendered HTML,
             kept mounted during the migration so the operator can compare. */}
         <span className="nav-divider" aria-hidden="true" />
@@ -48,6 +52,8 @@ export function App() {
         {/* Home is the Agents list (design: "Home becomes the Agents list"). */}
         <Route path="/" element={<Agents />} />
         <Route path="/agents" element={<Agents />} />
+        {/* Phase 3 — the unified create-agent flow. */}
+        <Route path="/create" element={<CreateAgentRoute />} />
         <Route
           path="*"
           element={

--- a/web/ui/src/lib/api.test.ts
+++ b/web/ui/src/lib/api.test.ts
@@ -12,6 +12,8 @@ vi.mock("./auth.ts", () => ({
 import * as auth from "./auth.ts";
 import {
   apiBase,
+  connectSessionCommand,
+  createAgentDef,
   HttpError,
   listAgentDefs,
   listAgentVaults,
@@ -153,5 +155,83 @@ describe("listAgents / listAgentDefs / listAgentVaults", () => {
       vi.fn(async () => new Response("", { status: 401 })),
     );
     await expect(listAgents()).rejects.toBeInstanceOf(HttpError);
+  });
+});
+
+describe("createAgentDef (POST)", () => {
+  it("POSTs the JSON body with the Bearer + content-type to /agent/api/agent-defs", async () => {
+    const fetchMock = fetchFn(async () => jsonResponse(201, { ok: true, def: { name: "eng" } }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const body = {
+      vault: "default",
+      name: "eng",
+      backend: "channel" as const,
+      systemPrompt: "You are…",
+      metadata: { mode: "single-threaded" },
+    };
+    const res = await createAgentDef(body);
+
+    expect(res.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("/agent/api/agent-defs");
+    expect(init?.method).toBe("POST");
+    const headers = new Headers(init?.headers);
+    expect(headers.get("authorization")).toBe("Bearer jwt-tok");
+    expect(headers.get("content-type")).toBe("application/json");
+    expect(JSON.parse(String(init?.body))).toEqual(body);
+  });
+
+  it("re-mints and retries once on a 401, then succeeds", async () => {
+    getAgentToken.mockResolvedValueOnce("stale").mockResolvedValueOnce("fresh");
+    const fetchMock = fetchFn(async () => jsonResponse(201, { ok: true, def: { name: "a" } }));
+    fetchMock
+      .mockResolvedValueOnce(new Response("", { status: 401 }))
+      .mockResolvedValueOnce(jsonResponse(201, { ok: true, def: { name: "a" } }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await createAgentDef({
+      vault: "default",
+      name: "a",
+      backend: "programmatic",
+      systemPrompt: "",
+      metadata: { mode: "single-threaded" },
+    });
+
+    expect(clearCachedToken).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(new Headers(fetchMock.mock.calls[0]![1]?.headers).get("authorization")).toBe(
+      "Bearer stale",
+    );
+    expect(new Headers(fetchMock.mock.calls[1]![1]?.headers).get("authorization")).toBe(
+      "Bearer fresh",
+    );
+    expect(res.ok).toBe(true);
+  });
+
+  it("throws HttpError with the daemon error message on a 400", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse(400, { error: "no def-vaults configured" })),
+    );
+    await expect(
+      createAgentDef({
+        vault: "default",
+        name: "x",
+        backend: "programmatic",
+        systemPrompt: "",
+        metadata: { mode: "single-threaded" },
+      }),
+    ).rejects.toMatchObject({ name: "HttpError", status: 400, message: "no def-vaults configured" });
+  });
+});
+
+describe("connectSessionCommand", () => {
+  it("builds the `claude mcp add` one-liner mirroring the daemon snippet", () => {
+    // In vitest apiBase() is "/agent/api" → MOUNT "/agent". Origin from the arg.
+    expect(connectSessionCommand("eng", "https://my.parachute.computer")).toBe(
+      "claude mcp add --transport http --scope user eng https://my.parachute.computer/agent/mcp/eng",
+    );
   });
 });

--- a/web/ui/src/lib/api.test.ts
+++ b/web/ui/src/lib/api.test.ts
@@ -231,7 +231,7 @@ describe("connectSessionCommand", () => {
   it("builds the `claude mcp add` one-liner mirroring the daemon snippet", () => {
     // In vitest apiBase() is "/agent/api" → MOUNT "/agent". Origin from the arg.
     expect(connectSessionCommand("eng", "https://my.parachute.computer")).toBe(
-      "claude mcp add --transport http --scope user eng https://my.parachute.computer/agent/mcp/eng",
+      "claude mcp add --transport http --scope user agent-eng https://my.parachute.computer/agent/mcp/eng",
     );
   });
 });

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -73,18 +73,38 @@ async function authedFetch(path: string, init: RequestInit = {}): Promise<Respon
   return fetch(path, { ...init, headers: retryHeaders });
 }
 
+/** Pull the server `error` (or text) off a non-2xx response for an HttpError. */
+async function errorDetail(res: Response): Promise<string> {
+  try {
+    const body = (await res.json()) as { error?: string };
+    return body.error ?? "";
+  } catch {
+    return await res.text().catch(() => "");
+  }
+}
+
 /** GET a JSON endpoint with the Bearer, throwing HttpError on a non-2xx. */
 async function getJson<T>(suffix: string): Promise<T> {
   const res = await authedFetch(`${apiBase()}${suffix}`);
   if (!res.ok) {
-    let detail = "";
-    try {
-      const body = (await res.json()) as { error?: string };
-      detail = body.error ?? "";
-    } catch {
-      detail = await res.text().catch(() => "");
-    }
-    throw new HttpError(res.status, detail || `${suffix} failed: ${res.status}`);
+    throw new HttpError(res.status, (await errorDetail(res)) || `${suffix} failed: ${res.status}`);
+  }
+  return (await res.json()) as T;
+}
+
+/**
+ * POST a JSON body to an endpoint with the Bearer + the same single 401
+ * re-mint-and-retry as `getJson`, throwing HttpError on a non-2xx. Used by the
+ * Phase-3 create flow (the first write path the SPA carries).
+ */
+async function postJson<T>(suffix: string, body: unknown): Promise<T> {
+  const res = await authedFetch(`${apiBase()}${suffix}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new HttpError(res.status, (await errorDetail(res)) || `${suffix} failed: ${res.status}`);
   }
   return (await res.json()) as T;
 }
@@ -179,4 +199,61 @@ export function listAgentDefs(): Promise<AgentDefsResponse> {
 /** List the module's def-vaults (read-only display). */
 export function listAgentVaults(): Promise<AgentVaultsResponse> {
   return getJson<AgentVaultsResponse>("/agent-vaults");
+}
+
+// ---------------------------------------------------------------------------
+// Create flow (Agent UI v2 — Phase 3). `POST /api/agent-defs` writes a vault-
+// native `#agent/definition` note (body = system prompt, metadata = config) and
+// auto-instantiates the agent + its channel routing — so the create flow is JUST
+// this one call; there is NO separate channel-provisioning step.
+// ---------------------------------------------------------------------------
+
+/** Execution-lifecycle mode — the top-level branch. Rides in `metadata.mode`. */
+export type AgentMode = "single-threaded" | "multi-threaded";
+
+/** The backend selectable in the create flow. `interactive` is RETIRED — not offered. */
+export type CreatableBackend = "programmatic" | "channel";
+
+/**
+ * The `POST /api/agent-defs` request body. Mirrors the daemon handler at
+ * `src/daemon.ts` ~2755-2789. The MODE is NOT a top-level field — it rides in
+ * `metadata.mode`; `metadata` is an object of strings (the daemon coerces).
+ * `wants` is a comma-separated string (the daemon's `wants:` shape), optional.
+ */
+export interface CreateAgentDefBody {
+  vault: string;
+  name: string;
+  backend: CreatableBackend;
+  systemPrompt: string;
+  wants?: string;
+  metadata: Record<string, string>;
+}
+
+/** `POST /api/agent-defs` 201 response — the created def in the detail shape. */
+export interface CreateAgentDefResponse {
+  ok: boolean;
+  def: AgentDefRow;
+}
+
+/**
+ * Create a vault-native agent definition. Auto-instantiates the agent + (for a
+ * channel backend) its channel inbound routing — one call, no separate channel
+ * POST. Throws `HttpError` on a non-2xx (e.g. 400 "no def-vaults configured",
+ * 409 name collision) so the form surfaces the daemon's message inline.
+ */
+export function createAgentDef(body: CreateAgentDefBody): Promise<CreateAgentDefResponse> {
+  return postJson<CreateAgentDefResponse>("/agent-defs", body);
+}
+
+/**
+ * The `claude mcp add` one-liner a channel-backend agent's operator runs to
+ * connect their own Claude Code session to the channel's MCP endpoint. Mirrors
+ * the daemon's server-rendered snippet (`src/daemon.ts:1194-1196`): the channel
+ * MCP mounts at `<origin><MOUNT>/mcp/<name>`, where MOUNT is the agent module's
+ * proxy prefix (`/agent` over the hub expose, derived from the API base by
+ * dropping the trailing `/api`). The agent name IS its channel.
+ */
+export function connectSessionCommand(name: string, origin: string): string {
+  const mount = apiBase().replace(/\/api$/, "");
+  return `claude mcp add --transport http --scope user ${name} ${origin}${mount}/mcp/${name}`;
 }

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -255,5 +255,9 @@ export function createAgentDef(body: CreateAgentDefBody): Promise<CreateAgentDef
  */
 export function connectSessionCommand(name: string, origin: string): string {
   const mount = apiBase().replace(/\/api$/, "");
-  return `claude mcp add --transport http --scope user ${name} ${origin}${mount}/mcp/${name}`;
+  // Server-name is `agent-<name>` to match the chat UI's connect snippet
+  // (src/daemon.ts ~1194: `var name = "agent-" + ch`), so an operator who connects
+  // the same channel from either surface registers ONE consistently-named MCP server.
+  // The URL path is the bare channel name (`/mcp/<name>`).
+  return `claude mcp add --transport http --scope user agent-${name} ${origin}${mount}/mcp/${name}`;
 }

--- a/web/ui/src/routes/Agents.tsx
+++ b/web/ui/src/routes/Agents.tsx
@@ -22,6 +22,7 @@
  * operator the full picture.
  */
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
 import {
   type AgentDefRow,
   type AgentRow,
@@ -178,8 +179,13 @@ export function Agents() {
           <section className="card" aria-label="Agents">
             <div className="section-head">
               <h2>All agents</h2>
-              <span className="count" data-testid="agents-count">
-                {merged.length} {merged.length === 1 ? "agent" : "agents"}
+              <span className="section-head-actions">
+                <span className="count" data-testid="agents-count">
+                  {merged.length} {merged.length === 1 ? "agent" : "agents"}
+                </span>
+                <Link to="/create" className="button-link" data-testid="new-agent-link">
+                  New agent
+                </Link>
               </span>
             </div>
             {merged.length === 0 ? (

--- a/web/ui/src/routes/CreateAgent.test.tsx
+++ b/web/ui/src/routes/CreateAgent.test.tsx
@@ -175,7 +175,7 @@ describe("CreateAgent form", () => {
 
     const connect = await screen.findByTestId("connect-session");
     const command = within(connect).getByTestId("connect-command").textContent ?? "";
-    expect(command).toMatch(/^claude mcp add --transport http --scope user eng /);
+    expect(command).toMatch(/^claude mcp add --transport http --scope user agent-eng /);
     expect(command).toContain("/mcp/eng");
     // The body was sent with backend:channel.
     expect(createAgentDef.mock.calls[0]![0].backend).toBe("channel");

--- a/web/ui/src/routes/CreateAgent.test.tsx
+++ b/web/ui/src/routes/CreateAgent.test.tsx
@@ -13,7 +13,7 @@ import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import * as api from "../lib/api.ts";
-import { CreateAgent } from "./CreateAgent.tsx";
+import { CreateAgent, CreateAgentRoute } from "./CreateAgent.tsx";
 
 vi.mock("../lib/api.ts", async (orig) => {
   const actual = (await orig()) as typeof api;
@@ -158,12 +158,15 @@ describe("CreateAgent form", () => {
     expect(within(success).getByRole("link", { name: /back to agents/i })).toBeInTheDocument();
   });
 
-  it("does NOT show the connect one-liner for a programmatic agent", async () => {
+  it("does NOT show the connect one-liner for a programmatic agent, and echoes the chosen mode", async () => {
     renderForm();
     fireEvent.change(screen.getByLabelText("Name"), { target: { value: "prog" } });
     fireEvent.click(screen.getByRole("button", { name: /create agent/i }));
-    await screen.findByTestId("create-success");
+    const success = await screen.findByTestId("create-success");
     expect(screen.queryByTestId("connect-session")).not.toBeInTheDocument();
+    // The success banner confirms the full selection (name · mode · backend) — mode
+    // comes from the form (the def-detail response doesn't echo it). Default = single-threaded.
+    expect(success).toHaveTextContent(/single-threaded/);
   });
 
   it("shows the `claude mcp add` one-liner on a backend:channel success", async () => {
@@ -193,5 +196,29 @@ describe("CreateAgent form", () => {
     renderForm([]);
     expect(screen.getByTestId("no-def-vaults")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /create agent/i })).toBeDisabled();
+  });
+});
+
+describe("CreateAgentRoute (container)", () => {
+  const listAgentVaults = vi.mocked(api.listAgentVaults);
+
+  it("surfaces the sign-in message when the def-vault load 401s", async () => {
+    listAgentVaults.mockRejectedValue(new api.HttpError(401, "unauthorized"));
+    render(
+      <MemoryRouter>
+        <CreateAgentRoute />
+      </MemoryRouter>,
+    );
+    expect(await screen.findByText(/sign in to the portal/i)).toBeInTheDocument();
+  });
+
+  it("renders the form once the def-vaults resolve", async () => {
+    listAgentVaults.mockResolvedValue({ vaults: [vaultRow()] });
+    render(
+      <MemoryRouter>
+        <CreateAgentRoute />
+      </MemoryRouter>,
+    );
+    expect(await screen.findByLabelText("Name")).toBeInTheDocument();
   });
 });

--- a/web/ui/src/routes/CreateAgent.test.tsx
+++ b/web/ui/src/routes/CreateAgent.test.tsx
@@ -1,0 +1,197 @@
+/**
+ * CreateAgent route tests (Agent UI v2, Phase 3) — the unified create flow.
+ *
+ * Covers: the form renders; submit calls `createAgentDef` with the correct body
+ * INCLUDING `metadata.mode`; mode defaults to single-threaded; backend defaults
+ * to programmatic; `interactive` is NEVER offered as a backend; the
+ * backend:channel success state shows the `claude mcp add` one-liner; and the
+ * no-def-vaults case surfaces the requirement. The api module is mocked per the
+ * existing pattern (`Agents.test.tsx`).
+ */
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as api from "../lib/api.ts";
+import { CreateAgent } from "./CreateAgent.tsx";
+
+vi.mock("../lib/api.ts", async (orig) => {
+  const actual = (await orig()) as typeof api;
+  return {
+    ...actual,
+    createAgentDef: vi.fn(),
+    listAgentVaults: vi.fn(),
+  };
+});
+
+const createAgentDef = vi.mocked(api.createAgentDef);
+
+function vaultRow(over: Partial<api.AgentVaultRow> = {}): api.AgentVaultRow {
+  return { vault: "default", url: "http://127.0.0.1:1940", tokenPresent: true, ...over };
+}
+
+function defResponse(over: Partial<api.AgentDefRow> = {}): api.CreateAgentDefResponse {
+  return {
+    ok: true,
+    def: {
+      noteId: "note-1",
+      name: "my-agent",
+      backend: "programmatic",
+      vault: "default",
+      status: "enabled",
+      pending: [],
+      systemPromptPreview: "",
+      wants: [],
+      channel: "my-agent",
+      ...over,
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  createAgentDef.mockResolvedValue(defResponse());
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function renderForm(vaults: api.AgentVaultRow[] = [vaultRow()]) {
+  return render(
+    <MemoryRouter>
+      <CreateAgent vaults={vaults} />
+    </MemoryRouter>,
+  );
+}
+
+describe("CreateAgent form", () => {
+  it("renders the name field, mode, backend, and a submit button", () => {
+    renderForm();
+    expect(screen.getByLabelText("Name")).toBeInTheDocument();
+    expect(screen.getByTestId("mode-single-threaded")).toBeInTheDocument();
+    expect(screen.getByTestId("mode-multi-threaded")).toBeInTheDocument();
+    expect(screen.getByTestId("backend-programmatic")).toBeInTheDocument();
+    expect(screen.getByTestId("backend-channel")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /create agent/i })).toBeInTheDocument();
+  });
+
+  it("defaults mode to single-threaded and backend to programmatic", () => {
+    renderForm();
+    const single = within(screen.getByTestId("mode-single-threaded")).getByRole("radio");
+    const prog = within(screen.getByTestId("backend-programmatic")).getByRole("radio");
+    expect(single).toBeChecked();
+    expect(prog).toBeChecked();
+  });
+
+  it("NEVER offers `interactive` as a backend", () => {
+    renderForm();
+    expect(screen.queryByTestId("backend-interactive")).not.toBeInTheDocument();
+    expect(screen.queryByText(/interactive/i)).not.toBeInTheDocument();
+    // Only the two documented radios exist.
+    const radios = screen.getAllByRole("radio");
+    const backendValues = radios
+      .map((r) => (r as HTMLInputElement).value)
+      .filter((v) => v === "programmatic" || v === "channel" || v === "interactive");
+    expect(backendValues).toEqual(["programmatic", "channel"]);
+  });
+
+  it("submits createAgentDef with the correct body including metadata.mode", async () => {
+    renderForm();
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "my-agent" } });
+    fireEvent.change(screen.getByLabelText("System prompt"), {
+      target: { value: "You are a helpful agent." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /create agent/i }));
+
+    await waitFor(() => expect(createAgentDef).toHaveBeenCalledTimes(1));
+    expect(createAgentDef).toHaveBeenCalledWith({
+      vault: "default",
+      name: "my-agent",
+      backend: "programmatic",
+      systemPrompt: "You are a helpful agent.",
+      metadata: { mode: "single-threaded" },
+    });
+  });
+
+  it("carries the chosen mode into metadata.mode (multi-threaded)", async () => {
+    renderForm();
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "batch" } });
+    fireEvent.click(within(screen.getByTestId("mode-multi-threaded")).getByRole("radio"));
+    fireEvent.click(screen.getByRole("button", { name: /create agent/i }));
+
+    await waitFor(() => expect(createAgentDef).toHaveBeenCalledTimes(1));
+    expect(createAgentDef.mock.calls[0]![0].metadata).toEqual({ mode: "multi-threaded" });
+  });
+
+  it("includes `wants` only when entered", async () => {
+    renderForm();
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "wanty" } });
+    fireEvent.change(screen.getByLabelText(/wants/i), {
+      target: { value: "vault:other, service:github" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /create agent/i }));
+
+    await waitFor(() => expect(createAgentDef).toHaveBeenCalledTimes(1));
+    expect(createAgentDef.mock.calls[0]![0].wants).toBe("vault:other, service:github");
+  });
+
+  it("blocks submit until the name is a valid slug", async () => {
+    renderForm();
+    const submit = screen.getByRole("button", { name: /create agent/i });
+    expect(submit).toBeDisabled(); // empty name
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "bad name!" } });
+    expect(screen.getByTestId("name-invalid")).toBeInTheDocument();
+    expect(submit).toBeDisabled();
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "good-name" } });
+    expect(submit).toBeEnabled();
+  });
+
+  it("shows a success state with name + backend and a link back to agents", async () => {
+    renderForm();
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "my-agent" } });
+    fireEvent.click(screen.getByRole("button", { name: /create agent/i }));
+
+    const success = await screen.findByTestId("create-success");
+    expect(within(success).getByText("my-agent")).toBeInTheDocument();
+    expect(within(success).getByText(/programmatic/)).toBeInTheDocument();
+    expect(within(success).getByRole("link", { name: /back to agents/i })).toBeInTheDocument();
+  });
+
+  it("does NOT show the connect one-liner for a programmatic agent", async () => {
+    renderForm();
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "prog" } });
+    fireEvent.click(screen.getByRole("button", { name: /create agent/i }));
+    await screen.findByTestId("create-success");
+    expect(screen.queryByTestId("connect-session")).not.toBeInTheDocument();
+  });
+
+  it("shows the `claude mcp add` one-liner on a backend:channel success", async () => {
+    createAgentDef.mockResolvedValue(defResponse({ name: "eng", backend: "channel", channel: "eng" }));
+    renderForm();
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "eng" } });
+    fireEvent.click(within(screen.getByTestId("backend-channel")).getByRole("radio"));
+    fireEvent.click(screen.getByRole("button", { name: /create agent/i }));
+
+    const connect = await screen.findByTestId("connect-session");
+    const command = within(connect).getByTestId("connect-command").textContent ?? "";
+    expect(command).toMatch(/^claude mcp add --transport http --scope user eng /);
+    expect(command).toContain("/mcp/eng");
+    // The body was sent with backend:channel.
+    expect(createAgentDef.mock.calls[0]![0].backend).toBe("channel");
+  });
+
+  it("surfaces a daemon 400 error inline", async () => {
+    createAgentDef.mockRejectedValue(new api.HttpError(400, "no def-vaults configured"));
+    renderForm();
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "x" } });
+    fireEvent.click(screen.getByRole("button", { name: /create agent/i }));
+    expect(await screen.findByTestId("create-error")).toHaveTextContent(/no def-vaults configured/i);
+  });
+
+  it("surfaces the def-vault requirement when none are configured and disables submit", () => {
+    renderForm([]);
+    expect(screen.getByTestId("no-def-vaults")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /create agent/i })).toBeDisabled();
+  });
+});

--- a/web/ui/src/routes/CreateAgent.tsx
+++ b/web/ui/src/routes/CreateAgent.tsx
@@ -33,7 +33,11 @@ import {
   listAgentVaults,
 } from "../lib/api.ts";
 
-/** The name field must be a slug (the daemon enforces the same `NAME_SLUG_RE`). */
+/**
+ * The name field must be a slug. Mirrors the daemon's canonical `NAME_SLUG_RE`
+ * (`src/agent-defs.ts`) byte-for-byte — keep in sync: a drift here would accept a
+ * name the daemon then 400s at submit (surfaced only after the round-trip).
+ */
 const NAME_SLUG_RE = /^[a-zA-Z0-9_-]+$/;
 
 interface CreateAgentProps {
@@ -45,7 +49,9 @@ type SubmitState =
   | { kind: "idle" }
   | { kind: "submitting" }
   | { kind: "error"; message: string }
-  | { kind: "ok"; result: CreateAgentDefResponse };
+  // Carry the chosen `mode` through: the def-detail response doesn't echo it, so the
+  // success banner re-uses the form's value to confirm what the operator selected.
+  | { kind: "ok"; result: CreateAgentDefResponse; mode: AgentMode };
 
 export function CreateAgent({ vaults }: CreateAgentProps) {
   const hasVaults = vaults.length > 0;
@@ -78,7 +84,7 @@ export function CreateAgent({ vaults }: CreateAgentProps) {
         // Only send `wants` when the operator entered something.
         ...(wants.trim().length > 0 ? { wants: wants.trim() } : {}),
       });
-      setSubmit({ kind: "ok", result });
+      setSubmit({ kind: "ok", result, mode });
     } catch (err) {
       const message =
         err instanceof HttpError
@@ -91,7 +97,7 @@ export function CreateAgent({ vaults }: CreateAgentProps) {
   }
 
   if (submit.kind === "ok") {
-    return <CreateSuccess result={submit.result} />;
+    return <CreateSuccess result={submit.result} mode={submit.mode} />;
   }
 
   return (
@@ -344,16 +350,15 @@ function RadioRow(props: {
  * to the Agents list, and — for a channel backend — surfaces the connect-your-
  * session one-liner + a copy button.
  */
-export function CreateSuccess({ result }: { result: CreateAgentDefResponse }) {
+export function CreateSuccess({ result, mode }: { result: CreateAgentDefResponse; mode: AgentMode }) {
   const def = result.def;
-  // The mode isn't echoed in the def detail shape, so re-derive it from the form
-  // is unnecessary; the def's name/backend carry the confirmation. We surface the
-  // backend (the def carries it) + the connect affordance keyed off it.
+  // `mode` comes from the form state (the def-detail response doesn't echo it) so the
+  // banner confirms the full selection: name · mode · backend.
   return (
     <div data-testid="create-success">
       <h1>Agent created</h1>
       <div className="success-banner" role="status">
-        <strong>{def.name}</strong> · {def.backend}
+        <strong>{def.name}</strong> · {mode} · {def.backend}
       </div>
 
       <p className="lede">

--- a/web/ui/src/routes/CreateAgent.tsx
+++ b/web/ui/src/routes/CreateAgent.tsx
@@ -1,0 +1,411 @@
+/**
+ * `/create` — the unified create-agent flow (Agent UI v2, Phase 3).
+ *
+ * One form that collapses the old create-agent page + the standalone
+ * Config/manage-channels page into a single flow: a `#agent/definition` note IS
+ * the agent (body = system prompt, metadata = config), and writing it
+ * auto-instantiates the agent AND its channel inbound routing — so creating is
+ * JUST `POST /api/agent-defs`; there is NO separate channel-provisioning step
+ * (`agent-defs.ts` uses `addChannelLive` under the hood).
+ *
+ * The two primary axes the v2 design surfaces:
+ *   - MODE (top-level branch) — single-threaded (default) vs multi-threaded.
+ *     Rides in `metadata.mode`, NOT a top-level body field.
+ *   - BACKEND — programmatic (default; daemon runs it headless) vs channel (you
+ *     run a Claude Code session on your own machine and connect it). The retired
+ *     `interactive` backend is NOT offered.
+ *
+ * For a channel-backend agent the success state shows the "connect your Claude
+ * Code session" affordance: the `claude mcp add` one-liner (computed from
+ * `window.location.origin`, mirroring `src/daemon.ts:1194-1196`) with a copy
+ * button. The def-vault add/remove editor + edit/delete of a def are Phase 4.
+ */
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import {
+  type AgentMode,
+  type AgentVaultRow,
+  type CreatableBackend,
+  type CreateAgentDefResponse,
+  connectSessionCommand,
+  createAgentDef,
+  HttpError,
+  listAgentVaults,
+} from "../lib/api.ts";
+
+/** The name field must be a slug (the daemon enforces the same `NAME_SLUG_RE`). */
+const NAME_SLUG_RE = /^[a-zA-Z0-9_-]+$/;
+
+interface CreateAgentProps {
+  /** The configured def-vaults (from `listAgentVaults`). Empty = none configured. */
+  vaults: AgentVaultRow[];
+}
+
+type SubmitState =
+  | { kind: "idle" }
+  | { kind: "submitting" }
+  | { kind: "error"; message: string }
+  | { kind: "ok"; result: CreateAgentDefResponse };
+
+export function CreateAgent({ vaults }: CreateAgentProps) {
+  const hasVaults = vaults.length > 0;
+
+  const [name, setName] = useState("");
+  const [vault, setVault] = useState(vaults[0]?.vault ?? "");
+  const [mode, setMode] = useState<AgentMode>("single-threaded");
+  const [backend, setBackend] = useState<CreatableBackend>("programmatic");
+  const [systemPrompt, setSystemPrompt] = useState("");
+  const [wants, setWants] = useState("");
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [submit, setSubmit] = useState<SubmitState>({ kind: "idle" });
+
+  const nameValid = NAME_SLUG_RE.test(name);
+  const canSubmit =
+    hasVaults && nameValid && vault.length > 0 && submit.kind !== "submitting";
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!canSubmit) return;
+    setSubmit({ kind: "submitting" });
+    try {
+      const result = await createAgentDef({
+        vault,
+        name,
+        backend,
+        systemPrompt,
+        // `mode` is NOT a top-level field — it rides in metadata.
+        metadata: { mode },
+        // Only send `wants` when the operator entered something.
+        ...(wants.trim().length > 0 ? { wants: wants.trim() } : {}),
+      });
+      setSubmit({ kind: "ok", result });
+    } catch (err) {
+      const message =
+        err instanceof HttpError
+          ? err.status === 401
+            ? "Not signed in to the hub — sign in to the portal, then reload."
+            : err.message
+          : (err as Error).message;
+      setSubmit({ kind: "error", message });
+    }
+  }
+
+  if (submit.kind === "ok") {
+    return <CreateSuccess result={submit.result} />;
+  }
+
+  return (
+    <div>
+      <h1>New agent</h1>
+      <p className="lede">
+        A <code>#agent/definition</code> note IS the agent — writing it instantiates the
+        agent and its channel routing in one step. The def-vault editor, schedules, and
+        editing land in a later phase.
+      </p>
+
+      {!hasVaults ? (
+        <div className="error-banner" role="alert" data-testid="no-def-vaults">
+          No def-vault is configured, and one is required to create an agent. The add /
+          remove def-vault editor arrives in a later phase; until then, configure a
+          def-vault out-of-band. Submitting anyway will return the daemon's{" "}
+          <code>no def-vaults configured</code> error.
+        </div>
+      ) : null}
+
+      {submit.kind === "error" ? (
+        <div className="error-banner" role="alert" data-testid="create-error">
+          {submit.message}
+        </div>
+      ) : null}
+
+      <form className="card" onSubmit={onSubmit} aria-label="Create agent">
+        {/* Name — the slug; the agent name == its channel. */}
+        <div className="field">
+          <label htmlFor="agent-name">Name</label>
+          <input
+            id="agent-name"
+            type="text"
+            value={name}
+            placeholder="my-agent"
+            autoComplete="off"
+            onChange={(e) => setName(e.target.value)}
+          />
+          <p className="field-hint">
+            A slug (letters, numbers, dash, underscore). This is also the agent's channel.
+          </p>
+          {name.length > 0 && !nameValid ? (
+            <p className="field-error" data-testid="name-invalid">
+              Must be a slug — letters, numbers, dash, underscore only.
+            </p>
+          ) : null}
+        </div>
+
+        {/* Def-vault — the vault the def note is written to. */}
+        <div className="field">
+          <label htmlFor="agent-vault">Def-vault</label>
+          <select
+            id="agent-vault"
+            value={vault}
+            disabled={!hasVaults}
+            onChange={(e) => setVault(e.target.value)}
+          >
+            {hasVaults ? (
+              vaults.map((v) => (
+                <option key={v.vault} value={v.vault}>
+                  {v.vault}
+                  {v.tokenPresent ? "" : " (token missing)"}
+                </option>
+              ))
+            ) : (
+              <option value="">No def-vaults configured</option>
+            )}
+          </select>
+          <p className="field-hint">The vault this agent's definition note is written to.</p>
+        </div>
+
+        {/* Mode — the top-level execution-lifecycle branch. → metadata.mode */}
+        <fieldset className="field">
+          <legend>Mode</legend>
+          <RadioRow
+            name="mode"
+            value="single-threaded"
+            checked={mode === "single-threaded"}
+            onChange={() => setMode("single-threaded")}
+            label="Single-threaded"
+            help="One continuous conversation — remembers everything on this channel."
+            testid="mode-single-threaded"
+          />
+          <RadioRow
+            name="mode"
+            value="multi-threaded"
+            checked={mode === "multi-threaded"}
+            onChange={() => setMode("multi-threaded")}
+            label="Multi-threaded"
+            help="Each run is its own thread; today every run starts fresh (per-conversation continuation is coming) — good for scheduled or stateless tasks."
+            testid="mode-multi-threaded"
+          />
+        </fieldset>
+
+        {/* Backend — programmatic (default) vs channel. interactive is RETIRED. */}
+        <fieldset className="field">
+          <legend>Backend</legend>
+          <RadioRow
+            name="backend"
+            value="programmatic"
+            checked={backend === "programmatic"}
+            onChange={() => setBackend("programmatic")}
+            label="Programmatic"
+            help="Parachute runs it headless — always on, sandboxed."
+            testid="backend-programmatic"
+          />
+          <RadioRow
+            name="backend"
+            value="channel"
+            checked={backend === "channel"}
+            onChange={() => setBackend("channel")}
+            label="Channel"
+            help="You run a Claude Code session on your own machine and connect it — your env, unsandboxed."
+            testid="backend-channel"
+          />
+        </fieldset>
+
+        {/* System prompt → body.systemPrompt */}
+        <div className="field">
+          <label htmlFor="agent-prompt">System prompt</label>
+          <textarea
+            id="agent-prompt"
+            rows={6}
+            value={systemPrompt}
+            placeholder="You are…"
+            onChange={(e) => setSystemPrompt(e.target.value)}
+          />
+          <p className="field-hint">
+            The agent's persona + instructions (the note body). Leave blank for Claude
+            Code's default.
+          </p>
+        </div>
+
+        {/* Advanced (collapsed) — wants. */}
+        <details
+          className="advanced"
+          open={advancedOpen}
+          onToggle={(e) => setAdvancedOpen((e.target as HTMLDetailsElement).open)}
+        >
+          <summary>Advanced</summary>
+          <div className="field">
+            <label htmlFor="agent-wants">Wants (connections)</label>
+            <input
+              id="agent-wants"
+              type="text"
+              value={wants}
+              placeholder="vault:other, service:github"
+              autoComplete="off"
+              onChange={(e) => setWants(e.target.value)}
+            />
+            <p className="field-hint">
+              Comma-separated connection keys the agent requests beyond its own vault. Each
+              needs approval before it's granted.
+            </p>
+          </div>
+        </details>
+
+        <div className="form-actions">
+          <button type="submit" disabled={!canSubmit}>
+            {submit.kind === "submitting" ? "Creating…" : "Create agent"}
+          </button>
+          <Link to="/" className="cancel-link">
+            Cancel
+          </Link>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+/**
+ * The `/create` route container: loads the def-vault list, then renders the
+ * prop-driven {@link CreateAgent} form. Splitting the fetch from the form keeps
+ * the form unit-testable without mocking the network. `CreateAgent` is remounted
+ * (via `key`) once the vaults resolve so its default vault picks up the first.
+ */
+export function CreateAgentRoute() {
+  type LoadState =
+    | { kind: "loading" }
+    | { kind: "error"; message: string }
+    | { kind: "ok"; vaults: AgentVaultRow[] };
+  const [state, setState] = useState<LoadState>({ kind: "loading" });
+
+  const load = useCallback(async () => {
+    setState({ kind: "loading" });
+    try {
+      const res = await listAgentVaults();
+      setState({ kind: "ok", vaults: res.vaults });
+    } catch (err) {
+      const message =
+        err instanceof HttpError
+          ? err.status === 401
+            ? "Not signed in to the hub — sign in to the portal, then reload."
+            : `Failed to load def-vaults: ${err.message}`
+          : `Failed to load def-vaults: ${(err as Error).message}`;
+      setState({ kind: "error", message });
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  if (state.kind === "loading") {
+    return <div className="loading">Loading…</div>;
+  }
+  if (state.kind === "error") {
+    return (
+      <div className="error-banner" role="alert">
+        {state.message}{" "}
+        <button type="button" className="secondary" onClick={() => void load()}>
+          Retry
+        </button>
+      </div>
+    );
+  }
+  // Remount on the resolved vault set so the form's default vault is the first.
+  return <CreateAgent key={state.vaults.map((v) => v.vault).join(",")} vaults={state.vaults} />;
+}
+
+/** A labelled radio with a help line — the mode / backend rows. */
+function RadioRow(props: {
+  name: string;
+  value: string;
+  checked: boolean;
+  onChange: () => void;
+  label: string;
+  help: string;
+  testid: string;
+}) {
+  return (
+    <label className={`radio-row${props.checked ? " selected" : ""}`} data-testid={props.testid}>
+      <input
+        type="radio"
+        name={props.name}
+        value={props.value}
+        checked={props.checked}
+        onChange={props.onChange}
+      />
+      <span className="radio-body">
+        <span className="radio-label">{props.label}</span>
+        <span className="radio-help">{props.help}</span>
+      </span>
+    </label>
+  );
+}
+
+/**
+ * Success state: confirms the created agent (name · mode · backend), links back
+ * to the Agents list, and — for a channel backend — surfaces the connect-your-
+ * session one-liner + a copy button.
+ */
+export function CreateSuccess({ result }: { result: CreateAgentDefResponse }) {
+  const def = result.def;
+  // The mode isn't echoed in the def detail shape, so re-derive it from the form
+  // is unnecessary; the def's name/backend carry the confirmation. We surface the
+  // backend (the def carries it) + the connect affordance keyed off it.
+  return (
+    <div data-testid="create-success">
+      <h1>Agent created</h1>
+      <div className="success-banner" role="status">
+        <strong>{def.name}</strong> · {def.backend}
+      </div>
+
+      <p className="lede">
+        The definition was written to <code>{def.vault}</code> and instantiated. It now
+        appears in the <Link to="/">Agents list</Link>.
+      </p>
+
+      {def.backend === "channel" ? <ConnectSession name={def.name} /> : null}
+
+      <p>
+        <Link to="/">← Back to agents</Link>
+      </p>
+    </div>
+  );
+}
+
+/** The channel-backend "connect your Claude Code session" affordance. */
+export function ConnectSession({ name }: { name: string }) {
+  const [copied, setCopied] = useState(false);
+  const origin = typeof window !== "undefined" ? window.location.origin : "";
+  const command = useMemo(() => connectSessionCommand(name, origin), [name, origin]);
+
+  async function copy() {
+    try {
+      await navigator.clipboard?.writeText(command);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard unavailable (insecure context / denied) — the text is still
+      // selectable; leave the button label unchanged.
+    }
+  }
+
+  return (
+    <section className="card" aria-label="Connect a session" data-testid="connect-session">
+      <h2>Connect your Claude Code session</h2>
+      <p className="muted">
+        Run this on your own machine to make a Claude Code session a responder for this
+        channel:
+      </p>
+      <div className="snippet-row">
+        <code className="snippet" data-testid="connect-command">
+          {command}
+        </code>
+        <button type="button" className="secondary" onClick={() => void copy()}>
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+      <p className="field-hint">
+        Your Claude Code session pulls messages from this channel; until you connect,
+        inbound messages queue durably in the vault.
+      </p>
+    </section>
+  );
+}

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -393,3 +393,169 @@ tr.agent-row.selected {
   padding: 0.05rem 0.35rem;
   color: var(--fg-muted);
 }
+
+/* ---- Section-head actions (e.g. the New-agent button on the list) ---- */
+.section-head-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.9rem;
+}
+
+/* A link styled as a button (react-router <Link>, so we can't use <button>). */
+.button-link {
+  display: inline-block;
+  background: var(--accent);
+  color: white;
+  border-radius: 6px;
+  padding: 0.4rem 0.85rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  transition: background 0.15s ease;
+}
+.button-link:hover {
+  background: var(--accent-hover);
+  color: white;
+  text-decoration: none;
+}
+
+/* ---- Create form ---- */
+.field {
+  display: block;
+  border: 0;
+  margin: 0 0 1.25rem;
+  padding: 0;
+}
+.field > label,
+.field > legend {
+  display: block;
+  font-weight: 500;
+  font-size: 0.9rem;
+  color: var(--fg);
+  margin-bottom: 0.35rem;
+  padding: 0;
+}
+.field input[type="text"],
+.field select,
+.field textarea {
+  width: 100%;
+  font: inherit;
+  font-size: 0.9rem;
+  color: var(--fg);
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.5rem 0.6rem;
+}
+.field textarea {
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  resize: vertical;
+}
+.field input[type="text"]:focus,
+.field select:focus,
+.field textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-soft);
+}
+.field-hint {
+  color: var(--fg-dim);
+  font-size: 0.8rem;
+  margin: 0.3rem 0 0;
+}
+.field-error {
+  color: var(--error);
+  font-size: 0.8rem;
+  margin: 0.3rem 0 0;
+}
+
+/* Radio rows (mode / backend) */
+.radio-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.65rem 0.8rem;
+  margin-bottom: 0.5rem;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+.radio-row:hover {
+  background: var(--bg-soft);
+}
+.radio-row.selected {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+.radio-row input[type="radio"] {
+  margin-top: 0.2rem;
+  accent-color: var(--accent);
+}
+.radio-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+.radio-label {
+  font-weight: 500;
+  font-size: 0.9rem;
+  color: var(--fg);
+}
+.radio-help {
+  font-size: 0.8rem;
+  color: var(--fg-muted);
+}
+
+.advanced {
+  margin: 0 0 1.25rem;
+}
+.advanced > summary {
+  cursor: pointer;
+  font-size: 0.88rem;
+  font-weight: 500;
+  color: var(--fg-muted);
+  margin-bottom: 0.75rem;
+}
+.advanced > summary:hover {
+  color: var(--fg);
+}
+
+.form-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+.cancel-link {
+  color: var(--fg-muted);
+  font-size: 0.9rem;
+}
+
+/* ---- Success state + connect snippet ---- */
+.success-banner {
+  background: var(--success-soft);
+  border: 1px solid var(--success);
+  color: var(--success);
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+  font-size: 0.95rem;
+}
+.snippet-row {
+  display: flex;
+  align-items: stretch;
+  gap: 0.6rem;
+  margin: 0.5rem 0;
+}
+.snippet {
+  flex: 1;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  background: var(--bg-soft);
+  border: 1px solid var(--border-light);
+  border-radius: 6px;
+  padding: 0.6rem 0.75rem;
+  color: var(--fg);
+  white-space: pre-wrap;
+  word-break: break-all;
+}


### PR DESCRIPTION
## Agent UI v2 — Phase 3: the unified create-agent flow

Adds the **create** flow to the SPA (Phase 2 shipped the read-only Agents view at `/agent/app/`). One form that collapses the old create-agent page + the standalone Config/manage-channels page: a `#agent/definition` note **is** the agent, and writing it auto-instantiates the agent **and** its channel inbound routing (`agent-defs.ts` → `addChannelLive`), so creating is **just `POST /api/agent-defs`** — no separate channel-provisioning step.

### What it surfaces
- **Mode** as the top-level branch — **single-threaded** (default; "one continuous conversation, remembers everything") vs **multi-threaded** ("each run is its own thread; today every run starts fresh — good for scheduled/stateless tasks"). Rides in `metadata.mode` (verified the daemon's `buildDefMetadata` → `parseAgentDef` consume it).
- **Backend** axis — **programmatic** (default, headless/sandboxed) vs **channel** (you run a Claude Code session and connect it). **`interactive` is not offered** (retired).
- **Channel-connect UX** — for `backend:channel`, the success state shows the `claude mcp add --transport http --scope user agent-<name> <hub>/agent/mcp/<name>` one-liner (server-name `agent-<name>` to match the existing chat-UI snippet) + a copy button + "messages queue durably until you connect."
- System prompt (note body), optional `wants` (advanced), slug validation, def-vault picker, no-def-vaults guidance, inline daemon-400 surfacing.

### Not in scope (Phase 4)
The def-vault add/remove editor, edit/delete of a def, schedules folding, and retiring the server-rendered HTML pages.

### Review + gates
- Independent reviewer (LGTM-with-nits) — all nits folded: success banner now echoes the chosen mode; slug-regex cites its canonical daemon source; added `CreateAgentRoute` container tests (vault-load 401 → sign-in message). Confirmed the create body shape, `interactive` absence, and the connect-one-liner alignment against the real daemon.
- `cd web/ui && bunx vitest run` = **50 pass / 0 fail**; `bun run build` clean; root `bun run typecheck` clean except the 2 pre-existing `bridge.ts` TS2589.

Commits: `df33420` (build) · `eeff949` (connect server-name alignment) · `f2018a5` (review nits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
