### PR TITLE
fix(agent): poll convergence tears down a deleted def's live agent (orphan fix)

### DIFF
--- a/src/agent-defs.test.ts
+++ b/src/agent-defs.test.ts
@@ -712,6 +712,16 @@ describe("AgentDefRegistry — lifecycle", () => {
     // Guard tripped → NO teardown despite the originals being absent from the page.
     expect(calls.deregistered).toEqual([]);
     expect(calls.removed).toEqual([]);
+
+    // The guard DEFERS the decision, it doesn't LOSE it: the truncated pass left the
+    // seen-set intact (it skipped rebuildSeenDefs), so a later CONFIDENT pass that
+    // genuinely drops researcher still catches it as a removal and tears it down.
+    current = [{ id: "Agents/uni", content: "role", metadata: { name: "uni" } }];
+    calls.deregistered.length = 0;
+    calls.removed.length = 0;
+    await reg.loadAll();
+    expect(calls.deregistered).toContain("researcher");
+    expect(calls.removed).toContain("researcher");
   });
 
   test("reload for an unknown def-vault is a safe skip", async () => {

--- a/src/agent-defs.test.ts
+++ b/src/agent-defs.test.ts
@@ -649,6 +649,71 @@ describe("AgentDefRegistry — lifecycle", () => {
     expect(calls.deregistered).toEqual(["uni-dev"]);
   });
 
+  test("loadAll TEARS DOWN a removed def — deregister + removeChannel (the no-delete-trigger path)", async () => {
+    // There is no vault `deleted` trigger (the hub maps only created/updated), so a def
+    // deleted out-of-band never fires the reactive teardown — the poll is the ONLY
+    // convergence path and must deregister, not just prune grants. Regression for the
+    // orphan-agent bug (a deleted agent kept answering until the daemon restarted).
+    const { deps, calls } = recorderDeps();
+    const present: Array<{ id: string; content?: string; metadata?: Record<string, unknown> }> = [
+      { id: "Agents/uni", content: "role", metadata: { name: "uni" } },
+      { id: "Agents/researcher", content: "role", metadata: { name: "researcher" } },
+    ];
+    const fetchFn = (async (url: string | URL | Request, init?: RequestInit) => {
+      const u = String(url);
+      const method = init?.method ?? "GET";
+      if (method === "PATCH") return new Response(null, { status: 200 });
+      if (u.includes("/api/notes?") && u.includes("tag=%23agent%2Fdefinition")) {
+        return new Response(JSON.stringify(present), { status: 200, headers: { "content-type": "application/json" } });
+      }
+      return new Response("[]", { status: 200 });
+    }) as typeof fetch;
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn });
+    await reg.loadAll(); // both live
+    expect(calls.deregistered).toEqual([]); // nothing torn down on a clean load
+    present.splice(1, 1); // delete researcher out-of-band (no delete trigger fires)
+    await reg.loadAll(); // confident read now sees only uni → researcher is a confirmed removal
+    expect(calls.deregistered).toEqual(["researcher"]);
+    expect(calls.removed).toEqual(["researcher"]);
+    expect(reg.list().map((d) => d.name)).toEqual(["uni"]); // gone from the live set
+  });
+
+  test("loadAll SKIPS removed-def teardown on a truncated (page-cap) read — no spurious deregister", async () => {
+    // A list at the page cap may be partial. Since the removed-def diff now does a
+    // DESTRUCTIVE teardown, a truncated read that omits the tail must NOT be mistaken for
+    // deletions — the guard defers the diff rather than tearing down live agents.
+    const { deps, calls } = recorderDeps();
+    const initial: Array<{ id: string; content?: string; metadata?: Record<string, unknown> }> = [
+      { id: "Agents/uni", content: "role", metadata: { name: "uni" } },
+      { id: "Agents/researcher", content: "role", metadata: { name: "researcher" } },
+    ];
+    // A full page (>= the 500 cap) that omits both originals — a truncated page, NOT a
+    // signal that both were deleted.
+    const truncated = Array.from({ length: 500 }, (_, i) => ({
+      id: `Agents/filler-${i}`,
+      content: "role",
+      metadata: { name: `filler-${i}` },
+    }));
+    let current = initial;
+    const fetchFn = (async (url: string | URL | Request, init?: RequestInit) => {
+      const u = String(url);
+      const method = init?.method ?? "GET";
+      if (method === "PATCH") return new Response(null, { status: 200 });
+      if (u.includes("/api/notes?") && u.includes("tag=%23agent%2Fdefinition")) {
+        return new Response(JSON.stringify(current), { status: 200, headers: { "content-type": "application/json" } });
+      }
+      return new Response("[]", { status: 200 });
+    }) as typeof fetch;
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn });
+    await reg.loadAll(); // confident: uni + researcher live
+    expect(calls.deregistered).toEqual([]);
+    current = truncated; // the next poll returns a truncated page
+    await reg.loadAll();
+    // Guard tripped → NO teardown despite the originals being absent from the page.
+    expect(calls.deregistered).toEqual([]);
+    expect(calls.removed).toEqual([]);
+  });
+
   test("reload for an unknown def-vault is a safe skip", async () => {
     const { deps } = recorderDeps();
     const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn: vaultFetch({}) });
@@ -1025,8 +1090,8 @@ describe("AgentDefRegistry — grant-GC reconcile (#96)", () => {
     expect(reconciled).toEqual([{ agent: "uni", liveConnections: [] }]);
   });
 
-  test("a REMOVED def (present in a prior load, gone now) → reconcile(agent, [])", async () => {
-    const { deps } = recorderDeps();
+  test("a REMOVED def (present in a prior load, gone now) → reconcile(agent, []) + teardown", async () => {
+    const { deps, calls } = recorderDeps();
     const reconciled: Array<{ agent: string; liveConnections: ConnectionSpec[] }> = [];
     const grants = fakeGrantsClient({ reconciled });
     // Two notes present at first; the second load drops "researcher".
@@ -1072,6 +1137,9 @@ describe("AgentDefRegistry — grant-GC reconcile (#96)", () => {
     // uni (still present, no wants) reconciles with [] too — that's its clean-load prune,
     // NOT a removal; distinguished by the agent name.
     expect(reconciled.find((r) => r.agent === "uni")).toEqual({ agent: "uni", liveConnections: [] });
+    // AND it's torn down (not just grant-pruned): the only auto path for a delete.
+    expect(calls.deregistered).toEqual(["researcher"]);
+    expect(calls.removed).toEqual(["researcher"]);
   });
 
   test("a delete reload → reconcile(agent, []) (confirmed removal)", async () => {

--- a/src/agent-defs.ts
+++ b/src/agent-defs.ts
@@ -1074,6 +1074,8 @@ export class AgentDefRegistry {
       // (re)instantiate what we got — instantiate only adds/updates, never tears down.
       // Practically unreachable at today's agent counts; the guard makes the teardown safe
       // by construction.
+      // `< cap` ⇒ the result fit on one page → it cannot be truncated; `>= cap` is the
+      // (possibly-)truncated case the `else` defers.
       const confident = notes.length < DEF_LIST_LIMIT;
       if (confident) {
         // Detect removed defs by diffing the prior seen set (noteId→name) against the ids

--- a/src/agent-defs.ts
+++ b/src/agent-defs.ts
@@ -58,6 +58,15 @@ import {
 
 const DEFAULT_DEF_VAULT_URL = "http://127.0.0.1:1940";
 
+/**
+ * Page cap for a def-vault list. The poll's removed-def diff now DEREGISTERS (a
+ * destructive teardown), so a list that hits this cap is treated as possibly-
+ * truncated — NOT a confident set — and the removal diff is skipped that pass (see
+ * {@link AgentDefRegistry.loadAll}'s truncation guard). 500 comfortably exceeds any
+ * realistic agent count; it exists so the teardown is safe by construction.
+ */
+const DEF_LIST_LIMIT = 500;
+
 /** A slug: alphanumeric, dash, underscore — the agent name + wake-channel key. */
 const NAME_SLUG_RE = /^[a-zA-Z0-9_-]+$/;
 
@@ -488,7 +497,7 @@ export class DefVaultClient {
   async listDefNotes(opts?: { limit?: number }): Promise<
     Array<{ id: string; content?: string; metadata?: Record<string, unknown> }>
   > {
-    const limit = opts?.limit ?? 500;
+    const limit = opts?.limit ?? DEF_LIST_LIMIT;
     const params = new URLSearchParams();
     params.set("tag", AGENT_DEFINITION_TAG); // URLSearchParams encodes `#`→`%23`, `/`→`%2F`
     params.set("include_content", "true");
@@ -1035,32 +1044,51 @@ export class AgentDefRegistry {
    * failure) is logged and never aborts the others, so one bad def can't sink the set.
    * Returns the count successfully instantiated.
    *
-   * Grant-GC (#96): after a SUCCESSFUL list (a confident read of the vault's whole def
-   * set), diff the prior-known def set against it — any note that was present and is now
-   * GONE has had its `#agent/definition` note deleted, so its grants are pruned ALL
-   * (`reconcileGrants(agent, [])`). A list FAILURE deliberately skips the diff (we
-   * `continue` BEFORE touching the prior set) so a transient vault outage never presents
-   * an empty current set that would nuke every agent's grants (safety guard).
+   * Removed-def convergence: after a CONFIDENT read (a successful, non-truncated list of
+   * the vault's whole def set), diff the prior-known def set against it — any note that
+   * was present and is now GONE has had its `#agent/definition` note deleted, so the agent
+   * is TORN DOWN (deregistered + wake channel removed) and its grants pruned ALL
+   * (`reconcileGrants(agent, [])`). This is the ONLY automatic path for a deletion — there
+   * is no vault `deleted` trigger (see {@link pruneRemovedDefs}). Two guards keep the
+   * teardown safe: a list FAILURE skips the diff (we `continue` BEFORE touching the prior
+   * set) and a TRUNCATED list (>= the page cap) skips it too, so neither a transient vault
+   * outage nor a partial page presents an under-set that wrongly tears down live agents.
    */
   async loadAll(): Promise<number> {
     let count = 0;
     for (const [vault, client] of this.clients) {
       let notes: Awaited<ReturnType<DefVaultClient["listDefNotes"]>>;
       try {
-        notes = await client.listDefNotes();
+        notes = await client.listDefNotes({ limit: DEF_LIST_LIMIT });
       } catch (err) {
         console.error(`agent-defs: listing defs from vault "${vault}" failed (continuing): ${(err as Error).message}`);
         // CONFIDENT-SET GUARD: a failed list is NOT a confident read — leave the prior
         // seen set untouched (no removed-def diff) so a hub/vault blip can't prune grants.
         continue;
       }
-      // The list succeeded → this IS a confident read. Detect removed defs by diffing
-      // the prior seen set (noteId→name) against the ids present now, BEFORE we mutate it.
-      const presentIds = new Set(notes.map((n) => n.id));
-      await this.pruneRemovedDefs(vault, presentIds);
-      // Rebuild the seen set from this confident read (carry-forward last-known names for
-      // notes that fail to parse, so a transient parse error doesn't drop them).
-      this.rebuildSeenDefs(vault, notes);
+      // TRUNCATION GUARD (the second way a read is non-confident): a list at the page cap
+      // may be partial. The removed-def diff now performs a DESTRUCTIVE teardown
+      // (pruneRemovedDefs deregisters), so a truncated read that omits the tail must NOT be
+      // mistaken for deletions. Skip the diff + the seen-set rebuild (rebuilding from a
+      // truncated list would drop the omitted tail and mis-flag it removed next pass); still
+      // (re)instantiate what we got — instantiate only adds/updates, never tears down.
+      // Practically unreachable at today's agent counts; the guard makes the teardown safe
+      // by construction.
+      const confident = notes.length < DEF_LIST_LIMIT;
+      if (confident) {
+        // Detect removed defs by diffing the prior seen set (noteId→name) against the ids
+        // present now, BEFORE we mutate it.
+        const presentIds = new Set(notes.map((n) => n.id));
+        await this.pruneRemovedDefs(vault, presentIds);
+        // Rebuild the seen set from this confident read (carry-forward last-known names for
+        // notes that fail to parse, so a transient parse error doesn't drop them).
+        this.rebuildSeenDefs(vault, notes);
+      } else {
+        console.warn(
+          `agent-defs: def list for "${vault}" returned ${notes.length} notes (>= the ${DEF_LIST_LIMIT} ` +
+            `page cap) — skipping the removed-def reconcile this pass to avoid a truncated-read teardown.`,
+        );
+      }
       for (const note of notes) {
         if (await this.instantiate(vault, note)) count++;
       }
@@ -1070,17 +1098,29 @@ export class AgentDefRegistry {
 
   /**
    * Reconcile every def that was in the prior seen set for `vault` but is NOT in
-   * `presentIds` (its note was deleted) — `reconcileGrants(agent, [])` prunes ALL its
-   * grants so a deleted def doesn't orphan live approved rows. Best-effort + no-op
-   * without a grants client. Called ONLY with a confident current id set (a successful
-   * list); never on a list failure (see {@link loadAll}).
+   * `presentIds` (its note was deleted) — tear the agent DOWN (drop the live
+   * programmatic registration + the wake channel) AND `reconcileGrants(agent, [])`
+   * prune ALL its grants. Best-effort throughout; grant cleanup is a no-op without a
+   * grants client. Called ONLY with a confident current id set (a successful,
+   * non-truncated list); never on a list failure or a truncated read (see {@link loadAll}).
+   *
+   * Why the poll MUST deregister (not just prune grants): there is NO vault `deleted`
+   * trigger — the hub's connection engine maps only `note.created`/`note.updated` to
+   * vault-trigger verbs (parachute-hub `admin-connections` `eventToVaultEvents`), so a
+   * def deleted out-of-band NEVER fires the reactive `reload(...,"deleted")` teardown.
+   * This poll is the ONLY automatic convergence path for a deletion, so it must do the
+   * SAME full teardown {@link confirmedRemoval} does, or a deleted agent stays live (an
+   * orphan: gone from the vault, still answering messages) until the daemon restarts.
    */
   private async pruneRemovedDefs(vault: string, presentIds: Set<string>): Promise<void> {
     const prior = this.seenDefs.get(vault);
     if (!prior) return; // first confident read of this vault — nothing to compare against.
     for (const [noteId, name] of prior) {
       if (presentIds.has(noteId)) continue; // still present — not a removal.
-      // Confirmed removal: the def note is gone from a confident vault read.
+      // Confirmed removal: the def note is gone from a confident vault read. Tear the
+      // agent + wake channel down, then prune its grants. (The seen-set entry is cleared
+      // by the `rebuildSeenDefs` that runs right after this in `loadAll`.)
+      await this.deregisterByNote(vault, noteId);
       await this.reconcileForRemovedAgent(name);
     }
   }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -3159,9 +3159,11 @@ function main(): void {
     console.log(
       `parachute-agent: vault-native agent defs — ${n} instantiated from ${bindings.length} def-vault(s).`,
     );
-    // Poll fallback (every 60s) for vaults without trigger support: re-load all defs
-    // so a created/updated/deleted note converges even with no webhook. The reload
-    // webhook is the fast path; this is the safety net. `unref` so it never holds the
+    // Poll fallback (every 60s): re-load all defs so a created/updated/deleted note
+    // converges even with no webhook. The created/updated reload webhook is the fast path;
+    // this is the safety net — AND the ONLY automatic path for a DELETE (there is no vault
+    // `deleted` trigger, so a def removed out-of-band converges only here; loadAll's
+    // removed-def diff deregisters the orphaned agent). `unref` so it never holds the
     // process open. Cheap + idempotent (re-instantiate replaces in place).
     const interval = parseInt(process.env.PARACHUTE_AGENT_DEF_POLL_MS ?? "", 10) || 60_000;
     agentDefPoll = setInterval(() => {


### PR DESCRIPTION
## What

Deleting an `#agent/definition` note **out-of-band** (anything other than the admin-SPA delete button — a direct vault API/MCP delete, an Obsidian sync, another surface) left the **live agent + wake channel running until the next daemon restart**. The orphaned agent kept answering messages after its def was gone from the vault.

## Root cause

There is **no vault `deleted` trigger**. The hub's connection engine maps only `note.created`/`note.updated` to vault-trigger verbs (`parachute-hub` `admin-connections` `eventToVaultEvents` — `note.deleted` has no mapping and throws). So a delete **never** fires the reactive `reload(...,"deleted")` teardown.

That leaves the **60s poll as the only automatic convergence path for a deletion** — but `loadAll` → `pruneRemovedDefs` only pruned the removed def's **grants** (`reconcileGrants(agent, [])`). It never called `deregisterByNote`, so the live programmatic registration + the wake channel survived. Only the admin-SPA delete button worked, because `deleteDef` does the teardown **in-process**; every other delete path orphaned the agent.

## Fix

- **`pruneRemovedDefs` now does the full teardown** the reactive `confirmedRemoval` already does: `deregisterByNote` (drop the programmatic registration + wake channel) **then** prune grants.
- **Truncation guard** (because the diff is now destructive): a def list at the page cap (`DEF_LIST_LIMIT = 500`) is treated as possibly-partial — **not** a confident set — so a truncated read can't be mistaken for deletions and tear down live agents. Sits alongside the existing list-failure guard. This also hardens the pre-existing grant-prune, which had the same latent exposure.
- Corrected the `loadAll`/`pruneRemovedDefs`/daemon-boot comments that wrongly claimed the poll already converged deletes.

## How it was found

Live end-to-end verification of the agent-to-agent callback feature (#123). While cleaning up two throwaway test agents, deleting their def notes did **not** deregister them (`/health` still listed them 72s later, past the 60s poll). The reactive `deleted` webhook never fired → traced to the missing vault delete-trigger → the poll's grant-only convergence. (The callback feature itself verified clean: worker→callback→orchestrator chain with the full metadata contract, no loop.)

## Tests

- `loadAll` tears down a removed def — `deregister` + `removeChannel` via the poll (the no-delete-trigger regression).
- `loadAll` skips the removed-def teardown on a truncated (page-cap) read — no spurious deregister.
- The existing #96 removal test now also asserts teardown.
- Gates: `tsc --noEmit` clean; `bun test ./src` **1019 pass / 0 fail**; SPA (vitest) **110 / 110**.

## Note for the merger

`origin/ag-unforced-dev` currently carries two **unmerged** commits with **no open PR** (`8aca779`, `9db9689` — a "robustness hardening (PR #3)" series, looks like another session's WIP). To avoid clobbering/entangling that branch, this fix is isolated on a one-off branch off `main`. It is **independent**: that series leaves `pruneRemovedDefs` unchanged (still grant-only), so there's no semantic overlap — at most a trivial textual conflict in `agent-defs.ts` whichever lands second.

Per RC versioning, no version bump in this PR (bump + tag on ship).