### PR TITLE
fix(agent): pending-inbound queue + replay (#121) and thread-as-container working-ensure

### DIFF
--- a/src/backends/registry.test.ts
+++ b/src/backends/registry.test.ts
@@ -863,6 +863,26 @@ describe("ProgrammaticAgentRegistry — pending-inbound queue + replay-on-regist
     expect(reg.queuePending("eng", { content: "after" })).toBe("unknown");
   });
 
+  test("a channel-move re-register clears the OLD channel's expected mark + pending buffer (no leak)", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+
+    // Register the agent on channel "old", then buffer a pending inbound for "old".
+    await reg.register({ name: "mover", channels: ["old"] });
+    reg.expectChannel("old");
+    reg.queuePending("old", { content: "stranded" });
+    expect(reg.pendingCount("old")).toBe(1);
+
+    // Re-register the SAME name onto a DIFFERENT wake channel — the old channel's indexes,
+    // expected mark, and pending buffer must all be dropped (nothing routes to "old" now).
+    await reg.register({ name: "mover", channels: ["new"] });
+    expect(reg.hasChannel("old")).toBe(false);
+    expect(reg.isExpected("old")).toBe(false);
+    expect(reg.pendingCount("old")).toBe(0);
+    expect(reg.hasChannel("new")).toBe(true);
+  });
+
   test("a pending inbound that arrives DURING a drain (after register) still replays in order", async () => {
     const backend = new FakeBackend();
     const rec = recorder();

--- a/src/backends/registry.test.ts
+++ b/src/backends/registry.test.ts
@@ -13,6 +13,7 @@ import { describe, test, expect } from "bun:test";
 import {
   ProgrammaticAgentRegistry,
   OUTBOUND_MAX_RETRIES,
+  PENDING_INBOUND_CAP,
   isTransientOutboundError,
   type WriteOutbound,
   type WriteThread,
@@ -97,13 +98,33 @@ function recorder(): { calls: { channel: string; reply: string; inReplyTo?: stri
   return { calls, fn };
 }
 
-/** A recorder WriteThread — captures every `#agent/thread` note the registry writes. */
-function threadRecorder(): { threads: ThreadNote[]; fn: WriteThread } {
+/**
+ * A recorder WriteThread — captures every `#agent/thread` note the registry writes.
+ *
+ * The thread-as-container lifecycle writes TWO notes per turn: a `phase:"start"`
+ * working-ensure BEFORE the turn, then a `phase:"end"` final record after. `threads`
+ * holds ALL writes in order; `ends()` / `starts()` filter by phase so a test can assert
+ * the FINAL records (the pre-thread-as-container assertions) without counting the
+ * working-ensure, or assert the working-ensure specifically.
+ */
+function threadRecorder(): {
+  threads: ThreadNote[];
+  ends: () => ThreadNote[];
+  starts: () => ThreadNote[];
+  fn: WriteThread;
+} {
   const threads: ThreadNote[] = [];
   const fn: WriteThread = async (thread) => {
     threads.push(thread);
   };
-  return { threads, fn };
+  return {
+    threads,
+    // `phase:"end"` is explicit on every registry-emitted final record; a write with no
+    // phase would also be a final record (back-compat), so treat absent as end too.
+    ends: () => threads.filter((t) => t.phase !== "start"),
+    starts: () => threads.filter((t) => t.phase === "start"),
+    fn,
+  };
 }
 
 /** A multi-threaded spec (materializes one `#agent/thread` note per fire). */
@@ -252,10 +273,14 @@ describe("ProgrammaticAgentRegistry — #agent/thread notes (unified lifecycle, 
     await reg.register(specMultiThreaded("digest", "digest", "Agents/digest"));
 
     reg.enqueue("digest", { content: "run the digest" });
-    await until(() => threads.threads.length === 1);
+    await until(() => threads.ends().length === 1);
 
-    expect(threads.threads).toHaveLength(1);
-    const thread = threads.threads[0]!;
+    // Thread-as-container: ONE working-ensure (phase:start, status:working) BEFORE the turn,
+    // then ONE final record (phase:end, status:ok) after — for the same per-fire note.
+    expect(threads.starts()).toHaveLength(1);
+    expect(threads.starts()[0]!.status).toBe("working");
+    expect(threads.ends()).toHaveLength(1);
+    const thread = threads.ends()[0]!;
     expect(thread.channel).toBe("digest");
     expect(thread.name).toBe("digest");
     expect(thread.status).toBe("ok");
@@ -265,11 +290,13 @@ describe("ProgrammaticAgentRegistry — #agent/thread notes (unified lifecycle, 
     expect(thread.output).toBe("reply:run the digest");
     expect(typeof thread.started_at).toBe("string");
     expect(typeof thread.ended_at).toBe("string");
+    // The start + end target the SAME per-fire note (same threadId) — no duplicate minted.
+    expect(threads.starts()[0]!.threadId).toBe(thread.threadId!);
     // The dual-write is ADDITIVE: a non-empty reply writes EXACTLY one outbound
-    // (the chat delivery) AND exactly one thread note (the primary record).
+    // (the chat delivery) AND exactly one FINAL thread note (the primary record).
     await until(() => rec.calls.length === 1);
     expect(rec.calls.length).toBe(1);
-    expect(threads.threads.length).toBe(1);
+    expect(threads.ends().length).toBe(1);
   });
 
   test("a SINGLE-THREADED turn ALSO materializes ONE #agent/thread note (the unified model — named after the def)", async () => {
@@ -281,17 +308,20 @@ describe("ProgrammaticAgentRegistry — #agent/thread notes (unified lifecycle, 
     await reg.register(specFor("eng"));
 
     reg.enqueue("eng", { content: "hello" });
-    await until(() => threads.threads.length === 1);
+    await until(() => threads.ends().length === 1);
 
     // BOTH modes materialize a thread note now (the structural unification): a
-    // single-threaded turn writes ONE, mode single-threaded, NAMED AFTER THE DEF (the
-    // deterministic upsert key the transport derives the stable path from).
-    expect(threads.threads).toHaveLength(1);
-    expect(threads.threads[0]!.mode).toBe("single-threaded");
-    expect(threads.threads[0]!.name).toBe("eng");
-    expect(threads.threads[0]!.channel).toBe("eng");
-    expect(threads.threads[0]!.input).toBe("hello");
-    expect(threads.threads[0]!.output).toBe("reply:hello");
+    // single-threaded turn writes ONE FINAL record, mode single-threaded, NAMED AFTER THE
+    // DEF (the deterministic upsert key the transport derives the stable path from).
+    // Thread-as-container: a working-ensure (phase:start) preceded it (same upsert key).
+    expect(threads.starts()).toHaveLength(1);
+    expect(threads.starts()[0]!.name).toBe("eng");
+    expect(threads.ends()).toHaveLength(1);
+    expect(threads.ends()[0]!.mode).toBe("single-threaded");
+    expect(threads.ends()[0]!.name).toBe("eng");
+    expect(threads.ends()[0]!.channel).toBe("eng");
+    expect(threads.ends()[0]!.input).toBe("hello");
+    expect(threads.ends()[0]!.output).toBe("reply:hello");
     // The single-threaded outbound reply was still written (no regression).
     expect(rec.calls).toHaveLength(1);
   });
@@ -306,15 +336,17 @@ describe("ProgrammaticAgentRegistry — #agent/thread notes (unified lifecycle, 
     // Two turns on the same channel — drained serially, FIFO.
     reg.enqueue("eng", { content: "turn one" });
     reg.enqueue("eng", { content: "turn two" });
-    await until(() => threads.threads.length === 2);
+    await until(() => threads.ends().length === 2);
 
-    // recordThread is called for BOTH turns (the registry seam can't simulate the
-    // transport's read-existing upsert, so we assert the UPSERT KEY is stable across
-    // turns — same channel + same name + same mode — which the transport maps to the
-    // SAME deterministic path `Threads/<channel>/<name>`, overwriting in place. The
-    // per-turn turn_count/usage aggregation is covered at the vault-transport layer).
-    expect(threads.threads).toHaveLength(2);
-    const [t1, t2] = threads.threads;
+    // recordThread (the FINAL record) is called for BOTH turns (the registry seam can't
+    // simulate the transport's read-existing upsert, so we assert the UPSERT KEY is stable
+    // across turns — same channel + same name + same mode — which the transport maps to the
+    // SAME deterministic path `Threads/<channel>/<name>`, overwriting in place. The per-turn
+    // turn_count/usage aggregation — incl. the start-ensure NOT double-counting — is covered
+    // at the vault-transport layer). Each turn ALSO emits its own working-ensure (phase:start).
+    expect(threads.starts()).toHaveLength(2);
+    expect(threads.ends()).toHaveLength(2);
+    const [t1, t2] = threads.ends();
     expect(t1!.mode).toBe("single-threaded");
     expect(t2!.mode).toBe("single-threaded");
     expect(t1!.name).toBe("eng");
@@ -334,13 +366,19 @@ describe("ProgrammaticAgentRegistry — #agent/thread notes (unified lifecycle, 
 
     reg.enqueue("digest", { content: "fire A" });
     reg.enqueue("digest", { content: "fire B" });
-    await until(() => threads.threads.length === 2);
+    await until(() => threads.ends().length === 2);
 
-    // One thread note PER FIRE (today one fire = one thread = one note; the transport
-    // assigns each a fresh uuid path, so they're distinct records).
-    expect(threads.threads).toHaveLength(2);
-    expect(threads.threads.map((t) => t.input)).toEqual(["fire A", "fire B"]);
-    expect(threads.threads.every((t) => t.mode === "multi-threaded")).toBe(true);
+    // One FINAL thread note PER FIRE (today one fire = one thread = one note; the transport
+    // assigns each a fresh uuid path, so they're distinct records). Each fire's start-ensure
+    // shares that fire's threadId (so start + end target the SAME per-fire note).
+    expect(threads.ends()).toHaveLength(2);
+    expect(threads.ends().map((t) => t.input)).toEqual(["fire A", "fire B"]);
+    expect(threads.ends().every((t) => t.mode === "multi-threaded")).toBe(true);
+    expect(threads.starts()).toHaveLength(2);
+    // Per fire the working-ensure + final record share a threadId (distinct across fires).
+    expect(threads.starts()[0]!.threadId).toBe(threads.ends()[0]!.threadId!);
+    expect(threads.starts()[1]!.threadId).toBe(threads.ends()[1]!.threadId!);
+    expect(threads.ends()[0]!.threadId).not.toBe(threads.ends()[1]!.threadId);
   });
 
   test("a FAILED MULTI-THREADED turn still materializes an #agent/thread note with status:error + the reason", async () => {
@@ -352,12 +390,14 @@ describe("ProgrammaticAgentRegistry — #agent/thread notes (unified lifecycle, 
     await reg.register(specMultiThreaded("digest"));
 
     reg.enqueue("digest", { content: "do it" });
-    await until(() => threads.threads.length === 1);
+    await until(() => threads.ends().length === 1);
 
-    expect(threads.threads).toHaveLength(1);
-    expect(threads.threads[0]!.mode).toBe("multi-threaded");
-    expect(threads.threads[0]!.status).toBe("error");
-    expect(threads.threads[0]!.output).toBe("mint refused");
+    // The working-ensure (phase:start) still ran BEFORE the turn; the FINAL record is error.
+    expect(threads.starts()).toHaveLength(1);
+    expect(threads.ends()).toHaveLength(1);
+    expect(threads.ends()[0]!.mode).toBe("multi-threaded");
+    expect(threads.ends()[0]!.status).toBe("error");
+    expect(threads.ends()[0]!.output).toBe("mint refused");
     // No outbound note for a failed turn (unchanged behavior).
     expect(rec.calls).toHaveLength(0);
   });
@@ -372,13 +412,15 @@ describe("ProgrammaticAgentRegistry — #agent/thread notes (unified lifecycle, 
     await reg.register(specFor("eng"));
 
     reg.enqueue("eng", { content: "do it" });
-    await until(() => threads.threads.length === 1);
+    await until(() => threads.ends().length === 1);
 
-    expect(threads.threads).toHaveLength(1);
-    expect(threads.threads[0]!.mode).toBe("single-threaded");
-    expect(threads.threads[0]!.name).toBe("eng");
-    expect(threads.threads[0]!.status).toBe("error");
-    expect(threads.threads[0]!.output).toBe("mint refused");
+    // The working-ensure (phase:start) still ran BEFORE the turn; the FINAL record is error.
+    expect(threads.starts()).toHaveLength(1);
+    expect(threads.ends()).toHaveLength(1);
+    expect(threads.ends()[0]!.mode).toBe("single-threaded");
+    expect(threads.ends()[0]!.name).toBe("eng");
+    expect(threads.ends()[0]!.status).toBe("error");
+    expect(threads.ends()[0]!.output).toBe("mint refused");
     // No outbound note for a failed turn (unchanged behavior).
     expect(rec.calls).toHaveLength(0);
   });
@@ -392,9 +434,12 @@ describe("ProgrammaticAgentRegistry — #agent/thread notes (unified lifecycle, 
     await reg.register(specMultiThreaded("digest"));
 
     reg.enqueue("digest", { content: "tool-only run" });
-    await until(() => threads.threads.length === 1);
-    expect(threads.threads[0]!.status).toBe("ok");
-    expect(threads.threads[0]!.output).toBe("");
+    await until(() => threads.ends().length === 1);
+    // The working-ensure (phase:start, no fake reply) preceded the empty-reply final record.
+    expect(threads.starts()).toHaveLength(1);
+    expect(threads.starts()[0]!.output).toBe("");
+    expect(threads.ends()[0]!.status).toBe("ok");
+    expect(threads.ends()[0]!.output).toBe("");
     // Empty reply → no outbound message note (the thread note IS the record).
     expect(rec.calls).toHaveLength(0);
   });
@@ -422,18 +467,25 @@ describe("ProgrammaticAgentRegistry — #agent/thread notes (unified lifecycle, 
     await reg.register(specFor("eng")); // single-threaded (default) — the ordering applies here now.
 
     reg.enqueue("eng", { content: "fire it" });
-    // FIX 1: the primary `ok` thread note is written first, then after retries exhaust, a
-    // second `error` thread note re-records the UN-DELIVERED reply.
-    await until(() => threads.threads.length === 2);
+    // Thread-as-container + FIX 1: a working-ensure (phase:start) is written first, then the
+    // primary `ok` FINAL record, then after retries exhaust a `error` FINAL record re-records
+    // the UN-DELIVERED reply — so `ends()` (the final records) is exactly [ok, error].
+    await until(() => threads.ends().length === 2);
 
-    // First (optimistic) record was `ok`; the second re-records the failure so the durable
-    // thread record does NOT falsely claim the reply landed.
-    expect(threads.threads[0]!.status).toBe("ok");
-    expect(threads.threads[0]!.output).toBe("reply:fire it");
-    expect(threads.threads[1]!.status).toBe("error");
-    expect(threads.threads[1]!.mode).toBe("single-threaded");
+    // The working-ensure preceded everything (status:working, no fake reply).
+    expect(threads.starts()).toHaveLength(1);
+    expect(threads.starts()[0]!.status).toBe("working");
+    // First FINAL (optimistic) record was `ok`; the second re-records the failure so the
+    // durable thread record does NOT falsely claim the reply landed.
+    expect(threads.ends()[0]!.status).toBe("ok");
+    expect(threads.ends()[0]!.output).toBe("reply:fire it");
+    expect(threads.ends()[1]!.status).toBe("error");
+    expect(threads.ends()[1]!.mode).toBe("single-threaded");
     // The undelivered reply text is preserved in the error record for recovery.
-    expect(threads.threads[1]!.output).toContain("reply:fire it");
+    expect(threads.ends()[1]!.output).toContain("reply:fire it");
+    // The re-record reuses the SAME per-turn threadId + sameTurn (no double-count, no dup).
+    expect(threads.ends()[1]!.threadId).toBe(threads.ends()[0]!.threadId!);
+    expect(threads.ends()[1]!.sameTurn).toBe(true);
     // Transient → the outbound was retried the full budget (1 initial + OUTBOUND_MAX_RETRIES).
     expect(outboundAttempts).toBe(1 + OUTBOUND_MAX_RETRIES);
   });
@@ -478,10 +530,11 @@ describe("ProgrammaticAgentRegistry — outbound retry on transient failure (FIX
     expect(recorded).toEqual([{ reply: "reply:important" }]);
     // The backend ran the turn EXACTLY ONCE (no re-run / fork on the retry).
     expect(backend.calls).toHaveLength(1);
-    // The thread note is the single `ok` record (the reply was ultimately delivered) — no
-    // error re-record because delivery succeeded.
-    expect(threads.threads).toHaveLength(1);
-    expect(threads.threads[0]!.status).toBe("ok");
+    // The FINAL thread note is the single `ok` record (the reply was ultimately delivered) —
+    // no error re-record because delivery succeeded. (A working-ensure preceded it.)
+    expect(threads.starts()).toHaveLength(1);
+    expect(threads.ends()).toHaveLength(1);
+    expect(threads.ends()[0]!.status).toBe("ok");
   });
 
   test("a PERSISTENT failure surfaces an error event + re-records the thread as error + does NOT claim success", async () => {
@@ -503,7 +556,7 @@ describe("ProgrammaticAgentRegistry — outbound retry on transient failure (FIX
     await reg.register(specFor("eng"));
 
     reg.enqueue("eng", { content: "doomed" });
-    await until(() => threads.threads.length === 2);
+    await until(() => threads.ends().length === 2);
     await new Promise<void>((r) => setTimeout(r, 5));
 
     // Retried the full budget then gave up (1 + OUTBOUND_MAX_RETRIES).
@@ -512,10 +565,11 @@ describe("ProgrammaticAgentRegistry — outbound retry on transient failure (FIX
     const errorEvents = turn.events.filter((e) => e.event.kind === "error");
     expect(errorEvents.length).toBeGreaterThanOrEqual(1);
     expect(turn.events.some((e) => e.event.kind === "done")).toBe(false);
-    // The thread record does NOT falsely claim a clean ok: the final record is error,
-    // carrying the un-delivered reply text for recovery.
-    expect(threads.threads[1]!.status).toBe("error");
-    expect(threads.threads[1]!.output).toContain("reply:doomed");
+    // The FINAL thread record does NOT falsely claim a clean ok: the second final record is
+    // error, carrying the un-delivered reply text for recovery. (A working-ensure preceded.)
+    expect(threads.ends()).toHaveLength(2);
+    expect(threads.ends()[1]!.status).toBe("error");
+    expect(threads.ends()[1]!.output).toContain("reply:doomed");
   });
 
   test("a PERMANENT (4xx) outbound failure does NOT retry — gives up immediately", async () => {
@@ -535,12 +589,14 @@ describe("ProgrammaticAgentRegistry — outbound retry on transient failure (FIX
     await reg.register(specFor("eng"));
 
     reg.enqueue("eng", { content: "rejected" });
-    await until(() => threads.threads.length === 2);
+    await until(() => threads.ends().length === 2);
     await new Promise<void>((r) => setTimeout(r, 5));
 
     // A 4xx is a real rejection → exactly ONE attempt, no retry.
     expect(attempts).toBe(1);
-    expect(threads.threads[1]!.status).toBe("error");
+    // The second FINAL record re-records the turn as error (the un-delivered reply).
+    expect(threads.ends()).toHaveLength(2);
+    expect(threads.ends()[1]!.status).toBe("error");
   });
 });
 
@@ -704,5 +760,193 @@ describe("ProgrammaticAgentRegistry — streaming turn view (onTurnEvent)", () =
     reg.enqueue("eng", { content: "hi" });
     await until(() => rec.calls.length === 1);
     expect(rec.calls).toEqual([{ channel: "eng", reply: "reply:hi" }]);
+  });
+});
+
+describe("ProgrammaticAgentRegistry — pending-inbound queue + replay-on-register (agent#121)", () => {
+  test("an inbound for an EXPECTED-but-not-yet-registered channel is QUEUED pending (not dropped)", () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+
+    // No live agent yet — but the channel is EXPECTED (the def-instantiation path marked it
+    // before bringing the agent up). enqueue() would no-op false here; queuePending OWNS it.
+    reg.expectChannel("eng");
+    expect(reg.hasChannel("eng")).toBe(false);
+    expect(reg.enqueue("eng", { content: "early" })).toBe(false); // not live → enqueue declines.
+    expect(reg.queuePending("eng", { content: "early" })).toBe("queued");
+    expect(reg.pendingCount("eng")).toBe(1);
+    // Nothing ran yet (no live agent), but nothing was lost either.
+    expect(backend.calls).toHaveLength(0);
+  });
+
+  test("queuePending for a genuinely UNKNOWN channel (not expected) returns 'unknown' (caller logs+drops)", () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    // Never expected, never registered → nothing maps to it.
+    expect(reg.queuePending("ghost", { content: "x" })).toBe("unknown");
+    expect(reg.pendingCount("ghost")).toBe(0);
+  });
+
+  test("on register() the channel's pending queue DRAINS into the serial worker, in arrival order (FIFO)", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+
+    // Three inbound arrive BEFORE the agent is live — all buffered pending.
+    reg.expectChannel("eng");
+    expect(reg.queuePending("eng", { content: "first" })).toBe("queued");
+    expect(reg.queuePending("eng", { content: "second" })).toBe("queued");
+    expect(reg.queuePending("eng", { content: "third" })).toBe("queued");
+    expect(reg.pendingCount("eng")).toBe(3);
+
+    // The agent registers → the buffer replays through the normal serial path, FIFO.
+    await reg.register(specFor("eng"));
+    await until(() => rec.calls.length === 3);
+
+    // The buffer is drained + the EXPECTED mark cleared (the live index is the truth now).
+    expect(reg.pendingCount("eng")).toBe(0);
+    expect(reg.isExpected("eng")).toBe(false);
+    // Turns ran in arrival order (the serial worker drains FIFO).
+    expect(backend.calls.map((c) => c.message)).toEqual(["first", "second", "third"]);
+    expect(rec.calls.map((c) => c.reply)).toEqual(["reply:first", "reply:second", "reply:third"]);
+  });
+
+  test("the pending buffer is CAPPED — past the cap the OLDEST is evicted (FIFO), newest kept", () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+
+    reg.expectChannel("eng");
+    // Fill to the cap, then push one MORE — the oldest ("m0") is evicted.
+    for (let i = 0; i < PENDING_INBOUND_CAP; i++) {
+      expect(reg.queuePending("eng", { content: `m${i}` })).toBe("queued");
+    }
+    expect(reg.pendingCount("eng")).toBe(PENDING_INBOUND_CAP);
+    expect(reg.queuePending("eng", { content: "overflow" })).toBe("queued");
+    // Still capped (didn't grow past the cap).
+    expect(reg.pendingCount("eng")).toBe(PENDING_INBOUND_CAP);
+  });
+
+  test("an UNKNOWN channel queuePending does NOT crash + leaves the registry usable", () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    expect(() => reg.queuePending("ghost", { content: "x" })).not.toThrow();
+    // The registry still works for a real registration afterward.
+    expect(reg.queuePending("ghost", { content: "y" })).toBe("unknown");
+  });
+
+  test("register() clears the EXPECTED mark even with an EMPTY pending buffer", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    reg.expectChannel("eng");
+    expect(reg.isExpected("eng")).toBe(true);
+    await reg.register(specFor("eng"));
+    expect(reg.isExpected("eng")).toBe(false);
+    expect(reg.pendingCount("eng")).toBe(0);
+  });
+
+  test("unexpectChannel drops a stale EXPECTED mark + its buffered pending (teardown)", () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    reg.expectChannel("eng");
+    reg.queuePending("eng", { content: "stranded" });
+    expect(reg.pendingCount("eng")).toBe(1);
+    reg.unexpectChannel("eng");
+    expect(reg.isExpected("eng")).toBe(false);
+    expect(reg.pendingCount("eng")).toBe(0);
+    // A subsequent inbound for the now-unexpected channel is 'unknown' (correctly dropped).
+    expect(reg.queuePending("eng", { content: "after" })).toBe("unknown");
+  });
+
+  test("a pending inbound that arrives DURING a drain (after register) still replays in order", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+
+    // Two pending before register.
+    reg.expectChannel("eng");
+    reg.queuePending("eng", { content: "p1" });
+    reg.queuePending("eng", { content: "p2" });
+
+    await reg.register(specFor("eng"));
+    // After register the channel is LIVE — a further inbound goes through enqueue directly.
+    await until(() => rec.calls.length === 2);
+    expect(reg.enqueue("eng", { content: "p3" })).toBe(true);
+    await until(() => rec.calls.length === 3);
+
+    expect(backend.calls.map((c) => c.message)).toEqual(["p1", "p2", "p3"]);
+  });
+});
+
+describe("ProgrammaticAgentRegistry — thread-as-container working-ensure (Part B)", () => {
+  test("the working-ensure (phase:start, status:working) is written BEFORE deliver() runs", async () => {
+    const backend = new FakeBackend();
+    // Gate the turn so we can observe the working-ensure write WHILE the turn is in flight.
+    const gate = deferred<void>();
+    backend.gate = { promise: gate.promise, resolve: gate.resolve };
+    const rec = recorder();
+    const threads = threadRecorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn, writeThread: threads.fn });
+    await reg.register(specFor("eng"));
+
+    reg.enqueue("eng", { content: "do work" });
+    // Wait until deliver() is in flight (the turn was handed the message + is blocked on the
+    // gate). The start-ensure is `await`ed BEFORE deliver() in the drain, so by the time
+    // deliver() has been called the working-ensure MUST already be written — and the FINAL
+    // (end) record must NOT be (the turn hasn't completed). This proves the ordering:
+    // working-ensure strictly precedes the turn.
+    await until(() => backend.calls.length === 1);
+    expect(threads.starts()).toHaveLength(1);
+    expect(threads.starts()[0]!.status).toBe("working");
+    expect(threads.starts()[0]!.output).toBe(""); // NO fake reply while working.
+    expect(threads.starts()[0]!.input).toBe("do work");
+    // The turn is in flight but hasn't produced its end record yet (gated).
+    expect(backend.calls).toHaveLength(1);
+    expect(threads.ends()).toHaveLength(0);
+
+    // Release the turn → it completes → the FINAL (ok) record lands, same threadId.
+    gate.resolve();
+    await until(() => threads.ends().length === 1);
+    expect(threads.ends()[0]!.status).toBe("ok");
+    expect(threads.ends()[0]!.threadId).toBe(threads.starts()[0]!.threadId!);
+  });
+
+  test("the start-ensure does NOT write a fake reply even though the turn ultimately replies", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const threads = threadRecorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn, writeThread: threads.fn });
+    await reg.register(specFor("eng"));
+
+    reg.enqueue("eng", { content: "hi" });
+    await until(() => threads.ends().length === 1);
+    // The working-ensure carries status:working + empty output; the end carries the reply.
+    expect(threads.starts()[0]!.status).toBe("working");
+    expect(threads.starts()[0]!.output).toBe("");
+    expect(threads.ends()[0]!.output).toBe("reply:hi");
+  });
+
+  test("the OUTBOUND reply is stamped with the turn's thread id (definition→thread→message link); multi-threaded → the per-fire note leaf", async () => {
+    const backend = new FakeBackend();
+    const threads = threadRecorder();
+    // A recorder that ALSO captures the threadId the worker passes to writeOutbound.
+    const outbound: { reply: string; threadId?: string }[] = [];
+    const writeOutbound: WriteOutbound = async (_channel, reply, _inReplyTo, threadId) => {
+      outbound.push({ reply, ...(threadId ? { threadId } : {}) });
+    };
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound, writeThread: threads.fn });
+    await reg.register(specMultiThreaded("digest"));
+
+    reg.enqueue("digest", { content: "go" });
+    await until(() => outbound.length === 1);
+    // The outbound carries the per-turn thread id, which for multi-threaded equals the
+    // per-fire thread note's leaf — the explicit message↔thread link.
+    expect(outbound[0]!.threadId).toBeDefined();
+    expect(outbound[0]!.threadId).toBe(threads.ends()[0]!.threadId!);
   });
 });

--- a/src/backends/registry.ts
+++ b/src/backends/registry.ts
@@ -369,10 +369,15 @@ export class ProgrammaticAgentRegistry {
       // The name moved to a different wake channel — drop the old channel index.
       // An in-flight drain on the old channel self-terminates (it re-reads
       // `byChannel`, now empty for that channel); we drop its `draining` flag too so
-      // the entry doesn't leak until that promise happens to settle.
+      // the entry doesn't leak until that promise happens to settle. Also drop the old
+      // channel's EXPECTED mark + any stranded pending buffer — nothing routes there now,
+      // so a residual mark/buffer would leak (reviewer nit; defense-in-depth — the normal
+      // flow only ever expects the NEW channel before this register).
       this.byChannel.delete(priorChannel);
       this.queues.delete(priorChannel);
       this.draining.delete(priorChannel);
+      this.expectedChannels.delete(priorChannel);
+      this.pending.delete(priorChannel);
     }
     const backendHandle = await this.backend.start(spec);
     const handle: ProgrammaticAgentHandle = {

--- a/src/backends/registry.ts
+++ b/src/backends/registry.ts
@@ -81,6 +81,15 @@ export type WriteOutbound = (
   channel: string,
   reply: string,
   inReplyTo?: string,
+  /**
+   * The per-turn thread id this reply belongs to — the explicit definition→thread→message
+   * link the outbound note carries (stamped into `metadata.thread`). For multi-threaded it
+   * IS the per-fire thread note's leaf (an exact link); for single-threaded it's a per-turn
+   * correlation id (the note's stable deterministic leaf is the def name — single-threaded
+   * outbound→note linkage by the stable path is a follow-up). INBOUND-note stamping is
+   * deferred (those notes are externally written; see the PR notes).
+   */
+  threadId?: string,
 ) => Promise<void>;
 
 /**
@@ -102,13 +111,17 @@ export interface ThreadNote {
   definition?: string;
   /** The mode the turn ran under — governs thread identity + whether the note upserts. */
   mode: AgentMode;
-  /** Outcome — `ok` (success) or `error` (the turn failed). */
-  status: "ok" | "error";
+  /**
+   * Outcome / lifecycle state after THIS write — `working` (the start-ensure, written
+   * BEFORE the turn: input shown, no reply yet), `ok` (success), or `error` (failed).
+   * `working` is only valid alongside `phase: "start"`.
+   */
+  status: "ok" | "error" | "working";
   /** The inbound text handed to the turn (the `-p` prompt). */
   input: string;
-  /** The reply on success, or the failure reason on error. */
+  /** The reply on success, the failure reason on error, or "" while `working`. */
   output: string;
-  /** ISO start/end of the turn. */
+  /** ISO start/end of the turn (a start-ensure does not advance the thread's last_turn_at). */
   started_at: string;
   ended_at: string;
   /** Optional token/cost usage for observability. */
@@ -124,6 +137,13 @@ export interface ThreadNote {
    * counted by the first record); no effect on multi-threaded.
    */
   sameTurn?: boolean;
+  /**
+   * The lifecycle PHASE of this write (thread-as-container). `"start"` = the WORKING-ENSURE
+   * before the turn (status `working`, turn_count UNCHANGED — no turn completed yet);
+   * `"end"` (DEFAULT when absent) = the final record after the turn (turn_count increments
+   * on the `end` write). So a turn is counted EXACTLY ONCE — on `end`, never on `start`.
+   */
+  phase?: "start" | "end";
 }
 
 /**
@@ -136,6 +156,15 @@ export interface ThreadNote {
  * the registry — when unwired (no vault-backed channel), a turn still runs, just no note.
  */
 export type WriteThread = (thread: ThreadNote) => Promise<void>;
+
+/**
+ * Cap on the per-channel PENDING-INBOUND queue (the agent#121 pre-registration buffer).
+ * A buffer that grows without bound is a memory-leak / DoS footgun if a channel's agent
+ * never comes up; past the cap the OLDEST pending message is dropped (FIFO eviction) with
+ * a loud log — bounded loss is better than unbounded growth, and the durable inbound notes
+ * still exist in the vault for the agent to re-read once it's live.
+ */
+export const PENDING_INBOUND_CAP = 50;
 
 /** How many times the outbound write is RETRIED on a transient failure (agent — PR #3
  *  FIX 1) before giving up. Total attempts = 1 + this. */
@@ -212,6 +241,26 @@ export class ProgrammaticAgentRegistry {
   private readonly queues = new Map<string, QueuedMessage[]>();
   /** channel → the in-flight drain promise (its presence == a worker is running). */
   private readonly draining = new Map<string, Promise<void>>();
+  /**
+   * channel → FIFO queue of PENDING-INBOUND messages that arrived BEFORE a live
+   * programmatic agent was registered for the channel (the agent#121 fix). The daemon
+   * OWNS these — it must never drop an inbound it can't yet process (the vault trigger
+   * acks success on the daemon's 200 and never retries, so a drop is permanent). On
+   * {@link register} the channel's pending queue is DRAINED into the normal {@link
+   * enqueue} path, so the queued turns run in arrival order once the agent is live.
+   * IN-MEMORY only (v1): a daemon restart loses pending, which is fine — the durable
+   * inbound notes still exist in the vault and `loadAll` + the 60s def-poll reconverge.
+   */
+  private readonly pending = new Map<string, QueuedMessage[]>();
+  /**
+   * Channels EXPECTED to gain a live programmatic agent (a def maps here / the
+   * instantiate path has started bringing one up) — the gate for {@link queuePending}.
+   * Only an EXPECTED channel queues a pre-registration inbound; a genuinely unknown
+   * channel (nothing maps to it) is logged + dropped (there's nothing to deliver to).
+   * Marked by {@link expectChannel} (the def-instantiation path) and by {@link register}
+   * itself; cleared by {@link unexpectChannel} (deregister/teardown).
+   */
+  private readonly expectedChannels = new Set<string>();
 
   private readonly backend: AgentBackend;
   private readonly writeOutbound: WriteOutbound;
@@ -334,7 +383,102 @@ export class ProgrammaticAgentRegistry {
     };
     this.byChannel.set(channel, handle);
     this.nameToChannel.set(spec.name, channel);
+    // The channel now has a live agent — it's no longer merely "expected" (the gate that
+    // let pre-registration inbound queue pending); the live byChannel index is the truth now.
+    this.expectedChannels.delete(channel);
+    // REPLAY-ON-REGISTER (agent#121): drain any inbound that arrived BEFORE this agent was
+    // live — they were buffered in the pending queue (never dropped). Feed them through the
+    // NORMAL enqueue path, in arrival order (FIFO), so the queued turns run exactly as if
+    // they'd arrived after registration. enqueue() requires the channel to be in byChannel,
+    // which it now is. Do this AFTER the indexes are set so enqueue routes correctly.
+    this.drainPending(channel);
     return handle;
+  }
+
+  /**
+   * Mark a channel as EXPECTED to gain a live programmatic agent — the gate that lets an
+   * inbound arriving BEFORE registration be QUEUED PENDING instead of dropped (agent#121).
+   * The def-instantiation path calls this BEFORE it brings the channel + agent up, so the
+   * narrow desync window (channel live, agent not yet registered) buffers rather than loses.
+   * Idempotent. {@link register} also marks-then-clears it; {@link unexpectChannel} clears it
+   * on teardown.
+   */
+  expectChannel(channel: string): void {
+    this.expectedChannels.add(channel);
+  }
+
+  /**
+   * Drop a channel's EXPECTED mark + any buffered pending inbound — called on teardown
+   * (deregister) of an agent that will NOT come back, so a stale def can't leave inbound
+   * stranded in the pending buffer forever. (deregister of a still-expected agent that WILL
+   * re-register should NOT call this — only a genuine removal.)
+   */
+  unexpectChannel(channel: string): void {
+    this.expectedChannels.delete(channel);
+    this.pending.delete(channel);
+  }
+
+  /**
+   * QUEUE an inbound that arrived before a live programmatic agent exists for the channel
+   * (agent#121). Returns:
+   *  - `"queued"`  — the channel is EXPECTED (a def maps here / instantiation in flight); the
+   *                  message is buffered (FIFO, capped at {@link PENDING_INBOUND_CAP}) and
+   *                  will replay on {@link register}. The daemon now OWNS it (never dropped).
+   *  - `"unknown"` — nothing maps to this channel (not expected, not registered): there is
+   *                  nothing to deliver to, so the caller logs + drops (still 200 — the vault
+   *                  must not retry into a permanent `_pending_at` stall).
+   *
+   * NOTE: a channel with a LIVE agent never reaches here — {@link enqueue} handles it. This is
+   * strictly the pre-registration / desync buffer.
+   */
+  queuePending(channel: string, msg: QueuedMessage): "queued" | "unknown" {
+    if (!this.expectedChannels.has(channel)) return "unknown";
+    const queue = this.pending.get(channel) ?? [];
+    queue.push(msg);
+    // Bounded buffer: past the cap, evict the OLDEST (FIFO) so we keep the most recent
+    // context and never grow unbounded. Loud log — a capped pending queue means an agent
+    // isn't coming up in time (a real operational signal), and the dropped message is still
+    // durable in the vault for the agent to re-read once live.
+    if (queue.length > PENDING_INBOUND_CAP) {
+      queue.shift();
+      console.warn(
+        `parachute-agent: pending-inbound queue for channel "${channel}" hit the cap ` +
+          `(${PENDING_INBOUND_CAP}) — dropped the oldest buffered message (still durable in ` +
+          `the vault). The programmatic agent for this channel is not coming up in time.`,
+      );
+    }
+    this.pending.set(channel, queue);
+    return "queued";
+  }
+
+  /**
+   * Drain a channel's PENDING-INBOUND buffer into the live serial queue — called by
+   * {@link register} once the agent is live. FIFO: the oldest pending inbound is enqueued
+   * first, so the buffered turns run in arrival order. A no-op when the buffer is empty.
+   */
+  private drainPending(channel: string): void {
+    const buffered = this.pending.get(channel);
+    if (!buffered || buffered.length === 0) return;
+    this.pending.delete(channel);
+    console.log(
+      `parachute-agent: replaying ${buffered.length} pending inbound message(s) for ` +
+        `channel "${channel}" now that its programmatic agent is registered.`,
+    );
+    for (const msg of buffered) {
+      // enqueue() routes to the serial worker (the channel is now in byChannel). FIFO order
+      // is preserved by iterating the buffer oldest-first.
+      this.enqueue(channel, msg);
+    }
+  }
+
+  /** How many inbound are buffered pending for a channel (tests + /health observability). */
+  pendingCount(channel: string): number {
+    return this.pending.get(channel)?.length ?? 0;
+  }
+
+  /** Is a channel currently marked EXPECTED (the pending-queue gate)? (tests) */
+  isExpected(channel: string): boolean {
+    return this.expectedChannels.has(channel);
   }
 
   /**
@@ -447,6 +591,25 @@ export class ProgrammaticAgentRegistry {
       // threaded ignores it (deterministic name leaf). One uuid per turn.
       const turnThreadId = crypto.randomUUID();
 
+      // ── THREAD-AS-CONTAINER (the user's model: definition -> thread -> message). ENSURE
+      // the thread note in a `working` state BEFORE the turn runs, so the thread is visible
+      // the moment processing starts (status `working` → `ok`/`error`), not only as a
+      // by-product of a completed turn. The SAME per-turn thread id ties this start-ensure
+      // to the end-record below: single-threaded UPSERTS its deterministic note (and the
+      // end-record overwrites it `working` → `ok`/`error`); multi-threaded CREATES the
+      // per-fire note (and the end-record updates the SAME note via `turnThreadId`).
+      //
+      // turn_count is NOT touched here. `phase: "start"` tells the transport to write
+      // `turn_count = prior` (UNCHANGED — no turn has completed) and NOT advance
+      // `last_turn_at`. The turn is counted EXACTLY ONCE, on the `end` record below — so
+      // start+end never double-count. Best-effort: a start-ensure write failure is logged
+      // (inside recordThread) and the turn STILL runs — a missing/stale working note must
+      // never strand the queue or skip the turn.
+      await this.recordThread(handle, msg, "working", "", startedAt, undefined, {
+        threadId: turnThreadId,
+        phase: "start",
+      });
+
       let result;
       try {
         // Forward each interim event to the streaming-view sink (keyed by channel)
@@ -468,7 +631,10 @@ export class ProgrammaticAgentRegistry {
         // thread note captures the turn outcome, so a failed turn is still a queryable
         // `status:error` (single-threaded upserts the rolling thread; multi-threaded writes
         // a per-fire note).
-        await this.recordThread(handle, msg, "error", reason, startedAt, undefined, { threadId: turnThreadId });
+        await this.recordThread(handle, msg, "error", reason, startedAt, undefined, {
+          threadId: turnThreadId,
+          phase: "end",
+        });
         this.emitTurnEvent(channel, { kind: "error", error: reason });
         continue;
       }
@@ -483,7 +649,10 @@ export class ProgrammaticAgentRegistry {
         // BOTH modes record the failed turn (status:error) on the thread note so a failure
         // always leaves a queryable trace (single-threaded upserts the rolling thread,
         // marking it errored; multi-threaded writes a per-fire status:error note).
-        await this.recordThread(handle, msg, "error", result.error, startedAt, undefined, { threadId: turnThreadId });
+        await this.recordThread(handle, msg, "error", result.error, startedAt, undefined, {
+          threadId: turnThreadId,
+          phase: "end",
+        });
         this.emitTurnEvent(channel, { kind: "error", error: result.error });
         continue;
       }
@@ -496,14 +665,22 @@ export class ProgrammaticAgentRegistry {
       // multi-threaded writes the per-fire note. Best-effort: a thread-note failure is
       // logged + the turn still resolves (we never re-run a `claude -p` turn — that would
       // burn quota for a duplicate).
-      await this.recordThread(handle, msg, "ok", result.reply ?? "", startedAt, result.usage, { threadId: turnThreadId });
+      await this.recordThread(handle, msg, "ok", result.reply ?? "", startedAt, result.usage, {
+        threadId: turnThreadId,
+        phase: "end",
+      });
 
       // The outbound reply — the channel-transcript delivery (the chat bubble). It is
       // ADDITIVE to the primary thread-note record already written above (for BOTH modes).
       // Empty reply → NO note (reviewer contract — `reply` can be ""): a turn that produced
       // no text (e.g. tool-only work) leaves the chat clean.
       if (result.reply && result.reply.length > 0) {
-        const delivered = await this.deliverOutboundWithRetry(channel, result.reply, msg.inReplyTo);
+        const delivered = await this.deliverOutboundWithRetry(
+          channel,
+          result.reply,
+          msg.inReplyTo,
+          turnThreadId,
+        );
         if (!delivered.ok) {
           // FIX 1 (PR #3) — the SCARY one. The reply was PRODUCED but, after the bounded
           // retry, still NOT persisted to the transcript (a persistent vault 5xx / network
@@ -532,7 +709,7 @@ export class ProgrammaticAgentRegistry {
               `Undelivered reply text: ${result.reply}`,
             startedAt,
             result.usage,
-            { threadId: turnThreadId, sameTurn: true },
+            { threadId: turnThreadId, sameTurn: true, phase: "end" },
           );
           this.emitTurnEvent(channel, {
             kind: "error",
@@ -565,11 +742,11 @@ export class ProgrammaticAgentRegistry {
   private async recordThread(
     handle: ProgrammaticAgentHandle,
     msg: QueuedMessage,
-    status: "ok" | "error",
+    status: "ok" | "error" | "working",
     output: string,
     startedAt: string,
     usage: ThreadNote["usage"],
-    opts: { threadId?: string; sameTurn?: boolean } = {},
+    opts: { threadId?: string; sameTurn?: boolean; phase?: "start" | "end" } = {},
   ): Promise<void> {
     if (!this.writeThread) return;
     const thread: ThreadNote = {
@@ -588,6 +765,9 @@ export class ProgrammaticAgentRegistry {
       // double-counting turn_count (single).
       ...(opts.threadId ? { threadId: opts.threadId } : {}),
       ...(opts.sameTurn ? { sameTurn: true } : {}),
+      // The lifecycle phase — `start` (working-ensure, no turn counted) vs `end` (final
+      // record, turn counted). Absent → `end` at the transport (back-compat).
+      ...(opts.phase ? { phase: opts.phase } : {}),
     };
     try {
       await this.writeThread(thread);
@@ -616,11 +796,12 @@ export class ProgrammaticAgentRegistry {
     channel: string,
     reply: string,
     inReplyTo?: string,
+    threadId?: string,
   ): Promise<{ ok: true } | { ok: false; error: string }> {
     let lastError = "";
     for (let attempt = 0; attempt <= OUTBOUND_MAX_RETRIES; attempt++) {
       try {
-        await this.writeOutbound(channel, reply, inReplyTo);
+        await this.writeOutbound(channel, reply, inReplyTo, threadId);
         return { ok: true };
       } catch (err) {
         lastError = (err as Error).message;

--- a/src/backends/registry.ts
+++ b/src/backends/registry.ts
@@ -499,6 +499,13 @@ export class ProgrammaticAgentRegistry {
     this.byChannel.delete(channel);
     this.nameToChannel.delete(name);
     this.queues.delete(channel);
+    // Clear the EXPECTED mark + any buffered pending inbound for this channel too —
+    // the agent is gone, so a pending message has nothing to drain into and would
+    // strand forever (and the next register would replay stale messages). The daemon's
+    // teardown wrapper also calls unexpectChannel, but clearing it here makes direct
+    // registry callers safe too (the reviewer's latent-footgun nit).
+    this.expectedChannels.delete(channel);
+    this.pending.delete(channel);
     // Clear the persisted resume id so a re-spawn starts fresh (the backend's
     // `stop` is a no-op beyond that — there's no process to kill).
     if (handle) {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -284,6 +284,29 @@ export function contextFor(
         });
         return;
       }
+      // PENDING-INBOUND BUFFER (agent#121). No LIVE programmatic agent for this channel —
+      // but if the channel is EXPECTED to gain one (a def maps here; instantiation may be
+      // in flight, or a brief channel/agent desync), we must OWN the message, not drop it:
+      // the vault trigger acks success on our 200 and NEVER retries, so a silent drop is a
+      // PERMANENT loss (0 turns, 0 threads, no reply — the bug). Buffer it; `register()`
+      // replays the buffer in order once the agent is live. A genuinely UNKNOWN channel
+      // (nothing maps to it) returns "unknown": nothing to deliver to, so we log + fall
+      // through to the push path (which reaches no one) and still 200. We do NOT advance the
+      // delivery high-water-mark here (no real delivery happened; the durable note + the
+      // pending buffer / replay is the durability).
+      if (programmatic) {
+        const outcome = programmatic.queuePending(channel, {
+          content: msg.content,
+          ...(msg.meta?.note_id ? { inReplyTo: msg.meta.note_id } : {}),
+        });
+        if (outcome === "queued") return;
+        // outcome === "unknown" — not an expected programmatic channel. It may still be a
+        // genuine push/bridge channel (telegram, a connected session), so fall through to
+        // the normal SSE/MCP push below rather than dropping outright. If THAT also reaches
+        // no one (0 subscribers), the message is logged-as-undelivered by leaving the
+        // high-water-mark behind (the existing no-silent-loss behavior), and for a truly
+        // orphaned channel there is, by definition, nothing more we can do.
+      }
       // Route on the bound `channel`, NOT msg.channel — the transport's own
       // channel is authoritative. This makes it impossible for a transport to
       // emit onto another channel (closing a silent cross-channel-leak footgun)
@@ -423,6 +446,15 @@ export function buildInstantiateDeps(
 ): InstantiateDeps {
   return {
     ensureChannel: async (name, binding) => {
+      // EXPECT-BEFORE-LIVE (agent#121). Mark this channel EXPECTED to gain a programmatic
+      // agent BEFORE we bring the channel transport live — closing the desync window: once
+      // the channel is live the vault trigger can fire an inbound, but the agent isn't
+      // `register()`ed until `setupAndRegister` runs (a later step). An inbound landing in
+      // that window now QUEUES PENDING (owned, replayed on register) instead of dropping.
+      // Harmless for a `channel`-backend agent — its inbound is handled by the channelQueue
+      // routing fork first, so the expected mark is never consulted for it. The mark is
+      // cleared on register (the live index takes over) or on teardown (unexpectChannel).
+      programmatic.expectChannel(normalizeChannel(name).name);
       await addChannelLive(
         channels,
         registry,
@@ -458,8 +490,13 @@ export function buildInstantiateDeps(
     // deregister is a no-op (returns false) where it isn't registered. OR the two so
     // a reload/delete tears the agent down regardless of its backend.
     deregister: async (name) => {
+      // Capture the wake channel BEFORE deregister drops the indexes, so we can clear the
+      // EXPECTED mark + any stranded pending buffer for a genuinely-removed agent (agent#121
+      // teardown — a deleted def must not leave its channel marked expected forever).
+      const wakeChannel = programmatic.getByName(name)?.channel;
       const fromProgrammatic = await programmatic.deregister(name);
       const fromChannel = channelQueue.deregister(name);
+      if (wakeChannel) programmatic.unexpectChannel(wakeChannel);
       return fromProgrammatic || fromChannel;
     },
     removeChannel: async (name) => removeChannelLive(channels, name),
@@ -575,15 +612,22 @@ export function channelQueueStoreFor(
  * fork the conversation).
  */
 export function buildWriteOutbound(channels: Map<string, Channel>): WriteOutbound {
-  return async (channel, reply, inReplyTo) => {
+  return async (channel, reply, inReplyTo, threadId) => {
     const ch = channels.get(channel);
     if (!ch) {
       throw new Error(`no live transport for channel "${channel}" — cannot post the reply`);
     }
+    // Carry the in-reply-to + the per-turn thread id through the transport's `meta` escape
+    // hatch. The vault transport stamps `meta.thread` into the outbound note's
+    // `metadata.thread` — the explicit definition→thread→message link the outbound note
+    // gets (multi-threaded: the per-fire note leaf; single-threaded: a per-turn id).
+    const meta: Record<string, string> = {};
+    if (inReplyTo) meta.in_reply_to = inReplyTo;
+    if (threadId) meta.thread = threadId;
     await ch.transport.reply({
       channel,
       text: reply,
-      ...(inReplyTo ? { meta: { in_reply_to: inReplyTo } } : {}),
+      ...(Object.keys(meta).length > 0 ? { meta } : {}),
     });
   };
 }
@@ -620,6 +664,15 @@ export function buildWriteThread(channels: Map<string, Channel>): WriteThread {
       started_at: thread.started_at,
       ended_at: thread.ended_at,
       ...(thread.usage ? { usage: thread.usage } : {}),
+      // Forward the per-turn thread id + same-turn flag + lifecycle phase to the transport.
+      // These are LOAD-BEARING (not optional decoration):
+      //  - threadId — multi-threaded targets the SAME per-fire note across the start-ensure,
+      //    the end-record, AND the outbound-failure re-record (else each mints a duplicate).
+      //  - sameTurn — the outbound-failure re-record keeps turn_count (no double-count).
+      //  - phase    — `start` (working-ensure: turn_count UNCHANGED) vs `end` (turn counted).
+      ...(thread.threadId ? { threadId: thread.threadId } : {}),
+      ...(thread.sameTurn ? { sameTurn: true } : {}),
+      ...(thread.phase ? { phase: thread.phase } : {}),
     });
   };
 }

--- a/src/programmatic-wiring.test.ts
+++ b/src/programmatic-wiring.test.ts
@@ -330,6 +330,84 @@ describe("inbound for a programmatic channel → deliver → outbound note", () 
   });
 });
 
+describe("inbound for an EXPECTED-but-not-yet-registered channel → queued pending, not dropped (agent#121)", () => {
+  async function inbound(base: string, channel: string, noteId: string, content: string) {
+    return fetch(`${base}/api/vault/inbound`, {
+      method: "POST",
+      headers: { ...adminAuth, "content-type": "application/json" },
+      body: JSON.stringify({
+        note: {
+          id: noteId,
+          content,
+          tags: ["#agent/message", "#agent/message/inbound"],
+          metadata: { channel, direction: "inbound", sender: "aaron", ts: "2026-06-16T00:00:01Z" },
+        },
+      }),
+    });
+  }
+
+  test("the inbound handler 200s AND the message is buffered pending (not dropped); register() replays it", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const programmatic = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    // The desync: the channel is LIVE + EXPECTED (the def-instantiation path marked it) but
+    // the programmatic agent is NOT yet registered. Before the fix, emit() would fall through
+    // to a 0-subscriber push and DROP the message (the vault 200s + never retries → lost).
+    programmatic.expectChannel("eng");
+    expect(programmatic.hasChannel("eng")).toBe(false);
+
+    const registry = new ClientRegistry();
+    const deliveryState = new DeliveryState();
+    const channels = new Map<string, Channel>([
+      ["eng", vaultChannel("eng", registry, deliveryState, programmatic)],
+    ]);
+    const { srv, base } = buildServer({ channels, programmatic, deliveryState });
+    try {
+      // Inbound arrives BEFORE the agent is live → handler still 200s (the daemon now OWNS
+      // the message; a 4xx/5xx would strand it in the vault's _pending_at forever).
+      const res = await inbound(base, "eng", "note-1", "early message");
+      expect(res.status).toBe(200);
+      // It was buffered pending — NOT delivered to the (absent) worker, NOT dropped.
+      await until(() => programmatic.pendingCount("eng") === 1);
+      expect(programmatic.pendingCount("eng")).toBe(1);
+      expect(backend.calls).toHaveLength(0);
+
+      // The agent registers (instantiation completes) → the pending buffer replays.
+      await programmatic.register({ name: "eng", channels: ["eng"], backend: "programmatic" });
+      await until(() => rec.calls.length === 1);
+      expect(backend.calls).toEqual([{ channel: "eng", message: "early message" }]);
+      expect(rec.calls).toEqual([{ channel: "eng", reply: "reply:early message", inReplyTo: "note-1" }]);
+      expect(programmatic.pendingCount("eng")).toBe(0);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("an inbound for an UNEXPECTED channel still 200s (no 4xx that would strand the vault trigger)", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const programmatic = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    // NOT expected, NOT registered — nothing maps to it. The handler must still 200 (a non-2xx
+    // would leave the vault webhook stuck in _pending_at), even though there's nothing to run.
+    const registry = new ClientRegistry();
+    const deliveryState = new DeliveryState();
+    const channels = new Map<string, Channel>([
+      ["orphan", vaultChannel("orphan", registry, deliveryState, programmatic)],
+    ]);
+    const { srv, base } = buildServer({ channels, programmatic, deliveryState });
+    try {
+      const res = await inbound(base, "orphan", "note-1", "to nobody");
+      expect(res.status).toBe(200);
+      await new Promise<void>((r) => setTimeout(r, 5));
+      // Nothing queued (not expected), nothing ran — logged + dropped, but never a 4xx.
+      expect(programmatic.pendingCount("orphan")).toBe(0);
+      expect(backend.calls).toHaveLength(0);
+    } finally {
+      srv.stop(true);
+    }
+  });
+});
+
 /** A live channels map containing `names` as keys — only membership matters to the
  *  boot re-register channel-existence guard (`channels.has(wakeChannel)`), so the
  *  transport is an inert stub. Mirrors a channels.json-derived map at the keys level. */

--- a/src/runner.test.ts
+++ b/src/runner.test.ts
@@ -404,9 +404,22 @@ class ModeFakeBackend implements AgentBackend {
 }
 
 const noopOutbound: WriteOutbound = async () => {};
-function threadRec(): { threads: ThreadNote[]; fn: WriteThread } {
+// A thread recorder that splits the thread-as-container start-ensure (phase:start) from the
+// final record (phase:end), so a test asserts the FINAL turn record without counting the
+// working-ensure the registry now writes before every turn.
+function threadRec(): {
+  threads: ThreadNote[];
+  ends: () => ThreadNote[];
+  starts: () => ThreadNote[];
+  fn: WriteThread;
+} {
   const threads: ThreadNote[] = [];
-  return { threads, fn: async (t) => void threads.push(t) };
+  return {
+    threads,
+    ends: () => threads.filter((t) => t.phase !== "start"),
+    starts: () => threads.filter((t) => t.phase === "start"),
+    fn: async (t) => void threads.push(t),
+  };
 }
 async function flushTurns(pred: () => boolean, tries = 200): Promise<void> {
   for (let i = 0; i < tries && !pred(); i++) await new Promise<void>((r) => setTimeout(r, 1));
@@ -438,15 +451,17 @@ describe("Runner — a scheduled fire honors the def's mode", () => {
     // runNow needs the job in the store; drive `fire` directly (the runner's fire is
     // what we're testing routes through the mode-aware deliver).
     await r["fire"](job({ id: "digest-job", channel: "digest", message: "run the digest" }));
-    await flushTurns(() => threads.threads.length === 1);
+    await flushTurns(() => threads.ends().length === 1);
 
     // Fresh-per-fire: the scheduled fire did NOT resume the chat thread.
     expect(backend.resumed.get("digest")).toBe(false);
-    // …and it materialized one thread note per fire (the multi-threaded record).
-    expect(threads.threads).toHaveLength(1);
-    expect(threads.threads[0]!.mode).toBe("multi-threaded");
-    expect(threads.threads[0]!.status).toBe("ok");
-    expect(threads.threads[0]!.input).toBe("run the digest");
+    // …and it materialized one FINAL thread note per fire (the multi-threaded record), after a
+    // working-ensure (thread-as-container — the thread is visible the moment the fire starts).
+    expect(threads.starts()).toHaveLength(1);
+    expect(threads.ends()).toHaveLength(1);
+    expect(threads.ends()[0]!.mode).toBe("multi-threaded");
+    expect(threads.ends()[0]!.status).toBe("ok");
+    expect(threads.ends()[0]!.input).toBe("run the digest");
   });
 
   test("REGRESSION: a SINGLE-THREADED def's scheduled fire RESUMES the thread + materializes ONE thread note", async () => {
@@ -459,14 +474,15 @@ describe("Runner — a scheduled fire honors the def's mode", () => {
 
     const r = wireRunner(reg);
     await r["fire"](job({ id: "uni-job", channel: "uni-dev", message: "daily check-in" }));
-    await flushTurns(() => threads.threads.length === 1);
+    await flushTurns(() => threads.ends().length === 1);
 
     // A single-threaded def's scheduled fire RESUMES the existing chat thread (today's behavior).
     expect(backend.resumed.get("uni-dev")).toBe(true);
-    // …and materializes ONE thread note (the unified model — single-threaded now writes a
-    // thread note too, named after the def, holding a rolling summary).
-    expect(threads.threads).toHaveLength(1);
-    expect(threads.threads[0]!.mode).toBe("single-threaded");
-    expect(threads.threads[0]!.name).toBe("uni-dev");
+    // …and materializes ONE FINAL thread note (the unified model — single-threaded now writes a
+    // thread note too, named after the def, holding a rolling summary), after a working-ensure.
+    expect(threads.starts()).toHaveLength(1);
+    expect(threads.ends()).toHaveLength(1);
+    expect(threads.ends()[0]!.mode).toBe("single-threaded");
+    expect(threads.ends()[0]!.name).toBe("uni-dev");
   });
 });

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -57,16 +57,38 @@ export interface ThreadRecord {
   definition?: string;
   /** The mode the turn ran under — governs thread identity + whether the note upserts. */
   mode: AgentMode;
-  /** Outcome of THIS turn — `ok` (success) or `error` (the turn failed). */
-  status: "ok" | "error";
+  /**
+   * Outcome / lifecycle state of the thread after THIS write:
+   *  - `working` — the turn has STARTED but not finished (the thread-as-container
+   *    start-ensure, written BEFORE `deliver()`): the input is shown, NO reply yet.
+   *    Only valid with `phase: "start"`.
+   *  - `ok` — the turn finished successfully (the reply landed in `output`).
+   *  - `error` — the turn failed (the reason is in `output`).
+   */
+  status: "ok" | "error" | "working";
   /** The inbound text the turn was handed (the `-p` prompt). */
   input: string;
-  /** The reply text on success, or the failure reason on error. */
+  /** The reply text on success, the failure reason on error, or "" while `working`. */
   output: string;
   /** ISO timestamp the turn started (single-threaded preserves the FIRST turn's). */
   started_at: string;
-  /** ISO timestamp the turn ended (becomes the thread's `last_turn_at`). */
+  /** ISO timestamp the turn ended (becomes the thread's `last_turn_at`; not advanced on a start-ensure). */
   ended_at: string;
+  /**
+   * The LIFECYCLE PHASE of this write — the thread-as-container model (`definition ->
+   * thread -> message`):
+   *  - `"start"` — the WORKING-ENSURE, written BEFORE the turn runs. The thread note is
+   *    materialized in a `working` state (input shown, no reply). It does NOT count a
+   *    turn — single-threaded writes `turn_count = prior` (UNCHANGED) and does NOT
+   *    advance `last_turn_at` (no turn completed yet). Idempotent-upsert for
+   *    single-threaded; CREATE for multi-threaded (the per-fire note).
+   *  - `"end"` (DEFAULT when absent — back-compat) — the FINAL record, written AFTER the
+   *    turn. Single-threaded increments `turn_count` (unless `sameTurn`) and advances
+   *    `last_turn_at`; this is exactly the pre-thread-as-container behavior.
+   * So `turn_count` is counted EXACTLY ONCE per turn, on the `end` write — never
+   * double-counted across the start+end pair.
+   */
+  phase?: "start" | "end";
   /** Optional token/cost usage for this turn (single-threaded accumulates into the note). */
   usage?: { inputTokens?: number; outputTokens?: number; totalCostUsd?: number };
   /**

--- a/src/transports/vault.test.ts
+++ b/src/transports/vault.test.ts
@@ -131,6 +131,23 @@ describe("VaultTransport — reply (outbound note write)", () => {
     expect(captured!.in_reply_to).toBe("inbound-99");
   });
 
+  test("reply() stamps metadata.thread from args.meta.thread (the definition→thread→message link)", async () => {
+    let captured: Record<string, string> | undefined;
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      if (String(url).endsWith("/api/notes")) {
+        const body = JSON.parse(String(init?.body)) as { metadata: Record<string, string> };
+        captured = body.metadata;
+      }
+      return new Response(JSON.stringify({ id: "n3" }), { status: 201 });
+    }) as typeof fetch;
+
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+    await t.reply({ channel: "eng", text: "re", meta: { in_reply_to: "inbound-99", thread: "fire-7" } });
+    expect(captured!.thread).toBe("fire-7");
+    expect(captured!.in_reply_to).toBe("inbound-99");
+  });
+
   test("reply() falls back to the proposed id when the response has no id", async () => {
     globalThis.fetch = (async () =>
       new Response("", { status: 201 })) as unknown as typeof fetch;
@@ -603,6 +620,135 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
         ended_at: "2026-06-18T07:00:01.000Z",
       }),
     ).rejects.toThrow(/write thread note failed/);
+  });
+
+  // ── Thread-as-container: the phase:"start" working-ensure (Part B) ────────────────────
+  // A turn now writes TWO thread notes: a `phase:"start"` working-ensure BEFORE the turn
+  // (status:working, NO reply, turn_count UNCHANGED) and a `phase:"end"` final record after
+  // (status:ok/error, turn counted). turn_count must be counted EXACTLY ONCE — on `end` —
+  // never double-counted across the start+end pair. These assert that at the transport.
+
+  test("SINGLE-THREADED start→end does NOT double-count: turn 1 start writes turn_count 0 (working), end writes 1", async () => {
+    let stored: { metadata: Record<string, string>; content: string } | undefined;
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const u = String(url);
+      const method = init?.method ?? "GET";
+      if (u.includes("/api/notes/") && method === "GET") {
+        if (!stored) return new Response("not found", { status: 404 });
+        return new Response(JSON.stringify(stored), { status: 200 });
+      }
+      if (u.includes("/api/notes/") && method === "PATCH") {
+        const body = JSON.parse(String(init?.body)) as { metadata: Record<string, string>; content: string };
+        stored = { metadata: body.metadata, content: body.content };
+        return new Response(JSON.stringify({ id: "thread-eng" }), { status: 200 });
+      }
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+
+    // START-ENSURE (before the turn): status working, turn_count UNCHANGED (prior 0 → 0).
+    await t.writeThread({
+      channel: "eng", name: "eng", mode: "single-threaded", status: "working",
+      input: "turn one", output: "", started_at: "2026-06-18T07:00:00.000Z",
+      ended_at: "2026-06-18T07:00:00.000Z", threadId: "t1", phase: "start",
+    });
+    expect(stored!.metadata.status).toBe("working");
+    expect(stored!.metadata.turn_count).toBe("0"); // NOT counted yet.
+    // The working body shows the input + an awaiting-reply state — NO fake reply.
+    expect(stored!.content).toContain("turn one");
+    expect(stored!.content).toContain("working");
+    expect(stored!.content).not.toContain("**Reply:**");
+    // last_turn_at is not stamped on a brand-new working-ensure (no turn completed yet).
+    expect(stored!.metadata.last_turn_at).toBeUndefined();
+
+    // END (after the turn): status ok, turn_count now 1 (counted exactly once).
+    await t.writeThread({
+      channel: "eng", name: "eng", mode: "single-threaded", status: "ok",
+      input: "turn one", output: "reply one", started_at: "2026-06-18T07:00:00.000Z",
+      ended_at: "2026-06-18T07:00:05.000Z", threadId: "t1", phase: "end",
+    });
+    expect(stored!.metadata.status).toBe("ok");
+    expect(stored!.metadata.turn_count).toBe("1"); // counted ONCE across start+end.
+    expect(stored!.metadata.last_turn_at).toBe("2026-06-18T07:00:05.000Z");
+    expect(stored!.content).toContain("reply one");
+  });
+
+  test("SINGLE-THREADED turn 2 start preserves prior count (1), end increments to 2 — start never double-counts", async () => {
+    let stored: { metadata: Record<string, string>; content: string } | undefined;
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const u = String(url);
+      const method = init?.method ?? "GET";
+      if (u.includes("/api/notes/") && method === "GET") {
+        if (!stored) return new Response("not found", { status: 404 });
+        return new Response(JSON.stringify(stored), { status: 200 });
+      }
+      if (u.includes("/api/notes/") && method === "PATCH") {
+        const body = JSON.parse(String(init?.body)) as { metadata: Record<string, string>; content: string };
+        stored = { metadata: body.metadata, content: body.content };
+        return new Response(JSON.stringify({ id: "thread-eng" }), { status: 200 });
+      }
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+    const tn = (status: "working" | "ok", input: string, output: string, ended: string, phase: "start" | "end") => ({
+      channel: "eng", name: "eng", mode: "single-threaded" as const, status,
+      input, output, started_at: "2026-06-18T07:00:00.000Z", ended_at: ended, phase,
+    });
+
+    // Turn 1 — start (0) then end (1).
+    await t.writeThread(tn("working", "one", "", "2026-06-18T07:00:00.000Z", "start"));
+    expect(stored!.metadata.turn_count).toBe("0");
+    await t.writeThread(tn("ok", "one", "reply one", "2026-06-18T07:00:05.000Z", "end"));
+    expect(stored!.metadata.turn_count).toBe("1");
+
+    // Turn 2 — start reads prior=1 → writes 1 (UNCHANGED, the no-double-count invariant),
+    // then end increments to 2. The start working-ensure must NOT bump the count.
+    await t.writeThread(tn("working", "two", "", "2026-06-18T08:00:00.000Z", "start"));
+    expect(stored!.metadata.turn_count).toBe("1"); // start preserves the count.
+    expect(stored!.metadata.status).toBe("working");
+    expect(stored!.metadata.started_at).toBe("2026-06-18T07:00:00.000Z"); // first turn's, preserved.
+    await t.writeThread(tn("ok", "two", "reply two", "2026-06-18T08:00:09.000Z", "end"));
+    expect(stored!.metadata.turn_count).toBe("2"); // counted twice total — once per turn.
+    expect(stored!.metadata.last_turn_at).toBe("2026-06-18T08:00:09.000Z");
+  });
+
+  test("MULTI-THREADED start writes turn_count 0 (working) at the per-fire path; end writes 1 at the SAME path", async () => {
+    const patches: { path: string; metadata: Record<string, string>; content: string }[] = [];
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const u = String(url);
+      if (u.includes("/api/notes/") && (init?.method ?? "GET") === "PATCH") {
+        const body = JSON.parse(String(init?.body)) as {
+          path: string; metadata: Record<string, string>; content: string;
+        };
+        patches.push({ path: decodeURIComponent(u), metadata: body.metadata, content: body.content });
+        return new Response(JSON.stringify({ id: "x" }), { status: 200 });
+      }
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+    const base = {
+      channel: "eng", name: "d", mode: "multi-threaded" as const, input: "q",
+      started_at: "2026-06-18T07:00:00.000Z", threadId: "fire-1",
+    };
+    // START — working, turn_count 0, the per-fire note created.
+    await t.writeThread({ ...base, status: "working", output: "", ended_at: "2026-06-18T07:00:00.000Z", phase: "start" });
+    // END — ok, turn_count 1, the SAME per-fire path (same threadId).
+    await t.writeThread({ ...base, status: "ok", output: "a", ended_at: "2026-06-18T07:00:05.000Z", phase: "end" });
+
+    expect(patches).toHaveLength(2);
+    expect(patches[0]!.metadata.status).toBe("working");
+    expect(patches[0]!.metadata.turn_count).toBe("0");
+    expect(patches[1]!.metadata.status).toBe("ok");
+    expect(patches[1]!.metadata.turn_count).toBe("1");
+    // Both writes hit the SAME per-fire path (the reused threadId) — start updates, not dupes.
+    expect(patches[0]!.path).toContain("/Threads/eng/fire-1");
+    expect(patches[1]!.path).toContain("/Threads/eng/fire-1");
+    // The working body shows no fake reply; the end body carries the real reply.
+    expect(patches[0]!.content).not.toContain("**Reply:**");
+    expect(patches[1]!.content).toContain("a");
   });
 });
 

--- a/src/transports/vault.test.ts
+++ b/src/transports/vault.test.ts
@@ -404,6 +404,47 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
     expect(stored!.content).toContain("NOT delivered");
   });
 
+  test("SINGLE-THREADED FULL lifecycle start→end(ok)→end(error,sameTurn): count goes 0→1→1, never double-counts (thread-as-container + FIX 1)", async () => {
+    // The real drain path now writes a `working` start-ensure BEFORE the turn, then an
+    // `end` record, then (on outbound failure) an `end` re-record with sameTurn. This is
+    // the one combination the prior FIX-1 test didn't exercise: a start-ensure preceding
+    // the re-record. The start must NOT count; the first end counts once; the sameTurn
+    // re-record must keep it.
+    let stored: { metadata: Record<string, string>; content: string } | undefined;
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const u = String(url);
+      const method = init?.method ?? "GET";
+      if (u.includes("/api/notes/") && method === "GET") {
+        if (!stored) return new Response("not found", { status: 404 });
+        return new Response(JSON.stringify(stored), { status: 200 });
+      }
+      if (u.includes("/api/notes/") && method === "PATCH") {
+        const body = JSON.parse(String(init?.body)) as { metadata: Record<string, string>; content: string };
+        stored = { metadata: body.metadata, content: body.content };
+        return new Response(JSON.stringify({ id: "thread-eng" }), { status: 200 });
+      }
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+    const base = {
+      channel: "eng", name: "eng", mode: "single-threaded" as const, input: "q",
+      started_at: "2026-06-18T07:00:00.000Z", ended_at: "2026-06-18T07:00:05.000Z", threadId: "t1",
+    };
+    // 1) start-ensure (working) — the container, BEFORE the turn. Must NOT count.
+    await t.writeThread({ ...base, status: "working", output: "", phase: "start" });
+    expect(stored!.metadata.turn_count).toBe("0");
+    expect(stored!.metadata.status).toBe("working");
+    // 2) end(ok) — the turn completed: count once.
+    await t.writeThread({ ...base, status: "ok", output: "a", phase: "end" });
+    expect(stored!.metadata.turn_count).toBe("1");
+    expect(stored!.metadata.status).toBe("ok");
+    // 3) end(error, sameTurn) — outbound write failed, re-record the SAME turn. No increment.
+    await t.writeThread({ ...base, status: "error", output: "reply produced but NOT delivered", phase: "end", sameTurn: true });
+    expect(stored!.metadata.turn_count).toBe("1"); // STILL 1 — start didn't count, sameTurn didn't re-count.
+    expect(stored!.metadata.status).toBe("error");
+  });
+
   test("MULTI-THREADED re-record reuses the passed threadId leaf — ONE note, not a duplicate (PR #3 FIX 1)", async () => {
     const patchPaths: string[] = [];
     globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {

--- a/src/transports/vault.ts
+++ b/src/transports/vault.ts
@@ -312,7 +312,10 @@ function buildThreadSummaryBody(t: {
   // moment processing starts; the end-record overwrites this body with the real ok/error
   // reply once the turn completes.
   if (t.status === "working") {
-    const auto = `${t.mode} thread for ${t.name} — ${turns}, currently working (awaiting reply).`;
+    // No turn has COMPLETED yet, so don't print a (confusing) "0 turns" count — the prior
+    // completed count rides in the metadata for queries; the body just says it's working.
+    const priorTurns = t.turnCount === 0 ? "first turn" : `${turns} so far`;
+    const auto = `${t.mode} thread for ${t.name} — working on the ${t.turnCount === 0 ? "first turn" : "next turn"} (${priorTurns}, awaiting reply).`;
     return (
       `## Summary\n\n${auto}\n\n` +
       `## Latest turn\n\n` +

--- a/src/transports/vault.ts
+++ b/src/transports/vault.ts
@@ -296,18 +296,32 @@ function buildThreadSummaryBody(t: {
   name: string;
   mode: string;
   turnCount: number;
-  status: "ok" | "error";
+  status: "ok" | "error" | "working";
   lastTurnAt: string;
   input: string;
   output: string;
 }): string {
   const turns = t.turnCount === 1 ? "1 turn" : `${t.turnCount} turns`;
-  const auto = `${t.mode} thread for ${t.name} — ${turns}, last ${t.status} at ${t.lastTurnAt}.`;
-  const turnHeading = t.status === "ok" ? "Reply" : "Error";
   // `## Summary` is EARMARKED for a future summarizer agent — but v1 OVERWRITES it every
   // turn (this body is fully regenerated from metadata; `prior.content` is never read), so
   // it's a module-owned default for now, NOT a preserved slot (see the function doc).
   // The `## Latest turn` block + the metadata roll-up are always module-owned.
+  //
+  // WORKING (the thread-as-container start-ensure, before the turn finishes): show the input
+  // and a clear "awaiting reply" state — NEVER print a fake reply. The thread is visible the
+  // moment processing starts; the end-record overwrites this body with the real ok/error
+  // reply once the turn completes.
+  if (t.status === "working") {
+    const auto = `${t.mode} thread for ${t.name} — ${turns}, currently working (awaiting reply).`;
+    return (
+      `## Summary\n\n${auto}\n\n` +
+      `## Latest turn\n\n` +
+      `**Input:** ${t.input}\n\n` +
+      `**Status:** working — awaiting reply.\n`
+    );
+  }
+  const auto = `${t.mode} thread for ${t.name} — ${turns}, last ${t.status} at ${t.lastTurnAt}.`;
+  const turnHeading = t.status === "ok" ? "Reply" : "Error";
   return (
     `## Summary\n\n${auto}\n\n` +
     `## Latest turn\n\n` +
@@ -733,6 +747,13 @@ export class VaultTransport implements Transport {
     // Thread the reply to the inbound note id when the bridge passes it through.
     const inReplyTo = args.meta?.in_reply_to;
     if (inReplyTo) metadata.in_reply_to = inReplyTo;
+    // The explicit definition→thread→message link: stamp the outbound note with its thread
+    // id (the programmatic worker passes the per-turn thread id through `meta.thread`). For a
+    // multi-threaded turn this IS the per-fire `#agent/thread` note's leaf; for a
+    // single-threaded turn it's a per-turn correlation id. INBOUND-note stamping is deferred
+    // (those notes are written externally, before the turn knows its thread).
+    const threadId = args.meta?.thread;
+    if (threadId) metadata.thread = threadId;
 
     const res = await fetch(`${this.vaultUrl}/vault/${this.vault}/api/notes`, {
       method: "POST",
@@ -828,6 +849,7 @@ export class VaultTransport implements Transport {
     let priorOutputTokens = 0;
     let priorCostUsd = 0;
     let priorStartedAt: string | undefined;
+    let priorLastTurnAt: string | undefined;
     if (singleThreaded) {
       const prior = await this.readThreadNote(path);
       if (prior) {
@@ -838,17 +860,35 @@ export class VaultTransport implements Transport {
         if (typeof prior.metadata?.started_at === "string" && prior.metadata.started_at) {
           priorStartedAt = prior.metadata.started_at;
         }
+        if (typeof prior.metadata?.last_turn_at === "string" && prior.metadata.last_turn_at) {
+          priorLastTurnAt = prior.metadata.last_turn_at;
+        }
       }
     }
 
-    // A re-record of the SAME turn (`sameTurn`) keeps the existing count — the first record
-    // already counted this turn; a status flip (ok→error on outbound-delivery failure) must
-    // not double-count it. A normal turn increments. Multi-threaded is always 1.
-    const turnCount = singleThreaded ? (thread.sameTurn ? priorTurnCount : priorTurnCount + 1) : 1;
-    // `started_at` is set ONCE on create (preserve the prior on upsert); `last_turn_at`
-    // advances every turn.
+    // ── THREAD-AS-CONTAINER turn_count discipline (the no-double-count invariant) ─────────
+    // `phase: "start"` is the WORKING-ENSURE written BEFORE the turn — NO turn has completed
+    // yet, so it must NOT advance turn_count: single-threaded writes `turn_count = prior`
+    // (UNCHANGED), multi-threaded writes 0 (the per-fire note is being created mid-turn).
+    // `phase: "end"` (or absent — back-compat) is the FINAL record AFTER the turn, which is
+    // where the turn is COUNTED: single-threaded increments `prior + 1` (UNLESS `sameTurn`,
+    // the ok→error outbound-failure re-record, which keeps the already-counted value), and
+    // multi-threaded is 1 (one fire = one thread = one turn). So across the start+end pair a
+    // turn is counted EXACTLY ONCE (on `end`) — never double-counted.
+    const isStart = thread.phase === "start";
+    let turnCount: number;
+    if (isStart) {
+      turnCount = singleThreaded ? priorTurnCount : 0;
+    } else if (singleThreaded) {
+      turnCount = thread.sameTurn ? priorTurnCount : priorTurnCount + 1;
+    } else {
+      turnCount = 1;
+    }
+    // `started_at` is set ONCE on create (preserve the prior on upsert). `last_turn_at`
+    // advances only when a turn COMPLETES (the `end` write); a `start` working-ensure leaves
+    // it at the prior value (single) or empty (multi-create — no turn has completed yet).
     const startedAt = priorStartedAt ?? thread.started_at;
-    const lastTurnAt = thread.ended_at;
+    const lastTurnAt = isStart ? (priorLastTurnAt ?? "") : thread.ended_at;
 
     // Cumulative usage: single-threaded SUMS this turn into the prior totals; multi-threaded
     // carries just this turn's (one fire = one thread).
@@ -865,9 +905,12 @@ export class VaultTransport implements Transport {
       mode: thread.mode,
       status: thread.status,
       started_at: startedAt,
-      last_turn_at: lastTurnAt,
       turn_count: String(turnCount),
     };
+    // `last_turn_at` is only meaningful once a turn has COMPLETED. A `start` working-ensure on
+    // a brand-new thread (no prior turn) has no last-turn time yet → omit it rather than
+    // stamp an empty string (which would index as a present-but-blank value).
+    if (lastTurnAt) metadata.last_turn_at = lastTurnAt;
     if (thread.definition) metadata.definition = thread.definition;
     // Usage is always present once a turn carried it OR we accumulated any — emit the
     // running totals so a query sees cumulative cost for the thread.


### PR DESCRIPTION
Two coherent parts plus a supporting finding. Central, subtle code — heavily commented, especially the turn_count and pending-replay logic. **No version bump.**

## Part A — pending-inbound queue + replay-on-register (fixes #121; agent-side, NO vault change)

**The bug.** In `daemon.ts` `contextFor.emit`, an inbound for a channel with no live programmatic agent (`programmatic.hasChannel(channel) === false` — a just-defined agent not yet instantiated, or a brief channel/agent desync) fell through to a 0-subscriber SSE/MCP push and was **silently dropped**, while `/api/vault/inbound` still returned 200. The vault trigger acks 200 as done (stamps `<trigger>_rendered_at`) and never retries → **permanent loss** (0 turns, 0 threads, no reply).

**The fix.** The daemon now OWNS an inbound it can't yet process:
- `ProgrammaticAgentRegistry` gains a per-channel **pending-inbound buffer** (FIFO, capped at `PENDING_INBOUND_CAP = 50`; past the cap the oldest is evicted with a loud log — bounded loss beats unbounded growth, and the durable inbound notes still exist in the vault), gated by an `expectedChannels` set.
- New registry API: `expectChannel` / `unexpectChannel` / `queuePending(channel,msg) → "queued"|"unknown"` / `pendingCount` / `isExpected`.
- `register()` **drains** the channel's pending buffer through the normal `enqueue` path (FIFO, arrival order) once the agent is live, then clears the expected mark (the live `byChannel` index is the truth).
- `emit` (daemon.ts) wires it: no live agent → `queuePending`; `"queued"` returns (200, owned); `"unknown"` falls through to the existing push (a genuine telegram/bridge channel still works). The handler **always 200s** — a 4xx/5xx would strand the trigger in `_pending_at`.
- `buildInstantiateDeps.ensureChannel` calls `expectChannel` **before** bringing the channel live (closing the desync window); `deregister` calls `unexpectChannel`.

In-memory is acceptable for v1: a daemon restart loses pending, but the durable inbound notes exist and `loadAll` + the 60s def-poll reconverge.

## Part B — thread-as-container (definition → thread → message)

The `#agent/thread` note is now a CONTAINER ensured when the agent **starts** processing a message, then UPDATED by the turn — not a post-turn by-product.

**API change — `phase: "start" | "end"`** on `ThreadRecord` (transport.ts) / `ThreadNote` (registry.ts):
- `drain` writes a **working-ensure** (`status: "working"`, input shown, NO reply) with `phase: "start"` BEFORE `deliver()`.
- The existing post-turn `recordThread` writes the final record with `phase: "end"` (the default when absent — back-compat).

**turn_count counted EXACTLY ONCE (on `end`), never double-counted across start+end** — in `VaultTransport.writeThread`:
- `phase: "start"` → `turn_count = prior` (single) / `0` (multi); `last_turn_at` NOT advanced; `started_at` preserved/initialized.
- `phase: "end"` → single increments `prior + 1` (unless `sameTurn`, the outbound-failure re-record); multi = 1; `last_turn_at` advanced.
- Trace: turn 1 start→0, end→1; turn 2 start→1 (unchanged), end→2; ok→error re-record stays 1.

The start-ensure and end-record share the per-turn `threadId`, so single-threaded UPSERTS its deterministic note and multi-threaded targets the SAME per-fire note (no duplicate). `buildThreadSummaryBody` handles the `working` state (no fake reply).

**Latent-bug fix:** `buildWriteThread` (daemon.ts) previously **dropped** `threadId` and `sameTurn` — so through the real daemon path a multi-threaded re-record would mint a duplicate note and single-threaded `sameTurn` would double-count. It now forwards `threadId` + `sameTurn` + `phase`.

**Message ↔ thread linkage:** the OUTBOUND `#agent/message` note is stamped with `metadata.thread` (the per-turn thread id), threaded `WriteOutbound` → `reply()` via `meta.thread`. For multi-threaded this IS the per-fire note leaf. **Deferred:** INBOUND-note stamping (those notes are written externally before the turn knows its thread); single-threaded outbound→note-by-stable-path. Not blocking.

## Part C — desync finding (supporting)

`agent-defs.ts loadAll` re-instantiates **every** enabled def on boot AND the 60s poll (`instantiate` always calls `ensureChannel` + `setupAndRegister`; `register()` is idempotent-replace). So any channel/agent desync **self-heals within one poll cycle**; the reload webhook is the fast path. Part A's expect+replay closes the residual window (inbound landing between channel-live and agent-register). No code change needed beyond Part A's `expectChannel` wiring.

## Tests & gate

`bun run test` (typecheck + `bun test ./src`) = **995 pass, 0 fail**.

- **Part A:** inbound for an expected-but-unregistered channel is QUEUED (not dropped) and the handler 200s; `register()` drains FIFO + runs turns in order; cap enforced; unknown channel logs + 200s (no crash); channel-move clears old marks/buffer.
- **Part B:** working-ensure write happens BEFORE `deliver` (gated-turn assertion); status working→ok/error; turn_count no-double-count at the transport (single 1→2, multi 0→1, sameTurn stays 1); start+end target the same note; working body has no fake reply; outbound stamped with thread id.
- **Regression:** existing thread/drain/outbound-failure tests (incl. FIX-1 re-record + turn_count) updated to be phase-aware via an `ends()`/`starts()` filter — they still verify their substance with the added working-ensure.

## Review

Independent reviewer pass: **LGTM with nits**, no critical issues. Both substantive nits fixed in the second commit (channel-move expected/pending leak + working-body wording); the turn_count invariant trace was independently verified.