### PR TITLE
feat(agent): channel→agent data-key CONTRACT — agent-only write, drop legacy tag reads, trigger keys on agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,11 +170,18 @@ A `vault` transport backs a channel with notes in a Parachute vault, so messages
 are durable, queryable, and a vault surface can render them. Multiple channels per
 vault: the note's routing-key metadata routes it.
 
-> **Routing-key expand phase (#133).** The routing key is now written under BOTH
-> `metadata.agent` (new, canonical) AND `metadata.channel` (legacy) on every note, and
-> READ as `agent ?? channel` via the `noteAgentKey` helper (`src/transports/vault.ts`) —
-> the expand phase of the data-model `channel → agent` rename. The vault inbound trigger
-> still keys on `channel` until a later cutover, so both keys stay populated for now.
+> **Routing-key CONTRACT landed (#133).** The data-model `channel → agent` rename's
+> CONTRACT phase is in: every note now writes the routing key under `metadata.agent`
+> ONLY (the `metadata.channel` dual-write is dropped), and the vault inbound trigger
+> keys on `has_metadata:["agent"]`. The `noteAgentKey` helper (`src/transports/vault.ts`)
+> still READS `agent ?? channel` as a read-only tolerance for any in-flight straggler
+> during the live cutover. The legacy `#channel-message*` / interim `#agent-message*`
+> tag dual-read + dual-schema were dropped too (we only ever wrote `#agent/message*`).
+> **Live cutover is a SEPARATE step:** merging this code has no live effect until the
+> vault trigger is re-registered to `has_metadata:["agent"]` and the daemon restarts.
+> Note the TRANSPORT/ENDPOINT "channel" concept is untouched — `channels.json`, the
+> `Channel` type, `/mcp/<channel>`, `InboundMessage.channel`, and the note path prefixes
+> all stay.
 
 **The `#agent/*` namespace is module-owned** (design
 `design/2026-06-17-vault-native-agents.md`). Every vault object this module manages
@@ -185,14 +192,15 @@ record of one thread — see the `#agent/thread` subsection below). The tag sche
 `parent_names` so a human `tag:#agent` query rolls up to everything the module owns.
 The module always queries the EXACT leaf tag (never relies on prefix magic), and
 keeps the "tag both queryable parent + directional child literally" floor so loop
-avoidance + transcript listing work with zero per-vault schema dependency. DUAL-READ
-recognizes the prior flat `#agent-message*` and legacy `#channel-message*` tags on
-READ (pre-namespace history) but only ever WRITES the namespaced tags.
+avoidance + transcript listing work with zero per-vault schema dependency. The
+channel→agent CONTRACT dropped the prior flat `#agent-message*` / legacy
+`#channel-message*` tag dual-read — the module both WRITES and READS only the
+`#agent/message*` tags now.
 
 **Note shape** — TWO tags per note, carried literally (two orthogonal axes):
 - the parent `#agent/message` — the QUERYABLE membership tag. A UI lists a channel's
-  whole transcript (both directions) with one `tag: "#agent/message"` + `metadata.channel`
-  query, because the parent is literally on every note.
+  whole transcript (both directions) with one `tag: "#agent/message"` + `metadata.agent`
+  (the routing key) query, because the parent is literally on every note.
 - a directional child — the trigger DISCRIMINATOR: `#agent/message/inbound` (human→session)
   or `#agent/message/outbound` (session reply).
 
@@ -203,17 +211,19 @@ A note tagged ONLY `#agent/message/inbound` is INVISIBLE to a `tag: "#agent/mess
 query unless that inheritance was separately declared — so we tag BOTH the parent and the
 child and don't depend on per-vault schema setup.
 
-Content = the message text; metadata: `{ channel, direction: "inbound"|"outbound", sender,
-in_reply_to (outbound), ts }`. Loop avoidance lives in the TAG, not metadata: the trigger
-fires on the inbound child tag only (exact match), which an outbound note never carries, so a
-reply never wakes its own session. **Inbound notes MUST carry BOTH `#agent/message` (parent,
-makes it queryable) AND `#agent/message/inbound` (child, fires the trigger), with the channel
-name in `metadata.channel`.** Outbound notes carry `#agent/message` + `#agent/message/outbound`.
+Content = the message text; metadata: `{ agent, direction: "inbound"|"outbound", sender,
+in_reply_to (outbound), ts }` — `agent` is the routing key (the channel→agent CONTRACT moved
+it off the dropped `channel` field; `noteAgentKey` keeps an `agent ?? channel` read fallback
+for stragglers). Loop avoidance lives in the TAG, not metadata: the trigger fires on the inbound
+child tag only (exact match), which an outbound note never carries, so a reply never wakes its own
+session. **Inbound notes MUST carry BOTH `#agent/message` (parent, makes it queryable) AND
+`#agent/message/inbound` (child, fires the trigger), with the routing key in `metadata.agent`.**
+Outbound notes carry `#agent/message` + `#agent/message/outbound`.
 
 **Flow.** INBOUND (human→session): a new `#agent/message` + `#agent/message/inbound` note →
 a vault **trigger** POSTs a webhook → the agent daemon's `POST /api/vault/inbound` → routes by
-`note.metadata.channel` → `ctx.emit` wakes the session (fans to SSE bridges + HTTP-MCP sessions
-alike). OUTBOUND (session→human): the session's `reply` writes a `#agent/message` +
+`noteAgentKey(note.metadata)` (reads `metadata.agent`) → `ctx.emit` wakes the session (fans to
+SSE bridges + HTTP-MCP sessions alike). OUTBOUND (session→human): the session's `reply` writes a `#agent/message` +
 `#agent/message/outbound` note via the vault REST API (`POST <vaultUrl>/vault/<vault>/api/notes`,
 Bearer `vault:<name>:write`).
 
@@ -226,7 +236,7 @@ Bearer `vault:<name>:write`).
 
 **Vault side** (operator config — activates the inbound trigger):
 1. (Optional, for indexed queries) declare the `#agent/message` tag schema with
-   indexed `channel`/`direction`/`sender` fields (`update-tag`).
+   indexed `agent`/`direction`/`sender` fields (`update-tag`).
 2. Add a trigger to the vault's `config.yaml` that fires on new inbound notes and
    webhooks the agent daemon. Loop avoidance is by tag: the vault predicate does
    EXACT tag membership, so firing on the inbound CHILD tag (`#agent/message/inbound`)
@@ -239,7 +249,7 @@ Bearer `vault:<name>:write`).
        events: ["created"]
        when:
          tags: ["#agent/message/inbound"]
-         has_metadata: ["channel"]
+         has_metadata: ["agent"]
          missing_metadata: ["channel_inbound_rendered_at"]
        action:
          webhook: "http://127.0.0.1:1941/api/vault/inbound?secret=<shared secret>"
@@ -256,8 +266,8 @@ The unified model is `definition -> thread -> message`: **everything is a thread
 EVERY completed turn materializes a `#agent/thread` note (a "run" was always a thread with
 one turn — the older `#agent/run` tag retired into this). The note is the durable,
 queryable record of one thread: its BODY is a rolling SUMMARY (`## Summary` /
-`## Latest turn`), and its metadata carries the thread state — `channel`, `definition`,
-`mode`, `status`, `started_at`, `last_turn_at`, `turn_count`, cumulative `usage`, and the
+`## Latest turn`), and its metadata carries the thread state — `agent` (the routing key),
+`definition`, `mode`, `status`, `started_at`, `last_turn_at`, `turn_count`, cumulative `usage`, and the
 Claude `session` UUID. The INDEXED `status`/`definition`/`mode` fields make threads
 operator-queryable ("all failed threads", "all threads of agent X", "all multi-threaded
 threads").

--- a/src/daemon-config-api.test.ts
+++ b/src/daemon-config-api.test.ts
@@ -592,11 +592,15 @@ describe("C — AGENT_VAULT_TRIGGER_TEMPLATE exposed via /.parachute/config", ()
       const body = (await res.json()) as { channels: unknown[]; triggerTemplate: typeof AGENT_VAULT_TRIGGER_TEMPLATE };
       expect(body.triggerTemplate).toEqual(AGENT_VAULT_TRIGGER_TEMPLATE);
       // Sanity on the shape the hub depends on (placeholders + webhook path).
-      // The trigger NAME stays `channel_inbound_<channel>` — `channel` is the
-      // domain routing key, not the module identity. The TAG moved to
-      // #agent/message and the webhook moved to the /agent mount.
+      // The trigger NAME stays `channel_inbound_<channel>` — kept STABLE so
+      // re-registration updates the existing trigger in place. The TAG is
+      // #agent/message and the webhook is on the /agent mount.
       expect(body.triggerTemplate.name).toBe("channel_inbound_<channel>");
       expect(body.triggerTemplate.when.tags).toEqual(["#agent/message/inbound"]);
+      // CONTRACT: the predicate keys on the `agent` routing key (was `channel`).
+      expect(body.triggerTemplate.when.has_metadata).toEqual(["agent"]);
+      // The rendered-at marker NAME is unchanged (cosmetic/internal).
+      expect(body.triggerTemplate.when.missing_metadata).toEqual(["channel_inbound_rendered_at"]);
       expect(body.triggerTemplate.action.webhook).toBe("<hub-origin>/agent/api/vault/inbound");
     } finally {
       srv.stop(true);

--- a/src/jobs.test.ts
+++ b/src/jobs.test.ts
@@ -195,12 +195,14 @@ describe("VaultJobStore — vault-native CRUD", () => {
     expect(body.metadata.jobId).toBe("morning"); // slug persisted for stable display
     expect(body.content).toBe("Run the morning weave");
     expect(body.metadata).toMatchObject({
-      channel: "uni-dev",
+      // CONTRACT: routing key under `metadata.agent` ONLY — no `channel`.
+      agent: "uni-dev",
       cron: "53 7 * * *",
       tz: "America/Los_Angeles",
       enabled: "true",
       createdAt: "2026-06-17T00:00:00.000Z",
     });
+    expect(body.metadata.channel).toBeUndefined();
     // nextRunAt is NEVER persisted.
     expect(body.metadata.nextRunAt).toBeUndefined();
     const headers = calls[0]!.init.headers as Record<string, string>;

--- a/src/transports/vault.test.ts
+++ b/src/transports/vault.test.ts
@@ -6,23 +6,22 @@
  * delivery. They cover:
  *   - reply(): writes the right POST .../api/notes tagged BOTH the queryable parent
  *     `#agent/message` AND the directional child `#agent/message/outbound` (no
- *     `outbound` metadata key), with direction, channel, Bearer token; returns the id;
+ *     `outbound` metadata key), with direction, `metadata.agent`, Bearer token; returns the id;
  *   - reply(): threads in_reply_to when the bridge passes it;
- *   - loadTranscript(): DUAL-READS — a note tagged only the LEGACY `#channel-message`
- *     (or the interim `#agent-message`) still appears (the impl unions a
- *     `#agent/message`, an `#agent-message`, and a `#channel-message` query by note id);
+ *   - loadTranscript(): queries the single `#agent/message` parent tag, filters by
+ *     `noteAgentKey(meta)` (the routing key) client-side;
  *   - ingestInbound(): emits the inbound content + meta onto its channel;
- *   - ingestInbound(): IGNORES a `#agent/message/outbound`-tagged note AND a LEGACY
- *     `#channel-message/outbound`-tagged note (loop avoidance, dual-read);
- *   - schema: `AGENT_VAULT_TAG_SCHEMA` declares the `#agent/*` namespace rollup PLUS
- *     the interim + legacy tag families so pre-namespace history keeps its inheritance;
+ *   - ingestInbound(): IGNORES a `#agent/message/outbound`-tagged note (loop avoidance);
+ *   - schema: `AGENT_VAULT_TAG_SCHEMA` declares the `#agent/*` namespace rollup;
  *   - registry: a vault channel instantiates from config.
  *
- * TAG NAMESPACE — `#agent/*` (design 2026-06-17-vault-native-agents). WRITE
- * assertions expect the NEW `#agent/message*` tags; READ assertions ALSO exercise
- * the interim `#agent-message*` and legacy `#channel-message*` families (dual-read).
- * The `metadata.channel` routing key, the channel-name slugs, `?channel=`, the
- * `Channel*` types, and the `channel/<name>/` note path prefix are DOMAIN — unchanged.
+ * TAG NAMESPACE — `#agent/*` (design 2026-06-17-vault-native-agents). WRITE + READ
+ * are the `#agent/message*` tags only — the channel→agent data-model rename CONTRACT
+ * dropped the legacy `#channel-message*` / interim `#agent-message*` dual-read. The
+ * routing key is written under `metadata.agent` ONLY (the `channel` dual-write is
+ * dropped); `noteAgentKey` keeps an `agent ?? channel` read fallback for stragglers.
+ * The channel-name slugs, `?channel=`, the `Channel*` types, and the `channel/<name>/`
+ * note path prefix are DOMAIN — unchanged.
  */
 
 import { describe, test, expect, afterEach } from "bun:test";
@@ -117,24 +116,21 @@ describe("VaultTransport — reply (outbound note write)", () => {
     // the note is queryable under it (a slash is namespace, NOT query inheritance —
     // a child-only-tagged note is invisible to a `tag:#agent/message` query), and
     // the directional child `#agent/message/outbound` is the trigger discriminator.
-    // We WRITE only the NEW namespaced tags; dual-read recognizes the interim +
-    // legacy families on READ.
+    // We WRITE only the `#agent/message*` tags.
     expect(sent.tags).toEqual(["#agent/message", "#agent/message/outbound"]);
     // Regression guard: the queryable parent tag MUST be present literally.
     expect(sent.tags).toContain("#agent/message");
     expect(sent.tags).toContain("#agent/message/outbound");
-    // Loop-avoidance / write-discipline: we NEVER write the interim/legacy tags going forward.
+    // Write-discipline: the interim/legacy tags are gone (CONTRACT dropped them).
     expect(sent.tags).not.toContain("#agent-message");
     expect(sent.tags).not.toContain("#agent-message/outbound");
     expect(sent.tags).not.toContain("#channel-message");
     expect(sent.tags).not.toContain("#channel-message/outbound");
     // The note PATH prefix is DOMAIN (`channel/<name>/`) — unchanged by the rename.
     expect(sent.path.startsWith("channel/eng/")).toBe(true);
-    expect(sent.metadata.channel).toBe("eng");
-    // EXPAND PHASE dual-write: the routing key is written under BOTH the new `agent`
-    // alias AND the legacy `channel` field, with the SAME value.
+    // CONTRACT: the routing key is written under `metadata.agent` ONLY — no `channel`.
     expect(sent.metadata.agent).toBe("eng");
-    expect(sent.metadata.agent).toBe(sent.metadata.channel);
+    expect(sent.metadata.channel).toBeUndefined();
     expect(sent.metadata.direction).toBe("outbound");
     expect(sent.metadata.sender).toBe("session");
     // The old `outbound:"1"` presence marker is gone — no such metadata key.
@@ -256,11 +252,10 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
     expect(sent.metadata.status).toBe("ok");
     expect(sent.metadata.definition).toBe("Agents/digest");
     expect(sent.metadata.mode).toBe("multi-threaded");
-    // Thread-state + channel + usage (stringified for the vault).
-    expect(sent.metadata.channel).toBe("eng");
-    // EXPAND PHASE dual-write: routing key under BOTH `agent` and legacy `channel`.
+    // Thread-state + routing key + usage (stringified for the vault).
+    // CONTRACT: routing key under `metadata.agent` ONLY — no `channel`.
     expect(sent.metadata.agent).toBe("eng");
-    expect(sent.metadata.agent).toBe(sent.metadata.channel);
+    expect(sent.metadata.channel).toBeUndefined();
     expect(sent.metadata.started_at).toBe("2026-06-18T07:00:00.000Z");
     expect(sent.metadata.last_turn_at).toBe("2026-06-18T07:00:12.000Z");
     expect(sent.metadata.turn_count).toBe("1");
@@ -1011,10 +1006,7 @@ describe("VaultTransport — loadTranscript (read the durable store)", () => {
       if (u.includes("/api/notes") && (init?.method ?? "GET") === "GET") {
         getUrls.push(u);
         capturedAuth = (init?.headers as Record<string, string> | undefined)?.authorization ?? "";
-        // The dual-read fires THREE queries (#agent/message + interim
-        // #agent-message + legacy #channel-message). Serve the NEW-tagged notes on
-        // the #agent/message query; an empty array on the interim + legacy queries
-        // (those dual-read paths have their own dedicated tests).
+        // CONTRACT: a SINGLE `#agent/message` query (no interim/legacy union).
         if (u.includes("tag=%23agent%2Fmessage")) {
           // Return notes OUT of ts order (prove the ascending sort) + a note from a
           // DIFFERENT channel (prove the client-side channel filter excludes it).
@@ -1024,25 +1016,24 @@ describe("VaultTransport — loadTranscript (read the durable store)", () => {
                 id: "n-out",
                 content: "session reply",
                 tags: ["#agent/message", "#agent/message/outbound"],
-                metadata: { channel: "eng", direction: "outbound", sender: "session", ts: "2026-06-08T00:00:02Z", in_reply_to: "n-in" },
+                metadata: { agent: "eng", direction: "outbound", sender: "session", ts: "2026-06-08T00:00:02Z", in_reply_to: "n-in" },
               },
               {
                 id: "n-other",
                 content: "different channel — must be excluded",
                 tags: ["#agent/message", "#agent/message/inbound"],
-                metadata: { channel: "other", direction: "inbound", sender: "x", ts: "2026-06-08T00:00:03Z" },
+                metadata: { agent: "other", direction: "inbound", sender: "x", ts: "2026-06-08T00:00:03Z" },
               },
               {
                 id: "n-in",
                 content: "hi session",
                 tags: ["#agent/message", "#agent/message/inbound"],
-                metadata: { channel: "eng", direction: "inbound", sender: "aaron", ts: "2026-06-08T00:00:01Z" },
+                metadata: { agent: "eng", direction: "inbound", sender: "aaron", ts: "2026-06-08T00:00:01Z" },
               },
             ]),
             { status: 200, headers: { "content-type": "application/json" } },
           );
         }
-        // interim #agent-message + legacy #channel-message queries → nothing here.
         return new Response("[]", { status: 200, headers: { "content-type": "application/json" } });
       }
       // ensureSchema PUTs
@@ -1053,20 +1044,20 @@ describe("VaultTransport — loadTranscript (read the durable store)", () => {
     await t.start(fakeCtx("eng"));
     const msgs = await t.loadTranscript();
 
-    // DUAL-READ: the new + interim + legacy parent tags are queried (unioned by id).
-    // Each query carries the encoded parent tag + include_content, and DELIBERATELY
-    // no `metadata=` operator filter (the channel field isn't indexed on a bare
+    // CONTRACT: exactly ONE `#agent/message` query — the interim/legacy union is gone.
+    // It carries the encoded parent tag + include_content, and DELIBERATELY no
+    // `metadata=` operator filter (the routing-key field isn't indexed on a bare
     // vault; we filter client-side). Overfetches the tag so other channels don't
     // crowd us out.
-    const agentGet = getUrls.find((u) => u.includes("tag=%23agent%2Fmessage"));
-    const interimGet = getUrls.find((u) => u.includes("tag=%23agent-message"));
-    const legacyGet = getUrls.find((u) => u.includes("tag=%23channel-message"));
-    expect(agentGet).toBeDefined();
-    expect(interimGet).toBeDefined(); // proves the interim flat tag is also queried (dual-read)
-    expect(legacyGet).toBeDefined(); // proves the legacy tag is also queried (dual-read)
-    expect(agentGet!.startsWith("http://127.0.0.1:1940/vault/default/api/notes?")).toBe(true);
-    expect(agentGet!).toContain("include_content=true");
-    expect(agentGet!).not.toContain("metadata=");
+    const agentGets = getUrls.filter((u) => u.includes("tag=%23agent%2Fmessage"));
+    expect(agentGets).toHaveLength(1);
+    // No interim/legacy queries are issued.
+    expect(getUrls.some((u) => u.includes("tag=%23agent-message"))).toBe(false);
+    expect(getUrls.some((u) => u.includes("tag=%23channel-message"))).toBe(false);
+    const agentGet = agentGets[0]!;
+    expect(agentGet.startsWith("http://127.0.0.1:1940/vault/default/api/notes?")).toBe(true);
+    expect(agentGet).toContain("include_content=true");
+    expect(agentGet).not.toContain("metadata=");
     expect(capturedAuth).toBe("Bearer write-token-xyz");
 
     // The "other" channel note is filtered OUT; the two "eng" notes remain, sorted
@@ -1081,98 +1072,17 @@ describe("VaultTransport — loadTranscript (read the durable store)", () => {
     expect(msgs[1]!.inReplyTo).toBe("n-in");
   });
 
-  test("DUAL-READ: a note tagged ONLY the LEGACY #channel-message still appears in the transcript", async () => {
-    // The dual-read proof (rule 2). The impl issues TWO tag queries — one for the
-    // NEW `#agent/message`, one for the legacy `#channel-message` — and unions the
-    // results by note id. A pre-rename note carrying ONLY the legacy tags (and the
-    // matching `metadata.channel`) must STILL load, so existing history survives the
-    // rename until the one-time re-tag run lands.
-    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
-      const u = String(url);
-      if (u.includes("/api/notes") && (init?.method ?? "GET") === "GET") {
-        if (u.includes("tag=%23agent%2Fmessage")) {
-          // A NEW-tagged note (post-rename) on this channel.
-          return new Response(
-            JSON.stringify([
-              {
-                id: "n-new",
-                content: "post-rename message",
-                tags: ["#agent/message", "#agent/message/inbound"],
-                metadata: { channel: "eng", direction: "inbound", sender: "aaron", ts: "2026-06-08T00:00:02Z" },
-              },
-            ]),
-            { status: 200, headers: { "content-type": "application/json" } },
-          );
-        }
-        if (u.includes("tag=%23channel-message")) {
-          // A LEGACY-only note (pre-rename) — carries ONLY the old tag family.
-          return new Response(
-            JSON.stringify([
-              {
-                id: "n-legacy",
-                content: "pre-rename message",
-                tags: ["#channel-message", "#channel-message/inbound"],
-                metadata: { channel: "eng", direction: "inbound", sender: "aaron", ts: "2026-06-08T00:00:01Z" },
-              },
-            ]),
-            { status: 200, headers: { "content-type": "application/json" } },
-          );
-        }
-        return new Response("[]", { status: 200 });
-      }
-      return new Response("{}", { status: 200 });
-    }) as typeof fetch;
-
-    const t = new VaultTransport(baseConfig());
-    await t.start(fakeCtx("eng"));
-    const msgs = await t.loadTranscript();
-
-    // Union of both queries: the legacy-only note is present alongside the new one,
-    // sorted ascending by ts (legacy ts is earlier → first).
-    expect(msgs.map((m) => m.id)).toEqual(["n-legacy", "n-new"]);
-    const legacy = msgs.find((m) => m.id === "n-legacy")!;
-    expect(legacy.text).toBe("pre-rename message");
-    expect(legacy.direction).toBe("inbound");
-  });
-
-  test("DUAL-READ: a note carried by BOTH queries (re-tagged) is NOT duplicated (union by id)", async () => {
-    // A note re-tagged to carry both families appears on each query; the union
-    // dedups by note id so it shows exactly once.
-    const dual = {
-      id: "n-both",
-      content: "re-tagged message",
-      tags: ["#agent/message", "#channel-message", "#agent/message/inbound", "#channel-message/inbound"],
-      metadata: { channel: "eng", direction: "inbound", sender: "aaron", ts: "2026-06-08T00:00:01Z" },
-    };
-    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
-      const u = String(url);
-      if (u.includes("/api/notes") && (init?.method ?? "GET") === "GET") {
-        // Both queries return the same note.
-        return new Response(JSON.stringify([dual]), { status: 200, headers: { "content-type": "application/json" } });
-      }
-      return new Response("{}", { status: 200 });
-    }) as typeof fetch;
-
-    const t = new VaultTransport(baseConfig());
-    await t.start(fakeCtx("eng"));
-    const msgs = await t.loadTranscript();
-    expect(msgs).toHaveLength(1);
-    expect(msgs[0]!.id).toBe("n-both");
-  });
-
   test("caps the returned transcript to the requested limit (most-recent by ts)", async () => {
     globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
       const u = String(url);
       if (u.includes("/api/notes") && (init?.method ?? "GET") === "GET") {
-        // Only the #agent/message query returns notes; the legacy query is empty
-        // (so the union doesn't double-count by id under dual-read).
         if (u.includes("tag=%23agent%2Fmessage")) {
           return new Response(
             JSON.stringify([1, 2, 3, 4].map((i) => ({
               id: "n" + i,
               content: "m" + i,
               tags: ["#agent/message", "#agent/message/inbound"],
-              metadata: { channel: "eng", direction: "inbound", sender: "aaron", ts: "2026-06-08T00:00:0" + i + "Z" },
+              metadata: { agent: "eng", direction: "inbound", sender: "aaron", ts: "2026-06-08T00:00:0" + i + "Z" },
             }))),
             { status: 200 },
           );
@@ -1188,26 +1098,17 @@ describe("VaultTransport — loadTranscript (read the durable store)", () => {
     expect(msgs.map((m) => m.id)).toEqual(["n3", "n4"]);
   });
 
-  test("falls back to the child tag for direction when metadata.direction is absent (new + legacy outbound tags)", async () => {
+  test("falls back to the outbound child tag for direction when metadata.direction is absent", async () => {
     globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
       const u = String(url);
       if (u.includes("/api/notes") && (init?.method ?? "GET") === "GET") {
         if (u.includes("tag=%23agent%2Fmessage")) {
           return new Response(
             JSON.stringify([
-              // NEW outbound child → direction inferred "outbound".
-              { id: "a", content: "x", tags: ["#agent/message", "#agent/message/outbound"], metadata: { channel: "eng", ts: "2026-06-08T00:00:01Z" } },
+              // Outbound child → direction inferred "outbound".
+              { id: "a", content: "x", tags: ["#agent/message", "#agent/message/outbound"], metadata: { agent: "eng", ts: "2026-06-08T00:00:01Z" } },
               // No direction signal at all → defaults to "inbound".
-              { id: "b", content: "y", tags: ["#agent/message", "#agent/message/inbound"], metadata: { channel: "eng", ts: "2026-06-08T00:00:02Z" } },
-            ]),
-            { status: 200 },
-          );
-        }
-        if (u.includes("tag=%23channel-message")) {
-          // LEGACY outbound child → dual-read recognizes it too → "outbound".
-          return new Response(
-            JSON.stringify([
-              { id: "c", content: "z", tags: ["#channel-message", "#channel-message/outbound"], metadata: { channel: "eng", ts: "2026-06-08T00:00:03Z" } },
+              { id: "b", content: "y", tags: ["#agent/message", "#agent/message/inbound"], metadata: { agent: "eng", ts: "2026-06-08T00:00:02Z" } },
             ]),
             { status: 200 },
           );
@@ -1221,8 +1122,6 @@ describe("VaultTransport — loadTranscript (read the durable store)", () => {
     const msgs = await t.loadTranscript();
     expect(msgs.find((m) => m.id === "a")!.direction).toBe("outbound");
     expect(msgs.find((m) => m.id === "b")!.direction).toBe("inbound");
-    // Dual-read: the legacy outbound child tag is recognized for direction too.
-    expect(msgs.find((m) => m.id === "c")!.direction).toBe("outbound");
   });
 
   test("throws a clear error on a non-ok vault response", async () => {
@@ -1274,14 +1173,12 @@ describe("VaultTransport — writeInbound (the chat's send → wakes the session
     expect(sent.tags).toContain("#agent/message/inbound");
     // It must NOT carry the outbound tag (that would be a reply, never wake).
     expect(sent.tags).not.toContain("#agent/message/outbound");
-    // Write-discipline: never write the legacy tag family going forward.
+    // Write-discipline: the legacy tag family is gone (CONTRACT dropped it).
     expect(sent.tags).not.toContain("#channel-message");
-    expect(sent.metadata.channel).toBe("eng");
-    // EXPAND PHASE dual-write: routing key under BOTH `agent` and legacy `channel`.
-    // BOTH must be present on the inbound note — the trigger fires on
-    // `has_metadata:["channel"]`, so `channel` must stay; `agent` is the new alias.
+    // CONTRACT: the routing key under `metadata.agent` ONLY — no `channel`. The vault
+    // trigger keys on `has_metadata:["agent"]` to fire on this inbound note.
     expect(sent.metadata.agent).toBe("eng");
-    expect(sent.metadata.agent).toBe(sent.metadata.channel);
+    expect(sent.metadata.channel).toBeUndefined();
     expect(sent.metadata.direction).toBe("inbound");
     expect(sent.metadata.sender).toBe("operator");
     expect(typeof sent.metadata.ts).toBe("string");
@@ -1358,7 +1255,9 @@ describe("VaultTransport — writeCallback (agent-to-agent reply_to substrate)",
     expect(sent!.metadata.correlation_id).toBe("corr-abc");
     expect(sent!.metadata.delegation_depth).toBe("3");
     // The channel it's routed to is THIS transport's channel (the sender's), direction inbound.
-    expect(sent!.metadata.channel).toBe("orchestrator");
+    // CONTRACT: routing key under `metadata.agent` ONLY — no `channel`.
+    expect(sent!.metadata.agent).toBe("orchestrator");
+    expect(sent!.metadata.channel).toBeUndefined();
     expect(sent!.metadata.direction).toBe("inbound");
     expect(sent!.metadata.sender).toBe("callback:worker");
     // LOOP GUARD: the callback note must NEVER carry a reply_to (terminal callback).
@@ -1417,7 +1316,7 @@ describe("VaultTransport — ingestInbound", () => {
       id: "note-in-1",
       content: "hello session",
       tags: ["#agent/message", "#agent/message/inbound"],
-      metadata: { channel: "eng", direction: "inbound", sender: "aaron", ts: "2026-06-08T00:00:00Z" },
+      metadata: { agent: "eng", direction: "inbound", sender: "aaron", ts: "2026-06-08T00:00:00Z" },
     });
     expect(ctx.emitted).toHaveLength(1);
     const m = ctx.emitted[0]!;
@@ -1428,11 +1327,11 @@ describe("VaultTransport — ingestInbound", () => {
     expect(m.meta.note_id).toBe("note-in-1");
     expect(m.meta.sender).toBe("aaron");
     expect(m.meta.direction).toBe("inbound");
-    // EXPAND PHASE dual-write onto the in-memory event meta: the routing key rides
-    // under BOTH `agent` and legacy `channel` (same value).
+    // CONTRACT: the routing key on the in-memory event meta is stamped under `agent`
+    // ONLY (the `channel` dual-write is dropped). The top-level InboundMessage.channel
+    // TS field stays the channel name.
     expect(m.meta.agent).toBe("eng");
-    expect(m.meta.channel).toBe("eng");
-    expect(m.meta.agent).toBe(m.meta.channel);
+    expect(m.meta.channel).toBeUndefined();
   });
 
   test("IGNORES a #agent/message/outbound-tagged note (loop avoidance)", () => {
@@ -1444,24 +1343,6 @@ describe("VaultTransport — ingestInbound", () => {
       content: "I am awake",
       tags: ["#agent/message", "#agent/message/outbound"],
       metadata: { channel: "eng", direction: "outbound", sender: "session" },
-    });
-    expect(ctx.emitted).toHaveLength(0);
-  });
-
-  test("DUAL-READ loop avoidance: IGNORES a LEGACY #channel-message/outbound-tagged note", () => {
-    // Belt-and-suspenders dual-read (rule 2): even a pre-rename reply note —
-    // carrying only the legacy outbound child tag, and WITHOUT a direction
-    // metadata field — must be dropped, so a still-live legacy trigger that
-    // mis-delivers our own old reply can never wake the session on it.
-    const t = new VaultTransport(baseConfig());
-    const ctx = fakeCtx("eng");
-    void t.start(ctx);
-    t.ingestInbound({
-      id: "our-own-legacy-reply",
-      content: "I am awake (legacy)",
-      tags: ["#channel-message", "#channel-message/outbound"],
-      // No direction field — the drop must come from the legacy outbound TAG alone.
-      metadata: { channel: "eng", sender: "session" },
     });
     expect(ctx.emitted).toHaveLength(0);
   });
@@ -1599,13 +1480,11 @@ describe("VaultTransport — ensureSchema (tag-schema declaration on connect)", 
     expect(jobBody.parent_names).toEqual(["#agent"]);
   });
 
-  test("schema declares the #agent/* namespace rollup PLUS the interim + legacy families (dual-read, 13 entries)", async () => {
+  test("schema declares ONLY the #agent/* namespace rollup (CONTRACT dropped interim + legacy, 7 entries)", async () => {
     // The `#agent/*` namespace (design 2026-06-17-vault-native-agents) rolls up
-    // definitions, messages, jobs, AND threads to the `#agent` root. DUAL-READ: the schema
-    // ALSO keeps declaring the interim flat `#agent-message*` AND legacy
-    // `#channel-message*` inheritance so pre-namespace history keeps its parent/child
-    // expansion until the one-time re-tag run lands. Exactly 13 entries (12 + the
-    // execution-lifecycle `#agent/thread` record tag).
+    // definitions, messages, jobs, AND threads to the `#agent` root. The channel→agent
+    // CONTRACT dropped the interim flat `#agent-message*` AND legacy `#channel-message*`
+    // schema entries — exactly 7 entries, all under `#agent/*`.
     const names = AGENT_VAULT_TAG_SCHEMA.map((e) => e.name);
     expect(names).toEqual([
       "#agent",
@@ -1615,13 +1494,10 @@ describe("VaultTransport — ensureSchema (tag-schema declaration on connect)", 
       "#agent/message/outbound",
       "#agent/job",
       "#agent/thread",
-      "#agent-message",
-      "#agent-message/inbound",
-      "#agent-message/outbound",
-      "#channel-message",
-      "#channel-message/inbound",
-      "#channel-message/outbound",
     ]);
+    // The interim/legacy families are gone entirely.
+    expect(names).not.toContain("#agent-message");
+    expect(names).not.toContain("#channel-message");
     // The namespace children all roll up to the `#agent` root (the human rollup).
     const byName = (n: string) => AGENT_VAULT_TAG_SCHEMA.find((e) => e.name === n)!;
     expect(byName("#agent/definition").parent_names).toEqual(["#agent"]);
@@ -1630,29 +1506,23 @@ describe("VaultTransport — ensureSchema (tag-schema declaration on connect)", 
     expect(byName("#agent/thread").parent_names).toEqual(["#agent"]);
     expect(byName("#agent/message/inbound").parent_names).toEqual(["#agent/message"]);
     expect(byName("#agent/message/outbound").parent_names).toEqual(["#agent/message"]);
-    // The interim + legacy children still declare their own parents (inheritance preserved).
-    expect(byName("#agent-message/inbound").parent_names).toEqual(["#agent-message"]);
-    expect(byName("#agent-message/outbound").parent_names).toEqual(["#agent-message"]);
-    expect(byName("#channel-message/inbound").parent_names).toEqual(["#channel-message"]);
-    expect(byName("#channel-message/outbound").parent_names).toEqual(["#channel-message"]);
     // `#agent/thread` declares INDEXED string fields so threads are operator-queryable —
     // "all failed threads" (status), "all threads of agent X" (definition), "all
     // multi-threaded threads" (mode). The three axes carry over from the run record VERBATIM.
     expect(byName("#agent/thread").fields).toEqual({
-      // Expand phase: the new `agent` routing-key alias is declared indexed (additive).
+      // The canonical `agent` routing-key alias is declared indexed.
       agent: { type: "string", indexed: true },
       status: { type: "string", indexed: true },
       definition: { type: "string", indexed: true },
       mode: { type: "string", indexed: true },
     });
-    // Expand phase: `#agent/message` newly declares the indexed `agent` alias.
+    // `#agent/message` declares the indexed `agent` routing key.
     expect(byName("#agent/message").fields).toEqual({
       agent: { type: "string", indexed: true },
     });
-    // Expand phase: `#agent/job` dual-indexes the routing key — new `agent` + legacy `channel`.
+    // CONTRACT: `#agent/job` indexes the routing key under `agent` ONLY — no `channel`.
     expect(byName("#agent/job").fields).toEqual({
       agent: { type: "string", indexed: true },
-      channel: { type: "string", indexed: true },
       enabled: { type: "string", indexed: true },
       lastStatus: { type: "string", indexed: true },
     });
@@ -1691,7 +1561,7 @@ describe("VaultTransport — ensureSchema (tag-schema declaration on connect)", 
     });
   });
 
-  test("ensureSchema sends the indexed `fields` body for #agent/job (query by agent/channel/enabled/lastStatus)", async () => {
+  test("ensureSchema sends the indexed `fields` body for #agent/job (query by agent/enabled/lastStatus)", async () => {
     let jobBody: { fields?: Record<string, unknown> } | undefined;
     globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
       const name = decodeURIComponent(String(url).split("/api/tags/")[1]!);
@@ -1703,9 +1573,8 @@ describe("VaultTransport — ensureSchema (tag-schema declaration on connect)", 
     await t.ensureSchema();
 
     expect(jobBody?.fields).toEqual({
-      // Expand phase: dual-index the routing key — new `agent` alias + legacy `channel`.
+      // CONTRACT: index the routing key under `agent` ONLY — no `channel`.
       agent: { type: "string", indexed: true },
-      channel: { type: "string", indexed: true },
       enabled: { type: "string", indexed: true },
       lastStatus: { type: "string", indexed: true },
     });
@@ -1882,10 +1751,9 @@ describe("VaultTransport — scheduled-job notes (vault-native store)", () => {
     expect(body.tags).toEqual(["#agent/job"]);
     expect(body.metadata.enabled).toBe("true");
     expect(body.metadata.jobId).toBe("m"); // slug persisted for stable display
-    // EXPAND PHASE dual-write: routing key under BOTH `agent` and legacy `channel`.
-    expect(body.metadata.channel).toBe("eng");
+    // CONTRACT: routing key under `metadata.agent` ONLY — no `channel`.
     expect(body.metadata.agent).toBe("eng");
-    expect(body.metadata.agent).toBe(body.metadata.channel);
+    expect(body.metadata.channel).toBeUndefined();
   });
 
   test("patchJobNote sends a PATCH with only the changed metadata", async () => {

--- a/src/transports/vault.ts
+++ b/src/transports/vault.ts
@@ -10,26 +10,25 @@
  * `2026-06-17-vault-native-agents.md`). The `#agent` prefix is owned entirely by
  * the agent module: every vault object the module manages hangs off it —
  * `#agent/definition` (the agent def), `#agent/message{,/inbound,/outbound}` (a
- * conversation turn), `#agent/job` (a scheduled trigger). Vault-native agents
- * (Phase 4a) moved the flat `#agent-message*` / `#agent-job` tags into this
- * namespace (`#agent/message*` / `#agent/job`).
+ * conversation turn), `#agent/job` (a scheduled trigger). We WRITE and READ only
+ * the `#agent/message*` tags — the channel→agent data-model rename CONTRACT phase
+ * dropped the legacy `#channel-message*` and interim `#agent-message*` dual-read
+ * (no surviving old-tagged data to recognize).
  *
- * TAG RENAME — DUAL-READ (the EARLIER channel→agent rename,
- * `parachute-patterns/migrations/2026-06-17-channel-to-agent.md` rule 2). The
- * message tag first moved `#channel-message*` → `#agent-message*`, and now
- * `#agent-message*` → `#agent/message*`. We WRITE only the NEWEST `#agent/message*`
- * tags going forward, but on READ we recognize BOTH the legacy `#channel-message*`
- * AND the interim `#agent-message*` tags — so all pre-namespace history still loads
- * in the transcript and a still-live legacy trigger (delivering an old-tagged note)
- * still routes. A one-time re-tag run + the legacy trigger's re-registration are
- * Aaron's-hand cutover steps; dual-read keeps everything working until then.
+ * ROUTING KEY (`metadata.agent`). Every note this module writes carries the routing
+ * key under `metadata.agent` ONLY — the CONTRACT phase of the channel→agent rename
+ * dropped the `metadata.channel` dual-write. The vault inbound trigger keys on
+ * `has_metadata:["agent"]`. The `noteAgentKey` helper still READS `agent ?? channel`
+ * as a tolerance fallback so a stray in-flight note written by an older build during
+ * the live cutover still routes — read-only, no longer written.
  *
  * How it differs from telegram / http-ui — the "external party" is the vault:
  *  - Inbound (human → session): a vault trigger POSTs the daemon's
  *    `/api/vault/inbound` webhook when a new `#agent/message/inbound` note
- *    appears; the daemon resolves the channel from `note.metadata.channel` and
- *    calls this transport's `ingestInbound(note)`, which `ctx.emit(...)`s →
- *    routes to the bridge / MCP session subscribed to that channel and wakes it.
+ *    appears; the daemon resolves the channel from `note.metadata.agent` (via
+ *    `noteAgentKey`) and calls this transport's `ingestInbound(note)`, which
+ *    `ctx.emit(...)`s → routes to the bridge / MCP session subscribed to that
+ *    channel and wakes it.
  *  - Outbound (session → human): when the session calls the `reply` tool, the
  *    bridge POSTs `/api/reply {channel,...}`; the daemon dispatches to this
  *    transport's `reply()`, which writes a `#agent/message/outbound` note via
@@ -55,8 +54,7 @@
  * inbound child only — `tags: ["#agent/message/inbound"]` — which an outbound
  * note (parent + `/outbound`) never carries, so a reply can't wake its own session.
  * As belt-and-suspenders, `ingestInbound` also drops any note tagged
- * `#agent/message/outbound` / the interim `#agent-message/outbound` / the legacy
- * `#channel-message/outbound` (or `direction: "outbound"`) — so even a mis-wired
+ * `#agent/message/outbound` (or `direction: "outbound"`) — so even a mis-wired
  * trigger can never wake us on our own reply.
  */
 
@@ -93,8 +91,7 @@ export interface VaultTransportConfig {
 export interface InboundNote {
   id: string;
   content?: string;
-  /** The note's tags — carries `#agent/message/{inbound,outbound}` (or the prior
-   *  `#agent-message/*` / `#channel-message/*` on pre-namespace notes) for loop avoidance. */
+  /** The note's tags — carries `#agent/message/{inbound,outbound}` for loop avoidance. */
   tags?: string[];
   metadata?: Record<string, unknown>;
 }
@@ -140,9 +137,8 @@ export interface JobNote {
 export interface JobNoteMetadata {
   /** The operator-facing slug (so the displayed id survives the vault's note-id assignment). */
   jobId: string;
-  /** The routing key under the NEW `agent` alias (dual-write, same value as `channel`). */
+  /** The routing key — written under `metadata.agent` only (the channel→agent CONTRACT). */
   agent: string;
-  channel: string;
   cron: string;
   tz?: string;
   /** "true" | "false" — the vault stores metadata as strings. */
@@ -257,9 +253,10 @@ const STATUS_META_KEY = "status";
 /** Metadata key carrying the ISO timestamp an inbound was claimed (for the TTL sweep). */
 const CLAIMED_AT_META_KEY = "claimedAt";
 
-/** The agent (routing) key carried on a vault note's metadata. Reads the NEW `agent`
- *  field, falling back to the legacy `channel` field (the expand-phase dual-read), so a
- *  note written by either an agent-speaking or a legacy channel-speaking writer routes. */
+/** The agent (routing) key carried on a vault note's metadata. Reads the canonical
+ *  `agent` field, falling back to the legacy `channel` field as a read-only TOLERANCE
+ *  for any in-flight note written by an older build during the live cutover. New writes
+ *  carry `agent` only (the channel→agent CONTRACT dropped the `channel` dual-write). */
 export function noteAgentKey(meta: Record<string, unknown> | undefined | null): string | undefined {
   const a = meta?.agent;
   if (typeof a === "string" && a) return a;
@@ -346,34 +343,6 @@ function buildThreadSummaryBody(t: {
   );
 }
 
-// ---------------------------------------------------------------------------
-// PRIOR tags (pre-namespace) — DUAL-READ only. We never WRITE these going forward,
-// but we recognize them on READ so pre-namespace history loads + a still-live prior
-// trigger keeps routing. See the file header (dual-read).
-//
-//  - LEGACY  `#channel-message*` — the original channel-era tag (the earliest
-//    rename's prior layer).
-//  - INTERIM `#agent-message*`    — the flat agent tag that preceded the `#agent/*`
-//    namespace (the namespace migration's prior layer).
-// ---------------------------------------------------------------------------
-const LEGACY_MESSAGE_TAG = "#channel-message";
-const LEGACY_MESSAGE_INBOUND_TAG = "#channel-message/inbound";
-const LEGACY_MESSAGE_OUTBOUND_TAG = "#channel-message/outbound";
-const INTERIM_MESSAGE_TAG = "#agent-message";
-const INTERIM_MESSAGE_INBOUND_TAG = "#agent-message/inbound";
-const INTERIM_MESSAGE_OUTBOUND_TAG = "#agent-message/outbound";
-
-/** The message parent tags we recognize on READ (new + interim + legacy) — the
- *  transcript query unions all so pre-namespace history still appears. */
-const READ_MESSAGE_TAGS = [AGENT_MESSAGE_TAG, INTERIM_MESSAGE_TAG, LEGACY_MESSAGE_TAG] as const;
-/** The outbound child tags we recognize on READ (new + interim + legacy) for
- *  direction / loop-avoidance detection. */
-const READ_OUTBOUND_TAGS = [
-  AGENT_MESSAGE_OUTBOUND_TAG,
-  INTERIM_MESSAGE_OUTBOUND_TAG,
-  LEGACY_MESSAGE_OUTBOUND_TAG,
-] as const;
-
 /**
  * The module-owned root namespace tag. Declared (with the three children rolling up
  * to it via `parent_names`) so a human `tag:#agent` query expands to EVERYTHING the
@@ -408,8 +377,9 @@ const JOB_PATH_PREFIX = "Channels";
  * thread, written for BOTH execution-lifecycle modes (the structural unification —
  * "a run was always a thread with one turn"). The note BODY is a rolling SUMMARY of the
  * thread (a future summarizer agent may own/enrich the `## Summary` slot — module-owned
- * in v1); metadata = `{ channel, definition, mode, status, started_at, last_turn_at,
- * turn_count, usage }`. The INDEXED string fields (`status`, `definition`, `mode`) make
+ * in v1); metadata = `{ agent, definition, mode, status, started_at, last_turn_at,
+ * turn_count, usage }` (`agent` is the routing key — the channel→agent CONTRACT).
+ * The INDEXED string fields (`status`, `definition`, `mode`) make
  * "all failed threads" / "all threads of agent X" / "all multi-threaded threads"
  * operator-queryable. `definition` is a plain note-id string for now (interim — typed
  * link fields are a future vault feature).
@@ -445,11 +415,9 @@ const THREAD_PATH_PREFIX = "Threads";
  * `tag:#agent/message` rolls up to both directions — without the module's own
  * exact-leaf queries depending on per-vault schema.
  *
- * DUAL-READ: we ALSO keep declaring the prior `#agent-message*` (interim) and
- * `#channel-message*` (legacy) schema. Their parent/children inheritance must stay
- * declared so a UI querying an old parent still expands to pre-namespace children
- * until the one-time re-tag run completes. New writes use the namespaced tags; the
- * prior entries are read-side scaffolding, retired in a later contract cycle.
+ * The channel→agent rename CONTRACT dropped the prior `#agent-message*` (interim) and
+ * `#channel-message*` (legacy) schema entries — there's no surviving old-tagged data
+ * to keep their inheritance declared for.
  *
  * This matches the vault's "clients bring their own tag schema" principle: the
  * WRITING module provisions its own tag schema at connect-time. It's MODULE-OWNED
@@ -486,9 +454,8 @@ export const AGENT_VAULT_TAG_SCHEMA: ReadonlyArray<{
     name: AGENT_MESSAGE_TAG,
     parent_names: [AGENT_ROOT_TAG],
     description: "A message in a Parachute channel (parent of /inbound + /outbound).",
-    // Expand phase: declare the NEW `agent` routing key indexed so agent-keyed queries
-    // are indexed. The legacy `channel` field was never declared indexed here (transcript
-    // filtering is client-side, index-free); we add only the new alias, additively.
+    // Declare the canonical `agent` routing key indexed so agent-keyed queries are
+    // indexed. (Transcript filtering itself stays client-side / index-free.)
     fields: {
       agent: { type: "string", indexed: true },
     },
@@ -510,17 +477,15 @@ export const AGENT_VAULT_TAG_SCHEMA: ReadonlyArray<{
     // Indexed query axes so an operator/agent can find jobs by target + state (mirrors
     // the #agent/thread axes). All stored as strings (the vault stores metadata as
     // strings; `enabled` is "true"/"false"):
-    //  - channel    → "all jobs targeting agent X"
+    //  - agent      → "all jobs targeting agent X"
     //  - enabled    → "active jobs" (enabled:"true") vs paused ("false")
     //  - lastStatus → "jobs whose last run errored"
     // The full field set is `JobNoteMetadata` in src/jobs.ts (design
     // 2026-06-17-runner-scheduled-agent-turns); the schema is permissive, so the other
     // job fields (jobId/cron/tz/createdAt/lastRunAt) ride as undeclared metadata.
     fields: {
-      // Expand phase: dual-index the routing key — the new `agent` alias alongside the
-      // existing legacy `channel` field (additive; both indexed).
+      // The canonical `agent` routing key, indexed for "all jobs targeting agent X".
       agent: { type: "string", indexed: true },
-      channel: { type: "string", indexed: true },
       enabled: { type: "string", indexed: true },
       lastStatus: { type: "string", indexed: true },
     },
@@ -536,46 +501,12 @@ export const AGENT_VAULT_TAG_SCHEMA: ReadonlyArray<{
     //  - definition → "all threads of agent X" (the def note id)
     //  - mode       → "all multi-threaded threads"
     fields: {
-      // Expand phase: declare the new `agent` routing key indexed (additive — the legacy
-      // `channel` field was never declared indexed here; we add only the new alias).
+      // The canonical `agent` routing key, indexed (mirrors #agent/message + #agent/job).
       agent: { type: "string", indexed: true },
       status: { type: "string", indexed: true },
       definition: { type: "string", indexed: true },
       mode: { type: "string", indexed: true },
     },
-  },
-  // --- Interim (dual-read) — the flat `#agent-message*` tags that preceded the
-  //     `#agent/*` namespace. Declared so pre-namespace history keeps its
-  //     inheritance until the one-time re-tag run lands. Never written going forward. ---
-  {
-    name: INTERIM_MESSAGE_TAG,
-    description: "Interim flat message tag (pre #agent/* namespace); read-only — see #agent/message.",
-  },
-  {
-    name: INTERIM_MESSAGE_INBOUND_TAG,
-    parent_names: [INTERIM_MESSAGE_TAG],
-    description: "Interim inbound message tag (pre-namespace); read-only.",
-  },
-  {
-    name: INTERIM_MESSAGE_OUTBOUND_TAG,
-    parent_names: [INTERIM_MESSAGE_TAG],
-    description: "Interim outbound message tag (pre-namespace); read-only.",
-  },
-  // --- Legacy (dual-read) — declared so pre-rename history keeps its inheritance
-  //     until the one-time re-tag run lands. Never written going forward. ---
-  {
-    name: LEGACY_MESSAGE_TAG,
-    description: "Legacy message tag (pre channel→agent rename); read-only — see #agent/message.",
-  },
-  {
-    name: LEGACY_MESSAGE_INBOUND_TAG,
-    parent_names: [LEGACY_MESSAGE_TAG],
-    description: "Legacy inbound message tag (pre-rename); read-only.",
-  },
-  {
-    name: LEGACY_MESSAGE_OUTBOUND_TAG,
-    parent_names: [LEGACY_MESSAGE_TAG],
-    description: "Legacy outbound message tag (pre-rename); read-only.",
   },
 ];
 
@@ -596,18 +527,19 @@ export const AGENT_VAULT_TAG_SCHEMA: ReadonlyArray<{
  * the hub mints).
  *
  * The predicate matches a NEW inbound note (`#agent/message/inbound`) that
- * carries a `channel` metadata field and hasn't been rendered yet. Loop avoidance
- * is by the inbound CHILD tag: an outbound (reply) note carries
- * `#agent/message/outbound`, never the inbound child, so it never fires this.
- * (The `channel` metadata field + `channel_inbound_rendered_at` marker are the
- * internal routing plumbing — UNCHANGED by the rename; only the TAG moved.)
+ * carries an `agent` metadata field (the routing key, post channel→agent CONTRACT)
+ * and hasn't been rendered yet. Loop avoidance is by the inbound CHILD tag: an
+ * outbound (reply) note carries `#agent/message/outbound`, never the inbound child,
+ * so it never fires this. (The trigger `name` and the `channel_inbound_rendered_at`
+ * marker are internal plumbing — kept STABLE so re-registration updates the existing
+ * trigger in place rather than orphaning one.)
  */
 export const AGENT_VAULT_TRIGGER_TEMPLATE = {
   name: "channel_inbound_<channel>", // hub substitutes the channel name
   events: ["created"],
   when: {
     tags: ["#agent/message/inbound"],
-    has_metadata: ["channel"],
+    has_metadata: ["agent"],
     missing_metadata: ["channel_inbound_rendered_at"],
   },
   action: {
@@ -778,12 +710,10 @@ export class VaultTransport implements Transport {
     const path = `${this.pathPrefix}/${safeChannel}/${id}`;
 
     const metadata: Record<string, string> = {
-      // Dual-write the routing key under BOTH the new `agent` alias and the legacy
-      // `channel` field (same value) — the expand phase. Keeps the existing
-      // `has_metadata:["channel"]` trigger + any channel-speaking reader working
-      // while the data model starts speaking `agent`.
+      // The routing key — written under `metadata.agent` ONLY (the channel→agent
+      // CONTRACT dropped the `channel` dual-write). `noteAgentKey` still reads
+      // `agent ?? channel` as a tolerance fallback for any in-flight straggler.
       agent: channel,
-      channel,
       // `direction` stays as a human/UI convenience field. The loop-avoidance
       // source of truth is now the `#agent/message/outbound` TAG below — the
       // trigger fires on the inbound child tag only, so this note never wakes us.
@@ -813,7 +743,6 @@ export class VaultTransport implements Transport {
         path,
         // Parent (queryable membership) + directional child (trigger discriminator).
         // Both literal — the slash child is NOT queryable under the parent on its own.
-        // We WRITE only the NEW tags; dual-read recognizes legacy on read.
         tags: [AGENT_MESSAGE_TAG, AGENT_MESSAGE_OUTBOUND_TAG],
         metadata,
       }),
@@ -974,9 +903,8 @@ export class VaultTransport implements Transport {
     // Indexed string fields (queryable) + the thread-state observability fields. The
     // vault stores metadata as strings; numbers are stringified.
     const metadata: Record<string, string> = {
-      // Dual-write the routing key (expand phase): new `agent` alias + legacy `channel`.
+      // The routing key — `metadata.agent` ONLY (the channel→agent CONTRACT).
       agent: thread.channel,
-      channel: thread.channel,
       mode: thread.mode,
       status: thread.status,
       started_at: startedAt,
@@ -1147,21 +1075,14 @@ export class VaultTransport implements Transport {
    *
    * The query is the canonical "list a channel's transcript" shape from the
    * tagging model: the parent message tag (carried literally on every note) + a
-   * `metadata.channel == <this channel>` filter. Because the parent is on every
-   * note, this returns BOTH inbound and outbound — the slash children are
+   * routing-key filter (`noteAgentKey(meta) == <this channel>`). Because the parent
+   * is on every note, this returns BOTH inbound and outbound — the slash children are
    * namespace, not query inheritance, so we never key off them here.
-   *
-   * DUAL-READ: we union the NEW `#agent/message` parent, the interim
-   * `#agent-message` parent, and the legacy `#channel-message` parent — three
-   * queries deduped by note id — so pre-namespace history still appears alongside
-   * new messages. We WRITE only the namespaced tag; this read-side union is dropped
-   * in a later contract cycle.
    *
    *   GET <vaultUrl>/vault/<vault>/api/notes
    *       ?tag=%23agent%2Fmessage             (the `#` + `/` MUST be percent-encoded)
    *       &include_content=true               (we need the bodies)
    *       &limit=<n>                          (default 200)
-   *   ... and again with ?tag=%23agent-message + ?tag=%23channel-message, unioned client-side.
    *
    * The vault returns a bare JSON array of note objects ({id, content, tags,
    * metadata, ...}). Direction comes from `metadata.direction`, falling back to
@@ -1223,32 +1144,23 @@ export class VaultTransport implements Transport {
       }
     };
 
-    // DUAL-READ: union the new + legacy parent tags, deduped by note id (a note
-    // re-tagged to carry both must not appear twice).
-    const byId = new Map<string, RawNote>();
-    for (const tag of READ_MESSAGE_TAGS) {
-      for (const note of await fetchByTag(tag)) {
-        if (typeof note.id === "string" && note.id && !byId.has(note.id)) {
-          byId.set(note.id, note);
-        }
-      }
-    }
-    const notes = [...byId.values()];
+    // Query the single `#agent/message` parent tag (the channel→agent CONTRACT
+    // dropped the legacy `#channel-message` / interim `#agent-message` union).
+    const notes = await fetchByTag(AGENT_MESSAGE_TAG);
 
     const messages: ChannelMessage[] = [];
     for (const note of notes) {
       if (typeof note.id !== "string" || !note.id) continue;
       const meta = note.metadata ?? {};
-      // Client-side channel filter (see the index-free note above): keep only
-      // notes whose routing key matches this channel. Dual-read `agent ?? channel`.
+      // Client-side routing-key filter (see the index-free note above): keep only
+      // notes whose routing key matches this channel (`noteAgentKey` reads `agent`).
       if (noteAgentKey(meta) !== channel) continue;
       const tags = note.tags ?? [];
-      // Direction: prefer the explicit metadata field; fall back to the child tag
-      // (new OR legacy outbound — dual-read).
+      // Direction: prefer the explicit metadata field; fall back to the outbound child tag.
       let direction: "inbound" | "outbound";
       if (meta.direction === "inbound" || meta.direction === "outbound") {
         direction = meta.direction;
-      } else if (READ_OUTBOUND_TAGS.some((t) => tags.includes(t))) {
+      } else if (tags.includes(AGENT_MESSAGE_OUTBOUND_TAG)) {
         direction = "outbound";
       } else {
         // Default to inbound (a human message) when neither signal is present —
@@ -1288,7 +1200,7 @@ export class VaultTransport implements Transport {
     /**
      * Extra metadata to STAMP onto the inbound note (e.g. the agent-to-agent callback
      * contract). Merged AFTER the base fields but BEFORE the non-overridable invariants
-     * (`channel`/`direction` always win — an inbound note must route + be inbound). A caller
+     * (`agent`/`direction` always win — an inbound note must route + be inbound). A caller
      * must NEVER pass `reply_to` here for a CALLBACK note (the terminal-callback loop guard);
      * see {@link writeCallback}.
      */
@@ -1303,11 +1215,10 @@ export class VaultTransport implements Transport {
     const metadata: Record<string, string> = {
       // Caller-supplied extra fields first, so the invariants below cannot be clobbered.
       ...(extraMeta ?? {}),
-      // Dual-write the routing key (expand phase): new `agent` alias + legacy `channel`.
-      // BOTH must be present here — this is the inbound path the vault trigger fires on
-      // (`has_metadata:["channel"]`), so dropping `channel` would break the trigger.
+      // The routing key under `metadata.agent` ONLY (the channel→agent CONTRACT
+      // dropped the `channel` dual-write). This is the inbound path the vault trigger
+      // fires on — the trigger keys on `has_metadata:["agent"]` to match it.
       agent: channel,
-      channel,
       direction: "inbound",
       sender: sender ?? "operator",
       ts,
@@ -1324,7 +1235,7 @@ export class VaultTransport implements Transport {
         path,
         // Parent (queryable membership) + inbound child (the trigger discriminator
         // that wakes the session). Both literal — the child alone is invisible to
-        // a `tag:#agent/message` query. We WRITE only the NEW tags.
+        // a `tag:#agent/message` query.
         tags: [AGENT_MESSAGE_TAG, AGENT_MESSAGE_INBOUND_TAG],
         metadata,
       }),
@@ -1485,7 +1396,7 @@ export class VaultTransport implements Transport {
     for (const note of notes) {
       if (typeof note.id !== "string" || !note.id) continue;
       const meta = note.metadata ?? {};
-      if (noteAgentKey(meta) !== channel) continue; // client-side filter (index-free); dual-read agent ?? channel.
+      if (noteAgentKey(meta) !== channel) continue; // client-side filter (index-free); noteAgentKey reads `agent` (channel fallback for stragglers).
       const status = coerceInboundStatus(meta[STATUS_META_KEY]);
       // Drop `handled` notes — they are not queue items (#103). Only pending + in-flight
       // make up the actionable queue; counting/returning handled would let them crowd
@@ -1609,7 +1520,7 @@ export class VaultTransport implements Transport {
     for (const note of notes) {
       if (typeof note.id !== "string" || !note.id) continue;
       const m = note.metadata ?? {};
-      const channel = noteAgentKey(m) ?? ""; // dual-read the routing key: agent ?? channel.
+      const channel = noteAgentKey(m) ?? ""; // routing key via noteAgentKey (`agent`, channel fallback for stragglers).
       const cron = typeof m.cron === "string" ? m.cron : "";
       if (!channel || !cron) continue; // not a well-formed job note; skip.
       // The operator-facing id is the slug in `metadata.jobId`; fall back to the
@@ -1655,9 +1566,8 @@ export class VaultTransport implements Transport {
     const path = `${JOB_PATH_PREFIX}/${safeChannel}/jobs/${safeId}`;
     const metadata: JobNoteMetadata = {
       jobId: job.id, // the operator-facing slug, so it survives the vault's note-id assignment.
-      // Dual-write the routing key (expand phase): new `agent` alias + legacy `channel`.
+      // The routing key under `metadata.agent` ONLY (the channel→agent CONTRACT).
       agent: job.channel,
-      channel: job.channel,
       cron: job.cron,
       enabled: job.enabled ? "true" : "false",
       createdAt: job.createdAt,
@@ -1739,16 +1649,15 @@ export class VaultTransport implements Transport {
    * so the subscribed bridge / MCP session wakes. Called by the daemon's
    * `/api/vault/inbound` webhook after it has resolved the channel.
    *
-   * Belt-and-suspenders over the trigger predicate: a note tagged outbound — the
-   * new `#agent/message/outbound` OR (dual-read) the interim `#agent-message/outbound`
-   * / the legacy `#channel-message/outbound` — OR explicitly `direction: "outbound"`
-   * is IGNORED — we never wake on our own reply, even if a mis-wired trigger delivers one.
+   * Belt-and-suspenders over the trigger predicate: a note tagged outbound
+   * (`#agent/message/outbound`) OR explicitly `direction: "outbound"` is IGNORED —
+   * we never wake on our own reply, even if a mis-wired trigger delivers one.
    */
   ingestInbound(note: InboundNote): void {
     if (!this.ctx) throw new Error("vault transport: not started");
     const meta = note.metadata ?? {};
     const tags = note.tags ?? [];
-    if (READ_OUTBOUND_TAGS.some((t) => tags.includes(t)) || meta.direction === "outbound") {
+    if (tags.includes(AGENT_MESSAGE_OUTBOUND_TAG) || meta.direction === "outbound") {
       return; // our own reply — never wake on it.
     }
     // Flatten the note's metadata into the inbound meta (string-valued), then
@@ -1760,15 +1669,14 @@ export class VaultTransport implements Transport {
     }
     this.ctx.emit({
       // `channel` here is the in-memory InboundMessage.channel TS field (NOT serialized
-      // note metadata) — left as the channel name. The routing key alias rides in `meta`.
+      // note metadata) — left as the channel name. The routing key rides in `meta.agent`.
       channel: this.ctx.channel,
       content: note.content ?? "",
       meta: {
         ...flatMeta,
-        // Dual-write the routing key onto the in-memory event meta (expand phase):
-        // new `agent` alias + legacy `channel`, same value.
+        // The routing key on the in-memory event meta under `agent` ONLY (the
+        // channel→agent CONTRACT dropped the `channel` dual-write).
         agent: this.ctx.channel,
-        channel: this.ctx.channel,
         source: "vault",
         note_id: note.id,
         sender: typeof meta.sender === "string" ? meta.sender : "",


### PR DESCRIPTION
The **CONTRACT phase** of the channel→agent data-model rename. The old data was wiped (uni's notes gone), so this drops all back-compat for the routing-key and message-tag axes.

## ⚠️ Merging this alone has NO live effect

The **live cutover is a SEPARATE, coordinated step**: re-register the running vault trigger to `has_metadata:["agent"]` and restart the daemon. Until that happens, merging this PR changes nothing on a running deployment. This PR is the code change only.

The note **surface must write `metadata.agent`** for inbound notes to route once the cutover lands.

## Drops

**A. The `metadata.channel` dual-WRITE** (`src/transports/vault.ts`) — every note now writes the routing key under `metadata.agent` **ONLY**:
- `reply()` outbound, `writeThread()` `#agent/thread`, `writeInbound()` inbound (the note the trigger fires on), `upsertJobNote()` `#agent/job`, and the `ingestInbound()` `ctx.emit` meta.
- `JobNoteMetadata.channel` field removed; `#agent/job` schema `channel` index field removed.

**B. The legacy `#channel-message*` + interim `#agent-message*` tag dual-READ** — we only ever wrote `#agent/message*`:
- The six `LEGACY_*`/`INTERIM_*` constants + the explanatory block comment.
- `READ_MESSAGE_TAGS` / `READ_OUTBOUND_TAGS` arrays + the transcript dedup-by-id Map → single-tag reads (`#agent/message` parent, `#agent/message/outbound` child).
- The interim + legacy tag-schema blocks (schema is now 7 entries, all `#agent/*`).

## Trigger flip (the keystone)

- `AGENT_VAULT_TRIGGER_TEMPLATE.when.has_metadata`: `["channel"]` → `["agent"]`.
- Trigger **name** (`channel_inbound_<channel>`) and the `channel_inbound_rendered_at` marker kept **STABLE** — so live re-registration UPDATES the existing trigger in place rather than orphaning one.

## Kept (transport/endpoint "channel" concept — untouched)

`channels.json`, the `Channel` type, `byChannel`/`hasChannel`/`channelOf`, the `/mcp/<channel>` URLs + oauth-discovery, `InboundMessage.channel`, the note path prefixes, and **`noteAgentKey`'s `agent ?? channel` READ fallback** (read-only tolerance for any in-flight straggler during the live cutover).

## Tests + docs

- `vault.test.ts`: dual-write assertions → `metadata.agent === <x>` AND `metadata.channel` undefined; deleted the dual-READ tests (legacy/interim query + legacy-history + legacy loop-avoidance); schema test → 7 entries; outbound-direction test → single tag.
- `daemon-config-api.test.ts`: trigger test asserts `has_metadata === ["agent"]` (+ marker name unchanged).
- `jobs.test.ts`: job upsert asserts `metadata.agent`, no `channel`.
- `daemon.test.ts` back-compat-read tests (a note carrying only `agent`, or only legacy `channel`) stay green via the kept `noteAgentKey` fallback.
- Repo `CLAUDE.md` swept: routing key note, trigger YAML, thread/note-shape prose.

## Gates

- `bun run typecheck` — exit 0 (clean).
- `bun test ./src/` — **1038 pass / 0 fail** (3067 expect() calls, 48 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)