### PR TITLE
feat(ui): per-agent secrets / env vars (e.g. GH_TOKEN)

### DIFF
--- a/web/ui/src/lib/api.test.ts
+++ b/web/ui/src/lib/api.test.ts
@@ -20,13 +20,16 @@ import {
   getAgentDef,
   HttpError,
   listAgentDefs,
+  listAgentSecrets,
   listAgentVaults,
   listAgents,
   listChannels,
   listMessages,
   messageStreamUrl,
+  removeAgentSecret,
   removeAgentVault,
   sendMessage,
+  setAgentSecret,
   turnEventsUrl,
 } from "./api.ts";
 
@@ -418,5 +421,54 @@ describe("chat SSE URL builders (Phase 4d)", () => {
 
   it("turnEventsUrl omits the token when null", () => {
     expect(turnEventsUrl("eng", null)).toBe("/agent/api/channels/eng/turn-events");
+  });
+});
+
+describe("agent secrets / env (#36)", () => {
+  it("listAgentSecrets GETs /agent/api/credentials/env (names only)", async () => {
+    const fetchMock = fetchFn(async () =>
+      jsonResponse(200, { default: [], channels: { eng: ["GH_TOKEN"] } }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await listAgentSecrets();
+    expect(res.channels.eng).toEqual(["GH_TOKEN"]);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("/agent/api/credentials/env");
+    expect(init?.method ?? "GET").toBe("GET");
+  });
+
+  it("setAgentSecret POSTs { channel, name, value } with the Bearer", async () => {
+    const fetchMock = fetchFn(async () => jsonResponse(200, { ok: true, scope: "channel", channel: "eng", name: "GH_TOKEN" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await setAgentSecret({ channel: "eng", name: "GH_TOKEN", value: "ghp_x" });
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("/agent/api/credentials/env");
+    expect(init?.method).toBe("POST");
+    expect(JSON.parse(String(init?.body))).toEqual({ channel: "eng", name: "GH_TOKEN", value: "ghp_x" });
+    expect(new Headers(init?.headers).get("authorization")).toBe("Bearer jwt-tok");
+  });
+
+  it("removeAgentSecret DELETEs WITH a JSON body { channel, name }", async () => {
+    const fetchMock = fetchFn(async () => jsonResponse(200, { ok: true, scope: "channel", channel: "eng", name: "GH_TOKEN", removed: true }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await removeAgentSecret({ channel: "eng", name: "GH_TOKEN" });
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("/agent/api/credentials/env");
+    expect(init?.method).toBe("DELETE");
+    expect(init?.body).toBeTruthy(); // DELETE carries a body (not all clients support this)
+    expect(JSON.parse(String(init?.body))).toEqual({ channel: "eng", name: "GH_TOKEN" });
+  });
+
+  it("setAgentSecret surfaces a 400 (denylisted name) as an HttpError", async () => {
+    vi.stubGlobal(
+      "fetch",
+      fetchFn(async () => jsonResponse(400, { error: "ANTHROPIC_API_KEY is reserved" })),
+    );
+    await expect(setAgentSecret({ channel: "eng", name: "ANTHROPIC_API_KEY", value: "x" })).rejects.toMatchObject({
+      status: 400,
+    });
   });
 });

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -122,8 +122,12 @@ async function deleteJson<T>(suffix: string): Promise<T> {
   return (await res.json()) as T;
 }
 
-/** Shared body-bearing-method helper (POST/PATCH) — Bearer + 401 retry + HttpError. */
-async function bodyJson<T>(method: "POST" | "PATCH", suffix: string, body: unknown): Promise<T> {
+/** Shared body-bearing-method helper (POST/PATCH/DELETE) — Bearer + 401 retry + HttpError. */
+async function bodyJson<T>(
+  method: "POST" | "PATCH" | "DELETE",
+  suffix: string,
+  body: unknown,
+): Promise<T> {
   const res = await authedFetch(`${apiBase()}${suffix}`, {
     method,
     headers: { "content-type": "application/json" },
@@ -133,6 +137,11 @@ async function bodyJson<T>(method: "POST" | "PATCH", suffix: string, body: unkno
     throw new HttpError(res.status, (await errorDetail(res)) || `${suffix} failed: ${res.status}`);
   }
   return (await res.json()) as T;
+}
+
+/** DELETE with a JSON body (the env-credential remove endpoint takes `{ channel?, name }`). */
+function deleteJsonWithBody<T>(suffix: string, body: unknown): Promise<T> {
+  return bodyJson<T>("DELETE", suffix, body);
 }
 
 // ---------------------------------------------------------------------------
@@ -402,6 +411,62 @@ export function addAgentVault(body: AddAgentVaultBody): Promise<AddAgentVaultRes
  */
 export function removeAgentVault(name: string): Promise<RemoveAgentVaultResponse> {
   return deleteJson<RemoveAgentVaultResponse>(`/agent-vaults/${encodeURIComponent(name)}`);
+}
+
+// ---------------------------------------------------------------------------
+// Per-agent secrets / env vars (#36). Thin client over the daemon's
+// `/api/credentials/env` endpoints (all `agent:admin`). A secret is a local,
+// 0600 env var (e.g. `GH_TOKEN`) injected into the agent's sandboxed `claude -p`
+// turns — NEVER written to a vault note, NEVER returned by value (the GET shape
+// is names-only). Scoped per channel (the agent's channel) or the operator
+// default. The Claude-auth trio is denylisted (the daemon rejects it with 400);
+// we mirror that client-side for a friendly pre-submit guard.
+// ---------------------------------------------------------------------------
+
+/** Env-var names the daemon refuses (they'd hijack the managed subscription billing). */
+export const DENYLISTED_ENV_NAMES: ReadonlySet<string> = new Set([
+  "ANTHROPIC_API_KEY",
+  "CLAUDE_API_KEY",
+  "CLAUDE_CODE_OAUTH_TOKEN",
+]);
+
+/** A settable env-var name shape (mirrors the daemon's `ENV_NAME_RE`). */
+export const ENV_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/**
+ * `GET /api/credentials/env` — env var NAMES only (never values), split into the
+ * operator-level `default` layer and per-`channels` overrides. Mirrors
+ * `describeChannelEnv` in `src/credentials.ts`.
+ */
+export interface AgentSecretsResponse {
+  default: string[];
+  channels: Record<string, string[]>;
+}
+
+/** List the env-var names set (default layer + per-channel). No values. */
+export function listAgentSecrets(): Promise<AgentSecretsResponse> {
+  return getJson<AgentSecretsResponse>("/credentials/env");
+}
+
+/**
+ * Set an env var for a channel (the agent's channel) or — with `channel`
+ * omitted — the operator default. Throws `HttpError` (400 on a denylisted/
+ * malformed name) so the form surfaces the daemon's message.
+ */
+export function setAgentSecret(body: {
+  channel?: string;
+  name: string;
+  value: string;
+}): Promise<{ ok: boolean; scope: string; channel?: string; name: string }> {
+  return postJson("/credentials/env", body);
+}
+
+/** Remove an env var (per-channel or default). DELETE carries a JSON body. */
+export function removeAgentSecret(body: {
+  channel?: string;
+  name: string;
+}): Promise<{ ok: boolean; scope: string; channel?: string; name: string; removed: boolean }> {
+  return deleteJsonWithBody("/credentials/env", body);
 }
 
 // ---------------------------------------------------------------------------

--- a/web/ui/src/routes/Agents.test.tsx
+++ b/web/ui/src/routes/Agents.test.tsx
@@ -25,6 +25,9 @@ vi.mock("../lib/api.ts", async (orig) => {
     createJob: vi.fn(),
     runJob: vi.fn(),
     deleteJob: vi.fn(),
+    listAgentSecrets: vi.fn(),
+    setAgentSecret: vi.fn(),
+    removeAgentSecret: vi.fn(),
   };
 });
 
@@ -40,6 +43,9 @@ const listJobs = vi.mocked(api.listJobs);
 const createJob = vi.mocked(api.createJob);
 const runJob = vi.mocked(api.runJob);
 const deleteJob = vi.mocked(api.deleteJob);
+const listAgentSecrets = vi.mocked(api.listAgentSecrets);
+const setAgentSecret = vi.mocked(api.setAgentSecret);
+const removeAgentSecret = vi.mocked(api.removeAgentSecret);
 
 function agentRow(over: Partial<api.AgentRow> = {}): api.AgentRow {
   return {
@@ -102,6 +108,7 @@ beforeEach(() => {
   listAgentDefs.mockResolvedValue({ defs: [] });
   listAgentVaults.mockResolvedValue({ vaults: [] });
   listJobs.mockResolvedValue({ jobs: [] });
+  listAgentSecrets.mockResolvedValue({ default: [], channels: {} });
 });
 
 afterEach(() => {
@@ -490,5 +497,74 @@ describe("Schedules — per-agent jobs in the detail panel (Phase 4b)", () => {
     expect(deleteJob).not.toHaveBeenCalled();
     fireEvent.click(await screen.findByTestId("schedule-delete-confirm-mine"));
     await waitFor(() => expect(deleteJob).toHaveBeenCalledWith("mine"));
+  });
+});
+
+describe("Agents — per-agent secrets (#36)", () => {
+  function openAgentWithChannel() {
+    listAgents.mockResolvedValue({
+      agents: [agentRow({ name: "alpha", backend: "programmatic", channel: "alpha", vault: "default" })],
+    });
+    listAgentDefs.mockResolvedValue({ defs: [defRow({ name: "alpha", channel: "alpha" })] });
+  }
+
+  it("lists this agent's env-var names (channel-scoped, values masked)", async () => {
+    openAgentWithChannel();
+    listAgentSecrets.mockResolvedValue({ default: ["OPERATOR_WIDE"], channels: { alpha: ["GH_TOKEN"] } });
+    renderRoute();
+
+    fireEvent.click(await screen.findByTestId("agent-row-alpha"));
+    // The agent's channel-scoped var shows; the operator-default var does NOT.
+    expect(await screen.findByTestId("secret-GH_TOKEN")).toBeInTheDocument();
+    expect(screen.queryByTestId("secret-OPERATOR_WIDE")).not.toBeInTheDocument();
+    // No raw value rendered.
+    expect(screen.queryByText("ghp_")).not.toBeInTheDocument();
+  });
+
+  it("adds a secret scoped to the agent's channel", async () => {
+    openAgentWithChannel();
+    setAgentSecret.mockResolvedValue({ ok: true, scope: "channel", channel: "alpha", name: "GH_TOKEN" });
+    renderRoute();
+
+    fireEvent.click(await screen.findByTestId("agent-row-alpha"));
+    fireEvent.click(await screen.findByTestId("add-secret-toggle"));
+    const form = await screen.findByTestId("add-secret-form");
+    fireEvent.change(within(form).getByLabelText("Name"), { target: { value: "GH_TOKEN" } });
+    fireEvent.change(within(form).getByLabelText("Value"), { target: { value: "ghp_secret" } });
+    fireEvent.click(within(form).getByRole("button", { name: /save secret/i }));
+
+    await waitFor(() =>
+      expect(setAgentSecret).toHaveBeenCalledWith({ channel: "alpha", name: "GH_TOKEN", value: "ghp_secret" }),
+    );
+  });
+
+  it("blocks a denylisted name client-side (no API call)", async () => {
+    openAgentWithChannel();
+    renderRoute();
+
+    fireEvent.click(await screen.findByTestId("agent-row-alpha"));
+    fireEvent.click(await screen.findByTestId("add-secret-toggle"));
+    const form = await screen.findByTestId("add-secret-form");
+    fireEvent.change(within(form).getByLabelText("Name"), { target: { value: "ANTHROPIC_API_KEY" } });
+    fireEvent.change(within(form).getByLabelText("Value"), { target: { value: "x" } });
+
+    expect(await screen.findByTestId("secret-name-denylisted")).toBeInTheDocument();
+    expect(within(form).getByRole("button", { name: /save secret/i })).toBeDisabled();
+    expect(setAgentSecret).not.toHaveBeenCalled();
+  });
+
+  it("removes a secret after a confirm", async () => {
+    openAgentWithChannel();
+    listAgentSecrets.mockResolvedValue({ default: [], channels: { alpha: ["GH_TOKEN"] } });
+    removeAgentSecret.mockResolvedValue({ ok: true, scope: "channel", channel: "alpha", name: "GH_TOKEN", removed: true });
+    renderRoute();
+
+    fireEvent.click(await screen.findByTestId("agent-row-alpha"));
+    fireEvent.click(await screen.findByTestId("secret-remove-GH_TOKEN"));
+    expect(removeAgentSecret).not.toHaveBeenCalled(); // confirm gate
+    fireEvent.click(await screen.findByTestId("secret-remove-confirm-GH_TOKEN"));
+    await waitFor(() =>
+      expect(removeAgentSecret).toHaveBeenCalledWith({ channel: "alpha", name: "GH_TOKEN" }),
+    );
   });
 });

--- a/web/ui/src/routes/Agents.tsx
+++ b/web/ui/src/routes/Agents.tsx
@@ -1188,8 +1188,11 @@ export function SecretsSection({
   }, [load]);
 
   // Client-side guard mirroring the daemon (a friendlier pre-submit error than a 400).
+  // EXACT match (no case-fold): the daemon's denylist is case-sensitive + SCREAMING_CASE,
+  // and env vars are case-sensitive on Unix — a lowercase `anthropic_api_key` is a
+  // different, harmless var the daemon accepts, so we must not block it here.
   const trimmedName = name.trim();
-  const nameDenylisted = DENYLISTED_ENV_NAMES.has(trimmedName.toUpperCase());
+  const nameDenylisted = DENYLISTED_ENV_NAMES.has(trimmedName);
   const nameShapeOk = trimmedName.length === 0 || ENV_NAME_RE.test(trimmedName);
   const canSave =
     trimmedName.length > 0 && nameShapeOk && !nameDenylisted && value.length > 0 && !saving;
@@ -1256,7 +1259,7 @@ export function SecretsSection({
       </p>
 
       {addOpen ? (
-        <form className="inline-form" onSubmit={onAdd} aria-label="Add secret" data-testid="add-secret-form">
+        <form className="inline-form" onSubmit={onAdd} aria-label="Add secret" aria-busy={saving} data-testid="add-secret-form">
           {addError ? (
             <div className="error-banner" role="alert" data-testid="add-secret-error">
               {addError}
@@ -1281,7 +1284,7 @@ export function SecretsSection({
             ) : null}
             {nameDenylisted ? (
               <p className="field-error" data-testid="secret-name-denylisted">
-                Reserved — {trimmedName.toUpperCase()} would hijack the agent's managed billing/auth.
+                Reserved — {trimmedName} would hijack the agent's managed billing/auth.
               </p>
             ) : null}
           </div>
@@ -1296,7 +1299,7 @@ export function SecretsSection({
               spellCheck={false}
               onChange={(e) => setValue(e.target.value)}
             />
-            <p className="field-hint">Stored encrypted-at-rest-adjacent (0600). Write-only — never re-displayed.</p>
+            <p className="field-hint">Stored 0600 on disk (access-controlled, not encrypted). Write-only — never re-displayed.</p>
           </div>
           <div className="form-actions">
             <button type="submit" disabled={!canSave}>

--- a/web/ui/src/routes/Agents.tsx
+++ b/web/ui/src/routes/Agents.tsx
@@ -47,6 +47,12 @@ import {
   listJobs,
   removeAgentVault,
   runJob,
+  type AgentSecretsResponse,
+  DENYLISTED_ENV_NAMES,
+  ENV_NAME_RE,
+  listAgentSecrets,
+  setAgentSecret,
+  removeAgentSecret,
 } from "../lib/api.ts";
 import {
   type ConnectionRow,
@@ -410,6 +416,12 @@ export function AgentDetail({
           the inject path only exists for a vault transport. Interactive /
           channel-less agents can't be scheduled, so the section is absent. */}
       {agent.channel ? <SchedulesSection channel={agent.channel} /> : null}
+
+      {/* Secrets / env vars — local 0600 env injected into this agent's sandboxed
+          (programmatic) turns. Scoped to the agent's channel. NEVER in the vault. */}
+      {agent.channel ? (
+        <SecretsSection channel={agent.channel} backend={agent.backend} />
+      ) : null}
 
       {/* Edit / delete — only for a vault-native def (a note we can mutate). */}
       {noteId ? (
@@ -1122,6 +1134,249 @@ function RadioRow(props: {
         <span className="radio-help">{props.help}</span>
       </span>
     </label>
+  );
+}
+
+/**
+ * The per-agent Secrets / env-vars section (#36). A thin UI over the daemon's
+ * `/api/credentials/env` endpoints: list (names only — values are NEVER returned),
+ * set, and remove an env var scoped to THIS agent's channel. The vars are stored
+ * locally (`~/.parachute/agent/credentials.json`, 0600) and injected into the
+ * agent's sandboxed `claude -p` turns — so e.g. a `GH_TOKEN` lets the agent's
+ * `git`/`gh` push & pull. They are NEVER written to a vault note. The Claude-auth
+ * trio is denylisted (the daemon 400s it; we guard client-side too). Only the
+ * PROGRAMMATIC backend consumes these (a channel-backend agent runs in the
+ * operator's own session, with the operator's own env) — surfaced with a note.
+ */
+export function SecretsSection({
+  channel,
+  backend,
+}: {
+  channel: string;
+  /** The agent's backend — only `"channel"` is special-cased (a note); kept as a
+   *  plain string so this section is decoupled from the merged-agent type. */
+  backend: string;
+}) {
+  type LoadState =
+    | { kind: "loading" }
+    | { kind: "error"; message: string }
+    | { kind: "ok"; names: string[] };
+  const [state, setState] = useState<LoadState>({ kind: "loading" });
+  const [addOpen, setAddOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [value, setValue] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [addError, setAddError] = useState<string | null>(null);
+  const [confirmRemove, setConfirmRemove] = useState<string | null>(null);
+  const [removing, setRemoving] = useState<string | null>(null);
+  const [rowError, setRowError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setState({ kind: "loading" });
+    try {
+      const res: AgentSecretsResponse = await listAgentSecrets();
+      // Only THIS agent's channel-scoped vars (the default layer is operator-wide,
+      // managed elsewhere — this section is per-agent).
+      setState({ kind: "ok", names: (res.channels[channel] ?? []).slice().sort() });
+    } catch (err) {
+      setState({ kind: "error", message: errMessage(err) });
+    }
+  }, [channel]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  // Client-side guard mirroring the daemon (a friendlier pre-submit error than a 400).
+  const trimmedName = name.trim();
+  const nameDenylisted = DENYLISTED_ENV_NAMES.has(trimmedName.toUpperCase());
+  const nameShapeOk = trimmedName.length === 0 || ENV_NAME_RE.test(trimmedName);
+  const canSave =
+    trimmedName.length > 0 && nameShapeOk && !nameDenylisted && value.length > 0 && !saving;
+
+  async function onAdd(e: React.FormEvent) {
+    e.preventDefault();
+    if (!canSave) return;
+    setSaving(true);
+    setAddError(null);
+    try {
+      await setAgentSecret({ channel, name: trimmedName, value });
+      setName("");
+      setValue("");
+      setAddOpen(false);
+      await load();
+    } catch (err) {
+      setAddError(errMessage(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function onRemove(varName: string) {
+    setRemoving(varName);
+    setRowError(null);
+    try {
+      await removeAgentSecret({ channel, name: varName });
+      setConfirmRemove(null);
+      await load();
+    } catch (err) {
+      setRowError(errMessage(err));
+    } finally {
+      setRemoving(null);
+    }
+  }
+
+  return (
+    <section className="detail-section" aria-label="Secrets" data-testid="secrets-section">
+      <div className="section-head">
+        <h3>Secrets (env vars)</h3>
+        <button
+          type="button"
+          className="secondary"
+          data-testid="add-secret-toggle"
+          onClick={() => {
+            setAddOpen((o) => !o);
+            setAddError(null);
+          }}
+        >
+          {addOpen ? "Cancel" : "Add secret"}
+        </button>
+      </div>
+      <p className="muted">
+        Local env vars (e.g. <code>GH_TOKEN</code>) injected into this agent's sandboxed turns —
+        stored 0600 on this machine, <strong>never in the vault</strong>. Values are write-only:
+        they're never shown again.
+        {backend === "channel" ? (
+          <>
+            {" "}
+            This agent uses the <strong>channel</strong> backend, so it runs in your own Claude
+            Code session with your own environment — these vars apply only to programmatic turns.
+          </>
+        ) : null}
+      </p>
+
+      {addOpen ? (
+        <form className="inline-form" onSubmit={onAdd} aria-label="Add secret" data-testid="add-secret-form">
+          {addError ? (
+            <div className="error-banner" role="alert" data-testid="add-secret-error">
+              {addError}
+            </div>
+          ) : null}
+          <div className="field">
+            <label htmlFor="secret-name">Name</label>
+            <input
+              id="secret-name"
+              type="text"
+              value={name}
+              placeholder="GH_TOKEN"
+              autoComplete="off"
+              autoCapitalize="off"
+              spellCheck={false}
+              onChange={(e) => setName(e.target.value)}
+            />
+            {trimmedName.length > 0 && !nameShapeOk ? (
+              <p className="field-error" data-testid="secret-name-invalid">
+                A valid env var name — letters, numbers, underscore; not starting with a digit.
+              </p>
+            ) : null}
+            {nameDenylisted ? (
+              <p className="field-error" data-testid="secret-name-denylisted">
+                Reserved — {trimmedName.toUpperCase()} would hijack the agent's managed billing/auth.
+              </p>
+            ) : null}
+          </div>
+          <div className="field">
+            <label htmlFor="secret-value">Value</label>
+            <input
+              id="secret-value"
+              type="password"
+              value={value}
+              placeholder="ghp_…"
+              autoComplete="off"
+              spellCheck={false}
+              onChange={(e) => setValue(e.target.value)}
+            />
+            <p className="field-hint">Stored encrypted-at-rest-adjacent (0600). Write-only — never re-displayed.</p>
+          </div>
+          <div className="form-actions">
+            <button type="submit" disabled={!canSave}>
+              {saving ? "Saving…" : "Save secret"}
+            </button>
+          </div>
+        </form>
+      ) : null}
+
+      {rowError ? (
+        <div className="error-banner" role="alert" data-testid="secret-row-error">
+          {rowError}
+        </div>
+      ) : null}
+
+      {state.kind === "loading" ? <div className="loading">Loading secrets…</div> : null}
+      {state.kind === "error" ? (
+        <div className="error-banner" role="alert" data-testid="secrets-load-error">
+          {state.message}{" "}
+          <button type="button" className="secondary" onClick={() => void load()}>
+            Retry
+          </button>
+        </div>
+      ) : null}
+      {state.kind === "ok" ? (
+        state.names.length === 0 ? (
+          <div className="empty" data-testid="secrets-empty">
+            No secrets set for this agent.
+          </div>
+        ) : (
+          <table>
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Value</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {state.names.map((n) => (
+                <tr key={n} data-testid={`secret-${n}`}>
+                  <td className="cell-name">{n}</td>
+                  <td className="cell-dim">••••••••</td>
+                  <td>
+                    {confirmRemove === n ? (
+                      <span className="confirm-inline">
+                        <button
+                          type="button"
+                          className="button-danger"
+                          data-testid={`secret-remove-confirm-${n}`}
+                          disabled={removing === n}
+                          onClick={() => void onRemove(n)}
+                        >
+                          {removing === n ? "Removing…" : "Confirm remove"}
+                        </button>
+                        <button type="button" className="cancel-link" onClick={() => setConfirmRemove(null)}>
+                          Cancel
+                        </button>
+                      </span>
+                    ) : (
+                      <button
+                        type="button"
+                        className="button-danger"
+                        data-testid={`secret-remove-${n}`}
+                        onClick={() => {
+                          setRowError(null);
+                          setConfirmRemove(n);
+                        }}
+                      >
+                        Remove
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )
+      ) : null}
+    </section>
   );
 }
 

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -619,12 +619,14 @@ button.button-danger:disabled {
 }
 
 /* ---- Schedules (Phase 4b): the per-agent schedule section in the detail panel ---- */
-.schedules {
+.schedules,
+.detail-section {
   margin-top: 1.25rem;
   padding-top: 1rem;
   border-top: 1px solid var(--border-light);
 }
-.schedules .section-head h3 {
+.schedules .section-head h3,
+.detail-section .section-head h3 {
   margin: 0;
   font-size: 1.05rem;
 }


### PR DESCRIPTION
## What

A UI to give a single agent scoped env vars — e.g. a **GITHUB PAT** (`GH_TOKEN`) so its sandboxed `claude -p` turns can `git`/`gh` push & pull. The **backend was already fully built + wired** (`credentials.json` 0600, the ANTHROPIC/CLAUDE denylist, `/api/credentials/env` endpoints, `buildAgentChildEnv` injection into the sandboxed turn) — this fills the only gap: the UI.

## Changes (SPA-only)
- **`api.ts`** — `listAgentSecrets` / `setAgentSecret` / `removeAgentSecret` over `/api/credentials/env` (names-only GET, set, **body-bearing DELETE** — widened the shared `bodyJson` helper to `POST|PATCH|DELETE`). Re-exports `DENYLISTED_ENV_NAMES` + `ENV_NAME_RE` so the form mirrors the daemon's guard.
- **`Agents.tsx` `SecretsSection`** — a per-agent panel (scoped to the agent's channel) in the detail view: list var names (**values masked, never fetched**), add (name + `password`-type value), remove (with a confirm). Client-side guard blocks the denylisted Claude-auth trio + malformed names *before* submit; the daemon 400s them regardless. A channel-backend note clarifies these apply to programmatic turns (a channel agent runs in your own session/env).
- **`styles.css`** — `.detail-section` shares the schedules-section spacing.

## Security (unchanged — enforced server-side)
Secrets stay **LOCAL + 0600**, **never in a vault note**, **never the Claude trio** (subscription billing stays intact), values are **write-only** (no read-back, no logging). The GET surface returns names only.

## Tests
api wrappers (GET / POST / body-DELETE / 400) + `SecretsSection` (lists only the channel-scoped vars, add scoped to the channel, denylist block = **no API call**, remove-with-confirm).

## Gates
- SPA **110 pass**; daemon **977 pass / 0 fail**; typecheck + SPA build clean.

No version bump (governance). No daemon change — pure provisioning UX over the existing endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)