### PR TITLE
feat(agent): declare #agent/job schema fields (channel/enabled/lastStatus indexed)

### DIFF
--- a/src/transports/vault.test.ts
+++ b/src/transports/vault.test.ts
@@ -26,7 +26,7 @@
  */
 
 import { describe, test, expect, afterEach } from "bun:test";
-import { VaultTransport, AGENT_VAULT_TAG_SCHEMA, AGENT_THREAD_TAG, InboundClaimConflictError } from "./vault.ts";
+import { VaultTransport, AGENT_VAULT_TAG_SCHEMA, AGENT_THREAD_TAG, AGENT_JOB_TAG, InboundClaimConflictError } from "./vault.ts";
 import type { TransportContext, InboundMessage } from "../transport.ts";
 import { instantiateTransport } from "../registry.ts";
 
@@ -1455,6 +1455,24 @@ describe("VaultTransport — ensureSchema (tag-schema declaration on connect)", 
       status: { type: "string", indexed: true },
       definition: { type: "string", indexed: true },
       mode: { type: "string", indexed: true },
+    });
+  });
+
+  test("ensureSchema sends the indexed `fields` body for #agent/job (query by channel/enabled/lastStatus)", async () => {
+    let jobBody: { fields?: Record<string, unknown> } | undefined;
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const name = decodeURIComponent(String(url).split("/api/tags/")[1]!);
+      if (name === AGENT_JOB_TAG) jobBody = JSON.parse(String(init?.body));
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+
+    const t = new VaultTransport(baseConfig());
+    await t.ensureSchema();
+
+    expect(jobBody?.fields).toEqual({
+      channel: { type: "string", indexed: true },
+      enabled: { type: "string", indexed: true },
+      lastStatus: { type: "string", indexed: true },
     });
   });
 

--- a/src/transports/vault.ts
+++ b/src/transports/vault.ts
@@ -386,7 +386,7 @@ export const AGENT_DEFINITION_TAG = "#agent/definition";
  * `#agent/message`. Introduced in Phase 2 as the flat `#agent-job`; moved into the
  * `#agent/*` namespace (`#agent/job`) by the vault-native-agents work (Phase 4a).
  */
-const AGENT_JOB_TAG = "#agent/job";
+export const AGENT_JOB_TAG = "#agent/job";
 /** Default path prefix under which job notes are written: `Channels/<ch>/jobs/<id>`. */
 const JOB_PATH_PREFIX = "Channels";
 
@@ -489,6 +489,20 @@ export const AGENT_VAULT_TAG_SCHEMA: ReadonlyArray<{
     name: AGENT_JOB_TAG,
     parent_names: [AGENT_ROOT_TAG],
     description: "A scheduled job — the runner injects this note's message on its cron schedule.",
+    // Indexed query axes so an operator/agent can find jobs by target + state (mirrors
+    // the #agent/thread axes). All stored as strings (the vault stores metadata as
+    // strings; `enabled` is "true"/"false"):
+    //  - channel    → "all jobs targeting agent X"
+    //  - enabled    → "active jobs" (enabled:"true") vs paused ("false")
+    //  - lastStatus → "jobs whose last run errored"
+    // The full field set + usage lives in the runner design + the in-vault reference note;
+    // the schema is permissive, so the other job fields (jobId/cron/tz/createdAt/lastRunAt)
+    // ride as undeclared metadata.
+    fields: {
+      channel: { type: "string", indexed: true },
+      enabled: { type: "string", indexed: true },
+      lastStatus: { type: "string", indexed: true },
+    },
   },
   {
     name: AGENT_THREAD_TAG,

--- a/src/transports/vault.ts
+++ b/src/transports/vault.ts
@@ -495,9 +495,9 @@ export const AGENT_VAULT_TAG_SCHEMA: ReadonlyArray<{
     //  - channel    → "all jobs targeting agent X"
     //  - enabled    → "active jobs" (enabled:"true") vs paused ("false")
     //  - lastStatus → "jobs whose last run errored"
-    // The full field set + usage lives in the runner design + the in-vault reference note;
-    // the schema is permissive, so the other job fields (jobId/cron/tz/createdAt/lastRunAt)
-    // ride as undeclared metadata.
+    // The full field set is `JobNoteMetadata` in src/jobs.ts (design
+    // 2026-06-17-runner-scheduled-agent-turns); the schema is permissive, so the other
+    // job fields (jobId/cron/tz/createdAt/lastRunAt) ride as undeclared metadata.
     fields: {
       channel: { type: "string", indexed: true },
       enabled: { type: "string", indexed: true },


### PR DESCRIPTION
## Why
Setting up a Uni Weaver job surfaced that the `#agent/job` tag **auto-creates but has no field schema** (`fields: null`) — so a scheduled job's metadata wasn't first-class or queryable, and there was no schema-level hint about what a job note looks like. (The auto-create itself works — the tag re-declares on every agent registration.)

## Change
Mirror the existing `#agent/thread` pattern and declare the useful indexed query axes on the `#agent/job` entry in `AGENT_VAULT_TAG_SCHEMA`:

| field | enables |
|---|---|
| `channel` | "all jobs targeting agent X" |
| `enabled` | active jobs (`enabled:"true"`) vs paused (`"false"`) |
| `lastStatus` | jobs whose last run errored |

All string-typed (the vault stores metadata as strings; `enabled` is `"true"`/`"false"`). The vault's field schema is **permissive**, so the other job fields (`jobId`/`cron`/`tz`/`createdAt`/`lastRunAt`) keep riding as undeclared metadata — the full field set + usage lives in the runner design doc and an in-vault reference note. `AGENT_JOB_TAG` is now exported (for the test).

This is the durable way to get fields into the schema — a manual `update-tag` would be clobbered by the module's next `ensureSchema()` push.

## Tests
- New: `ensureSchema sends the indexed fields body for #agent/job` (mirrors the thread-fields test).
- Gate: `tsc --noEmit` clean; `bun test ./src` **1018 pass / 0 fail**.

Note: separate from the open #125 (orphan-poll-teardown) — different files (`transports/vault.ts` vs `agent-defs.ts`), isolated on its own branch; no conflict.