### PR TITLE
fix(agent): resume-not-found → fresh-session fallback (session-expiry self-heal) (#132)

### DIFF
--- a/src/backends/programmatic.test.ts
+++ b/src/backends/programmatic.test.ts
@@ -28,6 +28,7 @@ import {
   buildProgrammaticClaudeArgs,
   PROGRAMMATIC_BACKEND_KIND,
   isTransientTurnError,
+  isSessionNotFoundError,
   TURN_MAX_ATTEMPTS,
   TURN_RETRY_BACKOFF_MS,
   type ProgrammaticBackendDeps,
@@ -1235,5 +1236,141 @@ describe("isTransientTurnError", () => {
     ]) {
       expect(isTransientTurnError(s)).toBe(false);
     }
+  });
+});
+
+describe("isSessionNotFoundError", () => {
+  test("resume-of-a-missing-session phrasings → true", () => {
+    for (const s of [
+      "No conversation found with session ID: 3f8c-...",
+      "no conversation found",
+      "Session not found",
+      "claude -p exited 1: Error: No session found for id abc",
+      "Could not find a session with that id",
+      "the conversation with that id was not found",
+    ]) {
+      expect(isSessionNotFoundError(s)).toBe(true);
+    }
+  });
+
+  test("generic / unrelated failures → false (conservative — never a bare 'not found')", () => {
+    for (const s of [
+      "claude -p exited 1: some other error",
+      "rate limit",
+      "",
+      "401 unauthorized",
+      "file not found", // a bare "not found" without conversation/session
+      "tag_scope_violation",
+    ]) {
+      expect(isSessionNotFoundError(s)).toBe(false);
+    }
+  });
+});
+
+// ---- session-expiry → fresh-create fallback (#132) -------------------------
+
+/**
+ * A spawnFn that branches on whether the wrapped argv carries `--resume`:
+ *  - a `--resume` turn returns `onResume` (default: a session-not-found failure),
+ *  - a `--session-id` (create) turn returns `onCreate` (default: success).
+ * Records each call so a test can assert the flag transition resume → fresh create.
+ */
+function flagBranchingSpawn(opts: {
+  onResume?: string;
+  onCreate?: string;
+  resumeCode?: number;
+  createCode?: number;
+}): {
+  fn: ProgrammaticSpawnFn;
+  calls: Array<{ argv: string[]; cmd: string }>;
+} {
+  const calls: Array<{ argv: string[]; cmd: string }> = [];
+  const fn: ProgrammaticSpawnFn = (argv) => {
+    const cmd = argv[2] ?? ""; // the fake engine echoes the claude command in argv[2]
+    calls.push({ argv, cmd });
+    const isResume = cmd.includes("--resume");
+    const out = isResume ? (opts.onResume ?? "") : (opts.onCreate ?? "");
+    const code = isResume ? (opts.resumeCode ?? 0) : (opts.createCode ?? 0);
+    return { stdout: new Response(out).body, stderr: new Response("").body, exited: Promise.resolve(code) };
+  };
+  return { fn, calls };
+}
+
+/** A non-success stream-json result with a session id + an arbitrary error message. */
+function failTurn(sessionId: string, message: string): string {
+  return ndjson(
+    { type: "system", subtype: "init", session_id: sessionId, apiKeySource: "none" },
+    { type: "result", subtype: "error_during_execution", is_error: true, result: message, session_id: sessionId },
+  );
+}
+
+describe("ProgrammaticBackend.deliver — session-expiry → fresh-create fallback (#132)", () => {
+  test("resume → session-not-found → fresh --session-id create succeeds; NEW id returned; two spawns", async () => {
+    mkDirs("fallback-ok");
+    const { fn, calls } = flagBranchingSpawn({
+      // The --resume turn fails with claude's session-not-found error…
+      onResume: failTurn("old-uuid", "No conversation found with session ID: old-uuid"),
+      // …and a fresh --session-id create turn SUCCEEDS (claude echoes the create id).
+      onCreate: successTurn("fresh-created-uuid", "recovered after fresh create"),
+    });
+    const backend = new ProgrammaticBackend(baseDeps(fn));
+    const handle = await backend.start(specWithVault("eng"));
+
+    const result = await backend.deliver(handle, "continue please", resumeSession("old-uuid"));
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.reply).toBe("recovered after fresh create");
+      // The sessionId is the NEW (create) id echoed by claude — NOT the dead "old-uuid".
+      expect(result.sessionId).toBe("fresh-created-uuid");
+      expect(result.sessionId).not.toBe("old-uuid");
+    }
+
+    // TWO spawns: first --resume old-uuid, then --session-id <fresh> (a DIFFERENT uuid).
+    expect(calls).toHaveLength(2);
+    expect(calls[0]!.cmd).toContain("--resume old-uuid");
+    expect(calls[0]!.cmd).not.toContain("--session-id");
+    expect(calls[1]!.cmd).toContain("--session-id");
+    expect(calls[1]!.cmd).not.toContain("--resume");
+    // The fresh create id is a generated uuid — present, and NOT the dead old one.
+    const createIdx = calls[1]!.argv[2]!.indexOf("--session-id ");
+    const freshId = calls[1]!.argv[2]!.slice(createIdx + "--session-id ".length).split(/\s/)[0]!;
+    expect(freshId).not.toBe("old-uuid");
+    expect(freshId.length).toBeGreaterThan(0);
+  });
+
+  test("a resume turn that fails with a NON-not-found (non-transient) error does NOT fall back", async () => {
+    mkDirs("fallback-no");
+    const { fn, calls } = flagBranchingSpawn({
+      // A generic, non-not-found, non-transient failure on the resume turn.
+      onResume: failTurn("old-uuid", "401 unauthorized: invalid token"),
+      onCreate: successTurn("would-not-be-used", "should never run"),
+    });
+    const backend = new ProgrammaticBackend(baseDeps(fn));
+    const handle = await backend.start(specWithVault("eng"));
+
+    const result = await backend.deliver(handle, "continue", resumeSession("old-uuid"));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain("401 unauthorized");
+    // ONE spawn only — no fresh-create fallback for a non-not-found failure.
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.cmd).toContain("--resume old-uuid");
+  });
+
+  test("session-not-found on a CREATE turn does NOT loop (the session.resume guard prevents the fallback)", async () => {
+    mkDirs("fallback-create");
+    // A CREATE turn (resume:false) that itself returns a not-found error. The fallback
+    // is guarded on session.resume, so a create's not-found can never re-trigger it.
+    const { fn, calls } = recordingSpawn({
+      stdout: failTurn("sess-CREATE", "No conversation found with session ID: sess-CREATE"),
+    });
+    const backend = new ProgrammaticBackend(baseDeps(fn));
+    const handle = await backend.start(specWithVault("eng"));
+
+    const result = await backend.deliver(handle, "first turn", createSession("sess-CREATE"));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain("No conversation found");
+    // EXACTLY one spawn — the guard prevented any fallback create.
+    expect(calls).toHaveLength(1);
   });
 });

--- a/src/backends/programmatic.ts
+++ b/src/backends/programmatic.ts
@@ -193,6 +193,28 @@ export function isTransientTurnError(reason: string): boolean {
   );
 }
 
+/**
+ * Does this turn-failure reason look like a `--resume` of a session that no longer
+ * exists — claude's "No conversation found with session ID" class (expiry / transcript
+ * cleanup / a missing session jsonl)? Governs the ONE-TIME fresh-create fallback in
+ * {@link ProgrammaticBackend.deliver} that keeps an expired session from BRICKING the
+ * thread on every future turn (issue #132).
+ *
+ * ⚠️ TEXT-BASED — this matches claude's ERROR WORDING (anthropics/claude-code#33912),
+ * which is VERSION-FRAGILE: if claude changes the phrasing this detector silently stops
+ * matching. It is deliberately CONSERVATIVE — it only governs a RECOVERY fallback, so a
+ * MISS degrades to today's behavior (the pre-existing brick), never anything worse; it
+ * can't, e.g., turn a real failure into a spurious success. A future STRUCTURED error
+ * signal (an exit-code or a stream-json error subtype) would be more robust and is the
+ * preferred long-term fix. Kept tight enough not to match a generic failure: it requires
+ * "conversation"/"session" near the not-found phrasing (never a bare "not found").
+ */
+export function isSessionNotFoundError(reason: string): boolean {
+  return /no conversation found|session not found|no session (?:found |with )|conversation .{0,30}not found|could not find .{0,20}session/i.test(
+    reason,
+  );
+}
+
 /** Default real sleep for the retry backoff (overridable via `deps.sleepFn` in tests). */
 const realSleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -337,6 +359,17 @@ export class ProgrammaticBackend implements AgentBackend {
    * A failure (mint refused, non-zero exit, `is_error: true`, non-success subtype,
    * empty output) returns `{ ok: false, error }` — it does NOT throw, so the daemon
    * always learns the outcome inline.
+   *
+   * SESSION-EXPIRY SELF-HEAL (#132): a `--resume` turn whose Claude session no longer
+   * exists ("No conversation found with session ID" — expiry / transcript cleanup) is
+   * NOT a transient error (no retry helps) and, left alone, would BRICK the thread on
+   * EVERY future turn (the stale id stays on the thread note). When a resume turn fails
+   * with a {@link isSessionNotFoundError} reason, `deliver` falls back ONCE to a fresh
+   * `--session-id <new uuid>` create, re-establishing continuity from this turn forward.
+   * The new turn's echoed session id flows out on the {@link DeliverResult} exactly as
+   * usual, so the registry persists the NEW id onto the thread note and later turns
+   * resume it. The fallback fires AT MOST once (only on a resume turn; the create it
+   * runs has `resume: false`, so it can never re-trigger).
    */
   async deliver(handle: AgentHandle, message: string, session: TurnSession, onInterim?: InterimSink): Promise<DeliverResult> {
     const spec = handle.spec;
@@ -464,36 +497,6 @@ export class ProgrammaticBackend implements AgentBackend {
       writeFileSync(systemPromptFile, spec.systemPrompt, { mode: 0o600 });
     }
 
-    // The DAEMON owns the session uuid (the caller resolved it from the durable
-    // `#agent/thread` note — single-threaded resumes its persisted session, multi-
-    // threaded gets a fresh uuid every fire). The backend reads no session store: it
-    // just runs the turn with the supplied {@link TurnSession} — `--resume <id>` to
-    // continue, `--session-id <id>` to create.
-    const argv = buildProgrammaticClaudeArgs({
-      message,
-      mcpConfigPath,
-      sessionId: session.id,
-      resumeSession: session.resume,
-      ...(this.deps.claudeBin ? { claudeBin: this.deps.claudeBin } : {}),
-      ...(systemPromptFile
-        ? { systemPromptFile, systemPromptMode: spec.systemPromptMode ?? "append" }
-        : {}),
-      ...(spec.model ? { model: spec.model } : {}),
-    });
-
-    // Sandbox-wrap via the SHARED seam — same egress floor + scoped-read
-    // confinement the interactive spawn gets. The wrapped argv carries the policy.
-    const wrapped = await wrapArgvInSandbox({
-      spec,
-      workspace,
-      runtimeReadOnly: this.deps.runtimeReadOnly,
-      hubOrigin: this.deps.hubOrigin,
-      ...(this.deps.vaultUrl ? { vaultUrl: this.deps.vaultUrl } : {}),
-      argv,
-      ...(this.deps.sandboxEngine ? { sandboxEngine: this.deps.sandboxEngine } : {}),
-      ...(this.deps.ripgrep ? { ripgrep: this.deps.ripgrep } : {}),
-    });
-
     // The agent's WORKING dir (design 2026-06-16-agent-filesystem-and-sharing.md):
     // the spec's `workspace` (a shared real dir) when set, else the private session
     // dir (today's behavior). The cwd is decoupled from the private dir —
@@ -523,23 +526,16 @@ export class ProgrammaticBackend implements AgentBackend {
     // Layer the scrubbed agent env UNDER the sandbox wrapper's env; the HOME/config/
     // temp vars layer LAST so they win. CLAUDE_CODE_OAUTH_TOKEN injected;
     // ANTHROPIC_API_KEY/CLAUDE_API_KEY absent (the subscription-billing guarantee).
+    // (Session-INDEPENDENT — computed ONCE; the per-turn `wrapped.env` layers on top
+    // inside `attemptTurn` below.)
     const childEnv = buildAgentChildEnv(
       this.deps.parentEnv ?? process.env,
       claudeOauthToken,
       mergedChannelEnv,
     );
-    const launchEnv: Record<string, string | undefined> = {
-      ...childEnv,
-      ...wrapped.env,
-      ...homeEnv,
-    };
 
-    // Run the turn, with a bounded retry on TRANSIENT upstream errors (API 529/overload,
-    // 5xx, rate-limit, network). The argv is fixed (built above with the turn-start
-    // `--resume` sid), so each attempt re-runs the SAME turn. STREAM stdout incrementally
-    // (interim events for the live view) while draining stderr in parallel; the interim
-    // sink is best-effort + must not throw. A spawn/IO fault is a value (not a throw); a
-    // non-transient failure or exhausted retries returns the failure for the daemon to learn.
+    // The interim sink is best-effort + must not throw (session-INDEPENDENT). A push
+    // to a closed SSE stream / a sink fault must never break the turn.
     const safeInterim: InterimSink = (e) => {
       if (!onInterim) return;
       try {
@@ -549,80 +545,148 @@ export class ProgrammaticBackend implements AgentBackend {
       }
     };
     const sleepFn = this.deps.sleepFn ?? realSleep;
-    for (let attempt = 1; attempt <= TURN_MAX_ATTEMPTS; attempt++) {
-      let parsed;
-      let stderr: string;
-      let code: number;
-      try {
-        const proc = this.deps.spawnFn(wrapped.argv, { env: launchEnv, cwd });
-        [parsed, stderr] = await Promise.all([
-          parseStreamJsonStream(proc.stdout, safeInterim),
-          drainStream(proc.stderr),
-        ]);
-        code = await proc.exited;
-      } catch (err) {
-        // A spawn/IO fault (ENOENT, resource) is a config/permanent class — not retried.
-        return { ok: false, error: `claude -p spawn failed: ${(err as Error).message}` };
-      }
 
-      if (parsed.success === true) {
-        // The captured session id is RETURNED (below) for the caller to persist onto
-        // the thread note — the backend no longer owns a session store. The id we
-        // passed in (session.id) and Claude's echoed parsed.sessionId are normally the
-        // same; the registry prefers the echoed one and falls back to session.id.
+    // Run ONE turn for the given session — build the session-DEPENDENT argv
+    // (`--resume <id>` vs `--session-id <id>`), sandbox-wrap it, then run the bounded
+    // transient-retry loop. Relocated into a closure so a session-expiry FALLBACK can
+    // run it a SECOND time with a fresh create session (#132). The session-independent
+    // setup above (workspace, .mcp.json, system-prompt file, cwd, home/child env,
+    // interim sink) is shared across both attempts.
+    const attemptTurn = async (turnSession: TurnSession): Promise<DeliverResult> => {
+      // The DAEMON owns the session uuid (the caller resolved it from the durable
+      // `#agent/thread` note — single-threaded resumes its persisted session, multi-
+      // threaded gets a fresh uuid every fire). The backend reads no session store: it
+      // just runs the turn with the supplied {@link TurnSession} — `--resume <id>` to
+      // continue, `--session-id <id>` to create.
+      const argv = buildProgrammaticClaudeArgs({
+        message,
+        mcpConfigPath,
+        sessionId: turnSession.id,
+        resumeSession: turnSession.resume,
+        ...(this.deps.claudeBin ? { claudeBin: this.deps.claudeBin } : {}),
+        ...(systemPromptFile
+          ? { systemPromptFile, systemPromptMode: spec.systemPromptMode ?? "append" }
+          : {}),
+        ...(spec.model ? { model: spec.model } : {}),
+      });
 
-        const usage: DeliverUsage | undefined = parsed.usage
-          ? {
-              ...(typeof parsed.usage.input_tokens === "number" ? { inputTokens: parsed.usage.input_tokens } : {}),
-              ...(typeof parsed.usage.output_tokens === "number" ? { outputTokens: parsed.usage.output_tokens } : {}),
-              ...(typeof parsed.totalCostUsd === "number" ? { totalCostUsd: parsed.totalCostUsd } : {}),
-            }
-          : typeof parsed.totalCostUsd === "number"
-            ? { totalCostUsd: parsed.totalCostUsd }
-            : undefined;
+      // Sandbox-wrap via the SHARED seam — same egress floor + scoped-read
+      // confinement the interactive spawn gets. The wrapped argv carries the policy.
+      const wrapped = await wrapArgvInSandbox({
+        spec,
+        workspace,
+        runtimeReadOnly: this.deps.runtimeReadOnly,
+        hubOrigin: this.deps.hubOrigin,
+        ...(this.deps.vaultUrl ? { vaultUrl: this.deps.vaultUrl } : {}),
+        argv,
+        ...(this.deps.sandboxEngine ? { sandboxEngine: this.deps.sandboxEngine } : {}),
+        ...(this.deps.ripgrep ? { ripgrep: this.deps.ripgrep } : {}),
+      });
 
+      const launchEnv: Record<string, string | undefined> = {
+        ...childEnv,
+        ...wrapped.env,
+        ...homeEnv,
+      };
+
+      // Run the turn, with a bounded retry on TRANSIENT upstream errors (API 529/overload,
+      // 5xx, rate-limit, network). The argv is fixed (built above for THIS turn's session),
+      // so each attempt re-runs the SAME turn. STREAM stdout incrementally (interim events
+      // for the live view) while draining stderr in parallel; the interim sink is best-effort
+      // + must not throw. A spawn/IO fault is a value (not a throw); a non-transient failure
+      // or exhausted retries returns the failure for the daemon to learn.
+      for (let attempt = 1; attempt <= TURN_MAX_ATTEMPTS; attempt++) {
+        let parsed;
+        let stderr: string;
+        let code: number;
+        try {
+          const proc = this.deps.spawnFn(wrapped.argv, { env: launchEnv, cwd });
+          [parsed, stderr] = await Promise.all([
+            parseStreamJsonStream(proc.stdout, safeInterim),
+            drainStream(proc.stderr),
+          ]);
+          code = await proc.exited;
+        } catch (err) {
+          // A spawn/IO fault (ENOENT, resource) is a config/permanent class — not retried.
+          return { ok: false, error: `claude -p spawn failed: ${(err as Error).message}` };
+        }
+
+        if (parsed.success === true) {
+          // The captured session id is RETURNED (below) for the caller to persist onto
+          // the thread note — the backend no longer owns a session store. The id we
+          // passed in (turnSession.id) and Claude's echoed parsed.sessionId are normally
+          // the same; the registry prefers the echoed one and falls back to turnSession.id.
+
+          const usage: DeliverUsage | undefined = parsed.usage
+            ? {
+                ...(typeof parsed.usage.input_tokens === "number" ? { inputTokens: parsed.usage.input_tokens } : {}),
+                ...(typeof parsed.usage.output_tokens === "number" ? { outputTokens: parsed.usage.output_tokens } : {}),
+                ...(typeof parsed.totalCostUsd === "number" ? { totalCostUsd: parsed.totalCostUsd } : {}),
+              }
+            : typeof parsed.totalCostUsd === "number"
+              ? { totalCostUsd: parsed.totalCostUsd }
+              : undefined;
+
+          return {
+            ok: true,
+            reply: parsed.reply ?? "",
+            ...(parsed.sessionId ? { sessionId: parsed.sessionId } : {}),
+            ...(usage ? { usage } : {}),
+          };
+        }
+
+        // FAILURE — compute the reason (non-zero exit / is_error / non-success subtype /
+        // no result event), same precedence as before.
+        const reason =
+          parsed.errorMessage ??
+          (parsed.subtype ? `claude -p turn failed (subtype: ${parsed.subtype})` : undefined) ??
+          (code !== 0
+            ? `claude -p exited ${code}${stderr.trim() ? `: ${stderr.trim().slice(0, 500)}` : ""}`
+            : "claude -p produced no success result (no result event in output)");
+
+        // Retry ONLY a transient error, and only while attempts remain (incremental backoff).
+        if (attempt < TURN_MAX_ATTEMPTS && isTransientTurnError(reason)) {
+          const backoff =
+            TURN_RETRY_BACKOFF_MS[attempt - 1] ?? TURN_RETRY_BACKOFF_MS[TURN_RETRY_BACKOFF_MS.length - 1] ?? 5_000;
+          console.warn(
+            `parachute-agent: transient turn error for channel "${channel}" ` +
+              `(attempt ${attempt}/${TURN_MAX_ATTEMPTS}, retrying in ${backoff}ms): ${reason}`,
+          );
+          await sleepFn(backoff);
+          continue;
+        }
+        // RETURN the session id even on a FINAL failure — a turn can fail AFTER
+        // establishing a session; the id is still the continuation handle for the next
+        // turn. The registry persists it onto the thread note (`result.sessionId ??
+        // turnSession.id`), so the next turn resumes the conversation.
+        // Non-transient, or out of attempts → return the failure (the daemon records
+        // status:error AND posts a user-facing failure note to the channel).
         return {
-          ok: true,
-          reply: parsed.reply ?? "",
+          ok: false,
+          error: reason,
           ...(parsed.sessionId ? { sessionId: parsed.sessionId } : {}),
-          ...(usage ? { usage } : {}),
         };
       }
+      // Unreachable — every loop path returns — but satisfies the type checker.
+      return { ok: false, error: "claude -p: retries exhausted" };
+    };
 
-      // FAILURE — compute the reason (non-zero exit / is_error / non-success subtype /
-      // no result event), same precedence as before.
-      const reason =
-        parsed.errorMessage ??
-        (parsed.subtype ? `claude -p turn failed (subtype: ${parsed.subtype})` : undefined) ??
-        (code !== 0
-          ? `claude -p exited ${code}${stderr.trim() ? `: ${stderr.trim().slice(0, 500)}` : ""}`
-          : "claude -p produced no success result (no result event in output)");
-
-      // Retry ONLY a transient error, and only while attempts remain (incremental backoff).
-      if (attempt < TURN_MAX_ATTEMPTS && isTransientTurnError(reason)) {
-        const backoff =
-          TURN_RETRY_BACKOFF_MS[attempt - 1] ?? TURN_RETRY_BACKOFF_MS[TURN_RETRY_BACKOFF_MS.length - 1] ?? 5_000;
-        console.warn(
-          `parachute-agent: transient turn error for channel "${channel}" ` +
-            `(attempt ${attempt}/${TURN_MAX_ATTEMPTS}, retrying in ${backoff}ms): ${reason}`,
-        );
-        await sleepFn(backoff);
-        continue;
-      }
-      // RETURN the session id even on a FINAL failure — a turn can fail AFTER
-      // establishing a session; the id is still the continuation handle for the next
-      // turn. The registry persists it onto the thread note (`result.sessionId ??
-      // turnSession.id`), so the next turn resumes the conversation.
-      // Non-transient, or out of attempts → return the failure (the daemon records
-      // status:error AND posts a user-facing failure note to the channel).
-      return {
-        ok: false,
-        error: reason,
-        ...(parsed.sessionId ? { sessionId: parsed.sessionId } : {}),
-      };
+    let result = await attemptTurn(session);
+    // Session-expiry recovery (#132): a --resume turn whose session no longer exists is
+    // NOT transient (no retry would help) and would otherwise brick the thread on every
+    // future turn (the stale id stays on the note). Fall back ONCE to a fresh create so
+    // continuity self-heals from here — the new turn's echoed id flows out for the
+    // registry to persist. Only on a RESUME turn; the create itself is never retried this
+    // way (the fallback session has resume:false → a not-found on it can't re-trigger).
+    if (!result.ok && session.resume && isSessionNotFoundError(result.error)) {
+      const fresh = crypto.randomUUID();
+      console.warn(
+        `parachute-agent: resume session for channel "${channel}" not found (expired?) — ` +
+          `starting a fresh session ${fresh}: ${result.error}`,
+      );
+      result = await attemptTurn({ id: fresh, resume: false });
     }
-    // Unreachable — every loop path returns — but satisfies the type checker.
-    return { ok: false, error: "claude -p: retries exhausted" };
+    return result;
   }
 
   /**


### PR DESCRIPTION
## The brick scenario

After the thread≡session work (#131), a single-threaded agent's turn 2+ runs `claude -p --resume <uuid>`, where `<uuid>` is the Claude session persisted on its `#agent/thread` note (`metadata.session`). If that session becomes **un-resumable** — most plausibly **expiry / transcript cleanup** (or the session jsonl going missing) — every subsequent turn fails with claude's `"No conversation found with session ID"` error.

That error is **not transient** (not matched by `isTransientTurnError`), so it isn't retried, and the stale session id stays on the thread note. The result: the thread is **bricked** — every future turn re-runs `--resume <dead-uuid>` and fails — until someone manually clears the note's session (or hits the restart endpoint #131 made functional).

This is a pre-existing class (the retired `AgentSessionState` store had the same latent issue); #131 only fixed the *first-turn* brick. This PR is the remaining resume-of-an-expired-session hardening.

## The fix — one-time fresh-create fallback

In `ProgrammaticBackend.deliver()`, when a `--resume` turn fails with a session-not-found-class error, fall back **ONCE** to a fresh `--session-id <new crypto.randomUUID()>` create, re-establishing the conversation from that turn forward. The new turn's echoed session id flows out on the `DeliverResult` exactly as today, so the registry persists the **NEW** id onto the thread note (it already persists `result.sessionId`) and future turns resume the new session. No brick.

The fallback fires **at most once**: it's guarded on `session.resume`, and the create it runs has `resume: false`, so a not-found on the create can never re-trigger it (no infinite loop).

Mechanically, `deliver()`'s session-dependent turn-run (argv build → `wrapArgvInSandbox` → the transient-retry loop) is extracted into a local `attemptTurn(turnSession)` closure so it can run a second time with the fresh create session. The session-INDEPENDENT setup (workspace, `.mcp.json`, system-prompt file, cwd, env, interim sink) is computed once and shared across both attempts — the normal success/transient/failure paths are behaviorally unchanged.

## Detection — text-based, with a fragility caveat

The new exported `isSessionNotFoundError(reason)` detector matches claude's error **wording** (canonical: `"No conversation found with session ID"`, anthropics/claude-code#33912). This is **version-fragile**: if claude changes the phrasing, the detector silently stops matching and the brick returns.

It is deliberately **conservative** — it only governs a recovery fallback, so a miss degrades to **today's behavior** (the pre-existing brick), never anything worse; it can't turn a real failure into a spurious success. The regex is kept tight enough not to match a generic failure (requires "conversation"/"session" near the not-found phrasing — never a bare "not found"). A future **structured** error signal (exit code / a stream-json error subtype) would be more robust and is the preferred long-term fix.

## Strictly better than today

Either the detector matches (the thread self-heals to a fresh session instead of bricking) or it doesn't (identical to current behavior). There is no path where this PR makes an outcome worse.

## Tests

`src/backends/programmatic.test.ts` (using the existing fake-`spawnFn` harness):
- **Fallback happy path** — a resume turn that returns session-not-found, then a `--session-id` create that succeeds: asserts `ok`, the returned `sessionId` is the NEW create id (not the dead `old-uuid`), and TWO spawns with the `--resume old-uuid` → `--session-id <fresh>` flag transition (fresh id ≠ old id).
- **Non-not-found resume failure does NOT fall back** — a generic non-transient resume failure → `{ ok: false }`, ONE spawn.
- **Not-found on a CREATE turn does NOT loop** — the `session.resume` guard → ONE spawn.
- **`isSessionNotFoundError` unit tests** — true for the not-found phrasings, false for generic failures / empty / bare "not found".

All existing programmatic tests stay green.

### Gates
- `bun run typecheck` → clean (`tsc --noEmit`)
- `bun test ./src/` → **1043 pass, 0 fail**

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)