### PR TITLE
ci: add GitHub Actions CI (typecheck + tests)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+# The gate the project already runs locally (`bun run test` = typecheck + bun test ./src/),
+# now enforced on every PR + push to main — closing the "no CI / nothing gates PRs" gap.
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# One in-flight run per ref; a new push cancels the previous run.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gate:
+    name: typecheck + tests (src)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+      - run: bun install --frozen-lockfile
+      - name: typecheck
+        run: bun run typecheck
+      - name: tests
+        run: bun test ./src/
+
+  spa:
+    name: web/ui (vitest)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+      - name: install (web/ui)
+        run: bun install
+        working-directory: web/ui
+      - name: test (vitest)
+        run: bun run test
+        working-directory: web/ui

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           bun-version: 1.3.14
       - name: install (web/ui)
-        run: bun install
+        run: bun install --frozen-lockfile
         working-directory: web/ui
       - name: test (vitest)
         run: bun run test


### PR DESCRIPTION
## Why
The deep audit flagged **no CI** as the biggest *process* gap — there's no `.github/workflows/`, so the ~1000-test suite + typecheck only run locally and nothing gates PRs (and you run your real `uni` agent on this module).

## What
A CI workflow on **PR + push-to-main**:
- **gate**: `bun install --frozen-lockfile` → `bun run typecheck` → `bun test ./src/` (the project's existing local gate, now enforced).
- **spa**: `web/ui` vitest (the SPA's separate runner).
- Concurrency-cancels superseded runs per ref.

Validated with `actionlint` + `yaml.safe_load` before commit (a workflow syntax error is a *silent* startup_failure — won't run, no logs).

## Known follow-up
agent#32 (unit tests reach a live vault via `VaultTransport.start()`'s schema-ensure) could surface as flake in the vault-less CI runner. That call is best-effort (swallows failures), so the gate should hold — but if the `gate` job flakes on it, the fix is stubbing the schema-ensure in the test harness (a small follow-up). I'll confirm the first run is green.