### PR TITLE
fix(gate): green the typecheck gate + wire it into the test scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "daemon": "bun src/daemon.ts",
     "bridge": "bun src/bridge.ts",
     "spawn-agent": "bun scripts/spawn-agent.ts",
-    "test": "bun test ./src/",
+    "test": "bun run typecheck && bun test ./src/",
     "test:spa": "cd web/ui && bun run test",
-    "test:all": "bun test ./src/ && cd web/ui && bun run test",
+    "test:all": "bun run test && bun run test:spa",
     "test:e2e": "bun e2e/llm/run.ts",
     "typecheck": "tsc --noEmit"
   },

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -76,17 +76,31 @@ const mcp = new Server(
 // Permission relay — receive permission_request from CC, forward to daemon
 // ---------------------------------------------------------------------------
 
-mcp.setNotificationHandler(
-  z.object({
-    method: z.literal("notifications/claude/agent/permission_request"),
-    params: z.object({
-      request_id: z.string(),
-      tool_name: z.string(),
-      description: z.string(),
-      input_preview: z.string(),
-    }),
+// The permission-request notification. The Zod schema does the runtime validation;
+// the params shape is hand-typed below. WHY the cast: the MCP SDK's
+// `setNotificationHandler<T>` computes `SchemaOutput<T>` over the schema, which trips
+// TS2589 ("type instantiation is excessively deep") on this nested inline Zod object —
+// a known SDK/Zod inference limit, NOT a runtime problem (the schema validates fine and
+// bun runs it). Passing the schema as the SDK's loose first-arg constraint sidesteps the
+// deep inference; the handler reads `params` via the explicit `PermissionNotifParams`.
+const PermissionNotifSchema = z.object({
+  method: z.literal("notifications/claude/agent/permission_request"),
+  params: z.object({
+    request_id: z.string(),
+    tool_name: z.string(),
+    description: z.string(),
+    input_preview: z.string(),
   }),
-  async ({ params }) => {
+});
+// Derived from the schema so the two can't drift (plain z.infer of this shallow
+// schema is fine — the TS2589 depth blowup is in the SDK's SchemaOutput<T> on the
+// setNotificationHandler generic path, not in a basic type alias).
+type PermissionNotifParams = z.infer<typeof PermissionNotifSchema>["params"];
+
+mcp.setNotificationHandler(
+  PermissionNotifSchema as unknown as Parameters<typeof mcp.setNotificationHandler>[0],
+  async (notification) => {
+    const { params } = notification as { params: PermissionNotifParams };
     try {
       await fetch(`${DAEMON_URL}/api/permission`, {
         method: "POST",


### PR DESCRIPTION
First PR of the post-audit sequence — a tiny, standalone gate fix (the precondition for the rest).

**The typecheck gate was red.** `src/bridge.ts:79-80` carried 2 `TS2589` (excessive type-instantiation depth) errors — the MCP SDK's `setNotificationHandler<T>` computes `SchemaOutput<T>` over a nested inline Zod schema, a known SDK/Zod inference limit. Valid at runtime (bun runs it; the schema validates), but `tsc --noEmit` failed. They sat unnoticed because **typecheck wasn't wired into the test gate** (the audit flagged exactly this class).

### Changes
- **`bridge.ts`** — keep the Zod schema for runtime validation, but pass it as the SDK's loose first-arg constraint to skip the deep inference; the handler reads `params` via an explicit hand-typed `PermissionNotifParams`. `typecheck` now exits 0.
- **`package.json`** — `test` now runs `typecheck && bun test ./src/` (the default gate catches type errors); `test:all` = `test && test:spa` (typecheck + server + SPA).

### Gate (now green)
`bun run test:all` → typecheck **0 errors**, bun **988/0**, vitest **87/0**.

Part of the audit-driven sequence: this → interactive-backend retirement → error-handling hardening → Connector 1 → continuation increment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)