### PR TITLE
feat(agent): agent-to-agent callback routing (reply_to) — orchestrator substrate

### DIFF
--- a/design/2026-06-20-agent-callbacks.md
+++ b/design/2026-06-20-agent-callbacks.md
@@ -74,7 +74,7 @@ delivers a callback via the new `WriteCallback` seam:
   | `callback` | `"true"` — distinguishes a callback inbound from an ordinary one |
   | `status` | `"ok"` \| `"error"` |
   | `source_channel` | the recipient channel/def whose turn finished |
-  | `source_thread` | the recipient's per-turn `#agent/thread` id (the orchestrator pulls the full thread record from here) |
+  | `source_thread` | the recipient's per-turn `#agent/thread` id. Resolvable for multi-threaded (the per-fire note leaf); for single-threaded it's a per-turn correlation id, NOT the note leaf — use `source_message` as the reliable pull-link there (resolvable `source_thread` for both modes is tracked in #124) |
   | `source_message` | the recipient's OUTBOUND reply note id, when a reply was produced + delivered (absent on an error / empty turn) |
   | `correlation_id` | echoed from the request when present |
   | `delegation_depth` | incoming depth + 1 |
@@ -135,6 +135,8 @@ order with `maxConcurrent === 1`.
 - Multi-threaded `source_thread` is the per-fire note leaf (an exact link); single-threaded
   `source_thread` is the per-turn correlation id (the deterministic thread note's leaf is the
   def name — the same single-threaded outbound→note-by-stable-path linkage gap that already
-  exists for `metadata.thread`).
+  exists for `metadata.thread`). Making `source_thread` a resolvable note id for both modes
+  (widen the writeThread seam to return the written id) is tracked in **#124**; until then,
+  `source_message` is the reliable pull-link for single-threaded recipients.
 - `correlation_id` is opaque end-to-end; no daemon-side request/response registry (the
   orchestrator's own session memory matches replies to requests).

--- a/design/2026-06-20-agent-callbacks.md
+++ b/design/2026-06-20-agent-callbacks.md
@@ -1,0 +1,140 @@
+# Agent-to-agent callback routing (`reply_to`) — the orchestrator substrate
+
+**Status:** shipped (2026-06-20, branch `ag-agent-callbacks`). Builds directly on the
+thread-as-container substrate (#122) and the pending-inbound queue / replay (#121). No
+new transport, no new backend — additive metadata + one new daemon→registry seam.
+
+## The problem
+
+The programmatic backend already lets an agent send a message to ANOTHER agent: write an
+`#agent/message/inbound` note to the recipient's channel (via the vault), the recipient's
+vault trigger fires, the daemon runs a `claude -p` turn, and a reply is written as an
+`#agent/message/outbound` note. That is fire-and-forget. An **orchestrator** agent that
+fans out N sub-tasks to N worker agents has no way to learn when each finishes — it would
+have to poll the workers' transcripts.
+
+We want **request/response between agent threads**: when an agent sends a message to
+another agent and wants to know when it's done, it sets a **callback address** on the
+message. When the recipient finishes its turn, the daemon delivers a lightweight
+**callback** back to the sender's channel — a NOTIFICATION + a LINK to the result, NOT the
+full result duplicated. The sender (an orchestrator) is woken by the callback and PULLS the
+full result if it wants.
+
+**Summary + link, orchestrator pulls** (the explicit design choice). Rationale: cleaner
+(the callback note stays small + uniform regardless of reply size) and a better security
+boundary (the orchestrator reaches for the result through its own vault read scope; the
+callback carries only opaque ids, not the recipient's possibly-sensitive output inlined
+into the sender's channel).
+
+## The model
+
+### 1. `reply_to` on inbound messages (the SEND side)
+
+An `#agent/message/inbound` note MAY carry these in `metadata` (the vault stores metadata
+as strings):
+
+| Field | Meaning |
+|---|---|
+| `reply_to` | The **sender's channel name** — where to deliver a callback when this turn finishes. A single-threaded agent's channel ↔ thread is 1:1, so an agent knows its own channel = its def name and stamps it here. Absent → no callback (an ordinary turn). |
+| `correlation_id` | (optional) An opaque id the sender uses to match a callback to the request it fired. Echoed verbatim onto the callback. The daemon never interprets it. |
+| `delegation_depth` | (optional, default 0) How many delegation HOPS deep this message is. Incremented on each callback hop; bounds runaway chains. |
+
+The sending agent sets these when it writes the inbound note to the recipient's channel.
+These ride from `note.metadata` → flattened into `meta` by the vault transport's
+`ingestInbound` → `contextFor.emit` (daemon.ts) extracts them via `callbackFieldsFromMeta`
+→ onto the `QueuedMessage` (`replyTo` / `correlationId` / `delegationDepth`) → available to
+the drain (registry.ts). The pending-inbound buffer (#121) carries them too, so a delegated
+request that arrives before its recipient agent is live still triggers a callback once the
+buffered turn replays on `register()`.
+
+**The SEND side relies on an agent knowing its own channel.** Today that means an
+orchestrator agent's prompt/tooling stamps `reply_to: <its own channel>` when it writes the
+inbound note to a worker. A dedicated **`delegate` MCP tool** — "send this message to agent
+X and register a callback to me" — that fills in `reply_to`/`correlation_id`/`delegation_depth`
+automatically is the natural follow-up; this PR ships the daemon-side substrate the tool
+would drive.
+
+### 2. The callback on turn-completion (the CORE, daemon-side)
+
+In the drain (`src/backends/registry.ts`), AFTER a turn completes — on **BOTH** `ok` and
+`error` (the orchestrator MUST learn about failures; a hung orchestrator waiting on a
+dropped failure is the worst outcome) — IF the originating message had `reply_to`, the drain
+delivers a callback via the new `WriteCallback` seam:
+
+- The daemon writes a NEW `#agent/message/inbound` note to the `reply_to` channel (so it
+  wakes the sender through the NORMAL inbound path — the vault trigger fires, webhooks back,
+  the daemon routes it to the sender's agent, exactly as if a human had messaged it).
+- **Content:** a brief notification + link, e.g.
+  `[callback] <recipientChannel> finished (ok) — see source_message / source_thread …`.
+  The full reply is NOT duplicated.
+- **Metadata (the contract):**
+
+  | Field | Value |
+  |---|---|
+  | `callback` | `"true"` — distinguishes a callback inbound from an ordinary one |
+  | `status` | `"ok"` \| `"error"` |
+  | `source_channel` | the recipient channel/def whose turn finished |
+  | `source_thread` | the recipient's per-turn `#agent/thread` id (the orchestrator pulls the full thread record from here) |
+  | `source_message` | the recipient's OUTBOUND reply note id, when a reply was produced + delivered (absent on an error / empty turn) |
+  | `correlation_id` | echoed from the request when present |
+  | `delegation_depth` | incoming depth + 1 |
+
+The callback note carries the inbound tags (`#agent/message` + `#agent/message/inbound`) so
+it routes, **BUT never carries `reply_to`** — a callback is terminal.
+
+`source_message` is captured by threading the written outbound note's id back through the
+`WriteOutbound` seam (its return type widened to `Promise<{ id?: string } | void>`, fully
+back-compat — `void` is a member of the union, so every existing recorder still satisfies it).
+
+### 3. Loop safety (critical)
+
+Three layers, defense-in-depth:
+
+1. **The callback never carries `reply_to`** (structural). Handling a callback can't
+   auto-trigger another callback — no ping-pong. Enforced at the daemon wiring AND stripped
+   defensively in `VaultTransport.writeCallback` even if a caller widened the shape.
+2. **`delegation_depth` ceiling** (`MAX_DELEGATION_DEPTH = 8`). On each hop the depth
+   increments; a message arriving at or past the ceiling delivers NO callback (logged
+   loudly — a hit means a delegation tree ran away or a cycle formed). This bounds any chain
+   even if layer 1 were somehow defeated. The turn itself still runs + records; only the
+   onward notification stops.
+3. **Unknown / not-live `reply_to` channel** reuses the #122 own-it-don't-strand posture:
+   `buildWriteCallback` logs + returns WITHOUT throwing (the recipient's turn already ran +
+   recorded; only the notification is lost, and the sender can poll the recipient's thread
+   out-of-band). It does NOT crash the recipient's drain.
+
+A callback delivery failure is best-effort like the other sinks — logged, never thrown out,
+never re-runs the (already-completed) turn.
+
+## Concurrency correctness (verified, not re-architected)
+
+#122 already gives the guarantee; this PR confirms + tests it. An orchestrator fires N
+sub-task messages; the N callbacks return to its single channel. They are handled by the
+orchestrator's **per-channel serial drain**: callbacks arrive as inbound notes on the
+orchestrator's channel, queue FIFO, and drain ONE at a time — there is never two concurrent
+`claude -p` for one channel (the `#draining` single-in-flight-promise invariant), so the
+orchestrator's single-threaded `--resume` session carries state across them without
+clobbering. A returning callback that lands before its turn finishes queues behind the
+in-flight one and drains next. None is lost (the pending buffer / replay covers the
+pre-registration window too). A test simulates N callbacks to one channel draining in FIFO
+order with `maxConcurrent === 1`.
+
+## What changed
+
+| File | Change |
+|---|---|
+| `src/backends/registry.ts` | `QueuedMessage` gains `replyTo`/`correlationId`/`delegationDepth`; new `WriteCallback` seam + `CallbackMeta` contract + `MAX_DELEGATION_DEPTH`; the drain calls `maybeDeliverCallback` at all four terminal points; `WriteOutbound` return widened to surface the outbound note id for `source_message`. |
+| `src/daemon.ts` | `callbackFieldsFromMeta` (extract + coerce); `contextFor.emit` threads the fields onto the enqueue + pending paths; `buildWriteCallback` (resolve the reply_to channel's transport, own-it on unknown); `buildWriteOutbound` returns the written note id; registry wired with `writeCallback`. |
+| `src/transport.ts` | `Transport.writeCallback?` + `CallbackMetadata` (the transport-local mirror of `CallbackMeta`). |
+| `src/transports/vault.ts` | `VaultTransport.writeCallback` (writes a callback inbound note, strips any stray `reply_to`); `writeInbound` gains an optional `extraMeta`. |
+
+## Deferred / follow-ups
+
+- A dedicated **`delegate` MCP tool** that fills in `reply_to`/`correlation_id`/`delegation_depth`
+  so an orchestrator agent doesn't hand-stamp them (the SEND-side ergonomics).
+- Multi-threaded `source_thread` is the per-fire note leaf (an exact link); single-threaded
+  `source_thread` is the per-turn correlation id (the deterministic thread note's leaf is the
+  def name — the same single-threaded outbound→note-by-stable-path linkage gap that already
+  exists for `metadata.thread`).
+- `correlation_id` is opaque end-to-end; no daemon-side request/response registry (the
+  orchestrator's own session memory matches replies to requests).

--- a/src/backends/registry.test.ts
+++ b/src/backends/registry.test.ts
@@ -1215,9 +1215,11 @@ describe("ProgrammaticAgentRegistry — agent-to-agent callbacks (reply_to)", ()
     // completes and delivers a callback BACK to the orchestrator's channel. Those callbacks
     // arrive as inbound on the orchestrator's channel and are handled by ITS per-channel
     // serial drain — one at a time, FIFO, never concurrent (its --resume session carries
-    // state across them). We simulate the orchestrator side directly: enqueue N callback-
-    // shaped inbound messages on one channel + assert they drain in order, none lost, and
-    // the backend never ran two concurrently.
+    // state across them). We exercise the DRAIN-SIDE FIFO property directly here (enqueue N
+    // callback-shaped inbound messages on one channel + assert they drain in order, none
+    // lost, the backend never ran two concurrently) — NOT the real vault-IPC delivery path
+    // (callback note → trigger → /api/vault/inbound → emit), which the wiring + vault suites
+    // cover. The serial drain is the same machinery either way, so this pins the invariant.
     const backend = new FakeBackend();
     backend.resultFor = (m) => ({ ok: true, reply: "ack:" + m });
     const out = recorderWithId();

--- a/src/backends/registry.test.ts
+++ b/src/backends/registry.test.ts
@@ -14,9 +14,12 @@ import {
   ProgrammaticAgentRegistry,
   OUTBOUND_MAX_RETRIES,
   PENDING_INBOUND_CAP,
+  MAX_DELEGATION_DEPTH,
   isTransientOutboundError,
   type WriteOutbound,
   type WriteThread,
+  type WriteCallback,
+  type CallbackMeta,
   type ThreadNote,
   type TurnEventSink,
   type TurnLifecycleEvent,
@@ -968,5 +971,274 @@ describe("ProgrammaticAgentRegistry — thread-as-container working-ensure (Part
     // per-fire thread note's leaf — the explicit message↔thread link.
     expect(outbound[0]!.threadId).toBeDefined();
     expect(outbound[0]!.threadId).toBe(threads.ends()[0]!.threadId!);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────────
+// AGENT-TO-AGENT CALLBACK ROUTING ("reply_to") — design 2026-06-20-agent-callbacks.md.
+// A FAKE WriteCallback recorder captures every callback the drain delivers (its target
+// channel + content + the metadata contract), so we can assert: a reply_to message gets
+// exactly one callback w/ the right metadata; a no-reply_to message gets none; ok AND error
+// both fire; the depth guard suppresses; and N callbacks to one channel drain FIFO + none
+// is lost (the orchestrator-resume concurrency story).
+// ───────────────────────────────────────────────────────────────────────────────
+
+/** A recorder WriteCallback — captures every callback the registry delivers, in order. */
+function callbackRecorder(): {
+  calls: { channel: string; content: string; meta: CallbackMeta }[];
+  fn: WriteCallback;
+} {
+  const calls: { channel: string; content: string; meta: CallbackMeta }[] = [];
+  const fn: WriteCallback = async (channel, content, meta) => {
+    calls.push({ channel, content, meta });
+  };
+  return { calls, fn };
+}
+
+/** A WriteOutbound that returns a deterministic note id, so source_message is assertable. */
+function recorderWithId(noteId = "outbound-note-1"): {
+  calls: { channel: string; reply: string }[];
+  fn: WriteOutbound;
+} {
+  const calls: { channel: string; reply: string }[] = [];
+  const fn: WriteOutbound = async (channel, reply) => {
+    calls.push({ channel, reply });
+    return { id: noteId };
+  };
+  return { calls, fn };
+}
+
+describe("ProgrammaticAgentRegistry — agent-to-agent callbacks (reply_to)", () => {
+  test("an inbound WITH reply_to → exactly ONE callback to the reply_to channel with the full metadata contract (ok)", async () => {
+    const backend = new FakeBackend();
+    backend.resultFor = (m) => ({ ok: true, reply: "done:" + m });
+    const out = recorderWithId("reply-note-42");
+    const cb = callbackRecorder();
+    const reg = new ProgrammaticAgentRegistry({
+      backend,
+      writeOutbound: out.fn,
+      writeCallback: cb.fn,
+    });
+    await reg.register(specFor("worker"));
+
+    reg.enqueue("worker", {
+      content: "sub-task",
+      inReplyTo: "inbound-note-7",
+      replyTo: "orchestrator",
+      correlationId: "corr-abc",
+      delegationDepth: 2,
+    });
+    await until(() => cb.calls.length === 1);
+    // Let any erroneous SECOND callback land, then assert there was exactly one.
+    await new Promise<void>((r) => setTimeout(r, 5));
+    expect(cb.calls).toHaveLength(1);
+
+    const { channel, content, meta } = cb.calls[0]!;
+    expect(channel).toBe("orchestrator"); // delivered to the SENDER's channel.
+    expect(content).toContain("[callback]");
+    expect(content).not.toContain("done:sub-task"); // summary + link, NOT the full reply.
+    expect(meta.callback).toBe("true");
+    expect(meta.status).toBe("ok");
+    expect(meta.source_channel).toBe("worker");
+    expect(meta.source_message).toBe("reply-note-42"); // the delivered outbound note id.
+    expect(meta.source_thread).toBeDefined(); // the per-turn thread id (pull link).
+    expect(meta.correlation_id).toBe("corr-abc"); // echoed verbatim.
+    expect(meta.delegation_depth).toBe("3"); // incoming 2 + 1 hop.
+    // The callback note must NOT itself carry a reply_to (terminal — the loop guard).
+    expect((meta as unknown as Record<string, unknown>).reply_to).toBeUndefined();
+  });
+
+  test("an inbound WITHOUT reply_to → NO callback (a normal turn never emits one)", async () => {
+    const backend = new FakeBackend();
+    const out = recorderWithId();
+    const cb = callbackRecorder();
+    const reg = new ProgrammaticAgentRegistry({
+      backend,
+      writeOutbound: out.fn,
+      writeCallback: cb.fn,
+    });
+    await reg.register(specFor("worker"));
+
+    reg.enqueue("worker", { content: "plain message" });
+    await until(() => out.calls.length === 1);
+    await new Promise<void>((r) => setTimeout(r, 5));
+    expect(out.calls).toHaveLength(1); // the turn ran + replied normally,
+    expect(cb.calls).toHaveLength(0); // but no callback fired.
+  });
+
+  test("the callback fires on an ERROR turn too (status:error, no source_message)", async () => {
+    const backend = new FakeBackend();
+    backend.resultFor = () => ({ ok: false, error: "mint refused" });
+    const out = recorderWithId();
+    const cb = callbackRecorder();
+    const reg = new ProgrammaticAgentRegistry({
+      backend,
+      writeOutbound: out.fn,
+      writeCallback: cb.fn,
+    });
+    await reg.register(specFor("worker"));
+
+    reg.enqueue("worker", { content: "do it", replyTo: "orchestrator", delegationDepth: 0 });
+    await until(() => cb.calls.length === 1);
+    await new Promise<void>((r) => setTimeout(r, 5));
+    expect(cb.calls).toHaveLength(1);
+    expect(out.calls).toHaveLength(0); // an error turn writes no outbound,
+    const { meta, content } = cb.calls[0]!;
+    expect(meta.status).toBe("error"); // but the orchestrator still learns it failed.
+    expect(content).toContain("error");
+    expect(meta.source_message).toBeUndefined(); // no delivered reply note.
+    expect(meta.delegation_depth).toBe("1"); // 0 + 1.
+  });
+
+  test("the callback fires when deliver() THROWS (defensive catch → status:error)", async () => {
+    const backend = new FakeBackend();
+    backend.throwOnce = new Error("surprise throw");
+    const out = recorderWithId();
+    const cb = callbackRecorder();
+    const reg = new ProgrammaticAgentRegistry({
+      backend,
+      writeOutbound: out.fn,
+      writeCallback: cb.fn,
+    });
+    await reg.register(specFor("worker"));
+
+    reg.enqueue("worker", { content: "boom", replyTo: "orchestrator" });
+    await until(() => cb.calls.length === 1);
+    expect(cb.calls[0]!.meta.status).toBe("error");
+  });
+
+  test("the callback fires status:error when the outbound write FAILS after retries (reply produced but not delivered)", async () => {
+    const backend = new FakeBackend();
+    backend.resultFor = (m) => ({ ok: true, reply: "done:" + m });
+    // Always-fail outbound (a permanent 4xx → no retry); the reply was produced but lost.
+    const alwaysFail: WriteOutbound = async () => {
+      throw new Error("vault transport: write reply failed (400) bad request");
+    };
+    const cb = callbackRecorder();
+    const reg = new ProgrammaticAgentRegistry({
+      backend,
+      writeOutbound: alwaysFail,
+      writeCallback: cb.fn,
+      outboundRetryBaseMs: 1,
+    });
+    await reg.register(specFor("worker"));
+
+    reg.enqueue("worker", { content: "x", replyTo: "orchestrator" });
+    await until(() => cb.calls.length === 1);
+    // The orchestrator learns the turn did NOT truly succeed (the reply never landed).
+    expect(cb.calls[0]!.meta.status).toBe("error");
+    expect(cb.calls[0]!.meta.source_message).toBeUndefined(); // the note never landed.
+  });
+
+  test("delegation_depth >= MAX → NO callback (the depth loop guard), turn still runs", async () => {
+    const backend = new FakeBackend();
+    backend.resultFor = (m) => ({ ok: true, reply: "done:" + m });
+    const out = recorderWithId();
+    const cb = callbackRecorder();
+    const reg = new ProgrammaticAgentRegistry({
+      backend,
+      writeOutbound: out.fn,
+      writeCallback: cb.fn,
+    });
+    await reg.register(specFor("worker"));
+
+    // An incoming message already AT the ceiling: a callback would push it over, so suppress.
+    reg.enqueue("worker", {
+      content: "deep",
+      replyTo: "orchestrator",
+      delegationDepth: MAX_DELEGATION_DEPTH,
+    });
+    await until(() => out.calls.length === 1); // the turn STILL ran + replied,
+    await new Promise<void>((r) => setTimeout(r, 5));
+    expect(out.calls).toHaveLength(1);
+    expect(cb.calls).toHaveLength(0); // but the callback was suppressed by the depth guard.
+  });
+
+  test("a message just UNDER the ceiling still gets a callback (boundary)", async () => {
+    const backend = new FakeBackend();
+    backend.resultFor = (m) => ({ ok: true, reply: "done:" + m });
+    const out = recorderWithId();
+    const cb = callbackRecorder();
+    const reg = new ProgrammaticAgentRegistry({
+      backend,
+      writeOutbound: out.fn,
+      writeCallback: cb.fn,
+    });
+    await reg.register(specFor("worker"));
+
+    reg.enqueue("worker", {
+      content: "near-edge",
+      replyTo: "orchestrator",
+      delegationDepth: MAX_DELEGATION_DEPTH - 1,
+    });
+    await until(() => cb.calls.length === 1);
+    expect(cb.calls).toHaveLength(1);
+    expect(cb.calls[0]!.meta.delegation_depth).toBe(String(MAX_DELEGATION_DEPTH)); // the last hop.
+  });
+
+  test("no WriteCallback wired → reply_to is inert (the turn runs normally, no crash)", async () => {
+    const backend = new FakeBackend();
+    backend.resultFor = (m) => ({ ok: true, reply: "done:" + m });
+    const out = recorderWithId();
+    // NOTE: writeCallback intentionally NOT passed.
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: out.fn });
+    await reg.register(specFor("worker"));
+
+    reg.enqueue("worker", { content: "x", replyTo: "orchestrator" });
+    await until(() => out.calls.length === 1);
+    expect(out.calls).toHaveLength(1); // the turn ran fine despite reply_to + no sink.
+  });
+
+  test("a WriteCallback that THROWS does not strand the drain (best-effort, logged)", async () => {
+    const backend = new FakeBackend();
+    backend.resultFor = (m) => ({ ok: true, reply: "done:" + m });
+    const out = recorderWithId();
+    const throwingCb: WriteCallback = async () => {
+      throw new Error("callback delivery boom");
+    };
+    const reg = new ProgrammaticAgentRegistry({
+      backend,
+      writeOutbound: out.fn,
+      writeCallback: throwingCb,
+    });
+    await reg.register(specFor("worker"));
+
+    // Two reply_to messages; the first callback throws — the second turn must still drain.
+    reg.enqueue("worker", { content: "first", replyTo: "orchestrator" });
+    reg.enqueue("worker", { content: "second", replyTo: "orchestrator" });
+    await until(() => out.calls.length === 2);
+    expect(out.calls.map((c) => c.reply)).toEqual(["done:first", "done:second"]);
+  });
+
+  test("CONCURRENCY: N callbacks returning to ONE orchestrator channel drain FIFO, none lost or clobbered", async () => {
+    // The orchestrator-resume story: an orchestrator fires N sub-tasks; each worker's turn
+    // completes and delivers a callback BACK to the orchestrator's channel. Those callbacks
+    // arrive as inbound on the orchestrator's channel and are handled by ITS per-channel
+    // serial drain — one at a time, FIFO, never concurrent (its --resume session carries
+    // state across them). We simulate the orchestrator side directly: enqueue N callback-
+    // shaped inbound messages on one channel + assert they drain in order, none lost, and
+    // the backend never ran two concurrently.
+    const backend = new FakeBackend();
+    backend.resultFor = (m) => ({ ok: true, reply: "ack:" + m });
+    const out = recorderWithId();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: out.fn });
+    await reg.register(specFor("orchestrator"));
+
+    const N = 6;
+    for (let i = 0; i < N; i++) {
+      // A callback inbound carries NO reply_to (terminal) — exactly the shape the daemon
+      // writes. The orchestrator processes each as "a sub-task finished" message.
+      reg.enqueue("orchestrator", { content: `callback-${i}` });
+    }
+    await until(() => backend.calls.length === N);
+    // FIFO: arrival order preserved, NONE lost or duplicated.
+    expect(backend.calls.map((c) => c.message)).toEqual(
+      Array.from({ length: N }, (_, i) => `callback-${i}`),
+    );
+    // The per-channel serial worker never ran two turns at once (the --resume invariant).
+    expect(backend.maxConcurrent).toBe(1);
+    expect(out.calls.map((c) => c.reply)).toEqual(
+      Array.from({ length: N }, (_, i) => `ack:callback-${i}`),
+    );
   });
 });

--- a/src/backends/registry.ts
+++ b/src/backends/registry.ts
@@ -203,10 +203,15 @@ export interface CallbackMeta {
   /** The channel/def whose turn just finished (the recipient) — provenance for the sender. */
   source_channel: string;
   /**
-   * The recipient's `#agent/thread` note path/leaf for THIS turn — the orchestrator
-   * pulls the full thread record (input/output/usage) from here. The per-turn thread id
-   * the drain minted (multi-threaded: the per-fire note leaf; single-threaded: the
-   * per-turn correlation id).
+   * The per-turn thread id the drain minted. RESOLVABILITY DIFFERS BY MODE:
+   *  - multi-threaded: this IS the per-fire note's leaf — the orchestrator can pull the
+   *    thread note at `Threads/<channel>/<source_thread>`.
+   *  - single-threaded: this is a per-turn CORRELATION id, NOT the note leaf (the
+   *    single-threaded note lives at the deterministic `Threads/<channel>/<name>`), so it
+   *    is NOT directly resolvable. Use `source_message` as the reliable pull-link for a
+   *    single-threaded recipient. Making this a resolvable thread id for both modes
+   *    (widen the writeThread seam to return the written note id) is tracked as a
+   *    follow-up (parachute-agent#124).
    */
   source_thread: string;
   /**

--- a/src/backends/registry.ts
+++ b/src/backends/registry.ts
@@ -74,8 +74,15 @@ export type TurnLifecycleEvent =
  * Write an outbound reply for a channel — the seam the registry posts a turn's
  * reply through. The daemon wires this to the channel transport's `reply()` (a
  * VaultTransport writes a `#agent/message/outbound` note). `inReplyTo` threads the
- * reply to the inbound note id when one is known. Returns nothing; a write failure
- * is the implementation's to surface (the registry logs whatever it throws).
+ * reply to the inbound note id when one is known.
+ *
+ * RETURN: optionally the written outbound note's id (`{ id }`) — the agent-to-agent
+ * callback uses it as the `source_message` an orchestrator pulls the full reply from.
+ * Returning `void` (or `{}`) is fine — the callback then just omits `source_message`
+ * (the sender still learns the turn finished; it has the `source_thread` to pull from).
+ * Kept BACK-COMPAT: every existing `async () => {}` recorder still satisfies this (`void`
+ * is a member of the union). A write failure is still surfaced as a throw (the registry's
+ * retry/record logic depends on the throw, not the return).
  */
 export type WriteOutbound = (
   channel: string,
@@ -90,7 +97,7 @@ export type WriteOutbound = (
    * deferred (those notes are externally written; see the PR notes).
    */
   threadId?: string,
-) => Promise<void>;
+) => Promise<{ id?: string } | void>;
 
 /**
  * One turn's input to materializing a `#agent/thread` note (the UNIFIED model
@@ -158,6 +165,77 @@ export interface ThreadNote {
 export type WriteThread = (thread: ThreadNote) => Promise<void>;
 
 /**
+ * A callback delivered back to a SENDER's channel when a turn it requested finishes —
+ * the agent-to-agent request/response substrate ("reply_to"). The daemon wires this to
+ * write a NEW `#agent/message/inbound` note to the `channel` (so it wakes the sender
+ * through the normal inbound path), carrying the {@link CallbackMeta} contract.
+ *
+ * The content is a brief NOTIFICATION + a LINK to the result (NOT the full reply
+ * duplicated) — the orchestrator reads `source_message`/`source_thread` off the metadata
+ * and PULLS the full result if it wants (the user's explicit choice: summary + link,
+ * orchestrator pulls — cleaner + a better security boundary than fan-out duplication).
+ *
+ * LOOP SAFETY (load-bearing): the callback note this writes carries the INBOUND tags so
+ * it routes, but the daemon's wiring MUST NOT put a `reply_to` on it — a callback is
+ * TERMINAL, so handling one can never auto-trigger another callback (no ping-pong).
+ *
+ * A write failure is the implementation's to surface (the registry logs whatever it
+ * throws); a callback NEVER re-runs the turn. Optional on the registry — when unwired (no
+ * vault-backed channels), reply_to is silently inert.
+ */
+export type WriteCallback = (channel: string, content: string, meta: CallbackMeta) => Promise<void>;
+
+/**
+ * The METADATA CONTRACT a callback inbound note carries (design
+ * 2026-06-20-agent-callbacks.md). The daemon's {@link WriteCallback} wiring stamps these
+ * onto the new `#agent/message/inbound` note's `metadata` (the vault stores them as
+ * strings). The orchestrator reads `source_message` / `source_thread` to PULL the full
+ * result. Deliberately a SUMMARY + LINK, never the duplicated reply body.
+ */
+export interface CallbackMeta {
+  /**
+   * `"true"` — the marker that distinguishes a callback inbound from an ordinary one, so
+   * an orchestrator's turn can tell "a sub-task finished" from "a new request arrived".
+   */
+  callback: "true";
+  /** The terminal outcome of the requested turn — `ok` (succeeded) or `error` (failed). */
+  status: "ok" | "error";
+  /** The channel/def whose turn just finished (the recipient) — provenance for the sender. */
+  source_channel: string;
+  /**
+   * The recipient's `#agent/thread` note path/leaf for THIS turn — the orchestrator
+   * pulls the full thread record (input/output/usage) from here. The per-turn thread id
+   * the drain minted (multi-threaded: the per-fire note leaf; single-threaded: the
+   * per-turn correlation id).
+   */
+  source_thread: string;
+  /**
+   * The recipient's OUTBOUND reply note id, when the turn produced (and delivered) a
+   * reply. The orchestrator pulls the full reply text from here. ABSENT when there was no
+   * reply (an error turn, or an empty/tool-only turn) — the callback still fires so the
+   * orchestrator learns the turn is done; it just has no reply note to pull.
+   */
+  source_message?: string;
+  /** The sender's opaque correlation id, echoed verbatim when one was set. Omitted otherwise. */
+  correlation_id?: string;
+  /**
+   * The depth of THIS callback = the incoming message's depth + 1. The sender's turn,
+   * woken by this callback, inherits it; if that turn delegates onward, the chain's depth
+   * keeps climbing toward {@link MAX_DELEGATION_DEPTH}.
+   */
+  delegation_depth: string;
+}
+
+/**
+ * The hard ceiling on delegation HOPS — the depth loop guard (design
+ * 2026-06-20-agent-callbacks.md §loop-safety). An inbound message arriving at or past this
+ * depth delivers NO callback (logged), which BOUNDS any chain even if the no-`reply_to`-on-
+ * callback rule were somehow circumvented. 8 is generous for real orchestration trees
+ * (an orchestrator → workers → sub-workers fan-out is 2-3 deep) while still finite.
+ */
+export const MAX_DELEGATION_DEPTH = 8;
+
+/**
  * Cap on the per-channel PENDING-INBOUND queue (the agent#121 pre-registration buffer).
  * A buffer that grows without bound is a memory-leak / DoS footgun if a channel's agent
  * never comes up; past the cap the OLDEST pending message is dropped (FIFO eviction) with
@@ -198,11 +276,39 @@ function delay(ms: number): Promise<void> {
 }
 
 /** A queued inbound message awaiting its serial turn. */
-interface QueuedMessage {
+export interface QueuedMessage {
   /** The inbound text handed to the `claude -p` turn as the prompt. */
   content: string;
   /** The inbound note id (if known), threaded into the outbound reply's `in_reply_to`. */
   inReplyTo?: string;
+  // ── AGENT-TO-AGENT CALLBACK ROUTING ("reply_to") ───────────────────────────────
+  // These ride from the inbound note's metadata (a SENDING agent stamps them when it
+  // writes an inbound note to THIS channel via the vault), through `contextFor.emit`
+  // (daemon.ts, which flattens note.metadata into `meta`), onto this queue item, so the
+  // drain can deliver a CALLBACK to the originating channel when this turn finishes.
+  /**
+   * The SENDER's channel name — where to deliver a callback when this turn completes
+   * (BOTH ok and error). A single-threaded agent's channel ↔ thread is 1:1, so an
+   * orchestrator knows its own channel = its def name and stamps it here when it writes
+   * the inbound note to the recipient. Absent → NO callback (a normal, non-orchestrated
+   * turn). A callback note itself NEVER carries `reply_to` (it's terminal — that is the
+   * primary loop guard; see {@link MAX_DELEGATION_DEPTH}).
+   */
+  replyTo?: string;
+  /**
+   * An OPAQUE id the sender uses to match a callback to the request it fired (it may
+   * have N sub-tasks in flight). Echoed verbatim onto the callback metadata; the daemon
+   * never interprets it. Absent → omitted from the callback.
+   */
+  correlationId?: string;
+  /**
+   * How many delegation HOPS deep this message is (0 = a top-level human/runner turn).
+   * Incremented on each callback hop; bounds runaway chains. A message arriving at or
+   * past {@link MAX_DELEGATION_DEPTH} delivers NO callback (the depth loop guard). The
+   * vault stores metadata as STRINGS, so daemon.ts coerces `metadata.delegation_depth`
+   * to a finite integer before it lands here; a missing/garbage value reads as 0.
+   */
+  delegationDepth?: number;
 }
 
 /** A registered programmatic agent's live status (surfaced in /health + the list). */
@@ -266,6 +372,11 @@ export class ProgrammaticAgentRegistry {
   private readonly writeOutbound: WriteOutbound;
   /** Optional thread-note sink — materialize an `#agent/thread` note (BOTH modes). */
   private readonly writeThread?: WriteThread;
+  /**
+   * Optional callback sink — deliver an agent-to-agent callback to a sender's channel on
+   * turn completion (the "reply_to" substrate). Unwired → reply_to is silently inert.
+   */
+  private readonly writeCallback?: WriteCallback;
   /** Optional streaming-view sink — push interim + lifecycle turn events per channel. */
   private readonly onTurnEvent?: TurnEventSink;
   /** Base backoff (ms) between outbound retries (FIX 1). Injectable so tests run fast. */
@@ -275,6 +386,7 @@ export class ProgrammaticAgentRegistry {
     backend: AgentBackend;
     writeOutbound: WriteOutbound;
     writeThread?: WriteThread;
+    writeCallback?: WriteCallback;
     onTurnEvent?: TurnEventSink;
     /** Override the outbound-retry backoff base (ms). Default {@link OUTBOUND_RETRY_BASE_MS}. */
     outboundRetryBaseMs?: number;
@@ -282,6 +394,7 @@ export class ProgrammaticAgentRegistry {
     this.backend = deps.backend;
     this.writeOutbound = deps.writeOutbound;
     if (deps.writeThread) this.writeThread = deps.writeThread;
+    if (deps.writeCallback) this.writeCallback = deps.writeCallback;
     if (deps.onTurnEvent) this.onTurnEvent = deps.onTurnEvent;
     this.outboundRetryBaseMs = deps.outboundRetryBaseMs ?? OUTBOUND_RETRY_BASE_MS;
   }
@@ -648,6 +761,9 @@ export class ProgrammaticAgentRegistry {
           phase: "end",
         });
         this.emitTurnEvent(channel, { kind: "error", error: reason });
+        // CALLBACK on the failure too — an orchestrator MUST learn its sub-task failed, not
+        // hang waiting forever. No outbound note was produced, so no `source_message`.
+        await this.maybeDeliverCallback(handle, msg, turnThreadId, "error");
         continue;
       }
 
@@ -666,6 +782,9 @@ export class ProgrammaticAgentRegistry {
           phase: "end",
         });
         this.emitTurnEvent(channel, { kind: "error", error: result.error });
+        // CALLBACK on the failure-as-value too (status:error) — the orchestrator learns the
+        // sub-task failed and can react. No delivered reply, so no `source_message`.
+        await this.maybeDeliverCallback(handle, msg, turnThreadId, "error");
         continue;
       }
 
@@ -686,6 +805,12 @@ export class ProgrammaticAgentRegistry {
       // ADDITIVE to the primary thread-note record already written above (for BOTH modes).
       // Empty reply → NO note (reviewer contract — `reply` can be ""): a turn that produced
       // no text (e.g. tool-only work) leaves the chat clean.
+      //
+      // `sourceMessage` — the delivered outbound note id, captured for the callback's
+      // `source_message` so an orchestrator can PULL the full reply text. Stays undefined
+      // for an empty/tool-only turn (no note) — the callback still fires (status:ok), it
+      // just has no reply note to point at (the orchestrator pulls from `source_thread`).
+      let sourceMessage: string | undefined;
       if (result.reply && result.reply.length > 0) {
         const delivered = await this.deliverOutboundWithRetry(
           channel,
@@ -693,6 +818,7 @@ export class ProgrammaticAgentRegistry {
           msg.inReplyTo,
           turnThreadId,
         );
+        if (delivered.ok) sourceMessage = delivered.noteId;
         if (!delivered.ok) {
           // FIX 1 (PR #3) — the SCARY one. The reply was PRODUCED but, after the bounded
           // retry, still NOT persisted to the transcript (a persistent vault 5xx / network
@@ -727,6 +853,11 @@ export class ProgrammaticAgentRegistry {
             kind: "error",
             error: `reply produced but not saved: ${delivered.error}`,
           });
+          // CALLBACK as status:error — the reply was produced but NOT delivered, so the
+          // turn did not truly succeed; the orchestrator must learn that. No `source_message`
+          // (the outbound note never landed); the undelivered text lives in the error thread
+          // note for an operator to recover.
+          await this.maybeDeliverCallback(handle, msg, turnThreadId, "error");
           continue;
         }
       }
@@ -737,6 +868,89 @@ export class ProgrammaticAgentRegistry {
       // Reached only when the outbound write SUCCEEDED, or there was no reply to write
       // (empty/tool-only turn → clean resolve, no note expected).
       this.emitTurnEvent(channel, { kind: "done", reply: result.reply ?? "" });
+      // CALLBACK on success — the turn finished cleanly (status:ok). `sourceMessage` is the
+      // delivered reply note (when there was one) the orchestrator pulls the full result from.
+      await this.maybeDeliverCallback(handle, msg, turnThreadId, "ok", sourceMessage);
+    }
+  }
+
+  /**
+   * Deliver an agent-to-agent CALLBACK to the originating channel when a requested turn
+   * finishes — the request/response substrate ("reply_to"). Called at EVERY terminal point
+   * of the drain (success, failure-as-value, defensive-catch throw, AND outbound-delivery
+   * failure), because an orchestrator must learn the outcome whether the sub-task succeeded
+   * OR failed — a hung orchestrator waiting on a dropped failure is the worst outcome.
+   *
+   * GUARDS (in order; each is a hard precondition — failing any one is a clean no-op):
+   *  1. No {@link WriteCallback} wired → reply_to is inert (a daemon with no vault channels).
+   *  2. No `replyTo` on the originating message → an ordinary, non-orchestrated turn. This
+   *     is THE common case + the first loop guard: a CALLBACK note is written WITHOUT a
+   *     `reply_to` (see the daemon's wiring), so handling a callback can NEVER itself emit a
+   *     callback — no ping-pong, structurally.
+   *  3. `delegationDepth >= MAX_DELEGATION_DEPTH` → the DEPTH loop guard. Even if guard 2
+   *     were somehow defeated, this bounds any chain to a finite hop count. We LOG loudly
+   *     (a hit is a real signal — a delegation tree ran away or a cycle formed) and drop the
+   *     callback. The turn itself already ran + recorded; only the onward notification stops.
+   *
+   * The callback CONTENT is a brief NOTIFICATION + a LINK (never the duplicated reply) — the
+   * orchestrator reads `source_thread`/`source_message` off the metadata and PULLS the full
+   * result (the user's explicit choice). METADATA is the {@link CallbackMeta} contract, with
+   * `delegation_depth` = incoming + 1 so the chain's depth climbs each hop.
+   *
+   * Best-effort like the other sinks: a write failure is LOGGED, never thrown — a callback
+   * failure must NOT strand the per-channel drain or re-run the (already-completed) turn.
+   */
+  private async maybeDeliverCallback(
+    handle: ProgrammaticAgentHandle,
+    msg: QueuedMessage,
+    turnThreadId: string,
+    status: "ok" | "error",
+    sourceMessage?: string,
+  ): Promise<void> {
+    // Guard 1 + 2: no sink, or this wasn't a delegated request → nothing to call back.
+    if (!this.writeCallback) return;
+    if (!msg.replyTo) return;
+
+    // Guard 3 (DEPTH): bound the delegation chain. The INCOMING depth (default 0) is how
+    // deep this message already is; the callback we'd write is one hop deeper. If the
+    // incoming message is already at/over the ceiling, stop — do not deliver.
+    const incomingDepth = msg.delegationDepth ?? 0;
+    if (incomingDepth >= MAX_DELEGATION_DEPTH) {
+      console.warn(
+        `parachute-agent: delegation depth ${incomingDepth} >= MAX (${MAX_DELEGATION_DEPTH}) for ` +
+          `channel "${handle.channel}" → NOT delivering a callback to "${msg.replyTo}" (loop guard). ` +
+          `A delegation chain ran away or a cycle formed; the turn ran + recorded normally.`,
+      );
+      return;
+    }
+
+    // The brief notification + link. NOT the full reply (the orchestrator pulls it).
+    const verb = status === "ok" ? "finished (ok)" : "finished with an error";
+    const content =
+      `[callback] ${handle.channel} ${verb} — see source_message / source_thread in this ` +
+      `note's metadata to pull the full result.`;
+
+    // The metadata contract. delegation_depth = incoming + 1 (this hop). correlation_id +
+    // source_message are echoed/included only when present. The daemon's WriteCallback
+    // wiring writes this as a `#agent/message/inbound` note to `msg.replyTo` and — CRUCIALLY
+    // — does NOT stamp a `reply_to` on it (the terminal-callback loop guard).
+    const meta: CallbackMeta = {
+      callback: "true",
+      status,
+      source_channel: handle.channel,
+      source_thread: turnThreadId,
+      ...(sourceMessage ? { source_message: sourceMessage } : {}),
+      ...(msg.correlationId ? { correlation_id: msg.correlationId } : {}),
+      delegation_depth: String(incomingDepth + 1),
+    };
+
+    try {
+      await this.writeCallback(msg.replyTo, content, meta);
+    } catch (err) {
+      console.error(
+        `parachute-agent: delivering callback to channel "${msg.replyTo}" failed ` +
+          `(continuing — the turn already completed + recorded): ${(err as Error).message}`,
+      );
     }
   }
 
@@ -809,12 +1023,15 @@ export class ProgrammaticAgentRegistry {
     reply: string,
     inReplyTo?: string,
     threadId?: string,
-  ): Promise<{ ok: true } | { ok: false; error: string }> {
+  ): Promise<{ ok: true; noteId?: string } | { ok: false; error: string }> {
     let lastError = "";
     for (let attempt = 0; attempt <= OUTBOUND_MAX_RETRIES; attempt++) {
       try {
-        await this.writeOutbound(channel, reply, inReplyTo, threadId);
-        return { ok: true };
+        // Capture the written note id (when the seam returns one) so the caller can
+        // point a callback's `source_message` at the delivered reply. A void return →
+        // no id (the callback then omits source_message — still fires).
+        const written = await this.writeOutbound(channel, reply, inReplyTo, threadId);
+        return { ok: true, ...(written && written.id ? { noteId: written.id } : {}) };
       } catch (err) {
         lastError = (err as Error).message;
         const transient = isTransientOutboundError(err);

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -269,9 +269,11 @@ export function callbackFieldsFromMeta(
   if (typeof meta.correlation_id === "string" && meta.correlation_id) {
     out.correlationId = meta.correlation_id;
   }
-  // Coerce the string-typed depth to a finite non-negative integer; anything unparseable
-  // (absent, "", "abc", a negative) reads as 0 — a safe floor (a turn at depth 0 always
-  // gets to call back; the ceiling is what stops a runaway chain).
+  // Coerce the string-typed depth to a finite positive integer. Anything else — absent, "",
+  // "abc", a negative, OR a literal "0" — is OMITTED here; the drain's `?? 0` fallback
+  // (maybeDeliverCallback) treats an absent `delegationDepth` as 0, so a depth-0 message
+  // still gets to call back (the ceiling, not the floor, is what stops a runaway chain).
+  // We only bother storing a value when it's a meaningful positive depth.
   const depth = Number(meta.delegation_depth);
   if (Number.isFinite(depth) && depth > 0) out.delegationDepth = Math.floor(depth);
   return out;

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -116,6 +116,8 @@ import {
   ProgrammaticAgentRegistry,
   type WriteOutbound,
   type WriteThread,
+  type WriteCallback,
+  type QueuedMessage,
   type TurnEventSink,
 } from "./backends/registry.ts";
 import {
@@ -242,6 +244,39 @@ const START_CMD: string[] = resolveStartCmd(INSTALL_DIR);
 // Registry + routing
 // ---------------------------------------------------------------------------
 
+/**
+ * Extract the agent-to-agent CALLBACK fields ("reply_to") from a flattened inbound `meta`
+ * (the vault transport's ingestInbound copies the note's metadata into `meta`, all string-
+ * valued). A SENDING agent stamps these on the inbound note it writes to the recipient:
+ *   - `reply_to`         — the sender's channel name; where to deliver the completion
+ *                          callback. Absent → no callback (an ordinary turn).
+ *   - `correlation_id`   — an opaque id the sender matches replies to requests with.
+ *   - `delegation_depth` — how many hops deep this message is (the loop guard's counter).
+ *                          The vault stores it as a STRING, so coerce to a finite integer
+ *                          here; a missing/garbage value reads as 0 (a top-level turn).
+ *
+ * Returns ONLY the keys that are present, so spreading it into a {@link QueuedMessage} is a
+ * clean no-op when this isn't a delegated request. NOTE we read `reply_to` from metadata —
+ * NOT to be confused with the Telegram quote-reply `reply_to` on ReplyArgs (a message-id,
+ * a different axis that lives on the outbound side).
+ */
+export function callbackFieldsFromMeta(
+  meta: Record<string, string> | undefined,
+): Pick<QueuedMessage, "replyTo" | "correlationId" | "delegationDepth"> {
+  if (!meta) return {};
+  const out: Pick<QueuedMessage, "replyTo" | "correlationId" | "delegationDepth"> = {};
+  if (typeof meta.reply_to === "string" && meta.reply_to) out.replyTo = meta.reply_to;
+  if (typeof meta.correlation_id === "string" && meta.correlation_id) {
+    out.correlationId = meta.correlation_id;
+  }
+  // Coerce the string-typed depth to a finite non-negative integer; anything unparseable
+  // (absent, "", "abc", a negative) reads as 0 — a safe floor (a turn at depth 0 always
+  // gets to call back; the ceiling is what stops a runaway chain).
+  const depth = Number(meta.delegation_depth);
+  if (Number.isFinite(depth) && depth > 0) out.delegationDepth = Math.floor(depth);
+  return out;
+}
+
 /** Build the per-channel context a transport routes through. Exported for tests
  *  (the inbound-routing fork lives here). */
 export function contextFor(
@@ -281,6 +316,11 @@ export function contextFor(
         programmatic.enqueue(channel, {
           content: msg.content,
           ...(msg.meta?.note_id ? { inReplyTo: msg.meta.note_id } : {}),
+          // AGENT-TO-AGENT CALLBACK ROUTING ("reply_to") — pull the callback fields a
+          // SENDING agent stamped on this inbound note's metadata (flattened into `meta` by
+          // the vault transport's ingestInbound). When `reply_to` is present, the drain
+          // delivers a callback to that channel on turn completion. See callbackFieldsFromMeta.
+          ...callbackFieldsFromMeta(msg.meta),
         });
         return;
       }
@@ -298,6 +338,10 @@ export function contextFor(
         const outcome = programmatic.queuePending(channel, {
           content: msg.content,
           ...(msg.meta?.note_id ? { inReplyTo: msg.meta.note_id } : {}),
+          // Carry the callback fields through the PENDING buffer too — a delegated request
+          // that arrives before its recipient agent is live must still trigger a callback
+          // once the buffered turn runs on register() (the agent#121 replay path).
+          ...callbackFieldsFromMeta(msg.meta),
         });
         if (outcome === "queued") return;
         // outcome === "unknown" — not an expected programmatic channel. It may still be a
@@ -624,11 +668,16 @@ export function buildWriteOutbound(channels: Map<string, Channel>): WriteOutboun
     const meta: Record<string, string> = {};
     if (inReplyTo) meta.in_reply_to = inReplyTo;
     if (threadId) meta.thread = threadId;
-    await ch.transport.reply({
+    const sent = await ch.transport.reply({
       channel,
       text: reply,
       ...(Object.keys(meta).length > 0 ? { meta } : {}),
     });
+    // Surface the written outbound note id so the agent-to-agent callback can point its
+    // `source_message` at it (the orchestrator pulls the full reply from there). `reply()`
+    // returns `{ sent: [noteId] }`; the first id is the note. Absent/empty → undefined,
+    // and the callback simply omits source_message.
+    return { ...(sent?.sent?.[0] ? { id: sent.sent[0] } : {}) };
   };
 }
 
@@ -674,6 +723,51 @@ export function buildWriteThread(channels: Map<string, Channel>): WriteThread {
       ...(thread.sameTurn ? { sameTurn: true } : {}),
       ...(thread.phase ? { phase: thread.phase } : {}),
     });
+  };
+}
+
+/**
+ * Build the {@link WriteCallback} the programmatic registry delivers an agent-to-agent
+ * completion callback through (the "reply_to" substrate). Resolve the SENDER's (`reply_to`)
+ * channel transport from the live `channels` map and write a CALLBACK inbound note there
+ * (`writeCallback` → a `#agent/message/inbound` note + the {@link CallbackMetadata}
+ * contract). The vault trigger on that note wakes the sender's agent through the normal
+ * inbound path — so an orchestrator is resumed by its own channel exactly as if a human
+ * had messaged it, and the per-channel serial drain handles N returning callbacks FIFO.
+ *
+ * UNKNOWN / not-live reply_to channel (reuses the #122 own-it-don't-strand posture): if the
+ * channel has no live VaultTransport, we LOG and return WITHOUT throwing — a callback that
+ * can't be delivered must not crash the recipient's drain or strand its queue. (We don't
+ * throw — unlike buildWriteOutbound/buildWriteThread, where a missing transport IS an error
+ * worth surfacing — because a callback is best-effort orchestration sugar: the recipient's
+ * turn already ran + recorded; only the onward notification is lost, and the sender can still
+ * poll the recipient's thread/transcript out-of-band.)
+ *
+ * LOOP SAFETY: `writeCallback` writes the inbound WITHOUT a `reply_to` (terminal callback),
+ * so the woken sender's turn cannot auto-emit another callback. Verified end-to-end:
+ * callback note → vault trigger → /api/vault/inbound → contextFor.emit → the sender's drain;
+ * `callbackFieldsFromMeta` finds no `reply_to`, so `maybeDeliverCallback` no-ops there.
+ */
+export function buildWriteCallback(channels: Map<string, Channel>): WriteCallback {
+  return async (channel, content, meta) => {
+    const ch = channels.get(channel);
+    const vt = ch?.transport instanceof VaultTransport ? ch.transport : undefined;
+    if (!vt || !vt.writeCallback) {
+      // Own-it-don't-strand: no live vault transport for the reply_to channel. The sender
+      // may have been torn down, or never been a vault-backed channel. Log + drop — the
+      // recipient turn already completed + recorded; we never throw (which would surface as
+      // an error in the recipient's drain).
+      console.warn(
+        `parachute-agent: callback for source "${meta.source_channel}" could not be delivered ` +
+          `— reply_to channel "${channel}" has no live vault transport (dropping the callback; ` +
+          `the turn itself completed + recorded normally).`,
+      );
+      return;
+    }
+    // `meta` is the registry's CallbackMeta; the transport's CallbackMetadata is the
+    // structurally-identical local mirror (the transport layer doesn't import the backend
+    // layer), so it passes without a cast.
+    await vt.writeCallback(content, meta);
   };
 }
 
@@ -734,6 +828,7 @@ export function createDefaultProgrammaticRegistry(
     backend,
     writeOutbound: buildWriteOutbound(channels),
     writeThread: buildWriteThread(channels),
+    writeCallback: buildWriteCallback(channels),
     ...(onTurnEvent ? { onTurnEvent } : {}),
   });
 }

--- a/src/programmatic-wiring.test.ts
+++ b/src/programmatic-wiring.test.ts
@@ -47,10 +47,18 @@ import {
   contextFor,
   reregisterProgrammaticAgents,
   buildWriteOutbound,
+  buildWriteCallback,
+  callbackFieldsFromMeta,
 } from "./daemon.ts";
 import { ClientRegistry } from "./routing.ts";
 import { DeliveryState } from "./delivery-state.ts";
-import { ProgrammaticAgentRegistry, type WriteOutbound } from "./backends/registry.ts";
+import {
+  ProgrammaticAgentRegistry,
+  MAX_DELEGATION_DEPTH,
+  type WriteOutbound,
+  type WriteCallback,
+  type CallbackMeta,
+} from "./backends/registry.ts";
 import type { AgentBackend, AgentHandle, AgentStatus, DeliverResult } from "./backends/types.ts";
 import type { AgentSpec } from "./sandbox/types.ts";
 import { VaultTransport } from "./transports/vault.ts";
@@ -656,5 +664,143 @@ describe("backend default + interactive rejection", () => {
     } finally {
       srv.stop(true);
     }
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────────
+// AGENT-TO-AGENT CALLBACK ROUTING ("reply_to") — the DAEMON-side wiring (design
+// 2026-06-20-agent-callbacks.md). The registry unit test owns the drain mechanics; here we
+// verify the WIRING: callbackFieldsFromMeta extraction + coercion, the contextFor.emit fork
+// threading the callback fields off `msg.meta` onto the QueuedMessage end-to-end, and
+// buildWriteCallback's own-it-don't-strand posture for an unknown reply_to channel.
+// ───────────────────────────────────────────────────────────────────────────────
+
+/** A recorder WriteCallback for the wiring tests. */
+function callbackRec(): { calls: { channel: string; content: string; meta: CallbackMeta }[]; fn: WriteCallback } {
+  const calls: { channel: string; content: string; meta: CallbackMeta }[] = [];
+  const fn: WriteCallback = async (channel, content, meta) => {
+    calls.push({ channel, content, meta });
+  };
+  return { calls, fn };
+}
+
+describe("callbackFieldsFromMeta — extraction + string→number coercion", () => {
+  test("present fields are extracted; delegation_depth coerced to an integer", () => {
+    const got = callbackFieldsFromMeta({
+      reply_to: "orchestrator",
+      correlation_id: "corr-1",
+      delegation_depth: "3",
+      // unrelated note metadata must be ignored.
+      channel: "worker",
+      ts: "2026-06-20T00:00:00Z",
+    });
+    expect(got).toEqual({ replyTo: "orchestrator", correlationId: "corr-1", delegationDepth: 3 });
+  });
+
+  test("absent reply_to → empty (a non-delegated turn); a clean spread no-op", () => {
+    expect(callbackFieldsFromMeta({ channel: "worker", ts: "x" })).toEqual({});
+    expect(callbackFieldsFromMeta(undefined)).toEqual({});
+  });
+
+  test("garbage / absent / non-positive delegation_depth reads as 0 (omitted)", () => {
+    expect(callbackFieldsFromMeta({ reply_to: "o", delegation_depth: "abc" })).toEqual({ replyTo: "o" });
+    expect(callbackFieldsFromMeta({ reply_to: "o", delegation_depth: "-5" })).toEqual({ replyTo: "o" });
+    expect(callbackFieldsFromMeta({ reply_to: "o" })).toEqual({ replyTo: "o" });
+  });
+});
+
+describe("contextFor.emit threads reply_to → a callback end-to-end through the real fork", () => {
+  test("an inbound emit carrying reply_to metadata → the drain delivers a callback to that channel", async () => {
+    const backend = new FakeBackend();
+    backend.resultFor = (m) => ({ ok: true, reply: "reply:" + m });
+    const out = recorder();
+    const cb = callbackRec();
+    const programmatic = new ProgrammaticAgentRegistry({
+      backend,
+      writeOutbound: out.fn,
+      writeCallback: cb.fn,
+    });
+    await programmatic.register({ name: "worker", channels: ["worker"], backend: "programmatic" });
+
+    const registry = new ClientRegistry();
+    const deliveryState = new DeliveryState();
+    const ctx = contextFor(registry, "worker", deliveryState, programmatic);
+
+    // Simulate a vault inbound note whose metadata carried the callback fields — the SAME
+    // shape ingestInbound flattens onto `meta` (all string-valued, incl. delegation_depth).
+    ctx.emit({
+      channel: "worker",
+      content: "do the sub-task",
+      meta: {
+        note_id: "inbound-99",
+        reply_to: "orchestrator",
+        correlation_id: "corr-xyz",
+        delegation_depth: "1",
+        source: "vault",
+      },
+      source: "vault",
+    });
+
+    await until(() => cb.calls.length === 1);
+    expect(cb.calls[0]!.channel).toBe("orchestrator");
+    expect(cb.calls[0]!.meta.status).toBe("ok");
+    expect(cb.calls[0]!.meta.source_channel).toBe("worker");
+    expect(cb.calls[0]!.meta.correlation_id).toBe("corr-xyz");
+    expect(cb.calls[0]!.meta.delegation_depth).toBe("2"); // incoming "1" → 1, +1 hop.
+  });
+
+  test("an inbound emit WITHOUT reply_to → no callback (the common path)", async () => {
+    const backend = new FakeBackend();
+    const out = recorder();
+    const cb = callbackRec();
+    const programmatic = new ProgrammaticAgentRegistry({
+      backend,
+      writeOutbound: out.fn,
+      writeCallback: cb.fn,
+    });
+    await programmatic.register({ name: "worker", channels: ["worker"], backend: "programmatic" });
+    const ctx = contextFor(new ClientRegistry(), "worker", new DeliveryState(), programmatic);
+
+    ctx.emit({ channel: "worker", content: "plain", meta: { note_id: "n1", source: "vault" }, source: "vault" });
+    await until(() => out.calls.length === 1);
+    await new Promise<void>((r) => setTimeout(r, 5));
+    expect(cb.calls).toHaveLength(0);
+  });
+});
+
+describe("buildWriteCallback — own-it-don't-strand for an unknown reply_to channel", () => {
+  const meta: CallbackMeta = {
+    callback: "true",
+    status: "ok",
+    source_channel: "worker",
+    source_thread: "thread-1",
+    delegation_depth: "1",
+  };
+
+  test("an unknown reply_to channel → LOGS + returns (no throw, so the drain isn't stranded)", async () => {
+    const channels = new Map<string, Channel>(); // empty — the reply_to channel is gone.
+    const write = buildWriteCallback(channels);
+    // Must NOT throw (the registry would otherwise log it as a callback error, but the
+    // own-it posture is to no-op cleanly for a torn-down sender).
+    await expect(write("ghost-orchestrator", "[callback] worker finished (ok)", meta)).resolves.toBeUndefined();
+  });
+
+  test("a live VaultTransport reply_to channel → writeCallback is invoked on it", async () => {
+    const vt = new VaultTransport({ vault: "default", vaultUrl: "http://127.0.0.1:1940", token: "x" });
+    // Bind a ctx so `this.channel` resolves, and stub writeCallback so we don't hit the network.
+    (vt as unknown as { ctx: unknown }).ctx = { channel: "orchestrator", emit() {}, emitPermissionVerdict() {} };
+    let captured: { content: string; meta: CallbackMeta } | undefined;
+    (vt as unknown as { writeCallback: unknown }).writeCallback = async (content: string, m: CallbackMeta) => {
+      captured = { content, meta: m };
+      return { sent: ["cb-note-1"] };
+    };
+    const channels = new Map<string, Channel>([
+      ["orchestrator", { name: "orchestrator", transport: vt, entry: { name: "orchestrator", transport: "vault" } }],
+    ]);
+    const write = buildWriteCallback(channels);
+    await write("orchestrator", "[callback] worker finished (ok)", meta);
+    expect(captured).toBeDefined();
+    expect(captured!.meta.source_channel).toBe("worker");
+    expect(captured!.content).toContain("[callback]");
   });
 });

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -106,6 +106,25 @@ export interface ThreadRecord {
   sameTurn?: boolean;
 }
 
+/**
+ * The METADATA a callback inbound note carries (the agent-to-agent "reply_to" substrate).
+ * Mirrors `CallbackMeta` in backends/registry.ts; kept local here so the transport layer
+ * doesn't import the backend layer (the registry already keeps a local copy of the thread
+ * note shape for the same reason). All string-valued — the vault stores metadata as strings.
+ *
+ * IMPORTANT: a callback note carries `callback:"true"` + status + the source links, but NEVER
+ * a `reply_to` — a callback is terminal, which is the structural loop guard.
+ */
+export interface CallbackMetadata {
+  callback: "true";
+  status: "ok" | "error";
+  source_channel: string;
+  source_thread: string;
+  source_message?: string;
+  correlation_id?: string;
+  delegation_depth: string;
+}
+
 export interface ReactArgs {
   channel: string;
   message_id: string;
@@ -179,6 +198,16 @@ export interface Transport {
    * one note per channel, multi-threaded writes one per fire. Returns the written note id(s).
    */
   writeThread?(thread: ThreadRecord): Promise<{ sent: string[] }>;
+  /**
+   * Optional: write an agent-to-agent CALLBACK as an INBOUND note on THIS channel (the
+   * "reply_to" substrate). A recipient agent's drain, on turn completion, calls this on the
+   * SENDER's channel transport to wake the sender with a completion notification. The note
+   * carries the inbound tags (so the vault trigger wakes the sender through the normal path)
+   * PLUS the {@link CallbackMetadata} contract — BUT it must NOT carry a `reply_to` (a
+   * callback is terminal; that is the loop guard). Only a durable transport (the
+   * VaultTransport) implements it; others omit it. Returns the written note id(s).
+   */
+  writeCallback?(content: string, meta: CallbackMetadata): Promise<{ sent: string[] }>;
   /**
    * Optional: handle an HTTP request the daemon didn't handle itself. The
    * daemon owns `Bun.serve`; a transport that needs to contribute routes (e.g.

--- a/src/transports/vault.test.ts
+++ b/src/transports/vault.test.ts
@@ -1110,6 +1110,90 @@ describe("VaultTransport — writeInbound (the chat's send → wakes the session
   });
 });
 
+describe("VaultTransport — writeCallback (agent-to-agent reply_to substrate)", () => {
+  test("writes an INBOUND note carrying the callback metadata contract, NO reply_to, both inbound tags", async () => {
+    let sent: { content: string; tags: string[]; metadata: Record<string, string> } | undefined;
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      if (String(url).endsWith("/api/notes") && init?.method === "POST") {
+        sent = JSON.parse(String(init?.body));
+      }
+      return new Response(JSON.stringify({ id: "callback-note-1" }), { status: 201 });
+    }) as typeof fetch;
+
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("orchestrator")); // the SENDER's channel.
+    const result = await t.writeCallback("[callback] worker finished (ok) — see source_message.", {
+      callback: "true",
+      status: "ok",
+      source_channel: "worker",
+      source_thread: "thread-uuid-1",
+      source_message: "reply-note-7",
+      correlation_id: "corr-abc",
+      delegation_depth: "3",
+    });
+
+    expect(result.sent).toEqual(["callback-note-1"]);
+    // The callback is an INBOUND note (so it wakes the sender via the normal vault trigger).
+    expect(sent!.tags).toEqual(["#agent/message", "#agent/message/inbound"]);
+    expect(sent!.tags).not.toContain("#agent/message/outbound");
+    // The metadata contract — all present fields stamped.
+    expect(sent!.metadata.callback).toBe("true");
+    expect(sent!.metadata.status).toBe("ok");
+    expect(sent!.metadata.source_channel).toBe("worker");
+    expect(sent!.metadata.source_thread).toBe("thread-uuid-1");
+    expect(sent!.metadata.source_message).toBe("reply-note-7");
+    expect(sent!.metadata.correlation_id).toBe("corr-abc");
+    expect(sent!.metadata.delegation_depth).toBe("3");
+    // The channel it's routed to is THIS transport's channel (the sender's), direction inbound.
+    expect(sent!.metadata.channel).toBe("orchestrator");
+    expect(sent!.metadata.direction).toBe("inbound");
+    expect(sent!.metadata.sender).toBe("callback:worker");
+    // LOOP GUARD: the callback note must NEVER carry a reply_to (terminal callback).
+    expect(sent!.metadata.reply_to).toBeUndefined();
+  });
+
+  test("omits source_message + correlation_id when absent (error callback, no reply)", async () => {
+    let sent: { metadata: Record<string, string> } | undefined;
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      if (String(url).endsWith("/api/notes") && init?.method === "POST") sent = JSON.parse(String(init?.body));
+      return new Response(JSON.stringify({ id: "n" }), { status: 201 });
+    }) as typeof fetch;
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("orchestrator"));
+    await t.writeCallback("[callback] worker finished with an error.", {
+      callback: "true",
+      status: "error",
+      source_channel: "worker",
+      source_thread: "thread-2",
+      delegation_depth: "1",
+    });
+    expect(sent!.metadata.status).toBe("error");
+    expect(sent!.metadata.source_message).toBeUndefined();
+    expect(sent!.metadata.correlation_id).toBeUndefined();
+  });
+
+  test("a stray reply_to on the meta is STRIPPED (defense-in-depth loop guard)", async () => {
+    let sent: { metadata: Record<string, string> } | undefined;
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      if (String(url).endsWith("/api/notes") && init?.method === "POST") sent = JSON.parse(String(init?.body));
+      return new Response(JSON.stringify({ id: "n" }), { status: 201 });
+    }) as typeof fetch;
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("orchestrator"));
+    // Simulate a (mistaken) caller widening the shape with a reply_to — it must NOT survive.
+    await t.writeCallback("x", {
+      callback: "true",
+      status: "ok",
+      source_channel: "worker",
+      source_thread: "t",
+      delegation_depth: "1",
+      // @ts-expect-error — intentionally passing an extra field the contract forbids.
+      reply_to: "should-be-stripped",
+    });
+    expect(sent!.metadata.reply_to).toBeUndefined();
+  });
+});
+
 describe("VaultTransport — ingestInbound", () => {
   test("emits the inbound content + meta onto its channel", () => {
     const t = new VaultTransport(baseConfig());
@@ -1174,6 +1258,34 @@ describe("VaultTransport — ingestInbound", () => {
       metadata: { channel: "eng", direction: "outbound" },
     });
     expect(ctx.emitted).toHaveLength(0);
+  });
+
+  test("FLATTENS the agent-to-agent callback fields (reply_to/correlation_id/delegation_depth) into meta", () => {
+    // The READ side of the callback round-trip: a SENDING agent stamps reply_to et al on the
+    // inbound note's metadata; ingestInbound must surface them in `meta` so contextFor.emit's
+    // callbackFieldsFromMeta can pick them up. (ingestInbound already flattens ALL metadata —
+    // this pins the behavior the callback substrate depends on.)
+    const t = new VaultTransport(baseConfig());
+    const ctx = fakeCtx("worker");
+    void t.start(ctx);
+    t.ingestInbound({
+      id: "note-deleg-1",
+      content: "do the sub-task",
+      tags: ["#agent/message", "#agent/message/inbound"],
+      metadata: {
+        channel: "worker",
+        direction: "inbound",
+        sender: "orchestrator",
+        reply_to: "orchestrator",
+        correlation_id: "corr-1",
+        delegation_depth: "2",
+      },
+    });
+    expect(ctx.emitted).toHaveLength(1);
+    const m = ctx.emitted[0]!.meta;
+    expect(m.reply_to).toBe("orchestrator");
+    expect(m.correlation_id).toBe("corr-1");
+    expect(m.delegation_depth).toBe("2"); // string-valued, as the vault stores it.
   });
 });
 

--- a/src/transports/vault.ts
+++ b/src/transports/vault.ts
@@ -65,6 +65,7 @@ import type {
   TransportContext,
   ReplyArgs,
   ThreadRecord,
+  CallbackMetadata,
 } from "../transport.ts";
 
 /** Config for a vault transport instance (from the channel registry entry). */
@@ -1177,7 +1178,18 @@ export class VaultTransport implements Transport {
    * Returns the created note id so the chat can dedup its optimistic local echo
    * against the same id when the note round-trips through the next poll.
    */
-  async writeInbound(text: string, sender?: string): Promise<{ id: string }> {
+  async writeInbound(
+    text: string,
+    sender?: string,
+    /**
+     * Extra metadata to STAMP onto the inbound note (e.g. the agent-to-agent callback
+     * contract). Merged AFTER the base fields but BEFORE the non-overridable invariants
+     * (`channel`/`direction` always win — an inbound note must route + be inbound). A caller
+     * must NEVER pass `reply_to` here for a CALLBACK note (the terminal-callback loop guard);
+     * see {@link writeCallback}.
+     */
+    extraMeta?: Record<string, string>,
+  ): Promise<{ id: string }> {
     const channel = this.channel;
     const ts = new Date().toISOString();
     const id = crypto.randomUUID();
@@ -1185,6 +1197,8 @@ export class VaultTransport implements Transport {
     const path = `${this.pathPrefix}/${safeChannel}/${id}`;
 
     const metadata: Record<string, string> = {
+      // Caller-supplied extra fields first, so the invariants below cannot be clobbered.
+      ...(extraMeta ?? {}),
       channel,
       direction: "inbound",
       sender: sender ?? "operator",
@@ -1248,6 +1262,44 @@ export class VaultTransport implements Transport {
    */
   async injectInbound(opts: { content: string; sender?: string }): Promise<{ id: string }> {
     return this.writeInbound(opts.content, opts.sender ?? "runner");
+  }
+
+  /**
+   * Write an agent-to-agent CALLBACK as an INBOUND note on THIS channel — the "reply_to"
+   * substrate. A recipient agent's drain, on turn completion, calls this on the SENDER's
+   * channel transport (resolved by the daemon's buildWriteCallback) so the sender is woken
+   * with a completion notification through the NORMAL inbound path: this writes a
+   * `#agent/message/inbound` note (parent + inbound child tags), the vault trigger fires,
+   * webhooks back, and the daemon routes it to the sender's agent — exactly like a human's
+   * chat send. The callback `content` is a brief notification + link; the metadata is the
+   * {@link CallbackMetadata} contract (`source_*` for the orchestrator to PULL the result).
+   *
+   * LOOP GUARD (structural): we stamp the callback metadata but NEVER a `reply_to` — a
+   * callback is terminal, so handling it can't auto-trigger another callback. We defensively
+   * STRIP any `reply_to` from the incoming meta to make that invariant impossible to violate
+   * even if a caller mistakenly supplied one. `sender` is a `callback:<source_channel>`
+   * marker so the transcript shows who/what authored it.
+   *
+   * Reuses {@link writeInbound} (the one inbound-write implementation), passing the callback
+   * fields as its `extraMeta`. Returns the written note id.
+   */
+  async writeCallback(content: string, meta: CallbackMetadata): Promise<{ sent: string[] }> {
+    // Defense-in-depth: never let a `reply_to` ride on a callback note (the terminal-callback
+    // loop guard). The CallbackMetadata type has no reply_to, but we strip explicitly in case
+    // a future caller widens the shape — a callback that carries reply_to would ping-pong.
+    const { reply_to: _stripReplyTo, ...safe } = meta as CallbackMetadata & { reply_to?: string };
+    void _stripReplyTo;
+    const extraMeta: Record<string, string> = {
+      callback: safe.callback,
+      status: safe.status,
+      source_channel: safe.source_channel,
+      source_thread: safe.source_thread,
+      delegation_depth: safe.delegation_depth,
+      ...(safe.source_message ? { source_message: safe.source_message } : {}),
+      ...(safe.correlation_id ? { correlation_id: safe.correlation_id } : {}),
+    };
+    const { id } = await this.writeInbound(content, `callback:${safe.source_channel}`, extraMeta);
+    return { sent: [id] };
   }
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## What

Request/response between agent threads, built ON the thread-as-container (#122) + pending-inbound (#121) substrate. When an agent sends a message to ANOTHER agent and wants to know when it's done, it sets a **callback address** on the message. When the recipient finishes its turn, the daemon delivers a lightweight **callback** back to the sender's channel — a NOTIFICATION + a LINK to the result, **not** the full result duplicated. The sender (an orchestrator) is woken by the callback and PULLS the full result if it wants.

**Summary + link, orchestrator pulls** (the explicit design choice): cleaner (callback notes stay small/uniform) + a better security boundary (the orchestrator reaches the result through its own read scope; the callback carries only opaque ids).

No new transport, no new backend — additive metadata + one new daemon→registry seam.

## The model

### `reply_to` on inbound (the SEND side)
An `#agent/message/inbound` note MAY carry, in `metadata`:
- `reply_to` — the **sender's channel name** (where to deliver the callback). Absent → no callback (ordinary turn).
- `correlation_id` — (optional) opaque id the sender matches replies to requests with; echoed verbatim.
- `delegation_depth` — (optional, default 0) hop count; the loop-guard counter.

These ride `note.metadata` → `ingestInbound` flattens into `meta` → `contextFor.emit` extracts via `callbackFieldsFromMeta` → onto `QueuedMessage` → the drain. The pending buffer carries them too (a delegated request that arrives before its recipient is live still calls back on replay).

### Callback on turn-completion (the core)
In the drain, after a turn completes on **BOTH ok and error** (the orchestrator MUST learn about failures), IF the message had `reply_to`, the daemon writes a NEW `#agent/message/inbound` note to the `reply_to` channel (wakes the sender through the normal vault-trigger path).

**Metadata contract:**

| Field | Value |
|---|---|
| `callback` | `"true"` |
| `status` | `"ok"` \| `"error"` |
| `source_channel` | the recipient channel/def that finished |
| `source_thread` | the recipient's per-turn `#agent/thread` id (pull the full thread record) |
| `source_message` | the recipient's OUTBOUND reply note id, when a reply landed (absent on error/empty turn) |
| `correlation_id` | echoed when present |
| `delegation_depth` | incoming + 1 |

Brief content (`[callback] <ch> finished (ok) — see source_message / source_thread …`), never the duplicated reply. `source_message` is captured by widening `WriteOutbound`'s return to `Promise<{ id?: string } | void>` (back-compat — `void` is in the union, so every existing recorder still satisfies it).

## Loop safety (3 layers, defense-in-depth)
1. **The callback note never carries `reply_to`** (structural — no ping-pong). Enforced at the daemon wiring AND stripped defensively in `VaultTransport.writeCallback`.
2. **`delegation_depth` ceiling** (`MAX_DELEGATION_DEPTH = 8`): a message at/past the ceiling delivers NO callback (logged loudly). Bounds any chain even if layer 1 were defeated. The turn still runs + records.
3. **Unknown / not-live `reply_to` channel** reuses the #122 own-it-don't-strand posture: `buildWriteCallback` logs + returns WITHOUT throwing — never crashes the recipient's drain.

A callback delivery failure is best-effort: logged, never thrown, never re-runs the (completed) turn.

## Concurrency (verified, not re-architected)
#122 already gives it. N callbacks returning to one orchestrator channel arrive as inbound notes, queue FIFO, and drain ONE at a time via the per-channel serial `#draining` invariant — never two concurrent `claude -p` for one channel, so the orchestrator's single-threaded `--resume` session carries state across them, none lost. A test simulates N callbacks draining FIFO with `maxConcurrent === 1`.

## Files
- `src/backends/registry.ts` — `QueuedMessage` gains `replyTo`/`correlationId`/`delegationDepth`; `WriteCallback` seam + `CallbackMeta` + `MAX_DELEGATION_DEPTH`; `maybeDeliverCallback` at all four drain terminal points; `WriteOutbound` returns the note id.
- `src/daemon.ts` — `callbackFieldsFromMeta`; `contextFor.emit` threads the fields (enqueue + pending); `buildWriteCallback`; `buildWriteOutbound` returns the note id.
- `src/transport.ts` — `Transport.writeCallback?` + `CallbackMetadata`.
- `src/transports/vault.ts` — `VaultTransport.writeCallback`; `writeInbound` optional `extraMeta`.
- `design/2026-06-20-agent-callbacks.md`.

## Tests / gate
`bun run test` (typecheck + `bun test ./src`) green — **1017 pass, 0 fail**. New coverage: all four drain terminal points, the depth guard at ceiling + ceiling-1, no-reply_to → no callback (regression), unwired/throwing sink, FIFO concurrency, `callbackFieldsFromMeta` coercion, end-to-end `contextFor.emit` threading, `buildWriteCallback` own-it, the full vault callback-note metadata contract + reply_to-strip, and the ingestInbound flatten round-trip.

Independent reviewer pass: LGTM, no critical issues, no must-fix bugs (the two comment-clarity nits applied; the shared-type-refactor nit left as a noted follow-up since the duck-type is typecheck-guarded).

## Deferred
- A dedicated **`delegate` MCP tool** that fills in `reply_to`/`correlation_id`/`delegation_depth` so an orchestrator doesn't hand-stamp them (SEND-side ergonomics).
- Single-threaded `source_thread` is a per-turn correlation id (the deterministic thread-note-by-stable-path linkage is the same gap that already exists for `metadata.thread`).

No version bump (per instructions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)