### PR TITLE
feat(agent): per-agent model selection (e.g. opus 4.8)

### DIFF
--- a/src/agent-defs.test.ts
+++ b/src/agent-defs.test.ts
@@ -87,6 +87,35 @@ describe("parseAgentDef", () => {
     expect(spec.egress).toEqual(["api.github.com", "registry.npmjs.org"]);
   });
 
+  test("metadata.model → spec.model (alias or full id); absent → undefined", () => {
+    const withModel = parseAgentDef(
+      { id: "n1", content: "x", metadata: { name: "a", model: "opus" } },
+      { vault: "default" },
+    );
+    expect(withModel.spec.model).toBe("opus");
+
+    const fullId = parseAgentDef(
+      { id: "n1", content: "x", metadata: { name: "a", model: "claude-opus-4-8" } },
+      { vault: "default" },
+    );
+    expect(fullId.spec.model).toBe("claude-opus-4-8");
+
+    const noModel = parseAgentDef(
+      { id: "n1", content: "x", metadata: { name: "a" } },
+      { vault: "default" },
+    );
+    expect(noModel.spec.model).toBeUndefined();
+  });
+
+  test("a malformed model (spaces/control chars) is a parse error, not a silent passthrough", () => {
+    expect(() =>
+      parseAgentDef(
+        { id: "n", content: "x", metadata: { name: "a", model: "opus 4.8" } },
+        { vault: "v" },
+      ),
+    ).toThrow(/not a valid model name/);
+  });
+
   test("a blank body → no systemPrompt (CC default untouched), no mode flag", () => {
     const def = parseAgentDef(
       { id: "n1", content: "   \n  ", metadata: { name: "a", systemPromptMode: "replace" } },

--- a/src/agent-defs.ts
+++ b/src/agent-defs.ts
@@ -317,6 +317,21 @@ export function parseAgentDef(note: {
     }
   }
 
+  // Model (optional) — passed to `claude -p --model` by the programmatic backend.
+  // A CC alias (`opus`/`sonnet`/`haiku`) or a full id (`claude-opus-4-8`). We
+  // validate only the CHARSET (no membership list — models evolve), so a typo'd-
+  // but-wellformed value still reaches `--model` and the turn errors clearly,
+  // while a malformed value (spaces/control chars) fails fast as a def error.
+  const model = metaStr(meta.model);
+  if (model !== undefined && model.length > 0) {
+    if (!/^[a-zA-Z0-9][a-zA-Z0-9._:-]*$/.test(model)) {
+      throw new AgentDefParseError(
+        `#agent/definition note ${noteId}: model "${model}" is not a valid model name (letters, numbers, dot, underscore, colon, dash)`,
+      );
+    }
+    spec.model = model;
+  }
+
   // Working directory (optional absolute host cwd). We do NOT statSync here (parse is
   // pure + may run on a box where the dir is mounted differently); the spawn path's
   // own checks apply when the turn runs.
@@ -693,6 +708,8 @@ interface LiveDef {
   pending: string[];
   /** Structured `wants:` connection keys (surfaced for the UI; never a secret). */
   wants: string[];
+  /** The model the programmatic backend runs turns on (from `metadata.model`); unset = CC default. */
+  model?: string;
 }
 
 /**
@@ -719,6 +736,8 @@ export interface AgentDefDetail {
   systemPromptPreview: string;
   /** Structured `wants:` connection keys the agent declared (empty when own-vault only). */
   wants: string[];
+  /** The model the programmatic backend runs turns on (e.g. `opus`); undefined = CC default. */
+  model?: string;
   /** The wake channel inbound routes to this agent on (== name). */
   channel: string;
 }
@@ -747,6 +766,8 @@ export interface AgentDefFull {
   mode: AgentMode;
   /** Structured `wants:` connection keys the agent declared (empty when own-vault only). */
   wants: string[];
+  /** The model the programmatic backend runs turns on (e.g. `opus`); undefined = CC default. */
+  model?: string;
   /** The FULL system prompt — the whole note body (NOT truncated). */
   systemPrompt: string;
   /** The resolved liveness status (`enabled` | `pending` | `error`). */
@@ -879,6 +900,7 @@ export class AgentDefRegistry {
         pending: [...d.pending],
         systemPromptPreview: d.systemPromptPreview,
         wants: [...d.wants],
+        ...(d.model ? { model: d.model } : {}),
         channel: d.name, // agent ≡ channel.
       }))
       .sort((a, b) => a.name.localeCompare(b.name));
@@ -942,6 +964,7 @@ export class AgentDefRegistry {
       pending: [...d.pending],
       systemPromptPreview: d.systemPromptPreview,
       wants: [...d.wants],
+      ...(d.model ? { model: d.model } : {}),
       channel: d.name,
     };
   }
@@ -996,6 +1019,7 @@ export class AgentDefRegistry {
       vault: detail.vault,
       mode: detail.mode,
       wants: [...detail.wants],
+      ...(detail.model ? { model: detail.model } : {}),
       systemPrompt: typeof note.content === "string" ? note.content : "",
       status: detail.status,
     };
@@ -1403,6 +1427,7 @@ export class AgentDefRegistry {
       systemPromptPreview,
       pending: pending ?? [],
       wants: def.wants.map((c) => connectionKey(c)),
+      ...(def.spec.model ? { model: def.spec.model } : {}),
     });
     // Track this note in the per-vault seen set (a confident, freshly-parsed read) so the
     // removed-def diff (loadAll) and the reload-delete path both address it by name. This

--- a/src/backends/programmatic.test.ts
+++ b/src/backends/programmatic.test.ts
@@ -279,6 +279,38 @@ describe("buildProgrammaticClaudeArgs", () => {
     expect(argv).not.toContain("--append-system-prompt-file");
     expect(argv).not.toContain("--system-prompt-file");
   });
+
+  test("model set → --model <value> as a discrete argv pair", () => {
+    const argv = buildProgrammaticClaudeArgs({
+      message: "hi",
+      mcpConfigPath: "/ws/.mcp.json",
+      model: "opus",
+    });
+    const i = argv.indexOf("--model");
+    expect(i).toBeGreaterThan(-1);
+    expect(argv[i + 1]).toBe("opus");
+  });
+
+  test("model unset/empty/whitespace → NO --model flag (inherit CC default)", () => {
+    expect(
+      buildProgrammaticClaudeArgs({ message: "hi", mcpConfigPath: "/ws/.mcp.json" }),
+    ).not.toContain("--model");
+    expect(
+      buildProgrammaticClaudeArgs({ message: "hi", mcpConfigPath: "/ws/.mcp.json", model: "" }),
+    ).not.toContain("--model");
+    expect(
+      buildProgrammaticClaudeArgs({ message: "hi", mcpConfigPath: "/ws/.mcp.json", model: "   " }),
+    ).not.toContain("--model");
+  });
+
+  test("model is trimmed before becoming the flag value", () => {
+    const argv = buildProgrammaticClaudeArgs({
+      message: "hi",
+      mcpConfigPath: "/ws/.mcp.json",
+      model: "  claude-opus-4-8  ",
+    });
+    expect(argv[argv.indexOf("--model") + 1]).toBe("claude-opus-4-8");
+  });
 });
 
 // ---- single-turn runner tests ----------------------------------------------

--- a/src/backends/programmatic.ts
+++ b/src/backends/programmatic.ts
@@ -189,6 +189,12 @@ export function buildProgrammaticClaudeArgs(opts: {
   systemPromptFile?: string;
   /** How the system prompt composes — append (default) keeps CC's base; replace overrides it. */
   systemPromptMode?: "append" | "replace";
+  /**
+   * Model to run the turn on (`claude -p --model <value>`) — a CC alias
+   * (`opus`/`sonnet`/`haiku`) or a full model id. Omitted/empty → no `--model`
+   * flag, inheriting CC's default. Passed as a discrete argv element (no shell).
+   */
+  model?: string;
 }): string[] {
   const bin = opts.claudeBin ?? "claude";
   const argv = [
@@ -203,6 +209,11 @@ export function buildProgrammaticClaudeArgs(opts: {
     opts.mcpConfigPath,
     "--dangerously-skip-permissions",
   ];
+  // Model is OPTIONAL — only add the flag when the spec set one, so an unset
+  // model inherits Claude Code's own default rather than pinning a value here.
+  if (typeof opts.model === "string" && opts.model.trim().length > 0) {
+    argv.push("--model", opts.model.trim());
+  }
   // System prompt (file-backed). Append KEEPS CC's capable default + adds the role;
   // replace overrides it entirely. Re-passed every turn (the flag isn't persistent).
   if (opts.systemPromptFile) {
@@ -429,6 +440,7 @@ export class ProgrammaticBackend implements AgentBackend {
       ...(systemPromptFile
         ? { systemPromptFile, systemPromptMode: spec.systemPromptMode ?? "append" }
         : {}),
+      ...(spec.model ? { model: spec.model } : {}),
     });
 
     // Sandbox-wrap via the SHARED seam — same egress floor + scoped-read

--- a/src/sandbox/types.ts
+++ b/src/sandbox/types.ts
@@ -290,6 +290,17 @@ export interface AgentSpec {
    */
   backend?: AgentBackendKind;
   /**
+   * Which model the PROGRAMMATIC backend runs the turn on — passed verbatim to
+   * `claude -p --model <value>`. Accepts a Claude Code alias (`opus` / `sonnet` /
+   * `haiku`) or a full model id (e.g. `claude-opus-4-8`). Unset → no `--model`
+   * flag, so the turn inherits Claude Code's own default (Sonnet today). Only the
+   * programmatic backend reads this (a `channel`-backend turn runs in the
+   * operator's own session, whose model the operator controls). Set from the def's
+   * `metadata.model`; persisted in spec.json. NOT shell-interpolated — it's a
+   * discrete argv element, so an arbitrary string can't inject.
+   */
+  model?: string;
+  /**
    * Per-channel system prompt — the operator gives the channel a specific role,
    * backend-visible, so the agent gets strong specificity decoupled from the
    * workspace + CLAUDE.md (design 2026-06-16-channel-system-prompt.md). Set when

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -195,6 +195,8 @@ export interface AgentDefRow {
   systemPromptPreview: string;
   /** Structured `wants:` connection keys (empty when own-vault only). */
   wants: string[];
+  /** The model the programmatic backend runs turns on (e.g. `opus`); absent = CC default. */
+  model?: string;
   /** The wake channel inbound routes to this agent on (== name). */
   channel: string;
 }
@@ -294,6 +296,8 @@ export interface AgentDefFull {
   mode: AgentMode;
   /** Structured `wants:` connection keys (empty when own-vault only). */
   wants: string[];
+  /** The model the programmatic backend runs turns on (e.g. `opus`); absent = CC default. */
+  model?: string;
   /** The FULL system prompt — the whole note body (NOT truncated). */
   systemPrompt: string;
   status: AgentDefStatus;

--- a/web/ui/src/lib/models.ts
+++ b/web/ui/src/lib/models.ts
@@ -16,11 +16,14 @@ export interface ModelOption {
   label: string;
 }
 
+// Labels intentionally carry NO version number — the values are CC aliases that
+// follow the latest build of each family, so a pinned "4.8" would rot (and lie)
+// the moment a newer Opus ships. The family + capability descriptor stays true.
 export const MODEL_OPTIONS: readonly ModelOption[] = [
-  { value: "", label: "Default (Claude Code's default — Sonnet today)" },
-  { value: "opus", label: "Opus 4.8 — most capable" },
-  { value: "sonnet", label: "Sonnet 4.6 — balanced" },
-  { value: "haiku", label: "Haiku 4.5 — fastest" },
+  { value: "", label: "Default (Claude Code's default)" },
+  { value: "opus", label: "Opus — most capable" },
+  { value: "sonnet", label: "Sonnet — balanced" },
+  { value: "haiku", label: "Haiku — fastest" },
 ];
 
 /**

--- a/web/ui/src/lib/models.ts
+++ b/web/ui/src/lib/models.ts
@@ -1,0 +1,34 @@
+/**
+ * The model choices the create/edit forms offer for an agent definition. The
+ * value is what rides in `metadata.model` → `claude -p --model <value>` for the
+ * PROGRAMMATIC backend (a `channel`-backend turn runs in the operator's own
+ * session, whose model they control). Empty value = no `--model` flag, so the
+ * turn inherits Claude Code's own default.
+ *
+ * We offer the CC aliases (`opus`/`sonnet`/`haiku`) rather than pinned ids so a
+ * def follows the latest of each family without an edit; an operator who wants a
+ * specific build can still hand-write a full id in the def note's `metadata.model`
+ * (the daemon accepts any well-formed value).
+ */
+export interface ModelOption {
+  /** The `--model` value (empty = inherit Claude Code's default). */
+  value: string;
+  label: string;
+}
+
+export const MODEL_OPTIONS: readonly ModelOption[] = [
+  { value: "", label: "Default (Claude Code's default — Sonnet today)" },
+  { value: "opus", label: "Opus 4.8 — most capable" },
+  { value: "sonnet", label: "Sonnet 4.6 — balanced" },
+  { value: "haiku", label: "Haiku 4.5 — fastest" },
+];
+
+/**
+ * A human label for a stored model value (for read-only display). A value not in
+ * the option list (e.g. a hand-written full id like `claude-opus-4-8`) renders
+ * as itself. Empty/undefined → the "Default" label.
+ */
+export function modelLabel(value: string | undefined): string {
+  if (!value) return "Default";
+  return MODEL_OPTIONS.find((o) => o.value === value)?.label ?? value;
+}

--- a/web/ui/src/routes/Agents.test.tsx
+++ b/web/ui/src/routes/Agents.test.tsx
@@ -301,9 +301,34 @@ describe("Agents — edit a def (Phase 4a)", () => {
     await waitFor(() => expect(editAgentDef).toHaveBeenCalledTimes(1));
     expect(editAgentDef).toHaveBeenCalledWith("note-1", {
       systemPrompt: "New body",
-      metadata: { mode: "multi-threaded" },
+      // `model` is ALWAYS sent (here "" — the def had none) so switching back to
+      // Default overwrites a prior value.
+      metadata: { mode: "multi-threaded", model: "" },
       wants: "vault:x:read",
     });
+  });
+
+  it("pre-fills the model from the full def and sends the changed model in metadata", async () => {
+    openEdit();
+    getAgentDef.mockResolvedValue({
+      def: fullDef({ name: "alpha", mode: "single-threaded", systemPrompt: "Body", model: "opus" }),
+    });
+    editAgentDef.mockResolvedValue({ ok: true, def: defRow({ name: "alpha" }) });
+    renderRoute();
+
+    fireEvent.click(await screen.findByTestId("agent-row-alpha"));
+    fireEvent.click(await screen.findByTestId("edit-agent"));
+    const form = await screen.findByTestId("edit-agent-form");
+    const select = within(form).getByTestId("edit-model") as HTMLSelectElement;
+    // Pre-filled from the def.
+    expect(select.value).toBe("opus");
+
+    // Switch to sonnet + save.
+    fireEvent.change(select, { target: { value: "sonnet" } });
+    fireEvent.click(within(form).getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => expect(editAgentDef).toHaveBeenCalledTimes(1));
+    expect(editAgentDef.mock.calls[0]?.[1]?.metadata).toMatchObject({ model: "sonnet" });
   });
 
   it("surfaces a load error with a retry", async () => {

--- a/web/ui/src/routes/Agents.tsx
+++ b/web/ui/src/routes/Agents.tsx
@@ -55,6 +55,7 @@ import {
   listConnections,
   teardownDefReloadConnections,
 } from "../lib/hub.ts";
+import { MODEL_OPTIONS, modelLabel } from "../lib/models.ts";
 
 type LoadState =
   | { kind: "loading" }
@@ -345,6 +346,8 @@ export function AgentDetail({
         <dd>{agent.live ? "yes" : "no (defined, not instantiated)"}</dd>
         {def ? (
           <>
+            <dt>Model</dt>
+            <dd data-testid="detail-model">{modelLabel(def.model)}</dd>
             <dt>Def status</dt>
             <dd>{def.status}</dd>
           </>
@@ -466,6 +469,7 @@ export function EditAgentForm({
   const [load, setLoad] = useState<LoadState>({ kind: "loading" });
   const [systemPrompt, setSystemPrompt] = useState("");
   const [mode, setMode] = useState<AgentMode>("single-threaded");
+  const [model, setModel] = useState("");
   const [wants, setWants] = useState("");
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
@@ -477,6 +481,7 @@ export function EditAgentForm({
       const d = res.def;
       setSystemPrompt(d.systemPrompt);
       setMode(d.mode);
+      setModel(d.model ?? "");
       setWants(d.wants.join(", "));
       setLoad({ kind: "ready", systemPrompt: d.systemPrompt, mode: d.mode, wants: d.wants.join(", ") });
     } catch (err) {
@@ -502,9 +507,11 @@ export function EditAgentForm({
     try {
       await editAgentDef(noteId, {
         systemPrompt,
-        // `mode` rides in metadata.mode (same as create). `wants` is the comma-string;
-        // send "" to clear when the operator emptied it (the daemon merges metadata).
-        metadata: { mode },
+        // `mode` + `model` ride in metadata (same as create). ALWAYS send `model`
+        // (even "") so switching back to Default overwrites a prior value — the
+        // daemon merges metadata, and an empty model parses as "no --model flag".
+        // `wants` is the comma-string; send "" to clear when emptied.
+        metadata: { mode, model },
         wants: wants.trim(),
       });
       onSaved();
@@ -570,6 +577,27 @@ export function EditAgentForm({
               testid="edit-mode-multi-threaded"
             />
           </fieldset>
+
+          {/* Model → metadata.model (programmatic `claude -p --model`). */}
+          <div className="field">
+            <label htmlFor="edit-model">Model</label>
+            <select
+              id="edit-model"
+              value={model}
+              data-testid="edit-model"
+              onChange={(e) => setModel(e.target.value)}
+            >
+              {MODEL_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+            </select>
+            <p className="field-hint">
+              Which model Parachute runs this agent on (programmatic backend). A channel-backend
+              agent uses whatever model your own session runs.
+            </p>
+          </div>
 
           {/* System prompt → body (the FULL note body). */}
           <div className="field">

--- a/web/ui/src/routes/CreateAgent.test.tsx
+++ b/web/ui/src/routes/CreateAgent.test.tsx
@@ -125,6 +125,25 @@ describe("CreateAgent form", () => {
     expect(createAgentDef.mock.calls[0]![0].metadata).toEqual({ mode: "multi-threaded" });
   });
 
+  it("includes metadata.model only when a non-default model is chosen", async () => {
+    renderForm();
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "opus-agent" } });
+    fireEvent.change(screen.getByTestId("agent-model"), { target: { value: "opus" } });
+    fireEvent.click(screen.getByRole("button", { name: /create agent/i }));
+
+    await waitFor(() => expect(createAgentDef).toHaveBeenCalledTimes(1));
+    expect(createAgentDef.mock.calls[0]![0].metadata).toEqual({ mode: "single-threaded", model: "opus" });
+  });
+
+  it("omits metadata.model when left at Default", async () => {
+    renderForm();
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "default-agent" } });
+    fireEvent.click(screen.getByRole("button", { name: /create agent/i }));
+
+    await waitFor(() => expect(createAgentDef).toHaveBeenCalledTimes(1));
+    expect(createAgentDef.mock.calls[0]![0].metadata).not.toHaveProperty("model");
+  });
+
   it("includes `wants` only when entered", async () => {
     renderForm();
     fireEvent.change(screen.getByLabelText("Name"), { target: { value: "wanty" } });

--- a/web/ui/src/routes/CreateAgent.tsx
+++ b/web/ui/src/routes/CreateAgent.tsx
@@ -32,6 +32,7 @@ import {
   HttpError,
   listAgentVaults,
 } from "../lib/api.ts";
+import { MODEL_OPTIONS } from "../lib/models.ts";
 
 /**
  * The name field must be a slug. Mirrors the daemon's canonical `NAME_SLUG_RE`
@@ -60,6 +61,7 @@ export function CreateAgent({ vaults }: CreateAgentProps) {
   const [vault, setVault] = useState(vaults[0]?.vault ?? "");
   const [mode, setMode] = useState<AgentMode>("single-threaded");
   const [backend, setBackend] = useState<CreatableBackend>("programmatic");
+  const [model, setModel] = useState("");
   const [systemPrompt, setSystemPrompt] = useState("");
   const [wants, setWants] = useState("");
   const [advancedOpen, setAdvancedOpen] = useState(false);
@@ -79,8 +81,9 @@ export function CreateAgent({ vaults }: CreateAgentProps) {
         name,
         backend,
         systemPrompt,
-        // `mode` is NOT a top-level field — it rides in metadata.
-        metadata: { mode },
+        // `mode` + `model` are NOT top-level fields — they ride in metadata.
+        // Omit `model` when "Default" so no `--model` flag is forced.
+        metadata: { mode, ...(model ? { model } : {}) },
         // Only send `wants` when the operator entered something.
         ...(wants.trim().length > 0 ? { wants: wants.trim() } : {}),
       });
@@ -214,6 +217,27 @@ export function CreateAgent({ vaults }: CreateAgentProps) {
             testid="backend-channel"
           />
         </fieldset>
+
+        {/* Model — rides in metadata.model → `claude -p --model` (programmatic). */}
+        <div className="field">
+          <label htmlFor="agent-model">Model</label>
+          <select
+            id="agent-model"
+            value={model}
+            data-testid="agent-model"
+            onChange={(e) => setModel(e.target.value)}
+          >
+            {MODEL_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+          <p className="field-hint">
+            Which model Parachute runs this agent on (programmatic backend). A channel-backend
+            agent uses whatever model your own session runs.
+          </p>
+        </div>
 
         {/* System prompt → body.systemPrompt */}
         <div className="field">


### PR DESCRIPTION
## What

Agents couldn't pick a model — the programmatic backend passed no `--model`, so every agent inherited Claude Code's default (Sonnet today). This adds a `model` knob on the agent definition, threaded end-to-end, with a selector in the **create + edit** forms.

## Backend
- **`AgentSpec.model`** (sandbox/types.ts) — the `--model` value; unset = inherit CC's default. Programmatic-only (a `channel` turn runs in the operator's own session).
- **`parseAgentDef`**: `metadata.model` → `spec.model`, charset-validated (no membership list — models evolve; a malformed value is a clean def error, a wellformed-but-typo'd one reaches `--model` and the turn errors clearly).
- **`buildProgrammaticClaudeArgs`**: appends `--model <value>` (trimmed) **only when set** — a discrete argv element, no shell interpolation. `deliver()` passes `spec.model`.
- Surfaced on `AgentDefDetail`/`AgentDefFull` (+ `LiveDef`) so the UI shows/pre-fills it. **No write-path change** — `model` rides the existing metadata passthrough (`createDef`/`editDef` + the daemon's `coerceStringMap`).

## UI
- **`web/ui/src/lib/models.ts`** — shared `MODEL_OPTIONS` (Default / Opus 4.8 / Sonnet 4.6 / Haiku 4.5, by CC alias) + `modelLabel()`.
- **Create + Edit** forms get a Model select. Create omits `metadata.model` at Default; **Edit always sends it** (even `""`) so switching back to Default overwrites a prior value (the daemon merges metadata; empty parses as "no `--model`"). Detail panel shows the resolved model.

## Tests
argv `--model` present/absent/trimmed · `parseAgentDef` model parse + malformed rejection · SPA create includes/omits model · edit pre-fills + sends model.

## Gates
- daemon **977 pass / 0 fail**; SPA **102 pass**; typecheck + SPA build clean.

No version bump (governance: PRs don't bump; bump+tag on ship).

🤖 Generated with [Claude Code](https://claude.com/claude-code)