### PR TITLE
feat(ui): auto-provision def-reload connectors from the agent admin page

### DIFF
--- a/web/ui/src/lib/hub.test.ts
+++ b/web/ui/src/lib/hub.test.ts
@@ -1,0 +1,223 @@
+/**
+ * hub.ts unit tests — the cookie-authed def-reload connection provisioning.
+ *
+ * Each test stubs `window.location.origin` + `fetch` and asserts the wire shape
+ * (origin-rooted path, `credentials: "include"`, the connection bodies/ids) and
+ * the status/teardown/error logic. No real network.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  type ConnectionRow,
+  defReloadStatus,
+  ensureDefReloadConnections,
+  HubError,
+  listConnections,
+  teardownDefReloadConnections,
+} from "./hub.ts";
+
+beforeEach(() => {
+  vi.stubGlobal("window", {
+    location: { origin: "https://hub.example", pathname: "/agent/app/" },
+  } as unknown as Window & typeof globalThis);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+});
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/** A def-reload connection row (semantic match), parameterized by vault + event. */
+function reloadRow(id: string, vault: string, event: string): ConnectionRow {
+  return {
+    id,
+    source: { module: "vault", vault, event },
+    sink: { module: "agent", action: "definition.reload" },
+  };
+}
+
+describe("listConnections", () => {
+  it("GETs <origin>/admin/connections with credentials:include and returns the array", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse(200, { ok: true, connections: [reloadRow("x", "research", "note.created")] }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const conns = await listConnections();
+    expect(conns).toHaveLength(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://hub.example/admin/connections",
+      expect.objectContaining({ credentials: "include" }),
+    );
+  });
+
+  it("throws a HubError with a friendly 401 message", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("", { status: 401 })),
+    );
+    await expect(listConnections()).rejects.toMatchObject({
+      name: "HubError",
+      status: 401,
+    });
+  });
+
+  it("maps a 404 to the hub-proxied-URL hint", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("", { status: 404 })),
+    );
+    await expect(listConnections()).rejects.toThrow(/hub-proxied URL/);
+  });
+});
+
+describe("defReloadStatus", () => {
+  it("active only when BOTH create and edit connectors are present (matched by semantics)", () => {
+    const both = [
+      reloadRow("a", "research", "note.created"),
+      reloadRow("b", "research", "note.updated"),
+    ];
+    expect(defReloadStatus("research", both)).toEqual({ create: true, edit: true, active: true });
+
+    const onlyCreate = [reloadRow("a", "research", "note.created")];
+    expect(defReloadStatus("research", onlyCreate)).toEqual({
+      create: true,
+      edit: false,
+      active: false,
+    });
+
+    expect(defReloadStatus("research", [])).toEqual({
+      create: false,
+      edit: false,
+      active: false,
+    });
+  });
+
+  it("does not match a different vault or a non-reload sink", () => {
+    const other = [
+      reloadRow("a", "OTHER", "note.created"),
+      // right vault/event but a different sink action (e.g. message.deliver)
+      {
+        id: "c",
+        source: { module: "vault", vault: "research", event: "note.created" },
+        sink: { module: "agent", action: "message.deliver" },
+      } as ConnectionRow,
+    ];
+    expect(defReloadStatus("research", other).active).toBe(false);
+    expect(defReloadStatus("research", other).create).toBe(false);
+  });
+});
+
+describe("ensureDefReloadConnections", () => {
+  it("POSTs both connectors with the canonical ids, events, filter, and sink", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse(200, { ok: true }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await ensureDefReloadConnections("research");
+    expect(result).toEqual({ ok: true, failures: [] });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    const bodies = fetchMock.mock.calls.map((c) => JSON.parse((c[1] as RequestInit).body as string));
+    const create = bodies.find((b) => b.source.event === "note.created");
+    const edit = bodies.find((b) => b.source.event === "note.updated");
+
+    expect(create).toMatchObject({
+      id: "agentdefs-create-research",
+      requestedBy: "agent",
+      source: { module: "vault", vault: "research", filter: { tags: ["#agent/definition"] } },
+      sink: { module: "agent", action: "definition.reload" },
+    });
+    expect(edit).toMatchObject({ id: "agentdefs-edit-research", source: { event: "note.updated" } });
+
+    // POST, JSON content-type, cookie-authed.
+    for (const call of fetchMock.mock.calls) {
+      const init = call[1] as RequestInit;
+      expect(init.method).toBe("POST");
+      expect(init.credentials).toBe("include");
+    }
+  });
+
+  it("reports a partial failure without throwing when one connector fails", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(200, { ok: true }))
+      .mockResolvedValueOnce(jsonResponse(400, { error: "invalid_source" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await ensureDefReloadConnections("research");
+    expect(result.ok).toBe(false);
+    expect(result.failures).toHaveLength(1);
+  });
+
+  it("throws when BOTH connectors fail (the no-session / wrong-origin case)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("", { status: 401 })),
+    );
+    await expect(ensureDefReloadConnections("research")).rejects.toMatchObject({
+      name: "HubError",
+      status: 401,
+    });
+  });
+});
+
+describe("teardownDefReloadConnections", () => {
+  it("DELETEs the canonical ids AND any semantically-matching connection id", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse(200, { ok: true }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    // A pair wired via the hub builder carries hub-derived ids, not ours.
+    const existing = [
+      reloadRow("conn_hubmade_create", "research", "note.created"),
+      reloadRow("conn_hubmade_edit", "research", "note.updated"),
+    ];
+    await teardownDefReloadConnections("research", existing);
+
+    const deletedIds = fetchMock.mock.calls.map((c) =>
+      decodeURIComponent((c[0] as string).replace("https://hub.example/admin/connections/", "")),
+    );
+    // canonical ids + the two hub-made ids (deduped)
+    expect(new Set(deletedIds)).toEqual(
+      new Set([
+        "agentdefs-create-research",
+        "agentdefs-edit-research",
+        "conn_hubmade_create",
+        "conn_hubmade_edit",
+      ]),
+    );
+    for (const call of fetchMock.mock.calls) {
+      expect((call[1] as RequestInit).method).toBe("DELETE");
+    }
+  });
+
+  it("ignores a 404 (already gone) but throws on a real failure", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("", { status: 404 })),
+    );
+    await expect(teardownDefReloadConnections("research")).resolves.toBeUndefined();
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("", { status: 403 })),
+    );
+    await expect(teardownDefReloadConnections("research")).rejects.toMatchObject({
+      name: "HubError",
+      status: 403,
+    });
+  });
+});
+
+describe("HubError", () => {
+  it("carries the status", () => {
+    const e = new HubError(418, "teapot");
+    expect(e.status).toBe(418);
+    expect(e.name).toBe("HubError");
+  });
+});

--- a/web/ui/src/lib/hub.test.ts
+++ b/web/ui/src/lib/hub.test.ts
@@ -116,7 +116,9 @@ describe("defReloadStatus", () => {
 
 describe("ensureDefReloadConnections", () => {
   it("POSTs both connectors with the canonical ids, events, filter, and sink", async () => {
-    const fetchMock = vi.fn(async () => jsonResponse(200, { ok: true }));
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) =>
+      jsonResponse(200, { ok: true }),
+    );
     vi.stubGlobal("fetch", fetchMock);
 
     const result = await ensureDefReloadConnections("research");
@@ -165,11 +167,27 @@ describe("ensureDefReloadConnections", () => {
       status: 401,
     });
   });
+
+  it("throws HubError(400) when the hub rejects both bodies (the validation failure mode)", async () => {
+    // The pre-fix hub 400'd every def-reload POST ("agent sink requires
+    // sink.params.channel"); guard the total-failure throw carries that status
+    // (not a generic wrap) so the UI surfaces the real reason.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse(400, { error: "invalid_request", error_description: "bad" })),
+    );
+    await expect(ensureDefReloadConnections("research")).rejects.toMatchObject({
+      name: "HubError",
+      status: 400,
+    });
+  });
 });
 
 describe("teardownDefReloadConnections", () => {
   it("DELETEs the canonical ids AND any semantically-matching connection id", async () => {
-    const fetchMock = vi.fn(async () => jsonResponse(200, { ok: true }));
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) =>
+      jsonResponse(200, { ok: true }),
+    );
     vi.stubGlobal("fetch", fetchMock);
 
     // A pair wired via the hub builder carries hub-derived ids, not ours.

--- a/web/ui/src/lib/hub.ts
+++ b/web/ui/src/lib/hub.ts
@@ -1,0 +1,220 @@
+/**
+ * Hub-client for the agent SPA — the cookie-authed, same-origin path to the
+ * hub's Connections engine (`/admin/connections`). Used to provision the
+ * **def-reload connectors**: vault triggers that webhook the agent the moment an
+ * `#agent/definition` note is created/edited, so a def change instantiates its
+ * agent LIVE instead of converging only via the daemon's 60s loadAll poll.
+ *
+ * ## Why this is secure (the operator's click IS the approval)
+ *
+ * `POST /admin/connections` is cookie-gated to the logged-in portal operator and
+ * same-origin-belted (`origin-check.ts` — the belt's own docstring names "the
+ * agent module's admin page" as a canonical consumer). So every call here rides
+ * the operator's OWN authenticated hub session over a same-origin `fetch()` with
+ * `credentials: "include"` — exactly the intended approval flow, just driven from
+ * the agent UI instead of the hub's generic Connections builder. The agent gains
+ * NO new authority: it already holds the def-vault's write token (the def-vault
+ * binding minted it) and already reads `#agent/definition` notes; the connector
+ * only flips that read from POLL to PUSH, webhooking the agent's OWN reload
+ * endpoint with the agent's OWN `agent:send` scope.
+ *
+ * ## Origin + transport
+ *
+ * The endpoints live at the HUB origin ROOT (`<origin>/admin/connections`), NOT
+ * under the `/agent` proxy prefix — mirroring `lib/auth.ts`'s `/admin/agent-token`
+ * mint. We hit `window.location.origin + "/admin/..."`. This works when the SPA
+ * is served through the hub proxy (`<hub-origin>/agent/app/`, same origin as the
+ * hub) — the path "most users" take. Served loopback-direct
+ * (`http://127.0.0.1:1941/agent/app/`) the root path resolves to the AGENT
+ * daemon, which doesn't serve `/admin/connections` → a 404 we map to a clear
+ * "use the hub-proxied URL" hint. The 60s poll covers reactivity either way, so
+ * a failure here is a convenience gap, never a correctness one.
+ */
+
+/** A non-2xx from a hub endpoint, carrying the status so callers can branch. */
+export class HubError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "HubError";
+  }
+}
+
+/** The hub origin root — same origin as the hub when served through its proxy. */
+function hubOrigin(): string {
+  return typeof window !== "undefined" ? window.location.origin : "";
+}
+
+/**
+ * One connection as `GET /admin/connections` projects it (the fields we read;
+ * the wire shape carries more). `source`/`sink` mirror the store records.
+ */
+export interface ConnectionRow {
+  id: string;
+  source: { module: string; vault?: string; event: string };
+  sink: { module: string; action: string };
+}
+
+/** The `definition.reload` sink action every def-reload connector targets. */
+const RELOAD_ACTION = "definition.reload";
+/** The two vault events a def-reload pair covers (create + edit). */
+const CREATE_EVENT = "note.created";
+const EDIT_EVENT = "note.updated";
+
+/** The def-discriminator tag the trigger filters on (created/edited defs only). */
+const DEFINITION_TAG = "#agent/definition";
+
+/**
+ * The stable connection id for a def-reload connector. Per (vault, kind) and
+ * NOT per-agent: a def change in a vault reloads whichever agent it defines, so
+ * one create-connector + one edit-connector per def-vault is the whole surface.
+ * Stable ids make the POST an idempotent upsert (re-add/re-enable is a no-op)
+ * and give teardown an exact target. Matches the hub's CONNECTION_ID_RE slug
+ * (vault names are already slug-validated upstream).
+ */
+function defReloadId(vault: string, kind: "create" | "edit"): string {
+  return `agentdefs-${kind}-${vault}`;
+}
+
+/** The `POST /admin/connections` body for one def-reload connector. */
+function defReloadBody(vault: string, kind: "create" | "edit") {
+  return {
+    id: defReloadId(vault, kind),
+    // Provenance — surfaces as the "agent" group in the hub Connections view,
+    // so an operator can see these were wired by the agent module's UI.
+    requestedBy: "agent",
+    source: {
+      module: "vault",
+      vault,
+      event: kind === "create" ? CREATE_EVENT : EDIT_EVENT,
+      filter: { tags: [DEFINITION_TAG] },
+    },
+    sink: { module: "agent", action: RELOAD_ACTION },
+  };
+}
+
+/** A hub `fetch` carrying the operator cookie. Browser sends `Origin` (passes the CSRF belt). */
+async function hubFetch(path: string, init: RequestInit = {}): Promise<Response> {
+  const headers = new Headers(init.headers);
+  headers.set("accept", "application/json");
+  return fetch(`${hubOrigin()}${path}`, { ...init, credentials: "include", headers });
+}
+
+/** Map a non-2xx hub status to an operator-facing message. */
+function hubErrorMessage(status: number, fallback: string): string {
+  if (status === 401) return "Not signed in to the hub portal — sign in, then retry.";
+  if (status === 403) return "Not authorized — reactive reload needs host-admin access.";
+  if (status === 404)
+    return "Reactive reload needs the hub-proxied URL — open the agent app via your hub origin, not the loopback daemon.";
+  return fallback || `hub request failed (${status})`;
+}
+
+/** Pull the server `error` field (or text) off a non-2xx response. */
+async function errorDetail(res: Response): Promise<string> {
+  try {
+    const body = (await res.json()) as { error?: string; error_description?: string };
+    return body.error_description ?? body.error ?? "";
+  } catch {
+    return await res.text().catch(() => "");
+  }
+}
+
+/**
+ * List the hub's connections. Throws `HubError` on a non-2xx (the caller treats
+ * a failure as "reactive status unavailable" rather than erroring the section).
+ */
+export async function listConnections(): Promise<ConnectionRow[]> {
+  const res = await hubFetch("/admin/connections");
+  if (!res.ok) {
+    throw new HubError(res.status, hubErrorMessage(res.status, await errorDetail(res)));
+  }
+  const body = (await res.json()) as { connections?: ConnectionRow[] };
+  return body.connections ?? [];
+}
+
+/**
+ * Whether a def-vault's reactive reload is fully wired. Matched by SEMANTICS
+ * (source.vault + event + sink.action), not by our id — so a pair created via
+ * the hub's own Connections builder counts too. `active` requires BOTH the
+ * create- and edit-event connectors (the hub binds one event per connection).
+ */
+export function defReloadStatus(
+  vault: string,
+  connections: ConnectionRow[],
+): { create: boolean; edit: boolean; active: boolean } {
+  const matches = (event: string) =>
+    connections.some(
+      (c) =>
+        c.source.module === "vault" &&
+        c.source.vault === vault &&
+        c.source.event === event &&
+        c.sink.module === "agent" &&
+        c.sink.action === RELOAD_ACTION,
+    );
+  const create = matches(CREATE_EVENT);
+  const edit = matches(EDIT_EVENT);
+  return { create, edit, active: create && edit };
+}
+
+/**
+ * Provision (idempotent upsert) BOTH def-reload connectors for a def-vault. Each
+ * POST is independent; a partial success is reported so the caller can surface
+ * "edit connector failed" precisely. Throws `HubError` only if BOTH fail with
+ * the same status (the common no-session / wrong-origin case) so the caller gets
+ * one clear message; otherwise resolves with `{ ok, failures }`.
+ */
+export async function ensureDefReloadConnections(
+  vault: string,
+): Promise<{ ok: boolean; failures: string[] }> {
+  const kinds: Array<"create" | "edit"> = ["create", "edit"];
+  const failures: string[] = [];
+  let firstStatus = 0;
+  for (const kind of kinds) {
+    const res = await hubFetch("/admin/connections", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(defReloadBody(vault, kind)),
+    });
+    if (!res.ok) {
+      if (firstStatus === 0) firstStatus = res.status;
+      failures.push(`${kind}: ${hubErrorMessage(res.status, await errorDetail(res))}`);
+    }
+  }
+  if (failures.length === kinds.length) {
+    // Total failure — surface the (uniform) reason as a single thrown error.
+    throw new HubError(firstStatus, hubErrorMessage(firstStatus, failures[0] ?? "provisioning failed"));
+  }
+  return { ok: failures.length === 0, failures };
+}
+
+/**
+ * Tear down a def-vault's def-reload connectors. Deletes BOTH the canonical
+ * ids AND any semantically-matching connection from the supplied list (so a
+ * pair wired via the hub builder, with hub-derived ids, is also removed).
+ * 404s are ignored (already gone). Throws `HubError` only on a non-404 failure.
+ */
+export async function teardownDefReloadConnections(
+  vault: string,
+  connections: ConnectionRow[] = [],
+): Promise<void> {
+  const ids = new Set<string>([defReloadId(vault, "create"), defReloadId(vault, "edit")]);
+  for (const c of connections) {
+    if (
+      c.source.module === "vault" &&
+      c.source.vault === vault &&
+      (c.source.event === CREATE_EVENT || c.source.event === EDIT_EVENT) &&
+      c.sink.module === "agent" &&
+      c.sink.action === RELOAD_ACTION
+    ) {
+      ids.add(c.id);
+    }
+  }
+  for (const id of ids) {
+    const res = await hubFetch(`/admin/connections/${encodeURIComponent(id)}`, { method: "DELETE" });
+    if (!res.ok && res.status !== 404) {
+      throw new HubError(res.status, hubErrorMessage(res.status, await errorDetail(res)));
+    }
+  }
+}

--- a/web/ui/src/lib/hub.ts
+++ b/web/ui/src/lib/hub.ts
@@ -170,7 +170,11 @@ export async function ensureDefReloadConnections(
 ): Promise<{ ok: boolean; failures: string[] }> {
   const kinds: Array<"create" | "edit"> = ["create", "edit"];
   const failures: string[] = [];
+  // First failure's status + RAW server detail, kept separate from the
+  // per-kind formatted messages so the total-failure throw maps the status once
+  // (no double-wrapping through hubErrorMessage).
   let firstStatus = 0;
+  let firstDetail = "";
   for (const kind of kinds) {
     const res = await hubFetch("/admin/connections", {
       method: "POST",
@@ -178,13 +182,17 @@ export async function ensureDefReloadConnections(
       body: JSON.stringify(defReloadBody(vault, kind)),
     });
     if (!res.ok) {
-      if (firstStatus === 0) firstStatus = res.status;
-      failures.push(`${kind}: ${hubErrorMessage(res.status, await errorDetail(res))}`);
+      const detail = await errorDetail(res);
+      if (firstStatus === 0) {
+        firstStatus = res.status;
+        firstDetail = detail;
+      }
+      failures.push(`${kind}: ${hubErrorMessage(res.status, detail)}`);
     }
   }
   if (failures.length === kinds.length) {
     // Total failure — surface the (uniform) reason as a single thrown error.
-    throw new HubError(firstStatus, hubErrorMessage(firstStatus, failures[0] ?? "provisioning failed"));
+    throw new HubError(firstStatus, hubErrorMessage(firstStatus, firstDetail || "provisioning failed"));
   }
   return { ok: failures.length === 0, failures };
 }

--- a/web/ui/src/routes/Agents.tsx
+++ b/web/ui/src/routes/Agents.tsx
@@ -1199,9 +1199,12 @@ export function DefVaultsSection({
       await removeAgentVault(name);
       // Best-effort teardown of this vault's def-reload connectors — the vault
       // is no longer a def-vault, so its triggers are stale. A failure is
-      // non-fatal (the connector just reloads a vault nothing reads).
+      // non-fatal (the connector just reloads a vault nothing reads). Fetch the
+      // connection list FRESH (fall back to the snapshot) so a builder-made
+      // connector with a hub-derived id is caught even if our state is stale.
       try {
-        await teardownDefReloadConnections(name, connections);
+        const fresh = await listConnections().catch(() => connections);
+        await teardownDefReloadConnections(name, fresh);
       } catch {
         // ignore — leaves a harmless stale connector, removable in the hub UI.
       }

--- a/web/ui/src/routes/Agents.tsx
+++ b/web/ui/src/routes/Agents.tsx
@@ -48,6 +48,13 @@ import {
   removeAgentVault,
   runJob,
 } from "../lib/api.ts";
+import {
+  type ConnectionRow,
+  defReloadStatus,
+  ensureDefReloadConnections,
+  listConnections,
+  teardownDefReloadConnections,
+} from "../lib/hub.ts";
 
 type LoadState =
   | { kind: "loading" }
@@ -1110,10 +1117,38 @@ export function DefVaultsSection({
   const [url, setUrl] = useState("");
   const [adding, setAdding] = useState(false);
   const [addError, setAddError] = useState<string | null>(null);
+  // A non-blocking notice after add — reactive reload may or may not have wired.
+  const [addNotice, setAddNotice] = useState<string | null>(null);
   // The vault currently in the remove-confirm state (its name), or null.
   const [confirmRemove, setConfirmRemove] = useState<string | null>(null);
   const [removing, setRemoving] = useState<string | null>(null);
   const [removeError, setRemoveError] = useState<string | null>(null);
+
+  // Reactive-reload (def-reload connectors) state. `connections` is the hub's
+  // connection list; `connLoaded` distinguishes "loaded, none match" from "the
+  // hub list is unavailable" (loopback-direct / no session) so the column can
+  // degrade to "—" instead of falsely reading "off". `toggling` names the vault
+  // mid-enable/disable.
+  const [connections, setConnections] = useState<ConnectionRow[]>([]);
+  const [connLoaded, setConnLoaded] = useState(false);
+  const [toggling, setToggling] = useState<string | null>(null);
+  const [reactiveError, setReactiveError] = useState<string | null>(null);
+
+  const refreshConnections = useCallback(async () => {
+    try {
+      const list = await listConnections();
+      setConnections(list);
+      setConnLoaded(true);
+    } catch {
+      // Hub unavailable from here (loopback-direct, no session) — the 60s poll
+      // still covers reactivity; we just can't SHOW or TOGGLE its status.
+      setConnLoaded(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refreshConnections();
+  }, [refreshConnections]);
 
   const nameValid = /^[a-zA-Z0-9_-]+$/.test(vaultName);
   const canAdd = nameValid && !adding;
@@ -1123,15 +1158,33 @@ export function DefVaultsSection({
     if (!canAdd) return;
     setAdding(true);
     setAddError(null);
+    setAddNotice(null);
+    const added = vaultName;
     try {
       await addAgentVault({
-        vault: vaultName,
+        vault: added,
         ...(url.trim().length > 0 ? { url: url.trim() } : {}),
       });
       setVaultName("");
       setUrl("");
       setAddOpen(false);
       onChanged();
+      // Auto-wire reactive reload (the operator's authenticated session IS the
+      // approval). Best-effort: a failure leaves the vault added with the 60s
+      // poll as the fallback, so it never blocks the add.
+      try {
+        const { ok } = await ensureDefReloadConnections(added);
+        setAddNotice(
+          ok
+            ? `Added "${added}" — reactive reload is on (def changes apply instantly).`
+            : `Added "${added}" — reactive reload partially wired; defs still converge within 60s.`,
+        );
+      } catch (err) {
+        setAddNotice(
+          `Added "${added}". Reactive reload couldn't be enabled (${errMessage(err)}) — def changes converge within 60s; you can enable it below.`,
+        );
+      }
+      await refreshConnections();
     } catch (err) {
       setAddError(errMessage(err));
     } finally {
@@ -1144,12 +1197,38 @@ export function DefVaultsSection({
     setRemoveError(null);
     try {
       await removeAgentVault(name);
+      // Best-effort teardown of this vault's def-reload connectors — the vault
+      // is no longer a def-vault, so its triggers are stale. A failure is
+      // non-fatal (the connector just reloads a vault nothing reads).
+      try {
+        await teardownDefReloadConnections(name, connections);
+      } catch {
+        // ignore — leaves a harmless stale connector, removable in the hub UI.
+      }
       setConfirmRemove(null);
       onChanged();
+      await refreshConnections();
     } catch (err) {
       setRemoveError(errMessage(err));
     } finally {
       setRemoving(null);
+    }
+  }
+
+  async function onToggleReactive(name: string, currentlyActive: boolean) {
+    setToggling(name);
+    setReactiveError(null);
+    try {
+      if (currentlyActive) {
+        await teardownDefReloadConnections(name, connections);
+      } else {
+        await ensureDefReloadConnections(name);
+      }
+      await refreshConnections();
+    } catch (err) {
+      setReactiveError(errMessage(err));
+    } finally {
+      setToggling(null);
     }
   }
 
@@ -1171,8 +1250,20 @@ export function DefVaultsSection({
       </div>
       <p className="muted">
         Vaults this module reads <code>#agent/definition</code> notes from. Removing one
-        deregisters every agent defined in it.
+        deregisters every agent defined in it. <strong>Reactive reload</strong> wires a vault
+        trigger so def changes apply instantly instead of waiting up to 60s.
       </p>
+
+      {addNotice ? (
+        <div className="info-banner" role="status" data-testid="add-def-vault-notice">
+          {addNotice}
+        </div>
+      ) : null}
+      {reactiveError ? (
+        <div className="error-banner" role="alert" data-testid="reactive-reload-error">
+          {reactiveError}
+        </div>
+      ) : null}
 
       {addOpen ? (
         <form className="inline-form" onSubmit={onAdd} aria-label="Add def-vault" data-testid="add-def-vault-form">
@@ -1234,11 +1325,14 @@ export function DefVaultsSection({
               <th>Vault</th>
               <th>URL</th>
               <th>Token</th>
+              <th>Reactive reload</th>
               <th></th>
             </tr>
           </thead>
           <tbody>
-            {vaults.map((v) => (
+            {vaults.map((v) => {
+              const reactive = defReloadStatus(v.vault, connections);
+              return (
               <tr key={v.vault} data-testid={`def-vault-${v.vault}`}>
                 <td className="cell-name">{v.vault}</td>
                 <td className="cell-dim">{v.url}</td>
@@ -1247,6 +1341,38 @@ export function DefVaultsSection({
                     <span className="pill status-enabled">present</span>
                   ) : (
                     <span className="pill status-error">missing</span>
+                  )}
+                </td>
+                <td data-testid={`reactive-reload-cell-${v.vault}`}>
+                  {!connLoaded ? (
+                    <span className="cell-dim" title="Open the agent app via your hub origin to manage reactive reload.">
+                      —
+                    </span>
+                  ) : (
+                    <span className="confirm-inline">
+                      {reactive.active ? (
+                        <span className="pill status-enabled" data-testid={`reactive-on-${v.vault}`}>
+                          on
+                        </span>
+                      ) : (
+                        <span className="pill" data-testid={`reactive-off-${v.vault}`}>
+                          off
+                        </span>
+                      )}
+                      <button
+                        type="button"
+                        className="cancel-link"
+                        data-testid={`reactive-toggle-${v.vault}`}
+                        disabled={toggling === v.vault}
+                        onClick={() => void onToggleReactive(v.vault, reactive.active)}
+                      >
+                        {toggling === v.vault
+                          ? "Working…"
+                          : reactive.active
+                            ? "Disable"
+                            : "Enable"}
+                      </button>
+                    </span>
                   )}
                 </td>
                 <td>
@@ -1284,7 +1410,8 @@ export function DefVaultsSection({
                   )}
                 </td>
               </tr>
-            ))}
+              );
+            })}
           </tbody>
         </table>
       )}

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -193,6 +193,15 @@ h3 {
   margin-bottom: 1rem;
   font-size: 0.9rem;
 }
+.info-banner {
+  background: var(--accent-soft);
+  border: 1px solid var(--accent);
+  color: var(--fg);
+  padding: 0.65rem 1rem;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+  font-size: 0.88rem;
+}
 .empty {
   border: 1px dashed var(--border);
   border-radius: 10px;


### PR DESCRIPTION
## What

Make a def-vault's **reactive reload** "simple and mostly automated for most users (while still being secure)." Adding a def-vault in the agent admin SPA now auto-wires the two def-reload connectors so an **out-of-band** `#agent/definition` change (via the vault MCP, a sync, etc.) instantiates/re-instantiates its agent **live** instead of converging only via the daemon's 60s `loadAll` poll. Editing through the SPA was already instant; this closes the out-of-band gap.

## Why it's secure (the operator's session IS the approval)

`POST /admin/connections` is **cookie-gated** to the logged-in portal operator and **same-origin-belted** — `origin-check.ts`'s own docstring names *"the agent module's admin page"* as a canonical consumer. Every call here rides the operator's **own authenticated hub session** over a same-origin `fetch()` with `credentials:"include"`: the intended approval flow, just driven from the agent UI instead of the hub's generic Connections builder.

The agent gains **no new authority** — it already holds the def-vault's write token (the binding minted it) and already reads `#agent/definition` notes; the connector only flips that read from **poll → push**, webhooking the agent's *own* `/api/vault/agent-def` endpoint with its *own* `agent:send` scope. Cross-boundary `wants:` grants stay operator-approved as before; only this self-scoped, no-new-access connector auto-provisions.

## Changes

- **`web/ui/src/lib/hub.ts`** (new) — cookie-authed, origin-rooted hub client mirroring `lib/auth.ts`'s `/admin/agent-token` pattern: `listConnections`, `defReloadStatus`, `ensureDefReloadConnections` (idempotent upsert by stable per-`(vault,event)` id), `teardownDefReloadConnections` (canonical ids + semantic match, 404-tolerant). Friendly 401/403/404 mapping (404 ⇒ "open via the hub-proxied URL"; loopback-direct can't reach the hub, where the poll already covers reactivity).
- **`web/ui/src/routes/Agents.tsx`** — Def-vaults section: auto-ensure on add (best-effort, **non-blocking** — failure leaves the vault added with the poll fallback), best-effort teardown on remove, and a per-vault **Reactive reload** on/off column with an Enable/Disable toggle for the repair/local case. Degrades to "—" when the hub list is unavailable.
- **`web/ui/src/lib/hub.test.ts`** (new) — 11 cases: wire shape, body/id shapes, status detection, partial/total failure, teardown dedup + 404 tolerance, error mapping.
- **`web/ui/src/styles.css`** — `.info-banner`.

No daemon changes — the reload sink (`POST /api/vault/agent-def`, `agent:send`) and the `connectionTemplates` already shipped (Phase 0); this is pure provisioning UX.

## Gates

- SPA: **98 pass** (7 files) — `bun run test:spa`
- Daemon: **972 pass / 0 fail**, typecheck clean — `bun run test`

No version bump (governance: PRs don't bump; bump+tag on ship).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
