### PR TITLE
fix(agent): re-enable the CAS single-claim guard (channelQueueStoreFor dropped ifUpdatedAt)

### DIFF
--- a/src/daemon-channel-queue-store.test.ts
+++ b/src/daemon-channel-queue-store.test.ts
@@ -1,0 +1,65 @@
+/**
+ * `channelQueueStoreFor` — the PRODUCTION adapter that wires a live `VaultTransport`
+ * into the `ChannelQueueStore` the pull-queue worker uses.
+ *
+ * Regression for the agent#101 CAS single-claim guard (PR #116): the adapter MUST
+ * forward the 4th `ifUpdatedAt` arg to `vt.setInboundStatus`, or the compare-and-set
+ * silently collapses to `force:true` (last-write-wins) and the double-claim race the
+ * CAS was built to close re-opens. The unit tests inject a FAKE store that honors all
+ * four args, so ONLY the live daemon adapter was lossy (a 3-param arrow is assignable
+ * to the wider interface slot, so the type checker can't catch it). This exercises the
+ * REAL adapter end-to-end against a `VaultTransport`.
+ */
+import { describe, test, expect, afterEach } from "bun:test";
+import { channelQueueStoreFor } from "./daemon.ts";
+import { VaultTransport } from "./transports/vault.ts";
+import type { Channel } from "./registry.ts";
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+function vaultChannels(): Map<string, Channel> {
+  const vault = new VaultTransport({ vault: "default", vaultUrl: "http://127.0.0.1:1940", token: "write-token" });
+  const channels = new Map<string, Channel>();
+  channels.set("eng", {
+    name: "eng",
+    transport: vault,
+    entry: { name: "eng", transport: "vault", config: { vault: "default", token: "write-token" } },
+  });
+  return channels;
+}
+
+/** Capture the PATCH bodies the vault transport sends. */
+function recordPatch(): { bodies: Record<string, unknown>[] } {
+  const bodies: Record<string, unknown>[] = [];
+  globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+    if ((init?.method ?? "GET") === "PATCH") bodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+    return new Response("{}", { status: 200 });
+  }) as typeof fetch;
+  return { bodies };
+}
+
+describe("channelQueueStoreFor — CAS arg forwarding (agent#101 regression)", () => {
+  test("setInboundStatus FORWARDS ifUpdatedAt → the vault does a CAS (if_updated_at), not force", async () => {
+    const store = channelQueueStoreFor(vaultChannels(), "eng");
+    expect(store).not.toBeNull();
+    const { bodies } = recordPatch();
+    await store!.setInboundStatus("note-1", "in-flight", "2026-06-22T00:00:00.000Z", "2026-06-22T00:00:00.000Z");
+    expect(bodies).toHaveLength(1);
+    // The CAS precondition is forwarded (the whole point of the single-claim guard) …
+    expect(bodies[0]!.if_updated_at).toBe("2026-06-22T00:00:00.000Z");
+    // … and it is NOT the force/last-write-wins path the dropped-arg bug fell back to.
+    expect(bodies[0]!.force).toBeUndefined();
+  });
+
+  test("setInboundStatus WITHOUT ifUpdatedAt → force:true (release/handled/sweep path, unchanged)", async () => {
+    const store = channelQueueStoreFor(vaultChannels(), "eng");
+    const { bodies } = recordPatch();
+    await store!.setInboundStatus("note-1", "pending", null);
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0]!.force).toBe(true);
+    expect(bodies[0]!.if_updated_at).toBeUndefined();
+  });
+});

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -628,7 +628,12 @@ export function channelQueueStoreFor(
   if (!(vt instanceof VaultTransport)) return null;
   return {
     listInboundQueue: (opts) => vt.listInboundQueue(opts),
-    setInboundStatus: (id, status, claimedAt) => vt.setInboundStatus(id, status, claimedAt),
+    // Forward ALL FOUR args — the 4th `ifUpdatedAt` is the CAS precondition the
+    // single-claim guard (agent#101) depends on. A 3-arg arrow silently dropped it,
+    // collapsing every claim to `force:true` (last-write-wins) and DISABLING the CAS in
+    // production (the double-claim race PR #116 closed was re-opened for channel agents).
+    setInboundStatus: (id, status, claimedAt, ifUpdatedAt) =>
+      vt.setInboundStatus(id, status, claimedAt, ifUpdatedAt),
     reply: async (args) => {
       return vt.reply({
         channel: name,


### PR DESCRIPTION
## The bug (found by the deep audit — production correctness)
The single-claim guard (agent#101 / PR #116) — which stops two connected sessions from both claiming the same inbound message — was **silently disabled in production**.

`channelQueueStoreFor` (`daemon.ts`) wired the store's `setInboundStatus` as a **3-param arrow** that dropped the 4th `ifUpdatedAt` arg:
```ts
setInboundStatus: (id, status, claimedAt) => vt.setInboundStatus(id, status, claimedAt),
```
`VaultTransport.setInboundStatus` does a compare-and-set (`if_updated_at`) **only** when `ifUpdatedAt` is supplied, otherwise `force:true` (last-write-wins). With the arg dropped, every claim took the `force` path → **CAS off → the double-claim race re-opened** for `channel`-backend agents.

Why nothing caught it: the type checker can't (a narrower arrow is assignable to the wider interface slot), and the unit tests inject a **fake** `ChannelQueueStore` that honors all four args — only the live daemon adapter was lossy.

## Fix
Forward all four args (one line). Plus a **new regression test that exercises the real adapter** against a `VaultTransport` (records the PATCH body):
- with `ifUpdatedAt` → `if_updated_at` CAS body (not `force`)
- without it → `force:true` (the release/handled/sweep path — unchanged)

This is the test class the audit flagged as missing: assert the *production adapter*, not just the fake store.

## Gate
`tsc --noEmit` clean; `bun test ./src` **1022 pass / 0 fail**.