### PR TITLE
feat(agent): data-model key channel → agent (expand phase — dual-write + dual-read)

### DIFF
--- a/src/daemon.test.ts
+++ b/src/daemon.test.ts
@@ -502,7 +502,7 @@ describe("Vault inbound webhook — POST /api/vault/inbound", () => {
     }
   });
 
-  test("missing note.metadata.channel → 400", async () => {
+  test("missing routing key (neither agent nor channel) → 400", async () => {
     const { srv, base } = buildVaultServer();
     try {
       const res = await fetch(`${base}/api/vault/inbound?secret=${SECRET}`, {
@@ -531,6 +531,56 @@ describe("Vault inbound webhook — POST /api/vault/inbound", () => {
       expect(emitted[0]!.content).toBe("wake up session");
       expect(emitted[0]!.meta.note_id).toBe("n-ok");
       expect(emitted[0]!.meta.source).toBe("vault");
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("EXPAND-PHASE dual-read: a note carrying ONLY metadata.agent (no channel) routes + emits", async () => {
+    const { srv, base, emitted } = buildVaultServer();
+    try {
+      const res = await fetch(`${base}/api/vault/inbound?secret=${SECRET}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          note: {
+            id: "agent-only-1",
+            content: "wake up via agent key",
+            tags: ["#agent/message", "#agent/message/inbound"],
+            // NO `channel` field — the routing key is carried ONLY under the new `agent` alias.
+            metadata: { agent: "eng", direction: "inbound", sender: "aaron" },
+          },
+        }),
+      });
+      expect(res.status).toBe(200);
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]!.channel).toBe("eng");
+      expect(emitted[0]!.content).toBe("wake up via agent key");
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("BACK-COMPAT dual-read: a note carrying ONLY legacy metadata.channel (no agent) still routes + emits", async () => {
+    const { srv, base, emitted } = buildVaultServer();
+    try {
+      const res = await fetch(`${base}/api/vault/inbound?secret=${SECRET}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          note: {
+            id: "channel-only-1",
+            content: "wake up via legacy channel key",
+            tags: ["#agent/message", "#agent/message/inbound"],
+            // ONLY the legacy `channel` field — a pre-expand writer; must still route.
+            metadata: { channel: "eng", direction: "inbound", sender: "aaron" },
+          },
+        }),
+      });
+      expect(res.status).toBe(200);
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]!.channel).toBe("eng");
+      expect(emitted[0]!.content).toBe("wake up via legacy channel key");
     } finally {
       srv.stop(true);
     }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -51,7 +51,7 @@ import {
   type Channel,
   type ChannelEntry,
 } from "./registry.ts";
-import { VaultTransport, AGENT_VAULT_TRIGGER_TEMPLATE } from "./transports/vault.ts";
+import { VaultTransport, AGENT_VAULT_TRIGGER_TEMPLATE, noteAgentKey } from "./transports/vault.ts";
 import {
   AgentDefRegistry,
   AgentDefWriteError,
@@ -2556,10 +2556,15 @@ export function createFetchHandler(
       if (!note || typeof note.id !== "string" || !note.id) {
         return json({ error: "body must include note.id" }, 400);
       }
-      const channelName =
-        typeof note.metadata?.channel === "string" ? note.metadata.channel : undefined;
+      // Dual-read the routing key: the NEW `agent` field, falling back to the legacy
+      // `channel` field (the expand-phase dual-read) — a note written by either an
+      // agent-speaking or a legacy channel-speaking writer routes.
+      const channelName = noteAgentKey(note.metadata);
       if (!channelName) {
-        return json({ error: "note.metadata.channel is required to route the message" }, 400);
+        return json(
+          { error: "note.metadata.agent (or legacy channel) is required to route the message" },
+          400,
+        );
       }
       const ch = channels.get(channelName);
       const vt = ch?.transport instanceof VaultTransport ? ch.transport : undefined;

--- a/src/transports/vault.test.ts
+++ b/src/transports/vault.test.ts
@@ -26,7 +26,7 @@
  */
 
 import { describe, test, expect, afterEach } from "bun:test";
-import { VaultTransport, AGENT_VAULT_TAG_SCHEMA, AGENT_THREAD_TAG, AGENT_JOB_TAG, InboundClaimConflictError } from "./vault.ts";
+import { VaultTransport, AGENT_VAULT_TAG_SCHEMA, AGENT_THREAD_TAG, AGENT_JOB_TAG, InboundClaimConflictError, noteAgentKey } from "./vault.ts";
 import type { TransportContext, InboundMessage } from "../transport.ts";
 import { instantiateTransport } from "../registry.ts";
 
@@ -56,6 +56,30 @@ function baseConfig() {
     webhookSecret: "s3cret",
   };
 }
+
+describe("noteAgentKey — the expand-phase dual-read routing key", () => {
+  test("returns `agent` when present", () => {
+    expect(noteAgentKey({ agent: "eng" })).toBe("eng");
+  });
+  test("falls back to legacy `channel` when `agent` is absent", () => {
+    expect(noteAgentKey({ channel: "ops" })).toBe("ops");
+  });
+  test("prefers `agent` over `channel` when BOTH are present", () => {
+    expect(noteAgentKey({ agent: "eng", channel: "legacy" })).toBe("eng");
+  });
+  test("returns undefined when neither is present", () => {
+    expect(noteAgentKey({})).toBeUndefined();
+    expect(noteAgentKey(undefined)).toBeUndefined();
+    expect(noteAgentKey(null)).toBeUndefined();
+  });
+  test("ignores empty-string / non-string values (falls through)", () => {
+    // An empty `agent` is not a usable routing key → fall back to channel.
+    expect(noteAgentKey({ agent: "", channel: "ops" })).toBe("ops");
+    // Non-string values are ignored entirely.
+    expect(noteAgentKey({ agent: 123 as unknown as string, channel: "ops" })).toBe("ops");
+    expect(noteAgentKey({ agent: "", channel: "" })).toBeUndefined();
+  });
+});
 
 describe("VaultTransport — reply (outbound note write)", () => {
   test("reply() POSTs .../api/notes tagged #agent/message + #agent/message/outbound + direction + channel + Bearer", async () => {
@@ -107,6 +131,10 @@ describe("VaultTransport — reply (outbound note write)", () => {
     // The note PATH prefix is DOMAIN (`channel/<name>/`) — unchanged by the rename.
     expect(sent.path.startsWith("channel/eng/")).toBe(true);
     expect(sent.metadata.channel).toBe("eng");
+    // EXPAND PHASE dual-write: the routing key is written under BOTH the new `agent`
+    // alias AND the legacy `channel` field, with the SAME value.
+    expect(sent.metadata.agent).toBe("eng");
+    expect(sent.metadata.agent).toBe(sent.metadata.channel);
     expect(sent.metadata.direction).toBe("outbound");
     expect(sent.metadata.sender).toBe("session");
     // The old `outbound:"1"` presence marker is gone — no such metadata key.
@@ -230,6 +258,9 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
     expect(sent.metadata.mode).toBe("multi-threaded");
     // Thread-state + channel + usage (stringified for the vault).
     expect(sent.metadata.channel).toBe("eng");
+    // EXPAND PHASE dual-write: routing key under BOTH `agent` and legacy `channel`.
+    expect(sent.metadata.agent).toBe("eng");
+    expect(sent.metadata.agent).toBe(sent.metadata.channel);
     expect(sent.metadata.started_at).toBe("2026-06-18T07:00:00.000Z");
     expect(sent.metadata.last_turn_at).toBe("2026-06-18T07:00:12.000Z");
     expect(sent.metadata.turn_count).toBe("1");
@@ -1246,6 +1277,11 @@ describe("VaultTransport — writeInbound (the chat's send → wakes the session
     // Write-discipline: never write the legacy tag family going forward.
     expect(sent.tags).not.toContain("#channel-message");
     expect(sent.metadata.channel).toBe("eng");
+    // EXPAND PHASE dual-write: routing key under BOTH `agent` and legacy `channel`.
+    // BOTH must be present on the inbound note — the trigger fires on
+    // `has_metadata:["channel"]`, so `channel` must stay; `agent` is the new alias.
+    expect(sent.metadata.agent).toBe("eng");
+    expect(sent.metadata.agent).toBe(sent.metadata.channel);
     expect(sent.metadata.direction).toBe("inbound");
     expect(sent.metadata.sender).toBe("operator");
     expect(typeof sent.metadata.ts).toBe("string");
@@ -1392,6 +1428,11 @@ describe("VaultTransport — ingestInbound", () => {
     expect(m.meta.note_id).toBe("note-in-1");
     expect(m.meta.sender).toBe("aaron");
     expect(m.meta.direction).toBe("inbound");
+    // EXPAND PHASE dual-write onto the in-memory event meta: the routing key rides
+    // under BOTH `agent` and legacy `channel` (same value).
+    expect(m.meta.agent).toBe("eng");
+    expect(m.meta.channel).toBe("eng");
+    expect(m.meta.agent).toBe(m.meta.channel);
   });
 
   test("IGNORES a #agent/message/outbound-tagged note (loop avoidance)", () => {
@@ -1598,9 +1639,22 @@ describe("VaultTransport — ensureSchema (tag-schema declaration on connect)", 
     // "all failed threads" (status), "all threads of agent X" (definition), "all
     // multi-threaded threads" (mode). The three axes carry over from the run record VERBATIM.
     expect(byName("#agent/thread").fields).toEqual({
+      // Expand phase: the new `agent` routing-key alias is declared indexed (additive).
+      agent: { type: "string", indexed: true },
       status: { type: "string", indexed: true },
       definition: { type: "string", indexed: true },
       mode: { type: "string", indexed: true },
+    });
+    // Expand phase: `#agent/message` newly declares the indexed `agent` alias.
+    expect(byName("#agent/message").fields).toEqual({
+      agent: { type: "string", indexed: true },
+    });
+    // Expand phase: `#agent/job` dual-indexes the routing key — new `agent` + legacy `channel`.
+    expect(byName("#agent/job").fields).toEqual({
+      agent: { type: "string", indexed: true },
+      channel: { type: "string", indexed: true },
+      enabled: { type: "string", indexed: true },
+      lastStatus: { type: "string", indexed: true },
     });
   });
 
@@ -1629,13 +1683,15 @@ describe("VaultTransport — ensureSchema (tag-schema declaration on connect)", 
     await t.ensureSchema();
 
     expect(threadBody?.fields).toEqual({
+      // Expand phase: the new `agent` routing-key alias is declared indexed (additive).
+      agent: { type: "string", indexed: true },
       status: { type: "string", indexed: true },
       definition: { type: "string", indexed: true },
       mode: { type: "string", indexed: true },
     });
   });
 
-  test("ensureSchema sends the indexed `fields` body for #agent/job (query by channel/enabled/lastStatus)", async () => {
+  test("ensureSchema sends the indexed `fields` body for #agent/job (query by agent/channel/enabled/lastStatus)", async () => {
     let jobBody: { fields?: Record<string, unknown> } | undefined;
     globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
       const name = decodeURIComponent(String(url).split("/api/tags/")[1]!);
@@ -1647,6 +1703,8 @@ describe("VaultTransport — ensureSchema (tag-schema declaration on connect)", 
     await t.ensureSchema();
 
     expect(jobBody?.fields).toEqual({
+      // Expand phase: dual-index the routing key — new `agent` alias + legacy `channel`.
+      agent: { type: "string", indexed: true },
       channel: { type: "string", indexed: true },
       enabled: { type: "string", indexed: true },
       lastStatus: { type: "string", indexed: true },
@@ -1824,6 +1882,10 @@ describe("VaultTransport — scheduled-job notes (vault-native store)", () => {
     expect(body.tags).toEqual(["#agent/job"]);
     expect(body.metadata.enabled).toBe("true");
     expect(body.metadata.jobId).toBe("m"); // slug persisted for stable display
+    // EXPAND PHASE dual-write: routing key under BOTH `agent` and legacy `channel`.
+    expect(body.metadata.channel).toBe("eng");
+    expect(body.metadata.agent).toBe("eng");
+    expect(body.metadata.agent).toBe(body.metadata.channel);
   });
 
   test("patchJobNote sends a PATCH with only the changed metadata", async () => {

--- a/src/transports/vault.ts
+++ b/src/transports/vault.ts
@@ -140,6 +140,8 @@ export interface JobNote {
 export interface JobNoteMetadata {
   /** The operator-facing slug (so the displayed id survives the vault's note-id assignment). */
   jobId: string;
+  /** The routing key under the NEW `agent` alias (dual-write, same value as `channel`). */
+  agent: string;
   channel: string;
   cron: string;
   tz?: string;
@@ -254,6 +256,16 @@ const AGENT_MESSAGE_OUTBOUND_TAG = "#agent/message/outbound";
 const STATUS_META_KEY = "status";
 /** Metadata key carrying the ISO timestamp an inbound was claimed (for the TTL sweep). */
 const CLAIMED_AT_META_KEY = "claimedAt";
+
+/** The agent (routing) key carried on a vault note's metadata. Reads the NEW `agent`
+ *  field, falling back to the legacy `channel` field (the expand-phase dual-read), so a
+ *  note written by either an agent-speaking or a legacy channel-speaking writer routes. */
+export function noteAgentKey(meta: Record<string, unknown> | undefined | null): string | undefined {
+  const a = meta?.agent;
+  if (typeof a === "string" && a) return a;
+  const c = meta?.channel;
+  return typeof c === "string" && c ? c : undefined;
+}
 
 /**
  * Coerce a raw `status` metadata value to an {@link InboundStatus}. The vault stores
@@ -474,6 +486,12 @@ export const AGENT_VAULT_TAG_SCHEMA: ReadonlyArray<{
     name: AGENT_MESSAGE_TAG,
     parent_names: [AGENT_ROOT_TAG],
     description: "A message in a Parachute channel (parent of /inbound + /outbound).",
+    // Expand phase: declare the NEW `agent` routing key indexed so agent-keyed queries
+    // are indexed. The legacy `channel` field was never declared indexed here (transcript
+    // filtering is client-side, index-free); we add only the new alias, additively.
+    fields: {
+      agent: { type: "string", indexed: true },
+    },
   },
   {
     name: AGENT_MESSAGE_INBOUND_TAG,
@@ -499,6 +517,9 @@ export const AGENT_VAULT_TAG_SCHEMA: ReadonlyArray<{
     // 2026-06-17-runner-scheduled-agent-turns); the schema is permissive, so the other
     // job fields (jobId/cron/tz/createdAt/lastRunAt) ride as undeclared metadata.
     fields: {
+      // Expand phase: dual-index the routing key — the new `agent` alias alongside the
+      // existing legacy `channel` field (additive; both indexed).
+      agent: { type: "string", indexed: true },
       channel: { type: "string", indexed: true },
       enabled: { type: "string", indexed: true },
       lastStatus: { type: "string", indexed: true },
@@ -515,6 +536,9 @@ export const AGENT_VAULT_TAG_SCHEMA: ReadonlyArray<{
     //  - definition → "all threads of agent X" (the def note id)
     //  - mode       → "all multi-threaded threads"
     fields: {
+      // Expand phase: declare the new `agent` routing key indexed (additive — the legacy
+      // `channel` field was never declared indexed here; we add only the new alias).
+      agent: { type: "string", indexed: true },
       status: { type: "string", indexed: true },
       definition: { type: "string", indexed: true },
       mode: { type: "string", indexed: true },
@@ -754,6 +778,11 @@ export class VaultTransport implements Transport {
     const path = `${this.pathPrefix}/${safeChannel}/${id}`;
 
     const metadata: Record<string, string> = {
+      // Dual-write the routing key under BOTH the new `agent` alias and the legacy
+      // `channel` field (same value) — the expand phase. Keeps the existing
+      // `has_metadata:["channel"]` trigger + any channel-speaking reader working
+      // while the data model starts speaking `agent`.
+      agent: channel,
       channel,
       // `direction` stays as a human/UI convenience field. The loop-avoidance
       // source of truth is now the `#agent/message/outbound` TAG below — the
@@ -945,6 +974,8 @@ export class VaultTransport implements Transport {
     // Indexed string fields (queryable) + the thread-state observability fields. The
     // vault stores metadata as strings; numbers are stringified.
     const metadata: Record<string, string> = {
+      // Dual-write the routing key (expand phase): new `agent` alias + legacy `channel`.
+      agent: thread.channel,
       channel: thread.channel,
       mode: thread.mode,
       status: thread.status,
@@ -1209,8 +1240,8 @@ export class VaultTransport implements Transport {
       if (typeof note.id !== "string" || !note.id) continue;
       const meta = note.metadata ?? {};
       // Client-side channel filter (see the index-free note above): keep only
-      // notes whose metadata.channel matches this channel.
-      if (meta.channel !== channel) continue;
+      // notes whose routing key matches this channel. Dual-read `agent ?? channel`.
+      if (noteAgentKey(meta) !== channel) continue;
       const tags = note.tags ?? [];
       // Direction: prefer the explicit metadata field; fall back to the child tag
       // (new OR legacy outbound — dual-read).
@@ -1272,6 +1303,10 @@ export class VaultTransport implements Transport {
     const metadata: Record<string, string> = {
       // Caller-supplied extra fields first, so the invariants below cannot be clobbered.
       ...(extraMeta ?? {}),
+      // Dual-write the routing key (expand phase): new `agent` alias + legacy `channel`.
+      // BOTH must be present here — this is the inbound path the vault trigger fires on
+      // (`has_metadata:["channel"]`), so dropping `channel` would break the trigger.
+      agent: channel,
       channel,
       direction: "inbound",
       sender: sender ?? "operator",
@@ -1450,7 +1485,7 @@ export class VaultTransport implements Transport {
     for (const note of notes) {
       if (typeof note.id !== "string" || !note.id) continue;
       const meta = note.metadata ?? {};
-      if (meta.channel !== channel) continue; // client-side channel filter (index-free).
+      if (noteAgentKey(meta) !== channel) continue; // client-side filter (index-free); dual-read agent ?? channel.
       const status = coerceInboundStatus(meta[STATUS_META_KEY]);
       // Drop `handled` notes — they are not queue items (#103). Only pending + in-flight
       // make up the actionable queue; counting/returning handled would let them crowd
@@ -1574,7 +1609,7 @@ export class VaultTransport implements Transport {
     for (const note of notes) {
       if (typeof note.id !== "string" || !note.id) continue;
       const m = note.metadata ?? {};
-      const channel = typeof m.channel === "string" ? m.channel : "";
+      const channel = noteAgentKey(m) ?? ""; // dual-read the routing key: agent ?? channel.
       const cron = typeof m.cron === "string" ? m.cron : "";
       if (!channel || !cron) continue; // not a well-formed job note; skip.
       // The operator-facing id is the slug in `metadata.jobId`; fall back to the
@@ -1620,6 +1655,8 @@ export class VaultTransport implements Transport {
     const path = `${JOB_PATH_PREFIX}/${safeChannel}/jobs/${safeId}`;
     const metadata: JobNoteMetadata = {
       jobId: job.id, // the operator-facing slug, so it survives the vault's note-id assignment.
+      // Dual-write the routing key (expand phase): new `agent` alias + legacy `channel`.
+      agent: job.channel,
       channel: job.channel,
       cron: job.cron,
       enabled: job.enabled ? "true" : "false",
@@ -1722,10 +1759,16 @@ export class VaultTransport implements Transport {
       flatMeta[k] = typeof v === "string" ? v : String(v);
     }
     this.ctx.emit({
+      // `channel` here is the in-memory InboundMessage.channel TS field (NOT serialized
+      // note metadata) — left as the channel name. The routing key alias rides in `meta`.
       channel: this.ctx.channel,
       content: note.content ?? "",
       meta: {
         ...flatMeta,
+        // Dual-write the routing key onto the in-memory event meta (expand phase):
+        // new `agent` alias + legacy `channel`, same value.
+        agent: this.ctx.channel,
+        channel: this.ctx.channel,
         source: "vault",
         note_id: note.id,
         sender: typeof meta.sender === "string" ? meta.sender : "",


### PR DESCRIPTION
## What

Rename the vault **DATA-MODEL** routing key `channel` → `agent`, but as a **SAFE EXPAND phase only**: the daemon now **WRITEs both `agent` and `channel`** (dual-write, same value) and **READs `agent ?? channel`** (dual-read).

This is the **EXPAND** step of an expand → migrate → contract migration:

- **Expand (this PR):** the data model starts speaking `agent` while still writing `channel`. Fully backward-compatible — nothing downstream has to change. A note written by an agent-speaking *or* a legacy channel-speaking writer routes either way.
- **Migrate (later):** re-tag / re-stamp existing notes (one-time, optional — dual-read covers old notes anyway).
- **Contract (later, user-gated cutover — NOT here):** flip the vault trigger from `has_metadata:["channel"]` → `["agent"]` and drop the `channel` write.

## Deliberately UNCHANGED (scope boundary)

Per the explicit scope choice, this PR does **not** touch:

- the vault trigger template `AGENT_VAULT_TRIGGER_TEMPLATE` (stays `has_metadata:["channel"]` — dual-write keeps `channel` present, so the existing trigger still fires)
- MCP endpoint URLs (`/mcp/<channel>`, `/agent/mcp/<channel>`), `src/oauth-discovery.ts`, `src/agent-mcp-config.ts`
- the `channels.json` registry
- all TypeScript field/var/param names (`channel`, `byChannel`, `ChannelMessage.channel`, `ThreadRecord.channel`, `this.ctx.channel`, …)
- the attached-queue names + the legacy `#channel-message` dual-read (a separate PR)

The **only** runtime change is the **serialized note metadata** (gains an `agent` alias) and the daemon's **read** of that metadata (dual-read).

## Exact dual-WRITE sites (`src/transports/vault.ts`)

Each gained `agent: <sameValue>` alongside the existing `channel:` in the note-metadata object it writes:

1. `reply()` — outbound note metadata
2. `writeThread()` — `#agent/thread` note metadata
3. `writeInbound()` — inbound note metadata (the path the trigger fires on — **both keys present**)
4. `upsertJobNote()` — `#agent/job` note metadata (+ `JobNoteMetadata.agent`)
5. `ingestInbound()` — the `ctx.emit` in-memory event `meta` (the top-level `InboundMessage.channel` TS field is left unchanged; the alias rides in `meta`)

## Dual-READ via the new `noteAgentKey(meta)` helper

```ts
export function noteAgentKey(meta): string | undefined  // agent ?? channel
```

Used at every routing-key read of a note's metadata:

1. `daemon.ts` `/api/vault/inbound` webhook router (the critical route) — error message updated to `note.metadata.agent (or legacy channel) is required to route the message`
2. `loadTranscript()` client-side channel filter
3. `listInboundQueue()` client-side channel filter
4. `listJobNotes()` routing-key mapping

## Schema

Declares `agent` as an **additively-indexed** alias on `#agent/message`, `#agent/thread`, and `#agent/job` (the legacy `channel` index on `#agent/job` is retained — additive).

## Tests (both gates green)

- `noteAgentKey` unit test (agent present / channel fallback / prefers agent / undefined when neither / empty-string fall-through)
- dual-write body-capture assertions on `writeInbound`, `reply`, `writeThread`, `upsertJobNote`, and the emit `meta` (both keys, same value)
- daemon inbound-routing: an `agent`-only note routes; a `channel`-only note still routes (back-compat); neither → 400
- schema-assertion tests updated for the new `agent` field

```
bun run typecheck   # clean
bun test ./src/     # 1041 pass / 0 fail
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)