### PR TITLE
feat(agent): retry transient turn errors with backoff + failure note on give-up

### DIFF
--- a/src/backends/programmatic.test.ts
+++ b/src/backends/programmatic.test.ts
@@ -27,6 +27,9 @@ import {
   ProgrammaticBackend,
   buildProgrammaticClaudeArgs,
   PROGRAMMATIC_BACKEND_KIND,
+  isTransientTurnError,
+  TURN_MAX_ATTEMPTS,
+  TURN_RETRY_BACKOFF_MS,
   type ProgrammaticBackendDeps,
   type ProgrammaticSpawnFn,
 } from "./programmatic.ts";
@@ -1088,5 +1091,105 @@ describe("ProgrammaticBackend.deliver — grant injection (4b)", () => {
     const handle = await backend.start(specWithVault("eng"));
     await backend.deliver(handle, "hi");
     expect(Object.keys(readMcpServers("eng"))).toEqual([vaultEntryKey("default")]);
+  });
+});
+
+describe("ProgrammaticBackend.deliver — transient-error retry with incremental backoff", () => {
+  const transientResult = (sid: string, msg: string) =>
+    ndjson(
+      { type: "system", subtype: "init", session_id: sid, apiKeySource: "none" },
+      { type: "result", subtype: "error_during_execution", is_error: true, result: msg, session_id: sid },
+    );
+
+  test("retries a TRANSIENT turn error (backoff), then succeeds", async () => {
+    mkDirs("retry-ok");
+    const sleeps: number[] = [];
+    const { fn, calls } = sequencedSpawn([
+      transientResult("s1", "API Error: 529 Overloaded. Try again."),
+      successTurn("s2", "recovered"),
+    ]);
+    const backend = new ProgrammaticBackend(
+      baseDeps(fn, {
+        sleepFn: async (ms) => {
+          sleeps.push(ms);
+        },
+      }),
+    );
+    const handle = await backend.start(specWithVault());
+    const result = await backend.deliver(handle, "go");
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.reply).toBe("recovered");
+    expect(calls.length).toBe(2); // one retry
+    expect(sleeps).toHaveLength(1); // one backoff
+    expect(sleeps[0]).toBe(TURN_RETRY_BACKOFF_MS[0]); // the first (incremental) interval
+  });
+
+  test("does NOT retry a non-transient turn error (fails fast, no sleep)", async () => {
+    mkDirs("retry-no");
+    const sleeps: number[] = [];
+    const { fn, calls } = recordingSpawn({
+      stdout: transientResult("s", "401 unauthorized: invalid token"),
+    });
+    const backend = new ProgrammaticBackend(
+      baseDeps(fn, {
+        sleepFn: async (ms) => {
+          sleeps.push(ms);
+        },
+      }),
+    );
+    const handle = await backend.start(specWithVault());
+    const result = await backend.deliver(handle, "go");
+    expect(result.ok).toBe(false);
+    expect(calls.length).toBe(1); // no retry
+    expect(sleeps.length).toBe(0);
+  });
+
+  test("a persistently TRANSIENT error exhausts the retries → { ok:false }", async () => {
+    mkDirs("retry-exhaust");
+    const sleeps: number[] = [];
+    const { fn, calls } = recordingSpawn({
+      stdout: transientResult("s", "API Error: 503 Service Unavailable"),
+    });
+    const backend = new ProgrammaticBackend(
+      baseDeps(fn, {
+        sleepFn: async (ms) => {
+          sleeps.push(ms);
+        },
+      }),
+    );
+    const handle = await backend.start(specWithVault());
+    const result = await backend.deliver(handle, "go");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain("503");
+    expect(calls.length).toBe(TURN_MAX_ATTEMPTS); // all attempts used
+    expect(sleeps.length).toBe(TURN_MAX_ATTEMPTS - 1); // one backoff before each retry
+  });
+});
+
+describe("isTransientTurnError", () => {
+  test("transient upstream/network signals → true", () => {
+    for (const s of [
+      "API Error: 529 Overloaded",
+      "503 Service Unavailable",
+      "429 rate limit exceeded",
+      "Internal Server Error",
+      "Bad Gateway",
+      "ETIMEDOUT",
+      "socket hang up (ECONNRESET)",
+    ]) {
+      expect(isTransientTurnError(s)).toBe(true);
+    }
+  });
+
+  test("permanent/deterministic signals → false (no pointless retry)", () => {
+    for (const s of [
+      "401 unauthorized",
+      "400 bad request",
+      'no Claude credential for channel "x"',
+      "claude -p turn failed (subtype: error_max_turns)",
+      "tag_scope_violation",
+    ]) {
+      expect(isTransientTurnError(s)).toBe(false);
+    }
   });
 });

--- a/src/backends/programmatic.test.ts
+++ b/src/backends/programmatic.test.ts
@@ -1104,24 +1104,28 @@ describe("ProgrammaticBackend.deliver — transient-error retry with incremental
   test("retries a TRANSIENT turn error (backoff), then succeeds", async () => {
     mkDirs("retry-ok");
     const sleeps: number[] = [];
+    const state = new AgentSessionState({ stateDir });
     const { fn, calls } = sequencedSpawn([
       transientResult("s1", "API Error: 529 Overloaded. Try again."),
       successTurn("s2", "recovered"),
     ]);
     const backend = new ProgrammaticBackend(
       baseDeps(fn, {
+        sessionState: state,
         sleepFn: async (ms) => {
           sleeps.push(ms);
         },
       }),
     );
-    const handle = await backend.start(specWithVault());
+    const handle = await backend.start(specWithVault("eng"));
     const result = await backend.deliver(handle, "go");
     expect(result.ok).toBe(true);
     if (result.ok) expect(result.reply).toBe("recovered");
     expect(calls.length).toBe(2); // one retry
     expect(sleeps).toHaveLength(1); // one backoff
     expect(sleeps[0]).toBe(TURN_RETRY_BACKOFF_MS[0]); // the first (incremental) interval
+    // The SUCCESSFUL attempt's sid is persisted (not the failed attempt's "s1").
+    expect(state.get("eng")).toBe("s2");
   });
 
   test("does NOT retry a non-transient turn error (fails fast, no sleep)", async () => {
@@ -1147,22 +1151,26 @@ describe("ProgrammaticBackend.deliver — transient-error retry with incremental
   test("a persistently TRANSIENT error exhausts the retries → { ok:false }", async () => {
     mkDirs("retry-exhaust");
     const sleeps: number[] = [];
+    const state = new AgentSessionState({ stateDir });
     const { fn, calls } = recordingSpawn({
       stdout: transientResult("s", "API Error: 503 Service Unavailable"),
     });
     const backend = new ProgrammaticBackend(
       baseDeps(fn, {
+        sessionState: state,
         sleepFn: async (ms) => {
           sleeps.push(ms);
         },
       }),
     );
-    const handle = await backend.start(specWithVault());
+    const handle = await backend.start(specWithVault("eng"));
     const result = await backend.deliver(handle, "go");
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.error).toContain("503");
     expect(calls.length).toBe(TURN_MAX_ATTEMPTS); // all attempts used
     expect(sleeps.length).toBe(TURN_MAX_ATTEMPTS - 1); // one backoff before each retry
+    // The session id is still persisted even on a FINAL failure (continuation handle).
+    expect(state.get("eng")).toBe("s");
   });
 });
 

--- a/src/backends/programmatic.ts
+++ b/src/backends/programmatic.ts
@@ -157,7 +157,46 @@ export interface ProgrammaticBackendDeps {
   claudeBin?: string;
   /** Optional ripgrep override threaded to the sandbox (macOS deny-path scan). */
   ripgrep?: { command: string; args?: string[] };
+  /**
+   * Sleep used by the turn-level transient-retry backoff. Injected so tests don't
+   * actually wait the backoff. Defaults to a real `setTimeout`-backed sleep.
+   */
+  sleepFn?: (ms: number) => Promise<void>;
 }
+
+/**
+ * Turn-level retry on TRANSIENT upstream errors (API 529/overload, 5xx, rate-limit,
+ * network). A 529 with no retry is exactly the "silent no-reply" a user hits under
+ * load; incremental backoff turns most of those into a delivered reply. The detector
+ * ({@link isTransientTurnError}) is conservative — a 4xx (auth/validation), a missing
+ * credential, or a deterministic subtype failure is NOT retried (it'd only burn time).
+ */
+export const TURN_MAX_ATTEMPTS = 3;
+/** Incremental backoff before each retry (ms); length = TURN_MAX_ATTEMPTS - 1. */
+export const TURN_RETRY_BACKOFF_MS: readonly number[] = [2_000, 5_000];
+
+/** Does this turn-failure reason look like a transient upstream error worth retrying? */
+export function isTransientTurnError(reason: string): boolean {
+  const r = reason.toLowerCase();
+  return (
+    /\b(429|500|502|503|504|529)\b/.test(reason) ||
+    r.includes("overloaded") ||
+    r.includes("rate limit") ||
+    r.includes("rate_limit") ||
+    r.includes("service unavailable") ||
+    r.includes("bad gateway") ||
+    r.includes("gateway time") ||
+    r.includes("internal server error") ||
+    r.includes("temporarily") ||
+    r.includes("timed out") ||
+    r.includes("timeout") ||
+    r.includes("etimedout") ||
+    r.includes("econnreset")
+  );
+}
+
+/** Default real sleep for the retry backoff (overridable via `deps.sleepFn` in tests). */
+const realSleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
 /**
  * Build the `claude -p` invocation argv (PRE-sandbox-wrap) for one turn.
@@ -496,16 +535,12 @@ export class ProgrammaticBackend implements AgentBackend {
       ...homeEnv,
     };
 
-    // Run the turn. A spawn/IO fault is a value (not a throw) — the daemon learns it.
-    // STREAM stdout incrementally (interim events for the live view) while draining
-    // stderr in parallel. The interim sink is best-effort + must not throw: wrap the
-    // caller's `onInterim` so a dead-stream error from the daemon's push can't abort
-    // the drain (which would strand the durable final-result parse). A no-sink turn
-    // passes a no-op, so the stream is still parsed incrementally with zero overhead
-    // beyond the (cheap) per-line dispatch.
-    let parsed;
-    let stderr: string;
-    let code: number;
+    // Run the turn, with a bounded retry on TRANSIENT upstream errors (API 529/overload,
+    // 5xx, rate-limit, network). The argv is fixed (built above with the turn-start
+    // `--resume` sid), so each attempt re-runs the SAME turn. STREAM stdout incrementally
+    // (interim events for the live view) while draining stderr in parallel; the interim
+    // sink is best-effort + must not throw. A spawn/IO fault is a value (not a throw); a
+    // non-transient failure or exhausted retries returns the failure for the daemon to learn.
     const safeInterim: InterimSink = (e) => {
       if (!onInterim) return;
       try {
@@ -514,59 +549,81 @@ export class ProgrammaticBackend implements AgentBackend {
         // A push to a closed SSE stream / a sink fault must never break the turn.
       }
     };
-    try {
-      const proc = this.deps.spawnFn(wrapped.argv, { env: launchEnv, cwd });
-      [parsed, stderr] = await Promise.all([
-        parseStreamJsonStream(proc.stdout, safeInterim),
-        drainStream(proc.stderr),
-      ]);
-      code = await proc.exited;
-    } catch (err) {
-      return { ok: false, error: `claude -p spawn failed: ${(err as Error).message}` };
-    }
+    const sleepFn = this.deps.sleepFn ?? realSleep;
+    for (let attempt = 1; attempt <= TURN_MAX_ATTEMPTS; attempt++) {
+      let parsed;
+      let stderr: string;
+      let code: number;
+      try {
+        const proc = this.deps.spawnFn(wrapped.argv, { env: launchEnv, cwd });
+        [parsed, stderr] = await Promise.all([
+          parseStreamJsonStream(proc.stdout, safeInterim),
+          drainStream(proc.stderr),
+        ]);
+        code = await proc.exited;
+      } catch (err) {
+        // A spawn/IO fault (ENOENT, resource) is a config/permanent class — not retried.
+        return { ok: false, error: `claude -p spawn failed: ${(err as Error).message}` };
+      }
 
-    // Persist the captured session id so the NEXT turn resumes it — even on a
-    // failed turn (a turn can fail AFTER establishing a session; the id is still
-    // the continuation handle). A blank id is a no-op in the store. SKIPPED for
-    // multi-threaded: in its fresh-per-fire form the returned session id is never
-    // persisted to the channel store (the next fire must start fresh — no resume, no
-    // persist; recording the minted id per thread is the deferred continuation increment).
-    if (!multiThreaded && parsed.sessionId) this.deps.sessionState.set(channel, parsed.sessionId);
+      if (parsed.success === true) {
+        // Persist the captured session id so the NEXT turn resumes it. SKIPPED for
+        // multi-threaded (each fire starts fresh — no resume, no persist). Blank id = no-op.
+        if (!multiThreaded && parsed.sessionId) this.deps.sessionState.set(channel, parsed.sessionId);
 
-    const usage: DeliverUsage | undefined = parsed.usage
-      ? {
-          ...(typeof parsed.usage.input_tokens === "number" ? { inputTokens: parsed.usage.input_tokens } : {}),
-          ...(typeof parsed.usage.output_tokens === "number" ? { outputTokens: parsed.usage.output_tokens } : {}),
-          ...(typeof parsed.totalCostUsd === "number" ? { totalCostUsd: parsed.totalCostUsd } : {}),
-        }
-      : typeof parsed.totalCostUsd === "number"
-        ? { totalCostUsd: parsed.totalCostUsd }
-        : undefined;
+        const usage: DeliverUsage | undefined = parsed.usage
+          ? {
+              ...(typeof parsed.usage.input_tokens === "number" ? { inputTokens: parsed.usage.input_tokens } : {}),
+              ...(typeof parsed.usage.output_tokens === "number" ? { outputTokens: parsed.usage.output_tokens } : {}),
+              ...(typeof parsed.totalCostUsd === "number" ? { totalCostUsd: parsed.totalCostUsd } : {}),
+            }
+          : typeof parsed.totalCostUsd === "number"
+            ? { totalCostUsd: parsed.totalCostUsd }
+            : undefined;
 
-    // FAILURE paths — all return a value, never throw:
-    //   - non-zero exit with no parseable success result;
-    //   - a result event with is_error / a non-success subtype;
-    //   - no result event at all (crashed/truncated turn).
-    if (parsed.success !== true) {
+        return {
+          ok: true,
+          reply: parsed.reply ?? "",
+          ...(parsed.sessionId ? { sessionId: parsed.sessionId } : {}),
+          ...(usage ? { usage } : {}),
+        };
+      }
+
+      // FAILURE — compute the reason (non-zero exit / is_error / non-success subtype /
+      // no result event), same precedence as before.
       const reason =
         parsed.errorMessage ??
         (parsed.subtype ? `claude -p turn failed (subtype: ${parsed.subtype})` : undefined) ??
         (code !== 0
           ? `claude -p exited ${code}${stderr.trim() ? `: ${stderr.trim().slice(0, 500)}` : ""}`
           : "claude -p produced no success result (no result event in output)");
+
+      // Retry ONLY a transient error, and only while attempts remain (incremental backoff).
+      if (attempt < TURN_MAX_ATTEMPTS && isTransientTurnError(reason)) {
+        const backoff =
+          TURN_RETRY_BACKOFF_MS[attempt - 1] ?? TURN_RETRY_BACKOFF_MS[TURN_RETRY_BACKOFF_MS.length - 1] ?? 5_000;
+        console.warn(
+          `parachute-agent: transient turn error for channel "${channel}" ` +
+            `(attempt ${attempt}/${TURN_MAX_ATTEMPTS}, retrying in ${backoff}ms): ${reason}`,
+        );
+        await sleepFn(backoff);
+        continue;
+      }
+      // Persist the session id even on a FINAL failure — a turn can fail AFTER
+      // establishing a session; the id is still the continuation handle for the next
+      // turn (matches the pre-retry behavior). SKIPPED for multi-threaded. NOT persisted
+      // on a retried attempt (the fixed argv re-resumes the turn-start sid each time).
+      if (!multiThreaded && parsed.sessionId) this.deps.sessionState.set(channel, parsed.sessionId);
+      // Non-transient, or out of attempts → return the failure (the daemon records
+      // status:error AND posts a user-facing failure note to the channel).
       return {
         ok: false,
         error: reason,
         ...(parsed.sessionId ? { sessionId: parsed.sessionId } : {}),
       };
     }
-
-    return {
-      ok: true,
-      reply: parsed.reply ?? "",
-      ...(parsed.sessionId ? { sessionId: parsed.sessionId } : {}),
-      ...(usage ? { usage } : {}),
-    };
+    // Unreachable — every loop path returns — but satisfies the type checker.
+    return { ok: false, error: "claude -p: retries exhausted" };
   }
 
   /**

--- a/src/backends/registry.test.ts
+++ b/src/backends/registry.test.ts
@@ -236,7 +236,7 @@ describe("ProgrammaticAgentRegistry — inbound enqueue + outbound", () => {
     expect(rec.calls).toHaveLength(0);
   });
 
-  test("an ok:false turn writes NO note + does not crash/loop", async () => {
+  test("an ok:false turn writes a user-facing FAILURE note + does not crash/loop", async () => {
     const backend = new FakeBackend();
     backend.resultFor = () => ({ ok: false, error: "mint refused" });
     const rec = recorder();
@@ -244,11 +244,13 @@ describe("ProgrammaticAgentRegistry — inbound enqueue + outbound", () => {
     await reg.register(specFor("eng"));
 
     reg.enqueue("eng", { content: "do it" });
-    await until(() => backend.calls.length === 1);
+    await until(() => rec.calls.length === 1);
     await new Promise<void>((r) => setTimeout(r, 5));
-    // Exactly ONE turn ran (no retry loop), and no note was written.
+    // Exactly ONE turn ran (the backend owns turn-retry, not the drain), and the drain
+    // posted a SINGLE user-facing failure note carrying the reason (no silent no-reply).
     expect(backend.calls).toHaveLength(1);
-    expect(rec.calls).toHaveLength(0);
+    expect(rec.calls).toHaveLength(1);
+    expect(rec.calls[0]!.reply).toContain("mint refused");
   });
 
   test("a deliver() that THROWS is caught — the worker survives + drains the rest", async () => {
@@ -260,10 +262,13 @@ describe("ProgrammaticAgentRegistry — inbound enqueue + outbound", () => {
 
     reg.enqueue("eng", { content: "first (throws)" });
     reg.enqueue("eng", { content: "second (ok)" });
-    await until(() => rec.calls.length === 1);
-    // Both turns ran; the throw on the first didn't strand the second.
+    await until(() => rec.calls.length === 2);
+    // Both turns ran; the throw on the first didn't strand the second. The caught throw
+    // posts a user-facing failure note (carrying the reason); the second succeeds normally.
     expect(backend.calls.map((c) => c.message)).toEqual(["first (throws)", "second (ok)"]);
-    expect(rec.calls).toEqual([{ channel: "eng", reply: "reply:second (ok)" }]);
+    expect(rec.calls).toHaveLength(2);
+    expect(rec.calls[0]!.reply).toContain("surprise throw");
+    expect(rec.calls[1]!).toEqual({ channel: "eng", reply: "reply:second (ok)" });
   });
 });
 
@@ -401,8 +406,9 @@ describe("ProgrammaticAgentRegistry — #agent/thread notes (unified lifecycle, 
     expect(threads.ends()[0]!.mode).toBe("multi-threaded");
     expect(threads.ends()[0]!.status).toBe("error");
     expect(threads.ends()[0]!.output).toBe("mint refused");
-    // No outbound note for a failed turn (unchanged behavior).
-    expect(rec.calls).toHaveLength(0);
+    // A user-facing failure note IS now written for a failed turn (carries the reason).
+    expect(rec.calls).toHaveLength(1);
+    expect(rec.calls[0]!.reply).toContain("mint refused");
   });
 
   test("a FAILED SINGLE-THREADED turn ALSO materializes an #agent/thread note with status:error (substantiates BOTH modes)", async () => {
@@ -424,8 +430,9 @@ describe("ProgrammaticAgentRegistry — #agent/thread notes (unified lifecycle, 
     expect(threads.ends()[0]!.name).toBe("eng");
     expect(threads.ends()[0]!.status).toBe("error");
     expect(threads.ends()[0]!.output).toBe("mint refused");
-    // No outbound note for a failed turn (unchanged behavior).
-    expect(rec.calls).toHaveLength(0);
+    // A user-facing failure note IS now written for a failed turn (carries the reason).
+    expect(rec.calls).toHaveLength(1);
+    expect(rec.calls[0]!.reply).toContain("mint refused");
   });
 
   test("a turn with an empty reply STILL materializes a thread note (status ok, empty output)", async () => {
@@ -698,11 +705,12 @@ describe("ProgrammaticAgentRegistry — streaming turn view (onTurnEvent)", () =
     await reg.register(specFor("eng"));
 
     reg.enqueue("eng", { content: "x" });
-    await until(() => turns.events.some((e) => e.event.kind === "error"));
+    await until(() => rec.calls.length === 1);
 
     expect(turns.events).toEqual([{ channel: "eng", event: { kind: "error", error: "mint refused" } }]);
-    // No outbound note for a failed turn.
-    expect(rec.calls).toHaveLength(0);
+    // The failed turn ALSO posts a user-facing failure note (carrying the reason).
+    expect(rec.calls).toHaveLength(1);
+    expect(rec.calls[0]!.reply).toContain("mint refused");
   });
 
   test("a backend THROW also emits 'error' (the defensive catch resolves the live view)", async () => {
@@ -1082,7 +1090,10 @@ describe("ProgrammaticAgentRegistry — agent-to-agent callbacks (reply_to)", ()
     await until(() => cb.calls.length === 1);
     await new Promise<void>((r) => setTimeout(r, 5));
     expect(cb.calls).toHaveLength(1);
-    expect(out.calls).toHaveLength(0); // an error turn writes no outbound,
+    // An error turn now posts a user-facing failure note to the worker's own channel
+    // (in addition to the orchestrator callback) — carrying the reason.
+    expect(out.calls).toHaveLength(1);
+    expect(out.calls[0]!.reply).toContain("mint refused");
     const { meta, content } = cb.calls[0]!;
     expect(meta.status).toBe("error"); // but the orchestrator still learns it failed.
     expect(content).toContain("error");

--- a/src/backends/registry.ts
+++ b/src/backends/registry.ts
@@ -766,6 +766,9 @@ export class ProgrammaticAgentRegistry {
           phase: "end",
         });
         this.emitTurnEvent(channel, { kind: "error", error: reason });
+        // Post a user-facing failure note so the channel shows SOMETHING (not a silent
+        // no-reply) — best-effort.
+        await this.postFailureNote(channel, msg.inReplyTo, turnThreadId, reason);
         // CALLBACK on the failure too — an orchestrator MUST learn its sub-task failed, not
         // hang waiting forever. No outbound note was produced, so no `source_message`.
         await this.maybeDeliverCallback(handle, msg, turnThreadId, "error");
@@ -787,6 +790,9 @@ export class ProgrammaticAgentRegistry {
           phase: "end",
         });
         this.emitTurnEvent(channel, { kind: "error", error: result.error });
+        // Post a user-facing failure note so the channel shows SOMETHING (not a silent
+        // no-reply) — best-effort.
+        await this.postFailureNote(channel, msg.inReplyTo, turnThreadId, result.error);
         // CALLBACK on the failure-as-value too (status:error) — the orchestrator learns the
         // sub-task failed and can react. No delivered reply, so no `source_message`.
         await this.maybeDeliverCallback(handle, msg, turnThreadId, "error");
@@ -1061,5 +1067,36 @@ export class ProgrammaticAgentRegistry {
       }
     }
     return { ok: false, error: lastError };
+  }
+
+  /**
+   * Post a brief, user-facing FAILURE note to the channel when a turn doesn't complete
+   * (the backend's transient-retry is exhausted, or a non-transient error). A silent
+   * no-reply reads as "nothing came through" — this makes the failure visible in the
+   * transcript, with the reason. Best-effort: a failed failure-note write is logged,
+   * never thrown (it must not break the drain). Reuses the bounded outbound-write retry.
+   */
+  private async postFailureNote(
+    channel: string,
+    inReplyTo: string | undefined,
+    threadId: string,
+    reason: string,
+  ): Promise<void> {
+    const short = reason.length > 240 ? `${reason.slice(0, 240)}…` : reason;
+    const text =
+      `⚠️ I couldn't complete that — the turn failed: ${short}\n\n` +
+      `This is often temporary; please try again in a moment.`;
+    try {
+      const delivered = await this.deliverOutboundWithRetry(channel, text, inReplyTo, threadId);
+      if (!delivered.ok) {
+        console.error(
+          `parachute-agent: failure note for channel "${channel}" not delivered: ${delivered.error}`,
+        );
+      }
+    } catch (err) {
+      console.error(
+        `parachute-agent: posting failure note for channel "${channel}" threw (continuing): ${(err as Error).message}`,
+      );
+    }
   }
 }

--- a/src/programmatic-wiring.test.ts
+++ b/src/programmatic-wiring.test.ts
@@ -313,7 +313,7 @@ describe("inbound for a programmatic channel → deliver → outbound note", () 
     }
   });
 
-  test("ok:false → no outbound note + no crash/loop", async () => {
+  test("ok:false → user-facing failure note + no crash/loop", async () => {
     const backend = new FakeBackend();
     backend.resultFor = () => ({ ok: false, error: "mint refused" });
     const rec = recorder();
@@ -328,10 +328,12 @@ describe("inbound for a programmatic channel → deliver → outbound note", () 
     const { srv, base } = buildServer({ channels, programmatic, deliveryState });
     try {
       await inbound(base, "eng", "note-1", "do it");
-      await until(() => backend.calls.length === 1);
+      await until(() => rec.calls.length === 1);
       await new Promise<void>((r) => setTimeout(r, 5));
       expect(backend.calls).toHaveLength(1);
-      expect(rec.calls).toHaveLength(0);
+      // A failed turn now posts a single user-facing failure note (carrying the reason).
+      expect(rec.calls).toHaveLength(1);
+      expect(rec.calls[0]!.reply).toContain("mint refused");
     } finally {
       srv.stop(true);
     }


### PR DESCRIPTION
## Why
A `claude -p` turn that hit a **transient** upstream error (API **529 Overloaded**, 5xx, rate-limit) silently produced **no reply** — the literal "I sent a message and nothing came through." Caught live on the `uni` agent: a 529 left the turn `status:error` with no outbound, and there was **no auto-retry**.

## Part A — turn-level retry with incremental backoff (`programmatic.ts`)
- `deliver()` now wraps spawn→parse→failure in a bounded loop (`TURN_MAX_ATTEMPTS = 3`) that retries **only a transient error** (`isTransientTurnError`: 529/5xx/429/overloaded/rate-limit/network) with **incremental backoff** (`[2s, 5s]`). Non-transient (4xx/auth/missing-credential/deterministic subtype) **fails fast**.
- The argv is fixed (turn-start `--resume`), so each attempt re-runs the same turn. `sleepFn` is injectable so tests don't actually wait. Session-id is still persisted on a final failure (preserved from pre-retry behavior — caught by an existing test).

## Part B — user-facing failure note on give-up (`registry.ts`)
Per the ask: *"if sufficient retries don't succeed, put a message in the channel that there was a failure with appropriate information."* Both turn-failure terminals (failure-as-value **and** the defensive catch) now post a brief `⚠️ I couldn't complete that — the turn failed: <reason>. …try again` note to the channel (via the existing bounded outbound-write retry; best-effort, never throws out of the drain). The orchestrator callback still fires.

## Tests
- New: transient→retry→success (one backoff); non-transient→fail-fast (no sleep); persistent-transient→exhausts retries; `isTransientTurnError` unit table.
- Updated the prior "no-outbound-on-failure" contract across the registry + wiring suites to assert the failure note carries the reason.
- Gate: `tsc --noEmit` clean; `bun test ./src` **1025 pass / 0 fail**.

Note: a just-completed deep audit flagged the `sleepFn`/`realSleep` scaffolding as "dead (the turn-retry the branch name implies is unbuilt)" — this PR **builds it**.