### PR TITLE
refactor(agent): rename backend value channel → attached (+ AttachedQueueRegistry)

### DIFF
--- a/.parachute/module.json
+++ b/.parachute/module.json
@@ -2,7 +2,7 @@
   "name": "agent",
   "manifestName": "parachute-agent",
   "displayName": "Agent",
-  "tagline": "Chat with your Claude Code sessions — a channel per session.",
+  "tagline": "Chat with your Claude Code sessions — a session per agent.",
   "port": 1941,
   "paths": ["/agent"],
   "health": "/health",
@@ -17,8 +17,8 @@
     "defines": ["agent:read", "agent:write", "agent:send", "agent:admin"]
   },
   "events": [
-    { "key": "message.received", "title": "A message arrived on a channel" },
-    { "key": "message.sent", "title": "A session replied on a channel" }
+    { "key": "message.received", "title": "A message arrived for an agent" },
+    { "key": "message.sent", "title": "An agent replied" }
   ],
   "actions": [
     {
@@ -45,8 +45,8 @@
   "connectionTemplates": [
     {
       "key": "link-to-vault",
-      "title": "Link a channel to a vault",
-      "description": "Back a channel with a Parachute vault: inbound notes wake the session, replies are written back as notes. The operator picks WHICH vault (the parameter) and names the channel; the channel's config UI creates the connection with the operator's approval (the click is the approval).",
+      "title": "Link an agent to a vault",
+      "description": "Back an agent with a Parachute vault: inbound notes wake the agent, replies are written back as notes. The operator picks WHICH vault (the parameter) and names the agent's channel; the agent's config UI creates the connection with the operator's approval (the click is the approval).",
       "requestedBy": "agent",
       "source": {
         "module": "vault",

--- a/src/agent-defs.test.ts
+++ b/src/agent-defs.test.ts
@@ -246,17 +246,32 @@ describe("parseAgentDef", () => {
     ).toThrow(/interactive/);
   });
 
-  test("accepts backend:channel (design 2026-06-18-channel-backend), threads it onto the spec", () => {
+  test("accepts backend:attached (design 2026-06-18-channel-backend), threads it onto the spec", () => {
     const def = parseAgentDef(
-      { id: "Agents/laptop", content: "You are the laptop agent.", metadata: { name: "laptop", backend: "channel" } },
+      { id: "Agents/laptop", content: "You are the laptop agent.", metadata: { name: "laptop", backend: "attached" } },
       { vault: "default" },
     );
-    expect(def.spec.backend).toBe("channel");
+    expect(def.spec.backend).toBe("attached");
     expect(def.name).toBe("laptop");
     // The body is still the system prompt (the session adopts it on next-message).
     expect(def.spec.systemPrompt).toBe("You are the laptop agent.");
     // Wake channel = the agent name (agent ≡ channel) — same collapse as programmatic.
     expect(def.spec.channels).toEqual(["laptop"]);
+  });
+
+  test("DUAL-READ: a persisted def with the legacy backend value \"channel\" normalizes to \"attached\"", () => {
+    // The backend VALUE was renamed `channel` → `attached`. An already-authored def note
+    // (or spec.json) carrying the legacy `metadata.backend: "channel"` must still LOAD —
+    // normalized to the canonical `attached` on read, no operator-facing break, no
+    // migration. (The routing key `channel` — metadata.channel / the `/mcp/<channel>`
+    // segment — is a SEPARATE concept and is deliberately unchanged.)
+    const def = parseAgentDef(
+      { id: "Agents/laptop", content: "You are the laptop agent.", metadata: { name: "laptop", backend: "channel" } },
+      { vault: "default" },
+    );
+    expect(def.spec.backend).toBe("attached"); // normalized, NOT the legacy "channel".
+    expect(def.name).toBe("laptop");
+    expect(def.spec.channels).toEqual(["laptop"]); // routing key unchanged.
   });
 
   // --- execution-lifecycle mode (the Phase-3 prerequisite) ---
@@ -813,14 +828,14 @@ describe("AgentDefRegistry — lifecycle", () => {
         {
           id: "Agents/uni-dev",
           content: longPrompt,
-          metadata: { name: "uni-dev", backend: "channel", mode: "multi-threaded", wants: "vault:research:read" },
+          metadata: { name: "uni-dev", backend: "attached", mode: "multi-threaded", wants: "vault:research:read" },
         },
       ],
       byId: {
         "Agents/uni-dev": {
           id: "Agents/uni-dev",
           content: longPrompt,
-          metadata: { name: "uni-dev", backend: "channel", mode: "multi-threaded", wants: "vault:research:read" },
+          metadata: { name: "uni-dev", backend: "attached", mode: "multi-threaded", wants: "vault:research:read" },
         },
       },
     });
@@ -830,7 +845,7 @@ describe("AgentDefRegistry — lifecycle", () => {
     expect(full).not.toBeNull();
     expect(full!.noteId).toBe("Agents/uni-dev");
     expect(full!.name).toBe("uni-dev");
-    expect(full!.backend).toBe("channel");
+    expect(full!.backend).toBe("attached");
     expect(full!.mode).toBe("multi-threaded");
     expect(full!.vault).toBe("default");
     expect(full!.wants).toEqual(["vault:research:read"]);

--- a/src/agent-defs.ts
+++ b/src/agent-defs.ts
@@ -234,28 +234,38 @@ export function parseAgentDef(note: {
   }
 
   // Backend — default programmatic (the reliable primary path). A vault-native def
-  // may select EITHER `programmatic` (the daemon runs `claude -p` turns) OR `channel`
+  // may select EITHER `programmatic` (the daemon runs `claude -p` turns) OR `attached`
   // (the design 2026-06-18-channel-backend path — the turn is handled by a Claude Code
-  // session the operator connects to the channel's MCP endpoint; the daemon runs no
-  // turn, the inbound notes accumulate as a durable queue). `interactive` (the retired
-  // tmux path) is REJECTED with a clear message (→ status:error on the note) rather
-  // than silently demoting — `channel` is what it was reaching for, done right.
+  // session the operator connects — "attaches" — to the channel's MCP endpoint; the
+  // daemon runs no turn, the inbound notes accumulate as a durable queue). `interactive`
+  // (the retired tmux path) is REJECTED with a clear message (→ status:error on the
+  // note) rather than silently demoting — `attached` is what it was reaching for, done right.
+  //
+  // DUAL-READ the legacy backend VALUE, mapping silently (no operator-facing break, no
+  // migration of already-authored def notes / spec.json):
+  //   legacy value → canonical value
+  //   ──────────────────────────────
+  //   channel      → attached   (the backend value was renamed `channel` → `attached`;
+  //                              the ROUTING KEY `channel` — metadata.channel, the
+  //                              `/mcp/<channel>` segment — is a SEPARATE concept, untouched)
   let backend: AgentBackendKind = "programmatic";
   const rawBackend = metaStr(meta.backend);
   if (rawBackend !== undefined) {
     if (rawBackend === "interactive") {
       throw new AgentDefParseError(
         `#agent/definition note ${noteId}: the "interactive" backend is retired — use ` +
-          `"programmatic" (daemon-run turns, the default) or "channel" (handled by a Claude ` +
+          `"programmatic" (daemon-run turns, the default) or "attached" (handled by a Claude ` +
           `Code session you connect to the channel).`,
       );
     }
-    if (rawBackend !== "programmatic" && rawBackend !== "channel") {
+    // DUAL-READ: the legacy backend value `"channel"` normalizes to `"attached"`.
+    const normalizedBackend = rawBackend === "channel" ? "attached" : rawBackend;
+    if (normalizedBackend !== "programmatic" && normalizedBackend !== "attached") {
       throw new AgentDefParseError(
-        `#agent/definition note ${noteId}: backend must be "programmatic" or "channel"`,
+        `#agent/definition note ${noteId}: backend must be "programmatic" or "attached"`,
       );
     }
-    backend = rawBackend;
+    backend = normalizedBackend;
   }
 
   // Execution-lifecycle mode (the Phase-3 prerequisite). An agent is SINGLE-THREADED
@@ -707,7 +717,7 @@ interface LiveDef {
   name: string;
   /** The resolved status (for /health + observability). */
   status: AgentDefStatus;
-  /** The agent backend the def selected (`programmatic` | `channel`). */
+  /** The agent backend the def selected (`programmatic` | `attached`). */
   backend: AgentBackendKind;
   /** The execution-lifecycle mode the def selected (`single-threaded` | `multi-threaded`). */
   mode: AgentMode;
@@ -731,7 +741,7 @@ export interface AgentDefDetail {
   noteId: string;
   /** The agent name (= wake channel + spec name). */
   name: string;
-  /** The agent backend (`programmatic` | `channel`). */
+  /** The agent backend (`programmatic` | `attached`). */
   backend: AgentBackendKind;
   /** The execution-lifecycle mode (`single-threaded` | `multi-threaded`). */
   mode: AgentMode;
@@ -767,7 +777,7 @@ export interface AgentDefFull {
   noteId: string;
   /** The agent name (= wake channel + spec name). */
   name: string;
-  /** The agent backend (`programmatic` | `channel`). */
+  /** The agent backend (`programmatic` | `attached`). */
   backend: AgentBackendKind;
   /** The def-vault this agent is defined in. */
   vault: string;
@@ -1259,8 +1269,13 @@ export class AgentDefRegistry {
         400,
       );
     }
-    if (args.backend !== "programmatic" && args.backend !== "channel") {
-      throw new AgentDefWriteError(`backend must be "programmatic" or "channel"`, 400);
+    // DUAL-READ the legacy backend value `"channel"` → canonical `"attached"`, so a
+    // caller (or a hand-driven API client) passing the pre-rename value still WRITES the
+    // canonical value. The routing key `channel` is a separate concept, unchanged.
+    const backend: AgentBackendKind =
+      (args.backend as string) === "channel" ? "attached" : args.backend;
+    if (backend !== "programmatic" && backend !== "attached") {
+      throw new AgentDefWriteError(`backend must be "programmatic" or "attached"`, 400);
     }
     // A name collision with a live def (in ANY vault — the wake channel is shared) would
     // resurrect last-writer-wins on the channel; reject up front for a clean error.
@@ -1272,7 +1287,7 @@ export class AgentDefRegistry {
         );
       }
     }
-    const metadata = this.buildDefMetadata(args);
+    const metadata = this.buildDefMetadata({ ...args, backend });
     const created = await client.createNote({
       content: args.systemPrompt,
       metadata,

--- a/src/agents.test.ts
+++ b/src/agents.test.ts
@@ -91,9 +91,9 @@ describe("buildSpecFromBody", () => {
     expect(() => buildSpecFromBody({ name: "a", channels: ["c"], workspace: 42 })).toThrow(/workspace must be a string/);
   });
 
-  // Backend selection post-retire: omitted → programmatic; "channel" is vault-native
-  // (rejected with the deflect message); "interactive" is retired (rejected); any
-  // other value is rejected.
+  // Backend selection post-retire: omitted → programmatic; "attached" (and the legacy
+  // value "channel") is vault-native (rejected with the deflect message); "interactive"
+  // is retired (rejected); any other value is rejected.
   test("omitted backend → programmatic (the new-request default)", () => {
     expect(buildSpecFromBody({ name: "a", channels: ["c"] }).backend).toBe("programmatic");
     expect(buildSpecFromBody({ name: "a", channels: ["c"], backend: null }).backend).toBe("programmatic");
@@ -104,7 +104,10 @@ describe("buildSpecFromBody", () => {
   test("backend:\"interactive\" is REJECTED (retired)", () => {
     expect(() => buildSpecFromBody({ name: "a", channels: ["c"], backend: "interactive" })).toThrow(/retired/);
   });
-  test("backend:\"channel\" is REJECTED via this endpoint (vault-native)", () => {
+  test("backend:\"attached\" is REJECTED via this endpoint (vault-native)", () => {
+    expect(() => buildSpecFromBody({ name: "a", channels: ["c"], backend: "attached" })).toThrow(/vault-native/);
+  });
+  test("the legacy backend:\"channel\" is ALSO deflected as vault-native (dual-read)", () => {
     expect(() => buildSpecFromBody({ name: "a", channels: ["c"], backend: "channel" })).toThrow(/vault-native/);
   });
   test("rejects an invalid backend value", () => {

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -41,12 +41,13 @@ import { resolveClaudeCredential } from "./credentials.ts";
 export const AGENT_NAME_SLUG = /^[a-z0-9_-]+$/i;
 
 /**
- * One agent as the `/api/agents` list returns it — a PROGRAMMATIC or CHANNEL agent
+ * One agent as the `/api/agents` list returns it — a PROGRAMMATIC or ATTACHED agent
  * (the only two live backends; interactive was retired 2026-06-19). Neither has a
  * tmux session, so `session` is the conventional `<name>-agent` display label,
- * `attached` is always false, and liveness rides in `status` (`idle` | `working` |
- * `queued:N`) rather than the old tmux `attached`/`mcp_sessions` flags. Built by
- * `listProgrammaticAgents` / `listChannelAgents` (daemon.ts). NEVER carries a secret.
+ * `attached` is always false (the boolean tmux-attach flag — NOT the backend value),
+ * and liveness rides in `status` (`idle` | `working` | `queued:N`) rather than the old
+ * tmux `attached`/`mcp_sessions` flags. Built by `listProgrammaticAgents` /
+ * `listChannelAgents` (daemon.ts). NEVER carries a secret.
  */
 export interface AgentInfo {
   /** Agent slug. */
@@ -60,7 +61,7 @@ export interface AgentInfo {
   /** Whether the session's workspace (with its spec.json) is present on disk. */
   hasWorkspace: boolean;
   /** Which backend drives this agent. */
-  backend: "programmatic" | "channel";
+  backend: "programmatic" | "attached";
   /** Live status — `idle` | `working` | `queued:N`. */
   status?: string;
   /** The wake channel this agent serves (present for channel agents). */
@@ -185,17 +186,19 @@ export function buildSpecFromBody(body: unknown): AgentSpec {
   }
 
   // Backend selector. Only `"programmatic"` is accepted via this web spawn POST
-  // (the default when omitted). `"channel"` is VAULT-NATIVE — define a channel agent
-  // as a #agent/definition note (the create-agent UX for channel is phase 5), not via
-  // this endpoint. `"interactive"` was RETIRED (design 2026-06-19-retire-interactive-
-  // backend.md) — it is no longer a selectable backend anywhere.
+  // (the default when omitted). `"attached"` (the backend value formerly named
+  // `"channel"`) is VAULT-NATIVE — define an attached agent as a #agent/definition note,
+  // not via this endpoint. `"interactive"` was RETIRED (design 2026-06-19-retire-
+  // interactive-backend.md) — it is no longer a selectable backend anywhere.
   if (b.backend !== undefined && b.backend !== null) {
     if (b.backend !== "programmatic") {
       throw new SpawnRequestError(
-        b.backend === "channel"
-          ? "channel-backend agents are vault-native — define them as an #agent/definition note, not via this endpoint"
+        // Accept the legacy `"channel"` value in the diagnostic branch (dual-read of the
+        // renamed backend value) — both map to the same vault-native guidance.
+        b.backend === "attached" || b.backend === "channel"
+          ? "attached-backend agents are vault-native — define them as an #agent/definition note, not via this endpoint"
           : b.backend === "interactive"
-            ? 'the "interactive" backend is retired — use "programmatic" (the default) or define a "channel" agent as a #agent/definition note'
+            ? 'the "interactive" backend is retired — use "programmatic" (the default) or define an "attached" agent as a #agent/definition note'
             : 'body.backend must be "programmatic"',
       );
     }

--- a/src/backends/attached-queue.test.ts
+++ b/src/backends/attached-queue.test.ts
@@ -1,9 +1,9 @@
 /**
- * Tests for the CHANNEL-backend queue registry (`src/backends/channel-queue.ts`) —
- * the parallel-to-ProgrammaticAgentRegistry registry a `backend:channel` agent's
+ * Tests for the ATTACHED-backend queue registry (`src/backends/attached-queue.ts`) —
+ * the parallel-to-ProgrammaticAgentRegistry registry a `backend:attached` agent's
  * connected Claude Code session pulls from (design 2026-06-18-channel-backend.md).
  *
- * A FAKE store (implements {@link ChannelQueueStore}) stands in for the channel's
+ * A FAKE store (implements {@link AttachedQueueStore}) stands in for the channel's
  * VaultTransport: it holds inbound notes in memory with a mutable `status`/`claimedAt`
  * (the vault IS the queue + source of truth), and records outbound replies. So the
  * claim/reply/release/sweep semantics + the restart-safety (re-read from the store)
@@ -12,9 +12,9 @@
 
 import { describe, test, expect } from "bun:test";
 import {
-  ChannelQueueRegistry,
-  type ChannelQueueStore,
-} from "./channel-queue.ts";
+  AttachedQueueRegistry,
+  type AttachedQueueStore,
+} from "./attached-queue.ts";
 import type { AgentSpec } from "../sandbox/types.ts";
 import { InboundClaimConflictError } from "../transports/vault.ts";
 import type { InboundQueueNote, InboundStatus } from "../transports/vault.ts";
@@ -24,7 +24,7 @@ import type { InboundQueueNote, InboundStatus } from "../transports/vault.ts";
  * outbound writes. Mirrors the VaultTransport methods the registry calls. The status
  * mutations persist in the Map, so re-reading models the vault's restart-safety.
  */
-class FakeStore implements ChannelQueueStore {
+class FakeStore implements AttachedQueueStore {
   readonly notes = new Map<string, InboundQueueNote>();
   readonly outbound: Array<{ text: string; inReplyTo?: string }> = [];
   /** If set, the NEXT `setInboundStatus` throws this (to test claim-fail safety). */
@@ -84,7 +84,7 @@ class FakeStore implements ChannelQueueStore {
 const specFor = (name: string, systemPrompt?: string): AgentSpec => ({
   name,
   channels: [name],
-  backend: "channel",
+  backend: "attached",
   ...(systemPrompt ? { systemPrompt } : {}),
 });
 
@@ -96,9 +96,9 @@ const inbound = (id: string, text: string, ts: string, status: InboundStatus = "
   status,
 });
 
-describe("ChannelQueueRegistry — registration", () => {
+describe("AttachedQueueRegistry — registration", () => {
   test("register indexes by channel + name; deregister drops it", () => {
-    const reg = new ChannelQueueRegistry();
+    const reg = new AttachedQueueRegistry();
     const store = new FakeStore();
     expect(reg.hasChannel("laptop")).toBe(false);
     reg.register(specFor("laptop"), store);
@@ -111,14 +111,14 @@ describe("ChannelQueueRegistry — registration", () => {
   });
 
   test("register throws for a spec with no channel", () => {
-    const reg = new ChannelQueueRegistry();
-    expect(() => reg.register({ name: "x", channels: [], backend: "channel" }, new FakeStore())).toThrow(/no channel/);
+    const reg = new AttachedQueueRegistry();
+    expect(() => reg.register({ name: "x", channels: [], backend: "attached" }, new FakeStore())).toThrow(/no channel/);
   });
 });
 
-describe("ChannelQueueRegistry — pending peek", () => {
+describe("AttachedQueueRegistry — pending peek", () => {
   test("counts only pending; previews the oldest-first", async () => {
-    const reg = new ChannelQueueRegistry();
+    const reg = new AttachedQueueRegistry();
     const store = new FakeStore();
     store.add(inbound("a", "first message", "2026-06-18T10:00:00Z"));
     store.add(inbound("b", "second message", "2026-06-18T10:01:00Z"));
@@ -131,16 +131,16 @@ describe("ChannelQueueRegistry — pending peek", () => {
     expect(view.items[0]!.preview).toBe("first message");
   });
 
-  test("a non-channel channel yields an empty no-op view", async () => {
-    const reg = new ChannelQueueRegistry();
+  test("a non-attached channel yields an empty no-op view", async () => {
+    const reg = new AttachedQueueRegistry();
     const view = await reg.pending("unknown");
     expect(view).toEqual({ count: 0, items: [] });
   });
 });
 
-describe("ChannelQueueRegistry — claimNext (single-claim)", () => {
+describe("AttachedQueueRegistry — claimNext (single-claim)", () => {
   test("claims the OLDEST pending, sets in-flight + claimedAt, returns text + systemPrompt", async () => {
-    const reg = new ChannelQueueRegistry();
+    const reg = new AttachedQueueRegistry();
     const store = new FakeStore();
     store.add(inbound("b", "newer", "2026-06-18T10:05:00Z"));
     store.add(inbound("a", "older", "2026-06-18T10:00:00Z"));
@@ -158,7 +158,7 @@ describe("ChannelQueueRegistry — claimNext (single-claim)", () => {
   });
 
   test("a SECOND claimNext does not return the same message (single-claim)", async () => {
-    const reg = new ChannelQueueRegistry();
+    const reg = new AttachedQueueRegistry();
     const store = new FakeStore();
     store.add(inbound("a", "older", "2026-06-18T10:00:00Z"));
     store.add(inbound("b", "newer", "2026-06-18T10:05:00Z"));
@@ -173,7 +173,7 @@ describe("ChannelQueueRegistry — claimNext (single-claim)", () => {
   });
 
   test("returns null when none pending", async () => {
-    const reg = new ChannelQueueRegistry();
+    const reg = new AttachedQueueRegistry();
     const store = new FakeStore();
     store.add(inbound("a", "done", "2026-06-18T10:00:00Z", "handled"));
     reg.register(specFor("laptop"), store);
@@ -181,7 +181,7 @@ describe("ChannelQueueRegistry — claimNext (single-claim)", () => {
   });
 
   test("a claim PATCH failure surfaces + leaves the note pending (no hand-out)", async () => {
-    const reg = new ChannelQueueRegistry();
+    const reg = new AttachedQueueRegistry();
     const store = new FakeStore();
     store.add(inbound("a", "older", "2026-06-18T10:00:00Z"));
     reg.register(specFor("laptop"), store);
@@ -191,7 +191,7 @@ describe("ChannelQueueRegistry — claimNext (single-claim)", () => {
   });
 
   test("FIX 3: a passed-through updatedAt is used as the CAS precondition on the claim", async () => {
-    const reg = new ChannelQueueRegistry();
+    const reg = new AttachedQueueRegistry();
     const store = new FakeStore();
     store.add({ ...inbound("a", "older", "2026-06-18T10:00:00Z"), updatedAt: "rev-1" });
     reg.register(specFor("laptop"), store);
@@ -203,7 +203,7 @@ describe("ChannelQueueRegistry — claimNext (single-claim)", () => {
   });
 
   test("FIX 3: a 428/409 conflict on the claim PATCH makes claimNext skip to the NEXT pending (no double-claim)", async () => {
-    const reg = new ChannelQueueRegistry();
+    const reg = new AttachedQueueRegistry();
     const store = new FakeStore();
     // Two pending notes, each with a known revision for the CAS precondition.
     store.add({ ...inbound("a", "older", "2026-06-18T10:00:00Z"), updatedAt: "rev-a" });
@@ -232,7 +232,7 @@ describe("ChannelQueueRegistry — claimNext (single-claim)", () => {
   });
 
   test("FIX 3: a conflict with NO other pending returns null (nothing claimable right now)", async () => {
-    const reg = new ChannelQueueRegistry();
+    const reg = new AttachedQueueRegistry();
     const store = new FakeStore();
     store.add({ ...inbound("a", "only", "2026-06-18T10:00:00Z"), updatedAt: "rev-a" });
     reg.register(specFor("laptop"), store);
@@ -248,9 +248,9 @@ describe("ChannelQueueRegistry — claimNext (single-claim)", () => {
   });
 });
 
-describe("ChannelQueueRegistry — reply (outbound + mark handled)", () => {
+describe("AttachedQueueRegistry — reply (outbound + mark handled)", () => {
   test("writes the outbound via the store reply, THEN marks the inbound handled", async () => {
-    const reg = new ChannelQueueRegistry();
+    const reg = new AttachedQueueRegistry();
     const store = new FakeStore();
     store.add(inbound("a", "question", "2026-06-18T10:00:00Z", "in-flight"));
     store.notes.get("a")!.claimedAt = "2026-06-18T10:01:00Z";
@@ -266,7 +266,7 @@ describe("ChannelQueueRegistry — reply (outbound + mark handled)", () => {
   });
 
   test("if the outbound write fails, the inbound is NOT marked handled (retryable)", async () => {
-    const reg = new ChannelQueueRegistry();
+    const reg = new AttachedQueueRegistry();
     const store = new FakeStore();
     store.add(inbound("a", "question", "2026-06-18T10:00:00Z", "in-flight"));
     reg.register(specFor("laptop"), store);
@@ -278,14 +278,14 @@ describe("ChannelQueueRegistry — reply (outbound + mark handled)", () => {
   });
 
   test("reply for an unregistered channel throws", async () => {
-    const reg = new ChannelQueueRegistry();
-    await expect(reg.reply("nope", { text: "x" })).rejects.toThrow(/no channel-backend agent/);
+    const reg = new AttachedQueueRegistry();
+    await expect(reg.reply("nope", { text: "x" })).rejects.toThrow(/no attached-backend agent/);
   });
 });
 
-describe("ChannelQueueRegistry — release", () => {
+describe("AttachedQueueRegistry — release", () => {
   test("returns an in-flight note to pending + clears claimedAt", async () => {
-    const reg = new ChannelQueueRegistry();
+    const reg = new AttachedQueueRegistry();
     const store = new FakeStore();
     store.add(inbound("a", "q", "2026-06-18T10:00:00Z", "in-flight"));
     store.notes.get("a")!.claimedAt = "2026-06-18T10:01:00Z";
@@ -300,10 +300,10 @@ describe("ChannelQueueRegistry — release", () => {
   });
 });
 
-describe("ChannelQueueRegistry — sweepExpired (TTL auto-release)", () => {
+describe("AttachedQueueRegistry — sweepExpired (TTL auto-release)", () => {
   test("resets a STALE in-flight note to pending; leaves a fresh one alone", async () => {
     const ttl = 15 * 60 * 1000; // 15 min.
-    const reg = new ChannelQueueRegistry({ claimTtlMs: ttl });
+    const reg = new AttachedQueueRegistry({ claimTtlMs: ttl });
     const store = new FakeStore();
     const now = new Date("2026-06-18T12:00:00Z");
     // 'stale' claimed 20 min ago (> TTL) → released; 'fresh' claimed 5 min ago → kept.
@@ -321,7 +321,7 @@ describe("ChannelQueueRegistry — sweepExpired (TTL auto-release)", () => {
   });
 
   test("an in-flight note with no claimedAt is left alone (can't judge its age)", async () => {
-    const reg = new ChannelQueueRegistry({ claimTtlMs: 1000 });
+    const reg = new AttachedQueueRegistry({ claimTtlMs: 1000 });
     const store = new FakeStore();
     store.add(inbound("a", "q", "2026-06-18T10:00:00Z", "in-flight")); // no claimedAt.
     reg.register(specFor("laptop"), store);
@@ -331,7 +331,7 @@ describe("ChannelQueueRegistry — sweepExpired (TTL auto-release)", () => {
   });
 
   test("one channel's store error doesn't abort the sweep of the others", async () => {
-    const reg = new ChannelQueueRegistry({ claimTtlMs: 1000 });
+    const reg = new AttachedQueueRegistry({ claimTtlMs: 1000 });
     const bad = new FakeStore();
     bad.listInboundQueue = async () => {
       throw new Error("vault down");
@@ -346,14 +346,14 @@ describe("ChannelQueueRegistry — sweepExpired (TTL auto-release)", () => {
   });
 });
 
-describe("ChannelQueueRegistry — restart safety (vault is the source of truth)", () => {
+describe("AttachedQueueRegistry — restart safety (vault is the source of truth)", () => {
   test("a claim survives a 'restart' (a fresh registry reading the same store)", async () => {
     const store = new FakeStore();
     store.add(inbound("a", "q1", "2026-06-18T10:00:00Z"));
     store.add(inbound("b", "q2", "2026-06-18T10:05:00Z"));
 
     // Registry instance #1 claims 'a'.
-    const reg1 = new ChannelQueueRegistry();
+    const reg1 = new AttachedQueueRegistry();
     reg1.register(specFor("laptop"), store);
     const claimed = await reg1.claimNext("laptop");
     expect(claimed!.id).toBe("a");
@@ -362,7 +362,7 @@ describe("ChannelQueueRegistry — restart safety (vault is the source of truth)
     // (status:in-flight on note 'a') persisted — so the new registry's first claim is
     // 'b' (a is still in-flight, not re-presented), and a handled message would not
     // reappear either. The vault is the source of truth, not in-memory state.
-    const reg2 = new ChannelQueueRegistry();
+    const reg2 = new AttachedQueueRegistry();
     reg2.register(specFor("laptop"), store);
     const afterRestart = await reg2.claimNext("laptop");
     expect(afterRestart!.id).toBe("b");

--- a/src/backends/attached-queue.ts
+++ b/src/backends/attached-queue.ts
@@ -1,20 +1,23 @@
 /**
- * The CHANNEL-backend queue registry (design 2026-06-18-channel-backend.md, phase 1).
+ * The ATTACHED-backend queue registry (design 2026-06-18-channel-backend.md, phase 1).
+ * (The backend VALUE was named `"channel"` before the rename; the ROUTING KEY `channel`
+ * — the agent's address / the `/mcp/<channel>` segment — is a separate concept and KEEPS
+ * its name, so `channel` still appears throughout as the routing-key identifier.)
  *
  * The PARALLEL to {@link ProgrammaticAgentRegistry}, NOT a reuse of it. A
- * `backend: "channel"` agent runs NO `claude -p` and has NO drain worker: the turn
- * is handled by a Claude Code session the OPERATOR runs and connects to the channel's
- * MCP endpoint. The inbound `#agent/message/inbound` notes themselves ARE the queue
- * (the vault is the queue + the source of truth), and their claim `status`
+ * `backend: "attached"` agent runs NO `claude -p` and has NO drain worker: the turn
+ * is handled by a Claude Code session the OPERATOR runs and connects ("attaches") to the
+ * channel's MCP endpoint. The inbound `#agent/message/inbound` notes themselves ARE the
+ * queue (the vault is the queue + the source of truth), and their claim `status`
  * (`pending | in-flight | handled`) lives on the note, so a claim survives a daemon
  * restart and a handled message is never re-presented.
  *
  * ── Why a separate registry (the daemon routing fork) ────────────────────────────
  * The programmatic registry's drain worker reads `deliver()`'s `reply` synchronously
- * and OWNS the outbound write. A channel agent has no synchronous turn and its
+ * and OWNS the outbound write. An attached agent has no synchronous turn and its
  * outbound is written by the MCP `reply` tool — reusing that worker would double-write
  * (worker + tool) or drop the reply (worker sees an empty `deliver`). So the fork is
- * at the daemon ROUTER: inbound for a `channel` agent routes HERE and is NOT enqueued
+ * at the daemon ROUTER: inbound for an `attached` agent routes HERE and is NOT enqueued
  * to the programmatic worker. This registry exposes only queue operations the MCP
  * surface calls — there is no in-process `deliver`-produces-reply.
  *
@@ -47,7 +50,7 @@ import type { InboundQueueNote, InboundStatus } from "../transports/vault.ts";
  * inbound-note store (the daemon wires this to the channel's VaultTransport; tests
  * inject a fake). Mirrors the vault-transport methods 1:1 so the seam is thin.
  */
-export interface ChannelQueueStore {
+export interface AttachedQueueStore {
   /** List this channel's inbound queue notes, ascending by ts (oldest first). */
   listInboundQueue(opts?: { limit?: number }): Promise<InboundQueueNote[]>;
   /**
@@ -67,7 +70,7 @@ export interface ChannelQueueStore {
   reply(args: { text: string; inReplyTo?: string }): Promise<{ sent: string[] }>;
 }
 
-/** Bound on the CAS re-list retries in {@link ChannelQueueRegistry.claimNext} — a
+/** Bound on the CAS re-list retries in {@link AttachedQueueRegistry.claimNext} — a
  *  safety net against a pathological all-contended queue (each pass claims/eliminates
  *  one note, so the loop is naturally bounded by the pending count anyway). */
 const MAX_CLAIM_ATTEMPTS = 25;
@@ -100,7 +103,7 @@ export interface ClaimedMessage {
   systemPrompt: string;
 }
 
-/** One registered channel-backend agent: its spec + the store its queue lives in. */
+/** One registered attached-backend agent: its spec + the store its queue lives in. */
 interface ChannelRecord {
   /** The agent slug (the spec name) == the wake channel (agent ≡ channel). */
   name: string;
@@ -109,7 +112,7 @@ interface ChannelRecord {
   /** The spec — carries the systemPrompt the session adopts on `next-message`. */
   spec: AgentSpec;
   /** The durable inbound-note store (the channel's VaultTransport, in production). */
-  store: ChannelQueueStore;
+  store: AttachedQueueStore;
 }
 
 /** How many pending items the `pending` peek returns at most (a nudge, not a dump). */
@@ -118,12 +121,12 @@ const PENDING_PEEK_CAP = 20;
 const PREVIEW_LEN = 120;
 
 /**
- * The daemon's registry of CHANNEL-backend agents + their durable queues. Keyed by
+ * The daemon's registry of ATTACHED-backend agents + their durable queues. Keyed by
  * CHANNEL (the inbound-routing index + the MCP-surface lookup are both O(1)). One
  * instance per daemon, constructed at boot; the store is injected per-agent so tests
  * drive it with a fake store, no real vault.
  */
-export class ChannelQueueRegistry {
+export class AttachedQueueRegistry {
   /** channel → record. */
   private readonly byChannel = new Map<string, ChannelRecord>();
   /** name → channel (the lifecycle index; an agent has exactly one channel). */
@@ -135,13 +138,13 @@ export class ChannelQueueRegistry {
   }
 
   /**
-   * Register (or replace) a channel-backend agent. Lightweight: index the record by
+   * Register (or replace) a attached-backend agent. Lightweight: index the record by
    * channel + name. Idempotent-replace by name (a reload / boot re-register swaps the
    * spec + store in place). Throws if the spec declares no channel.
    */
-  register(spec: AgentSpec, store: ChannelQueueStore): void {
+  register(spec: AgentSpec, store: AttachedQueueStore): void {
     if (spec.channels.length === 0) {
-      throw new Error(`channel-queue registry: spec "${spec.name}" declares no channels`);
+      throw new Error(`attached-queue registry: spec "${spec.name}" declares no channels`);
     }
     const channel = channelOf(spec);
     // If the name moved channels (rare), drop the stale channel index.
@@ -153,7 +156,7 @@ export class ChannelQueueRegistry {
     this.nameToChannel.set(spec.name, channel);
   }
 
-  /** Deregister a channel-backend agent by NAME — drop its indexes. The durable queue
+  /** Deregister a attached-backend agent by NAME — drop its indexes. The durable queue
    *  notes stay in the vault (deregistering an agent doesn't delete its history). */
   deregister(name: string): boolean {
     const channel = this.nameToChannel.get(name);
@@ -163,12 +166,12 @@ export class ChannelQueueRegistry {
     return true;
   }
 
-  /** Is a channel-backend agent registered for this channel? (the routing-fork check) */
+  /** Is a attached-backend agent registered for this channel? (the routing-fork check) */
   hasChannel(channel: string): boolean {
     return this.byChannel.has(channel);
   }
 
-  /** Is a channel-backend agent registered under this name? (the mutual-exclusion check) */
+  /** Is a attached-backend agent registered under this name? (the mutual-exclusion check) */
   hasName(name: string): boolean {
     return this.nameToChannel.has(name);
   }
@@ -179,7 +182,7 @@ export class ChannelQueueRegistry {
   }
 
   /**
-   * The registered channel-backend agents as plain records (name + channel + the
+   * The registered attached-backend agents as plain records (name + channel + the
    * spec's surfaceable, non-secret fields). The `GET /api/agents` list (#102) maps
    * these into {@link AgentInfo}; tests assert the shape. Sorted by name for a stable
    * list. NEVER carries a token/secret — the spec's vault binding is a name + access
@@ -285,7 +288,7 @@ export class ChannelQueueRegistry {
    */
   async reply(channel: string, args: { inReplyTo?: string; text: string }): Promise<{ sent: string[] }> {
     const rec = this.byChannel.get(channel);
-    if (!rec) throw new Error(`channel-queue registry: no channel-backend agent for "${channel}"`);
+    if (!rec) throw new Error(`attached-queue registry: no attached-backend agent for "${channel}"`);
     const sent = await rec.store.reply({
       text: args.text,
       ...(args.inReplyTo ? { inReplyTo: args.inReplyTo } : {}),
@@ -305,7 +308,7 @@ export class ChannelQueueRegistry {
    */
   async release(channel: string, id: string): Promise<void> {
     const rec = this.byChannel.get(channel);
-    if (!rec) throw new Error(`channel-queue registry: no channel-backend agent for "${channel}"`);
+    if (!rec) throw new Error(`attached-queue registry: no attached-backend agent for "${channel}"`);
     await rec.store.setInboundStatus(id, "pending", null);
   }
 
@@ -328,7 +331,7 @@ export class ChannelQueueRegistry {
         notes = await rec.store.listInboundQueue();
       } catch (err) {
         console.warn(
-          `channel-queue: sweep list for "${rec.channel}" failed (continuing): ${(err as Error).message}`,
+          `attached-queue: sweep list for "${rec.channel}" failed (continuing): ${(err as Error).message}`,
         );
         continue;
       }
@@ -341,12 +344,12 @@ export class ChannelQueueRegistry {
           await rec.store.setInboundStatus(n.id, "pending", null);
           released++;
           console.log(
-            `channel-queue: auto-released stale in-flight note ${n.id} on "${rec.channel}" ` +
+            `attached-queue: auto-released stale in-flight note ${n.id} on "${rec.channel}" ` +
               `(claimed ${n.claimedAt}, TTL ${this.claimTtlMs}ms).`,
           );
         } catch (err) {
           console.warn(
-            `channel-queue: sweep release of ${n.id} on "${rec.channel}" failed (continuing): ` +
+            `attached-queue: sweep release of ${n.id} on "${rec.channel}" failed (continuing): ` +
               `${(err as Error).message}`,
           );
         }

--- a/src/channel-backend-wiring.test.ts
+++ b/src/channel-backend-wiring.test.ts
@@ -1,13 +1,13 @@
 /**
- * Tests for the CHANNEL-backend daemon wiring (design 2026-06-18-channel-backend.md,
+ * Tests for the ATTACHED-backend daemon wiring (design 2026-06-18-attached-backend.md,
  * phases 1-2) — the two load-bearing seams:
  *
- *   1. The DAEMON ROUTING FORK (`contextFor`): an inbound for a `backend:channel`
+ *   1. The DAEMON ROUTING FORK (`contextFor`): an inbound for a `backend:attached`
  *      agent must NOT enqueue to the ProgrammaticAgentRegistry (no `claude -p`) and
  *      lands as a durable queue note; an inbound for a programmatic agent still
  *      enqueues as before (no regression).
  *   2. The CHANNEL MCP SURFACE (`dispatchChannelTool`): pending / next-message /
- *      reply / release dispatch to the ChannelQueueRegistry; the outbound from `reply`
+ *      reply / release dispatch to the AttachedQueueRegistry; the outbound from `reply`
  *      goes through the channel transport's reply (the `#agent/message/outbound` path —
  *      loop-safe).
  *
@@ -23,9 +23,9 @@ import {
   type WriteOutbound,
 } from "./backends/registry.ts";
 import {
-  ChannelQueueRegistry,
-  type ChannelQueueStore,
-} from "./backends/channel-queue.ts";
+  AttachedQueueRegistry,
+  type AttachedQueueStore,
+} from "./backends/attached-queue.ts";
 import { dispatchChannelTool } from "./mcp-http.ts";
 import { SCOPE_READ, SCOPE_WRITE } from "./auth.ts";
 import type { AgentBackend, AgentHandle, AgentStatus, DeliverResult } from "./backends/types.ts";
@@ -55,8 +55,8 @@ function noopWriteOutbound(): WriteOutbound {
   return async () => {};
 }
 
-/** A fake channel-queue store: in-memory notes + recorded outbound. */
-class FakeStore implements ChannelQueueStore {
+/** A fake attached-queue store: in-memory notes + recorded outbound. */
+class FakeStore implements AttachedQueueStore {
   readonly notes = new Map<string, InboundQueueNote>();
   readonly outbound: Array<{ text: string; inReplyTo?: string }> = [];
   add(n: InboundQueueNote): void {
@@ -80,19 +80,19 @@ class FakeStore implements ChannelQueueStore {
 const channelSpec = (name: string, systemPrompt?: string): AgentSpec => ({
   name,
   channels: [name],
-  backend: "channel",
+  backend: "attached",
   ...(systemPrompt ? { systemPrompt } : {}),
 });
 
 // --- 1. the daemon routing fork --------------------------------------------
 
-describe("daemon routing fork (contextFor) — channel vs programmatic", () => {
-  test("a channel-backend inbound does NOT enqueue to the programmatic worker", async () => {
+describe("daemon routing fork (contextFor) — attached vs programmatic", () => {
+  test("an attached-backend inbound does NOT enqueue to the programmatic worker", async () => {
     const backend = new FakeProgrammaticBackend();
     const programmatic = new ProgrammaticAgentRegistry({ backend, writeOutbound: noopWriteOutbound() });
-    const channelQueue = new ChannelQueueRegistry();
+    const channelQueue = new AttachedQueueRegistry();
     const store = new FakeStore();
-    // Register a CHANNEL agent for "laptop" (its queue store is the fake).
+    // Register an ATTACHED agent for "laptop" (its queue store is the fake).
     channelQueue.register(channelSpec("laptop"), store);
 
     const registry = new ClientRegistry();
@@ -119,7 +119,7 @@ describe("daemon routing fork (contextFor) — channel vs programmatic", () => {
     const backend = new FakeProgrammaticBackend();
     const programmatic = new ProgrammaticAgentRegistry({ backend, writeOutbound: noopWriteOutbound() });
     await programmatic.register({ name: "eng", channels: ["eng"], backend: "programmatic" });
-    const channelQueue = new ChannelQueueRegistry(); // no channel agent for "eng".
+    const channelQueue = new AttachedQueueRegistry(); // no attached agent for "eng".
 
     const registry = new ClientRegistry();
     const ctx = contextFor(registry, "eng", new DeliveryState(), programmatic, channelQueue);
@@ -138,7 +138,7 @@ describe("daemon routing fork (contextFor) — channel vs programmatic", () => {
     const backend = new FakeProgrammaticBackend();
     const programmatic = new ProgrammaticAgentRegistry({ backend, writeOutbound: noopWriteOutbound() });
     await programmatic.register({ name: "dual", channels: ["dual"], backend: "programmatic" });
-    const channelQueue = new ChannelQueueRegistry();
+    const channelQueue = new AttachedQueueRegistry();
     channelQueue.register(channelSpec("dual"), new FakeStore());
 
     const ctx = contextFor(new ClientRegistry(), "dual", new DeliveryState(), programmatic, channelQueue);
@@ -158,7 +158,7 @@ function parse(result: { content: Array<{ type: "text"; text: string }> }): unkn
 
 describe("channel MCP surface (dispatchChannelTool)", () => {
   test("pending → { count, items }", async () => {
-    const reg = new ChannelQueueRegistry();
+    const reg = new AttachedQueueRegistry();
     const store = new FakeStore();
     store.add({ id: "a", text: "hi", sender: "operator", ts: "2026-06-18T10:00:00Z", status: "pending" });
     reg.register(channelSpec("laptop"), store);
@@ -169,7 +169,7 @@ describe("channel MCP surface (dispatchChannelTool)", () => {
   });
 
   test("next-message claims + returns id/text/inReplyTo/systemPrompt", async () => {
-    const reg = new ChannelQueueRegistry();
+    const reg = new AttachedQueueRegistry();
     const store = new FakeStore();
     store.add({ id: "a", text: "the question", sender: "operator", ts: "2026-06-18T10:00:00Z", status: "pending" });
     reg.register(channelSpec("laptop", "You are laptop."), store);
@@ -184,14 +184,14 @@ describe("channel MCP surface (dispatchChannelTool)", () => {
   });
 
   test("next-message returns a null-message sentinel when the queue is empty", async () => {
-    const reg = new ChannelQueueRegistry();
+    const reg = new AttachedQueueRegistry();
     reg.register(channelSpec("laptop"), new FakeStore());
     const r = await dispatchChannelTool("laptop", reg, RW, "next-message", {});
     expect(parse(r)).toEqual({ message: null, note: "no pending messages" });
   });
 
   test("reply writes the outbound (loop-safe path) + marks handled", async () => {
-    const reg = new ChannelQueueRegistry();
+    const reg = new AttachedQueueRegistry();
     const store = new FakeStore();
     store.add({ id: "a", text: "q", sender: "operator", ts: "2026-06-18T10:00:00Z", status: "in-flight", claimedAt: "2026-06-18T10:01:00Z" });
     reg.register(channelSpec("laptop"), store);
@@ -205,7 +205,7 @@ describe("channel MCP surface (dispatchChannelTool)", () => {
   });
 
   test("release un-claims back to pending", async () => {
-    const reg = new ChannelQueueRegistry();
+    const reg = new AttachedQueueRegistry();
     const store = new FakeStore();
     store.add({ id: "a", text: "q", sender: "operator", ts: "t", status: "in-flight", claimedAt: "2026-06-18T10:00:00Z" });
     reg.register(channelSpec("laptop"), store);
@@ -216,7 +216,7 @@ describe("channel MCP surface (dispatchChannelTool)", () => {
   });
 
   test("write tools require agent:write; a read-only token is refused", async () => {
-    const reg = new ChannelQueueRegistry();
+    const reg = new AttachedQueueRegistry();
     reg.register(channelSpec("laptop"), new FakeStore());
     for (const tool of ["next-message", "reply", "release"]) {
       const r = await dispatchChannelTool("laptop", reg, [SCOPE_READ], tool, { id: "a", text: "x" });
@@ -228,10 +228,10 @@ describe("channel MCP surface (dispatchChannelTool)", () => {
     expect(ok.isError).toBeUndefined();
   });
 
-  test("a non-channel channel gates cleanly (tool error, not a crash)", async () => {
-    const reg = new ChannelQueueRegistry(); // nothing registered.
+  test("a non-attached channel gates cleanly (tool error, not a crash)", async () => {
+    const reg = new AttachedQueueRegistry(); // nothing registered.
     const r = await dispatchChannelTool("nope", reg, RW, "pending", {});
     expect(r.isError).toBe(true);
-    expect(r.content[0]!.text).toContain("no channel-backend agent");
+    expect(r.content[0]!.text).toContain("no attached-backend agent");
   });
 });

--- a/src/daemon-agent-defs-api.test.ts
+++ b/src/daemon-agent-defs-api.test.ts
@@ -65,7 +65,7 @@ import { createFetchHandler } from "./daemon.ts";
 import { MintError } from "./mint-token.ts";
 import { ClientRegistry } from "./routing.ts";
 import { AgentDefRegistry, type InstantiateDeps } from "./agent-defs.ts";
-import { ChannelQueueRegistry, type ChannelQueueStore } from "./backends/channel-queue.ts";
+import { AttachedQueueRegistry, type AttachedQueueStore } from "./backends/attached-queue.ts";
 import type { Channel } from "./registry.ts";
 import type { AgentSpec } from "./sandbox/types.ts";
 import type { InboundQueueNote, InboundStatus } from "./transports/vault.ts";
@@ -197,7 +197,7 @@ function serverWith(
   channels: Map<string, Channel>,
   o?: {
     agentDefs?: AgentDefRegistry;
-    channelQueue?: ChannelQueueRegistry;
+    channelQueue?: AttachedQueueRegistry;
     addDefVault?: AddDefVault;
   },
 ) {
@@ -221,8 +221,8 @@ const emptyChannels = () => new Map<string, Channel>();
 // GET /api/agents — includes channel-backend agents (#102)
 // ===========================================================================
 describe("GET /api/agents includes channel-backend agents (#102)", () => {
-  /** A minimal channel-queue store with a pending count we control. */
-  function storeWithPending(count: number): ChannelQueueStore {
+  /** A minimal attached-queue store with a pending count we control. */
+  function storeWithPending(count: number): AttachedQueueStore {
     const notes: InboundQueueNote[] = Array.from({ length: count }, (_, i) => ({
       id: `in-${i}`,
       text: `m${i}`,
@@ -241,14 +241,14 @@ describe("GET /api/agents includes channel-backend agents (#102)", () => {
     return {
       name,
       channels: [name],
-      backend: "channel",
+      backend: "attached",
       ...(vault ? { vault: { name: vault, access: "write" } } : {}),
       systemPrompt: "You are the laptop agent.",
     };
   }
 
-  test("a registered channel agent appears with backend:channel + queued status + channel + vault", async () => {
-    const channelQueue = new ChannelQueueRegistry();
+  test("a registered attached agent appears with backend:attached + queued status + channel + vault", async () => {
+    const channelQueue = new AttachedQueueRegistry();
     channelQueue.register(channelSpec("laptop", "research"), storeWithPending(2));
     const { srv, base } = serverWith(emptyChannels(), { channelQueue });
     const res = await fetch(`${base}/api/agents`, { headers: adminAuth });
@@ -256,7 +256,7 @@ describe("GET /api/agents includes channel-backend agents (#102)", () => {
     const body = (await res.json()) as { agents: Array<Record<string, unknown>> };
     const laptop = body.agents.find((a) => a.name === "laptop");
     expect(laptop).toBeDefined();
-    expect(laptop!.backend).toBe("channel");
+    expect(laptop!.backend).toBe("attached");
     expect(laptop!.status).toBe("queued:2");
     expect(laptop!.channel).toBe("laptop");
     expect(laptop!.vault).toBe("research");
@@ -267,7 +267,7 @@ describe("GET /api/agents includes channel-backend agents (#102)", () => {
   });
 
   test("an empty pending queue → status idle", async () => {
-    const channelQueue = new ChannelQueueRegistry();
+    const channelQueue = new AttachedQueueRegistry();
     channelQueue.register(channelSpec("idlebot"), storeWithPending(0));
     const { srv, base } = serverWith(emptyChannels(), { channelQueue });
     const res = await fetch(`${base}/api/agents`, { headers: adminAuth });
@@ -277,7 +277,7 @@ describe("GET /api/agents includes channel-backend agents (#102)", () => {
   });
 
   test("no Authorization → 401 (admin-gated)", async () => {
-    const { srv, base } = serverWith(emptyChannels(), { channelQueue: new ChannelQueueRegistry() });
+    const { srv, base } = serverWith(emptyChannels(), { channelQueue: new AttachedQueueRegistry() });
     const res = await fetch(`${base}/api/agents`);
     expect(res.status).toBe(401);
     srv.stop();
@@ -310,7 +310,7 @@ describe("GET /api/agent-defs", () => {
       id: "Agents/uni-dev",
       content: "a".repeat(500), // long prompt → preview truncates to 200.
       tags: ["#agent/definition"],
-      metadata: { name: "uni-dev", backend: "channel", mode: "multi-threaded" },
+      metadata: { name: "uni-dev", backend: "attached", mode: "multi-threaded" },
     });
     const { reg } = registryWithFakeVault({ fake });
     await reg.loadAll(); // instantiate the seeded def.
@@ -322,7 +322,7 @@ describe("GET /api/agent-defs", () => {
     const d = body.defs[0]!;
     expect(d.noteId).toBe("Agents/uni-dev");
     expect(d.name).toBe("uni-dev");
-    expect(d.backend).toBe("channel");
+    expect(d.backend).toBe("attached");
     expect(d.mode).toBe("multi-threaded"); // the list carries the mode (edit form pre-fill).
     expect(d.vault).toBe("default");
     expect(d.status).toBe("enabled");
@@ -352,7 +352,7 @@ describe("GET /api/agent-defs/:noteId (full def)", () => {
       id: "Agents/uni-dev",
       content: "F".repeat(500), // long body → list preview truncates; full returns all.
       tags: ["#agent/definition"],
-      metadata: { name: "uni-dev", backend: "channel", mode: "multi-threaded", wants: "vault:research:read" },
+      metadata: { name: "uni-dev", backend: "attached", mode: "multi-threaded", wants: "vault:research:read" },
     });
     const { reg } = registryWithFakeVault({ fake });
     await reg.loadAll();
@@ -386,7 +386,7 @@ describe("GET /api/agent-defs/:noteId (full def)", () => {
     const d = body.def;
     expect(d.noteId).toBe("Agents/uni-dev");
     expect(d.name).toBe("uni-dev");
-    expect(d.backend).toBe("channel");
+    expect(d.backend).toBe("attached");
     expect(d.mode).toBe("multi-threaded");
     expect(d.vault).toBe("default");
     expect(d.wants).toEqual(["vault:research:read"]);
@@ -498,6 +498,32 @@ describe("POST /api/agent-defs", () => {
     srv.stop();
   });
 
+  test("dual-read: the legacy backend value \"channel\" is accepted + persisted as \"attached\"", async () => {
+    // The backend VALUE was renamed `channel` → `attached`. An API client still sending
+    // the pre-rename value must be ACCEPTED (not 400) and the def must be WRITTEN +
+    // returned with the canonical `attached`. (The routing key `channel` is untouched.)
+    const { reg, fake } = registryWithFakeVault();
+    const { srv, base } = serverWith(emptyChannels(), { agentDefs: reg });
+    const res = await fetch(`${base}/api/agent-defs`, {
+      method: "POST",
+      headers: adminAuth,
+      body: JSON.stringify({
+        vault: "default",
+        name: "legacybot",
+        backend: "channel", // the legacy value.
+        systemPrompt: "You are legacybot.",
+      }),
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { ok: boolean; def: Record<string, unknown> };
+    expect(body.def.backend).toBe("attached"); // normalized on the way out.
+    // And the persisted note metadata is the canonical value, never the legacy one.
+    const written = [...fake.notes.values()].find((n) => n.metadata.name === "legacybot");
+    expect(written).toBeDefined();
+    expect(written!.metadata.backend).toBe("attached");
+    srv.stop();
+  });
+
   test("validation: bad name slug → 400", async () => {
     const { reg } = registryWithFakeVault();
     const { srv, base } = serverWith(emptyChannels(), { agentDefs: reg });
@@ -539,7 +565,7 @@ describe("POST /api/agent-defs", () => {
     const res = await fetch(`${base}/api/agent-defs`, {
       method: "POST",
       headers: adminAuth,
-      body: JSON.stringify({ vault: "default", name: "uni-dev", backend: "channel" }),
+      body: JSON.stringify({ vault: "default", name: "uni-dev", backend: "attached" }),
     });
     expect(res.status).toBe(409);
     expect((await res.json()) as { error: string }).toMatchObject({

--- a/src/daemon-channel-queue-store.test.ts
+++ b/src/daemon-channel-queue-store.test.ts
@@ -1,6 +1,6 @@
 /**
  * `channelQueueStoreFor` — the PRODUCTION adapter that wires a live `VaultTransport`
- * into the `ChannelQueueStore` the pull-queue worker uses.
+ * into the `AttachedQueueStore` the pull-queue worker uses.
  *
  * Regression for the agent#101 CAS single-claim guard (PR #116): the adapter MUST
  * forward the 4th `ifUpdatedAt` arg to `vt.setInboundStatus`, or the compare-and-set

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -121,9 +121,9 @@ import {
   type TurnEventSink,
 } from "./backends/registry.ts";
 import {
-  ChannelQueueRegistry,
-  type ChannelQueueStore,
-} from "./backends/channel-queue.ts";
+  AttachedQueueRegistry,
+  type AttachedQueueStore,
+} from "./backends/attached-queue.ts";
 import { AgentSessionState } from "./agent-session-state.ts";
 import { readPersistedSpec, sessionWorkspace } from "./spawn-agent.ts";
 import { normalizeChannel } from "./sandbox/types.ts";
@@ -286,7 +286,7 @@ export function contextFor(
   channel: string,
   deliveryState: DeliveryState,
   programmatic?: ProgrammaticAgentRegistry,
-  channelQueue?: ChannelQueueRegistry,
+  channelQueue?: AttachedQueueRegistry,
 ): TransportContext {
   return {
     channel,
@@ -294,16 +294,16 @@ export function contextFor(
       // ── DAEMON ROUTING FORK (design 2026-06-18-channel-backend.md, the load-bearing
       // change). Route inbound by the agent's BACKEND:
       //
-      //   backend: channel → the ChannelQueueRegistry path. The inbound
+      //   backend: attached → the AttachedQueueRegistry path. The inbound
       //     `#agent/message/inbound` note IS the queue item (durable in the vault,
       //     status:pending by default). There is NO `claude -p`, NO serial worker, and
       //     NO live push — a connected Claude Code session PULLS it via the channel MCP
-      //     surface. So a channel inbound is a NO-OP here beyond its own durability:
+      //     surface. So an attached inbound is a NO-OP here beyond its own durability:
       //     we MUST NOT enqueue to the programmatic worker (that would run a turn the
-      //     channel model deliberately doesn't), and we don't advance the delivery
+      //     attached model deliberately doesn't), and we don't advance the delivery
       //     high-water-mark (there's no live subscriber to deliver to; the durable note
-      //     queue + claim status is the durability, not replay). Checked FIRST so a
-      //     channel agent NEVER falls through to the programmatic enqueue below.
+      //     queue + claim status is the durability, not replay). Checked FIRST so an
+      //     attached agent NEVER falls through to the programmatic enqueue below.
       if (channelQueue?.hasChannel(channel)) {
         return;
       }
@@ -405,7 +405,7 @@ async function addChannelLive(
   entry: ChannelEntry,
   deliveryState: DeliveryState,
   programmatic?: ProgrammaticAgentRegistry,
-  channelQueue?: ChannelQueueRegistry,
+  channelQueue?: AttachedQueueRegistry,
 ): Promise<Channel> {
   const existing = channels.get(entry.name);
   if (existing) {
@@ -488,7 +488,7 @@ export function buildInstantiateDeps(
   registry: ClientRegistry,
   deliveryState: DeliveryState,
   programmatic: ProgrammaticAgentRegistry,
-  channelQueue: ChannelQueueRegistry,
+  channelQueue: AttachedQueueRegistry,
 ): InstantiateDeps {
   return {
     ensureChannel: async (name, binding) => {
@@ -511,16 +511,20 @@ export function buildInstantiateDeps(
       );
     },
     setupAndRegister: async (spec) => {
-      // ── BACKEND FORK (design 2026-06-18-channel-backend.md). A `channel` agent
+      // ── BACKEND FORK (design 2026-06-18-channel-backend.md). An `attached` agent
       // does NOT register with the programmatic registry (no `claude -p`, no serial
-      // worker) — it registers with the ChannelQueueRegistry, whose store is the
+      // worker) — it registers with the AttachedQueueRegistry, whose store is the
       // agent's live VaultTransport (the durable inbound-note queue). A `programmatic`
       // agent takes the existing path (persist spec.json + register the serial worker).
-      if (spec.backend === "channel") {
+      //
+      // DUAL-READ: a spec carrying the legacy backend value `"channel"` (un-normalized,
+      // e.g. read straight from an old spec.json) is treated as `"attached"` here too —
+      // belt-and-suspenders on top of the parse-path normalization in agent-defs.ts.
+      if (spec.backend === "attached" || (spec.backend as string) === "channel") {
         const store = channelQueueStoreFor(channels, spec.channels[0]);
         if (!store) {
           throw new Error(
-            `cannot register channel-backend agent "${spec.name}": its wake channel is not a ` +
+            `cannot register attached-backend agent "${spec.name}": its wake channel is not a ` +
               `live vault transport (the queue needs the vault as its durable store)`,
           );
         }
@@ -610,10 +614,10 @@ function defaultAddDefVault(
 }
 
 /**
- * Build a {@link ChannelQueueStore} for a channel name from its live VaultTransport —
- * the durable inbound-note queue a CHANNEL-backend agent's connected session pulls
+ * Build a {@link AttachedQueueStore} for a channel name from its live VaultTransport —
+ * the durable inbound-note queue an ATTACHED-backend agent's connected session pulls
  * from (design 2026-06-18). Returns null when the channel isn't a live vault transport
- * (a channel agent's queue REQUIRES the vault as its source of truth). The store is a
+ * (an attached agent's queue REQUIRES the vault as its source of truth). The store is a
  * thin adapter over the transport's `listInboundQueue` / `setInboundStatus` / `reply`
  * — the same `reply()` the programmatic worker uses, so the outbound is durable +
  * loop-safe (tagged `#agent/message/outbound`, which the inbound trigger never fires on).
@@ -621,7 +625,7 @@ function defaultAddDefVault(
 export function channelQueueStoreFor(
   channels: Map<string, Channel>,
   channelName: string | { name: string } | undefined,
-): ChannelQueueStore | null {
+): AttachedQueueStore | null {
   const name = typeof channelName === "string" ? channelName : channelName?.name;
   if (!name) return null;
   const vt = channels.get(name)?.transport;
@@ -631,7 +635,7 @@ export function channelQueueStoreFor(
     // Forward ALL FOUR args — the 4th `ifUpdatedAt` is the CAS precondition the
     // single-claim guard (agent#101) depends on. A 3-arg arrow silently dropped it,
     // collapsing every claim to `force:true` (last-write-wins) and DISABLING the CAS in
-    // production (the double-claim race PR #116 closed was re-opened for channel agents).
+    // production (the double-claim race PR #116 closed was re-opened for attached agents).
     setInboundStatus: (id, status, claimedAt, ifUpdatedAt) =>
       vt.setInboundStatus(id, status, claimedAt, ifUpdatedAt),
     reply: async (args) => {
@@ -916,7 +920,7 @@ export function listProgrammaticAgents(programmatic: ProgrammaticAgentRegistry):
  * each) — best-effort: a queue read failure degrades that agent's status to `idle`,
  * never failing the whole list. NEVER surfaces a token/secret.
  */
-export async function listChannelAgents(channelQueue: ChannelQueueRegistry): Promise<AgentInfo[]> {
+export async function listChannelAgents(channelQueue: AttachedQueueRegistry): Promise<AgentInfo[]> {
   const dir = defaultSessionsDir();
   const records = channelQueue.list();
   return Promise.all(
@@ -935,7 +939,7 @@ export async function listChannelAgents(channelQueue: ChannelQueueRegistry): Pro
         attached: false,
         workspace,
         hasWorkspace: existsSync(join(workspace, "spec.json")),
-        backend: "channel",
+        backend: "attached",
         status,
         channel: rec.channel,
         ...(rec.systemPrompt ? { systemPromptMode: "append" as const } : {}),
@@ -1187,14 +1191,14 @@ export function createFetchHandler(
     deliveryState?: DeliveryState;
     programmatic?: ProgrammaticAgentRegistry;
     /**
-     * The CHANNEL-backend queue registry (design 2026-06-18-channel-backend.md) — the
+     * The ATTACHED-backend queue registry (design 2026-06-18-channel-backend.md) — the
      * durable inbound-note queue + claim tracker a connected Claude Code session pulls
      * from via the channel MCP surface (`next-message` / `pending` / `reply` /
      * `release`). `main` passes the boot instance (the SAME one the transports'
      * `contextFor` routing fork checks); tests inject a fake-store-backed instance.
-     * Optional — when absent, the channel MCP tools no-op (no channel agents).
+     * Optional — when absent, the channel MCP tools no-op (no attached agents).
      */
-    channelQueue?: ChannelQueueRegistry;
+    channelQueue?: AttachedQueueRegistry;
     /**
      * The per-channel turn-event SSE registry (the streaming view, design build
      * item #1). The `/api/channels/<ch>/turn-events` SSE route registers subscribers
@@ -1259,7 +1263,7 @@ export function createFetchHandler(
   // channel MCP surface dispatches to). Defaulted to a fresh instance so a plain
   // createFetchHandler still serves the channel MCP tools (it just has no channel
   // agents registered until one is instantiated). Tests inject a fake-store-backed one.
-  const channelQueue: ChannelQueueRegistry = opts?.channelQueue ?? new ChannelQueueRegistry();
+  const channelQueue: AttachedQueueRegistry = opts?.channelQueue ?? new AttachedQueueRegistry();
 
   // Per-channel delivery high-water-mark store (durable infra). `contextFor.emit`
   // advances it on a real delivery; the daemon's `main` passes the boot-time
@@ -2058,9 +2062,13 @@ export function createFetchHandler(
       if (typeof body.name !== "string" || body.name.length === 0) {
         return json({ error: "body.name (string) is required" }, 400);
       }
-      const backend = body.backend === undefined ? "programmatic" : body.backend;
-      if (backend !== "programmatic" && backend !== "channel") {
-        return json({ error: 'body.backend must be "programmatic" or "channel"' }, 400);
+      // DUAL-READ the legacy backend value `"channel"` → canonical `"attached"`, so an
+      // API client still passing the pre-rename value is accepted (and persisted as the
+      // canonical value by createDef). The routing key `channel` is a separate concept.
+      const rawBackend = body.backend === undefined ? "programmatic" : body.backend;
+      const backend = rawBackend === "channel" ? "attached" : rawBackend;
+      if (backend !== "programmatic" && backend !== "attached") {
+        return json({ error: 'body.backend must be "programmatic" or "attached"' }, 400);
       }
       if (body.systemPrompt !== undefined && typeof body.systemPrompt !== "string") {
         return json({ error: "body.systemPrompt must be a string" }, 400);
@@ -2948,15 +2956,15 @@ function main(): void {
   // its interim progress to `turnEvents` (the chat's live view).
   const programmatic = createDefaultProgrammaticRegistry(channels, buildTurnEventSink(turnEvents));
 
-  // The CHANNEL-backend queue registry (design 2026-06-18-channel-backend.md),
+  // The ATTACHED-backend queue registry (design 2026-06-18-channel-backend.md),
   // constructed ONCE at boot and shared by the fetch handler (the channel MCP surface),
-  // the transports' `contextFor` (the routing fork — a channel inbound is NOT enqueued
-  // to the programmatic worker), the agent-def instantiate path (a `backend:channel`
+  // the transports' `contextFor` (the routing fork — an attached inbound is NOT enqueued
+  // to the programmatic worker), the agent-def instantiate path (a `backend:attached`
   // def registers here, not with programmatic), and the periodic sweep below. The
   // durable queue + claim state lives on the inbound notes in each channel's vault, so
   // this registry holds no per-message state of its own — it's the claim/peek/reply
   // surface over those notes.
-  const channelQueue = new ChannelQueueRegistry();
+  const channelQueue = new AttachedQueueRegistry();
 
   // The terminal WS handler set (pty↔socket relay + backpressure flow control,
   // src/terminal.ts). One handler object serves every terminal connection;
@@ -3117,16 +3125,16 @@ function main(): void {
   runner.start();
   console.log(`parachute-agent: runner started (scheduled-job tick)`);
 
-  // CHANNEL-BACKEND CLAIM TTL SWEEP (design 2026-06-18-channel-backend.md). A periodic
-  // tick scans every channel-backend agent's in-flight inbound notes and resets any
+  // ATTACHED-BACKEND CLAIM TTL SWEEP (design 2026-06-18-channel-backend.md). A periodic
+  // tick scans every attached-backend agent's in-flight inbound notes and resets any
   // claimed longer than the claim TTL (15 min) back to `pending` — so a crashed /
   // abandoned connected session can't strand the queue. Cheap + idempotent (a
-  // channel with no channel agents lists nothing). `unref` so it never holds the
+  // channel with no attached agents lists nothing). `unref` so it never holds the
   // process open; runs at the same 30s cadence as the runner tick.
   const sweepIntervalMs = parseInt(process.env.PARACHUTE_AGENT_SWEEP_MS ?? "", 10) || 30_000;
   const channelSweep = setInterval(() => {
     void channelQueue.sweepExpired().catch((err) => {
-      console.error(`parachute-agent: channel-queue sweep failed (continuing): ${(err as Error).message}`);
+      console.error(`parachute-agent: attached-queue sweep failed (continuing): ${(err as Error).message}`);
     });
   }, sweepIntervalMs);
   channelSweep.unref?.();

--- a/src/mcp-http.ts
+++ b/src/mcp-http.ts
@@ -13,7 +13,7 @@
  * Stateful Streamable HTTP (a `sessionIdGenerator` + `enableJsonResponse:false`)
  * gives each session an SSE GET stream the server can push onto. This file is the
  * productionized form: per-channel session registry, the push surface, the
- * CHANNEL-backend pull surface (`pending`/`next-message`/`reply`/`release` —
+ * ATTACHED-backend pull surface (`pending`/`next-message`/`reply`/`release` —
  * design 2026-06-18), and read-vs-write scope enforcement.
  *
  * NOTE — the deaf-on-restart BACKLOG REPLAY (the connect-hook that replayed
@@ -52,7 +52,7 @@ import type {
   DownloadArgs,
 } from "./transport.ts";
 import { SCOPE_WRITE, grantsScope } from "./auth.ts";
-import type { ChannelQueueRegistry } from "./backends/channel-queue.ts";
+import type { AttachedQueueRegistry } from "./backends/attached-queue.ts";
 
 // ---------------------------------------------------------------------------
 // Per-channel session registry
@@ -356,11 +356,11 @@ const TOOL_DEFS = [
 const WRITE_TOOLS = new Set(["reply", "react", "edit_message"]);
 
 // ---------------------------------------------------------------------------
-// CHANNEL-BACKEND tool surface — the MCP pull/reply protocol (design
-// 2026-06-18-channel-backend.md, phase 2). When the channel has a `backend:channel`
+// ATTACHED-BACKEND tool surface — the MCP pull/reply protocol (design
+// 2026-06-18-channel-backend.md, phase 2). When the channel has a `backend:attached`
 // agent registered, the session connects + PULLs the durable queue instead of being
 // pushed to: `pending` / `next-message` / `reply` / `release`, dispatched to the
-// {@link ChannelQueueRegistry}. The session "is" the agent by adopting the
+// {@link AttachedQueueRegistry}. The session "is" the agent by adopting the
 // systemPrompt `next-message` returns (the def body) — reinforced by INSTRUCTIONS
 // below, since MCP can't force a system prompt on the caller.
 // ---------------------------------------------------------------------------
@@ -380,7 +380,7 @@ const CHANNEL_INSTRUCTIONS = [
   "The human reads ONLY what you send via `reply`. Your transcript text is invisible to them — always finish a handled message with a `reply`.",
 ].join("\n");
 
-/** The channel-backend pull/reply tool list (design 2026-06-18, phase 2). */
+/** The attached-backend pull/reply tool list (design 2026-06-18, phase 2). */
 const CHANNEL_TOOL_DEFS = [
   {
     name: "pending",
@@ -424,33 +424,33 @@ const CHANNEL_TOOL_DEFS = [
   },
 ];
 
-/** Channel-backend tools that mutate the queue/write outbound require agent:write
+/** Attached-backend tools that mutate the queue/write outbound require agent:write
  *  (`pending` + `next-message`... next-message claims, so it mutates → write; pending
  *  is read-only). reply + release + next-message mutate; pending is read. */
 const CHANNEL_WRITE_TOOLS = new Set(["next-message", "reply", "release"]);
 
 /**
- * Dispatch one CHANNEL-backend tool call to the {@link ChannelQueueRegistry},
+ * Dispatch one ATTACHED-backend tool call to the {@link AttachedQueueRegistry},
  * enforcing write scope on the mutating tools. Returns a tool-error result (not a
- * throw) when no channel-backend agent is registered for `channel` — so a session that
- * connected to a non-channel channel and called these tools gets a clean "not a channel
+ * throw) when no attached-backend agent is registered for `channel` — so a session that
+ * connected to a non-attached channel and called these tools gets a clean "not an attached
  * agent" message rather than a crash. Pure over its inputs (the daemon's per-session
  * handler + the unit tests both call it).
  */
 export async function dispatchChannelTool(
   channel: string,
-  channelQueue: ChannelQueueRegistry,
+  channelQueue: AttachedQueueRegistry,
   scopes: string[],
   name: string,
   args: Record<string, unknown>,
 ): Promise<ToolResult> {
-  // Gate cleanly for a non-channel channel — these tools are meaningful only when a
-  // backend:channel agent is registered. (The daemon also only serves CHANNEL_TOOL_DEFS
+  // Gate cleanly for a non-attached channel — these tools are meaningful only when an
+  // attached-backend agent is registered. (The daemon also only serves CHANNEL_TOOL_DEFS
   // when the agent is registered, so a well-behaved client never reaches here for a
-  // non-channel channel — but a hand-crafted call should fail gracefully, not 500.)
+  // non-attached channel — but a hand-crafted call should fail gracefully, not 500.)
   if (!channelQueue.hasChannel(channel)) {
     return {
-      content: [{ type: "text", text: `channel "${channel}" has no channel-backend agent — the pull/reply tools are not available here` }],
+      content: [{ type: "text", text: `channel "${channel}" has no attached-backend agent — the pull/reply tools are not available here` }],
       isError: true,
     };
   }
@@ -524,15 +524,15 @@ function buildServer(
   channel: string,
   transport: Transport,
   session: McpSession,
-  channelQueue?: ChannelQueueRegistry,
+  channelQueue?: AttachedQueueRegistry,
 ): Server {
-  // ── CHANNEL-BACKEND FORK (design 2026-06-18). When a `backend:channel` agent is
+  // ── ATTACHED-BACKEND FORK (design 2026-06-18). When a `backend:attached` agent is
   // registered for this channel, serve the PULL/REPLY surface (pending / next-message
   // / reply / release) + its reinforcing INSTRUCTIONS, dispatched to the
-  // ChannelQueueRegistry. Otherwise serve the existing push surface (reply / react /
+  // AttachedQueueRegistry. Otherwise serve the existing push surface (reply / react /
   // edit / download), dispatched to the transport. Resolved at connect time — a
   // channel doesn't switch backends under a live session.
-  const isChannelBackend = !!channelQueue?.hasChannel(channel);
+  const isAttachedBackend = !!channelQueue?.hasChannel(channel);
   const server = new Server(
     // Per-channel name (`agent-<name>`) so it reads clearly in `/mcp` and lines
     // up with the `--dangerously-load-development-channels=server:agent-<name>`
@@ -546,12 +546,12 @@ function buildServer(
         },
         tools: {},
       },
-      instructions: isChannelBackend ? CHANNEL_INSTRUCTIONS : INSTRUCTIONS,
+      instructions: isAttachedBackend ? CHANNEL_INSTRUCTIONS : INSTRUCTIONS,
     },
   );
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
-    tools: isChannelBackend ? CHANNEL_TOOL_DEFS : TOOL_DEFS,
+    tools: isAttachedBackend ? CHANNEL_TOOL_DEFS : TOOL_DEFS,
   }));
 
   // Dispatch reads `session.scopes` live (the daemon refreshes it per request),
@@ -559,7 +559,7 @@ function buildServer(
   server.setRequestHandler(CallToolRequestSchema, async (req) => {
     const args = (req.params.arguments ?? {}) as Record<string, unknown>;
     const result =
-      isChannelBackend && channelQueue
+      isAttachedBackend && channelQueue
         ? await dispatchChannelTool(channel, channelQueue, session.scopes, req.params.name, args)
         : await dispatchTool(channel, transport, session.scopes, req.params.name, args);
     // Our ToolResult is the content/isError subset of the SDK's CallToolResult
@@ -708,7 +708,7 @@ export async function handleMcp(
   channel: string,
   transport: Transport,
   scopes: string[],
-  channelQueue?: ChannelQueueRegistry,
+  channelQueue?: AttachedQueueRegistry,
 ): Promise<Response> {
   const sid = req.headers.get("mcp-session-id");
 

--- a/src/sandbox/types.ts
+++ b/src/sandbox/types.ts
@@ -109,24 +109,33 @@ export type AgentChannel = string | AgentChannelSpec;
  *    is posted back as an outbound `#agent/message/outbound` note. No idle session →
  *    nothing to go deaf, no reconnect, no replay, no consent gate. The reliable
  *    primary path; best for clean per-message "do a task, report back" turns.
- *  - `"channel"` (design 2026-06-18-channel-backend.md): the turn is delivered over
- *    a channel to a Claude Code session the OPERATOR runs themselves (their machine,
- *    their env/creds, unsandboxed) and has connected to the channel's MCP endpoint.
- *    The daemon runs NO `claude -p`; the inbound `#agent/message/inbound` notes
- *    accumulate as a durable queue (the vault IS the queue). The connected session
- *    PULLs the next message (an MCP tool), works, and REPLYs (an MCP tool) — the
- *    daemon writes the outbound note + marks the inbound handled. Routed to the
- *    {@link ChannelQueueRegistry}, entirely bypassing the programmatic serial worker
- *    (the daemon routing fork). Claim state lives on the inbound note's `status`
- *    (`pending | in-flight | handled`), so it's restart-safe.
+ *  - `"attached"` (design 2026-06-18-channel-backend.md; the backend value was named
+ *    `"channel"` before this rename — see the BACK-COMPAT note below): the turn is
+ *    delivered over a channel to a Claude Code session the OPERATOR runs themselves
+ *    (their machine, their env/creds, unsandboxed) and has connected (is "attached") to
+ *    the channel's MCP endpoint. The daemon runs NO `claude -p`; the inbound
+ *    `#agent/message/inbound` notes accumulate as a durable queue (the vault IS the
+ *    queue). The connected session PULLs the next message (an MCP tool), works, and
+ *    REPLYs (an MCP tool) — the daemon writes the outbound note + marks the inbound
+ *    handled. Routed to the {@link AttachedQueueRegistry}, entirely bypassing the
+ *    programmatic serial worker (the daemon routing fork). Claim state lives on the
+ *    inbound note's `status` (`pending | in-flight | handled`), so it's restart-safe.
  *
- * BACK-COMPAT: a persisted `spec.json` that carries the retired `backend:"interactive"`
- * value (or omits `backend` entirely — pre-field specs were interactive) is no longer
- * re-registered on boot (the boot re-register reads `spec.backend === "programmatic"`
- * exactly; anything else is skipped — see daemon.ts), so a stale interactive spec on
- * disk is inert, never migrated and never launched.
+ * BACK-COMPAT (backend VALUE rename `"channel"` → `"attached"`): an already-persisted
+ * def (or `spec.json`) whose `backend` is the legacy `"channel"` is DUAL-READ —
+ * normalized to `"attached"` on read (`parseAgentDef` in agent-defs.ts; the daemon
+ * routing fork also accepts a legacy un-normalized value defensively). Only the new
+ * `"attached"` value is ever WRITTEN. (Note: the ROUTING KEY `channel` — the agent's
+ * address, the `/mcp/<channel>` URL segment, `metadata.channel` on notes — is a
+ * SEPARATE concept and is deliberately unchanged.)
+ *
+ * BACK-COMPAT (retired `interactive`): a persisted `spec.json` that carries the retired
+ * `backend:"interactive"` value (or omits `backend` entirely — pre-field specs were
+ * interactive) is no longer re-registered on boot (the boot re-register reads
+ * `spec.backend === "programmatic"` exactly; anything else is skipped — see daemon.ts),
+ * so a stale interactive spec on disk is inert, never migrated and never launched.
  */
-export type AgentBackendKind = "programmatic" | "channel";
+export type AgentBackendKind = "programmatic" | "attached";
 
 /**
  * How a channel's {@link AgentSpec.systemPrompt} composes with Claude Code's own
@@ -283,8 +292,9 @@ export interface AgentSpec {
   /**
    * Which backend drives the agent (design 2026-06-16-pluggable-agent-backend.md +
    * 2026-06-18-channel-backend.md) — `"programmatic"` (the default; on-demand
-   * `claude -p` turns, no resident process) or `"channel"` (handled by a Claude Code
-   * session the operator connects to the channel's MCP endpoint). The `interactive`
+   * `claude -p` turns, no resident process) or `"attached"` (handled by a Claude Code
+   * session the operator connects — "attaches" — to the channel's MCP endpoint; the
+   * value was named `"channel"` before the rename, dual-read on load). The `interactive`
    * (tmux) backend was retired 2026-06-19. See {@link AgentBackendKind}. Persisted in
    * spec.json so a daemon restart re-registers a programmatic agent on boot.
    */

--- a/src/transports/vault.ts
+++ b/src/transports/vault.ts
@@ -192,8 +192,8 @@ export interface ChannelMessage {
 export type InboundStatus = "pending" | "in-flight" | "handled";
 
 /**
- * One inbound queue item for a CHANNEL-backend agent — an `#agent/message/inbound`
- * note as the {@link ChannelQueueRegistry} reads it. Carries the claim `status` +
+ * One inbound queue item for an ATTACHED-backend agent — an `#agent/message/inbound`
+ * note as the {@link AttachedQueueRegistry} reads it. Carries the claim `status` +
  * `claimedAt` (for the TTL sweep) alongside the message text + threading id.
  */
 export interface InboundQueueNote {
@@ -1322,7 +1322,7 @@ export class VaultTransport implements Transport {
   // inbound `#agent/message/inbound` notes themselves ARE the queue; the claim
   // `status` (pending | in-flight | handled) lives on each note so the vault is
   // the source of truth (restart-safe). These methods own the vault I/O (URL +
-  // token + encoding) so the ChannelQueueRegistry stays storage-agnostic — the
+  // token + encoding) so the AttachedQueueRegistry stays storage-agnostic — the
   // same separation jobs.ts has from the job-note I/O. The channel's existing
   // `vault:<name>:write` token covers GET + the status PATCH; no new mint.
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## What changed

Renames the `AgentBackendKind` backend **value** `"channel"` → `"attached"`. The two live backends are now `"programmatic"` | `"attached"`.

- **`src/sandbox/types.ts`** — `AgentBackendKind = "programmatic" | "attached"`; doc comments updated.
- **`src/agent-defs.ts`** — the two parse/validation spots accept `"attached"`; validation error messages now read `"programmatic" or "attached"`.
- **`src/daemon.ts`** — routing fork `spec.backend === "attached"`; `/api/agents` returns `backend: "attached"`; the create-def route validates `"attached"`.
- **`src/agents.ts`** — `AgentInfo.backend` type + the web-spawn deflect message (still rejects an attached/channel backend as vault-native — define it as an `#agent/definition` note).
- **Registry rename** — `src/backends/channel-queue.ts` → `src/backends/attached-queue.ts` (git-tracked rename), class `ChannelQueueRegistry` → `AttachedQueueRegistry`, store type `ChannelQueueStore` → `AttachedQueueStore`, test file `channel-queue.test.ts` → `attached-queue.test.ts`. All imports/usages updated (daemon.ts, mcp-http.ts, tests).
- **`.parachute/module.json`** — public copy reframed for the **Agent** product: tagline `"a session per agent"`, events `"A message arrived for an agent"` / `"An agent replied"`, connectionTemplate `"Link an agent to a vault"`.
- **Tests** — `backend: "channel"` → `"attached"` where constructed/expected; the renamed imports; **added dual-read tests**.

## Dual-read for persisted defs (back-compat)

An already-persisted def whose `metadata.backend` (or a `spec.json`) carries the legacy `"channel"` value **still loads** — it is normalized to `"attached"` on read (`parseAgentDef`), so existing def notes and spec.json files keep working with no migration and no operator-facing break. Only the canonical `"attached"` is ever **written**. The daemon routing fork and the create-def paths also accept a legacy `"channel"` defensively. New tests assert this at both the parse level (`agent-defs.test.ts`) and the API level (`daemon-agent-defs-api.test.ts`).

## Out of scope — the routing key `channel` is deliberately untouched

This PR renames **only the backend value**. The **routing key** `channel` — the agent's address — is left exactly as-is for a separate later PR: `metadata.channel` on notes, the `/agent/mcp/<channel>` URL segment, the `hasChannel`/`byChannel`/`getByChannel` methods, the `channel` parameter/variable names, `channels.json`, `CHANNEL_AUDIENCE`/`env-compat`, and the `#channel-message` legacy tags. The `module.json` `channel` parameter key and protocol filters also stay.

## Gate

- `bun run typecheck` — clean (exit 0)
- `bun test ./src/` — **1030 pass / 0 fail** (3016 expect calls, 49 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)