### PR TITLE
feat(agent): enrich turn-events SSE with tool inputs + result previews (expandable watch-it-work)

### DIFF
--- a/src/backends/stream-json.test.ts
+++ b/src/backends/stream-json.test.ts
@@ -12,7 +12,13 @@
  *  - blank/garbage input → an empty parse, never a throw.
  */
 import { describe, test, expect } from "bun:test";
-import { parseStreamJson, parseStreamJsonStream, type InterimTurnEvent } from "./stream-json.ts";
+import {
+  parseStreamJson,
+  parseStreamJsonStream,
+  MAX_TOOL_INPUT_CHARS,
+  MAX_TOOL_RESULT_CHARS,
+  type InterimTurnEvent,
+} from "./stream-json.ts";
 
 /** Join NDJSON event objects into the line-delimited blob claude emits. */
 function ndjson(...events: unknown[]): string {
@@ -204,7 +210,8 @@ describe("parseStreamJsonStream — interim events + final turn", () => {
     expect(events).toEqual([
       { kind: "init", sessionId: "sess-1" },
       { kind: "text", text: "let me check" },
-      { kind: "tool", tool: "Read" },
+      // empty input `{}` still stringifies to "{}" and rides as the input field
+      { kind: "tool", tool: "Read", input: "{}" },
       { kind: "text", text: " — done." },
     ]);
     // The FINAL turn is exactly what the blob parser would compute — durable path intact.
@@ -306,5 +313,203 @@ describe("parseStreamJsonStream — interim events + final turn", () => {
     expect(turn.success).toBe(false);
     expect(turn.errorMessage).toBe("kaboom");
     expect(turn.sessionId).toBe("err-1");
+  });
+});
+
+describe("parseStreamJsonStream — enriched tool events (inputs + result previews)", () => {
+  test("a tool_use carries its input JSON-stringified on the tool event", async () => {
+    const blob = ndjson(
+      { type: "system", subtype: "init", session_id: "tin-1" },
+      {
+        type: "assistant",
+        message: {
+          content: [{ type: "tool_use", id: "tu_1", name: "Read", input: { file_path: "/etc/hosts" } }],
+        },
+        session_id: "tin-1",
+      },
+      { type: "result", subtype: "success", is_error: false, result: "done", session_id: "tin-1" },
+    );
+    const { events } = await collectInterim(blob);
+    expect(events).toEqual([
+      { kind: "init", sessionId: "tin-1" },
+      { kind: "tool", tool: "Read", input: JSON.stringify({ file_path: "/etc/hosts" }) },
+    ]);
+  });
+
+  test("an OVERSIZE tool input is truncated with the … marker", async () => {
+    const bigCmd = "x".repeat(MAX_TOOL_INPUT_CHARS + 500);
+    const blob = ndjson(
+      { type: "system", subtype: "init", session_id: "tin-big" },
+      {
+        type: "assistant",
+        message: { content: [{ type: "tool_use", id: "tu_b", name: "Bash", input: { command: bigCmd } }] },
+        session_id: "tin-big",
+      },
+      { type: "result", subtype: "success", is_error: false, result: "done", session_id: "tin-big" },
+    );
+    const { events } = await collectInterim(blob);
+    const toolEvent = events.find((e) => e.kind === "tool");
+    expect(toolEvent).toBeDefined();
+    const input = (toolEvent as { input?: string }).input!;
+    // exactly MAX chars + the 1-char marker, and it ends with the marker
+    expect(input.length).toBe(MAX_TOOL_INPUT_CHARS + 1);
+    expect(input.endsWith("…")).toBe(true);
+  });
+
+  test("a tool_use with NO input omits the input field (back-compat shape)", async () => {
+    const blob = ndjson(
+      { type: "system", subtype: "init", session_id: "tin-none" },
+      {
+        type: "assistant",
+        message: { content: [{ type: "tool_use", id: "tu_n", name: "Glob" }] },
+        session_id: "tin-none",
+      },
+      { type: "result", subtype: "success", is_error: false, result: "done", session_id: "tin-none" },
+    );
+    const { events } = await collectInterim(blob);
+    expect(events).toEqual([
+      { kind: "init", sessionId: "tin-none" },
+      { kind: "tool", tool: "Glob" },
+    ]);
+  });
+
+  test("a tool_result → {kind:'tool_result', tool, ok, preview} labeled via the tool_use_id map", async () => {
+    const blob = ndjson(
+      { type: "system", subtype: "init", session_id: "tr-1" },
+      {
+        type: "assistant",
+        message: { content: [{ type: "tool_use", id: "tu_42", name: "Read", input: { file_path: "/a" } }] },
+        session_id: "tr-1",
+      },
+      {
+        type: "user",
+        message: {
+          content: [{ type: "tool_result", tool_use_id: "tu_42", is_error: false, content: "file contents here" }],
+        },
+        session_id: "tr-1",
+      },
+      { type: "result", subtype: "success", is_error: false, result: "done", session_id: "tr-1" },
+    );
+    const { events } = await collectInterim(blob);
+    expect(events).toContainEqual({
+      kind: "tool_result",
+      tool: "Read", // labeled via the tool_use_id → name map
+      ok: true,
+      preview: "file contents here",
+    });
+  });
+
+  test("a tool_result with array content parts joins the text parts into the preview", async () => {
+    const blob = ndjson(
+      { type: "system", subtype: "init", session_id: "tr-arr" },
+      {
+        type: "assistant",
+        message: { content: [{ type: "tool_use", id: "tu_arr", name: "Bash", input: { command: "ls" } }] },
+        session_id: "tr-arr",
+      },
+      {
+        type: "user",
+        message: {
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "tu_arr",
+              is_error: false,
+              content: [
+                { type: "text", text: "line1\n" },
+                { type: "text", text: "line2" },
+              ],
+            },
+          ],
+        },
+        session_id: "tr-arr",
+      },
+      { type: "result", subtype: "success", is_error: false, result: "done", session_id: "tr-arr" },
+    );
+    const { events } = await collectInterim(blob);
+    expect(events).toContainEqual({ kind: "tool_result", tool: "Bash", ok: true, preview: "line1\nline2" });
+  });
+
+  test("an OVERSIZE tool_result preview is truncated with the … marker", async () => {
+    const bigOut = "y".repeat(MAX_TOOL_RESULT_CHARS + 500);
+    const blob = ndjson(
+      { type: "system", subtype: "init", session_id: "tr-big" },
+      {
+        type: "assistant",
+        message: { content: [{ type: "tool_use", id: "tu_big", name: "Bash", input: {} }] },
+        session_id: "tr-big",
+      },
+      {
+        type: "user",
+        message: { content: [{ type: "tool_result", tool_use_id: "tu_big", is_error: false, content: bigOut }] },
+        session_id: "tr-big",
+      },
+      { type: "result", subtype: "success", is_error: false, result: "done", session_id: "tr-big" },
+    );
+    const { events } = await collectInterim(blob);
+    const resultEvent = events.find((e) => e.kind === "tool_result");
+    expect(resultEvent).toBeDefined();
+    const preview = (resultEvent as { preview?: string }).preview!;
+    expect(preview.length).toBe(MAX_TOOL_RESULT_CHARS + 1);
+    expect(preview.endsWith("…")).toBe(true);
+  });
+
+  test("is_error:true → ok:false", async () => {
+    const blob = ndjson(
+      { type: "system", subtype: "init", session_id: "tr-err" },
+      {
+        type: "assistant",
+        message: { content: [{ type: "tool_use", id: "tu_e", name: "Bash", input: { command: "false" } }] },
+        session_id: "tr-err",
+      },
+      {
+        type: "user",
+        message: {
+          content: [{ type: "tool_result", tool_use_id: "tu_e", is_error: true, content: "command failed" }],
+        },
+        session_id: "tr-err",
+      },
+      { type: "result", subtype: "success", is_error: false, result: "done", session_id: "tr-err" },
+    );
+    const { events } = await collectInterim(blob);
+    expect(events).toContainEqual({ kind: "tool_result", tool: "Bash", ok: false, preview: "command failed" });
+  });
+
+  test("a tool_result whose tool_use_id is unknown still emits, just without the tool label", async () => {
+    const blob = ndjson(
+      { type: "system", subtype: "init", session_id: "tr-orphan" },
+      {
+        type: "user",
+        message: {
+          content: [{ type: "tool_result", tool_use_id: "tu_unknown", is_error: false, content: "orphan result" }],
+        },
+        session_id: "tr-orphan",
+      },
+      { type: "result", subtype: "success", is_error: false, result: "done", session_id: "tr-orphan" },
+    );
+    const { events } = await collectInterim(blob);
+    // no `tool` key (unknown id), but ok + preview present
+    expect(events).toContainEqual({ kind: "tool_result", ok: true, preview: "orphan result" });
+  });
+
+  test("the blob parser (no sink) ignores tool inputs + results entirely — final turn unchanged", () => {
+    const blob = ndjson(
+      { type: "system", subtype: "init", session_id: "blob-tr" },
+      {
+        type: "assistant",
+        message: { content: [{ type: "tool_use", id: "tu_x", name: "Read", input: { file_path: "/x" } }] },
+        session_id: "blob-tr",
+      },
+      {
+        type: "user",
+        message: { content: [{ type: "tool_result", tool_use_id: "tu_x", is_error: false, content: "stuff" }] },
+        session_id: "blob-tr",
+      },
+      { type: "result", subtype: "success", is_error: false, result: "final", session_id: "blob-tr" },
+    );
+    const t = parseStreamJson(blob);
+    expect(t.reply).toBe("final");
+    expect(t.success).toBe(true);
+    expect(t.sessionId).toBe("blob-tr");
   });
 });

--- a/src/backends/stream-json.test.ts
+++ b/src/backends/stream-json.test.ts
@@ -356,6 +356,61 @@ describe("parseStreamJsonStream — enriched tool events (inputs + result previe
     expect(input.endsWith("…")).toBe(true);
   });
 
+  test("an input at EXACTLY the cap is NOT truncated (no marker)", async () => {
+    // A JSON string whose serialized form is exactly MAX_TOOL_INPUT_CHARS chars: the
+    // `> max` (strictly-greater) guard must leave it untouched, no `…`.
+    const padTo = MAX_TOOL_INPUT_CHARS - JSON.stringify({ command: "" }).length;
+    const exactCmd = "z".repeat(padTo);
+    const inputObj = { command: exactCmd };
+    const expected = JSON.stringify(inputObj);
+    expect(expected.length).toBe(MAX_TOOL_INPUT_CHARS); // sanity: we built it right
+    const blob = ndjson(
+      { type: "system", subtype: "init", session_id: "tin-exact" },
+      {
+        type: "assistant",
+        message: { content: [{ type: "tool_use", id: "tu_x", name: "Bash", input: inputObj }] },
+        session_id: "tin-exact",
+      },
+      { type: "result", subtype: "success", is_error: false, result: "done", session_id: "tin-exact" },
+    );
+    const { events } = await collectInterim(blob);
+    expect(events).toContainEqual({ kind: "tool", tool: "Bash", input: expected });
+    expect((events.find((e) => e.kind === "tool") as { input?: string }).input!.endsWith("…")).toBe(false);
+  });
+
+  test("the id→name map accumulates MULTIPLE tool_use ids before their results arrive", async () => {
+    // Two tool_use blocks fire, THEN two tool_results — each result must be labeled
+    // with the right tool via the per-parse id→name map (no cross-talk, map survives).
+    const blob = ndjson(
+      { type: "system", subtype: "init", session_id: "multi" },
+      {
+        type: "assistant",
+        message: {
+          content: [
+            { type: "tool_use", id: "tu_a", name: "Read", input: { file_path: "/a" } },
+            { type: "tool_use", id: "tu_b", name: "Bash", input: { command: "ls" } },
+          ],
+        },
+        session_id: "multi",
+      },
+      {
+        type: "user",
+        message: {
+          content: [
+            { type: "tool_result", tool_use_id: "tu_b", is_error: false, content: "bash out" },
+            { type: "tool_result", tool_use_id: "tu_a", is_error: false, content: "read out" },
+          ],
+        },
+        session_id: "multi",
+      },
+      { type: "result", subtype: "success", is_error: false, result: "done", session_id: "multi" },
+    );
+    const { events } = await collectInterim(blob);
+    // tu_b → Bash, tu_a → Read (results arrived in reverse order; labels still correct)
+    expect(events).toContainEqual({ kind: "tool_result", tool: "Bash", ok: true, preview: "bash out" });
+    expect(events).toContainEqual({ kind: "tool_result", tool: "Read", ok: true, preview: "read out" });
+  });
+
   test("a tool_use with NO input omits the input field (back-compat shape)", async () => {
     const blob = ndjson(
       { type: "system", subtype: "init", session_id: "tin-none" },

--- a/src/backends/stream-json.ts
+++ b/src/backends/stream-json.ts
@@ -70,23 +70,52 @@ export interface ParsedTurn {
 }
 
 /**
+ * Hard caps on the live-view payload fields. SSE frames must stay SMALL — a tool's
+ * `input` (a Bash command, a long Write body) or a `tool_result` (a file read, a
+ * grep dump) can be arbitrarily large, so both are bounded here. Truncation appends
+ * the {@link TRUNCATION_MARKER} so the consumer can show "…".
+ *
+ * Operator-visibility note: the turn-events SSE this feeds is `agent:read`-gated —
+ * operator-only, owner-operated. Tool inputs/results are INTENTIONALLY visible to the
+ * operator (it's their own agent doing their own work), so there is no redaction here
+ * beyond size-bounding; the only concern is keeping each frame small.
+ */
+export const MAX_TOOL_INPUT_CHARS = 2000;
+export const MAX_TOOL_RESULT_CHARS = 2000;
+const TRUNCATION_MARKER = "…";
+
+/** Truncate `s` to at most `max` chars, appending the marker when it was cut. */
+function truncate(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max) + TRUNCATION_MARKER : s;
+}
+
+/**
  * An interim progress event surfaced WHILE a turn runs (the streaming view). The
- * three kinds:
- *  - `text`   — a chunk of the agent's assistant message (each assistant event's
- *               text block; chunk-level, NOT token-level — design §1's "chunk-level
- *               is fine"). The chat UI appends these into the live in-progress bubble.
- *  - `tool`   — the agent invoked a tool; `tool` is its name (e.g. "Read", "Bash",
- *               an MCP tool). The chat UI shows a "using <tool>" indicator.
- *  - `init`   — the turn established a session; carries the `sessionId`. Lets the UI
- *               start a fresh live bubble (and a consumer correlate by session id).
+ * kinds:
+ *  - `text`        — a chunk of the agent's assistant message (each assistant event's
+ *                    text block; chunk-level, NOT token-level — design §1's "chunk-level
+ *                    is fine"). The chat UI appends these into the live in-progress bubble.
+ *  - `tool`        — the agent invoked a tool; `tool` is its name (e.g. "Read", "Bash",
+ *                    an MCP tool). `input` (optional) is the tool_use block's `input`
+ *                    object JSON-stringified + bounded to {@link MAX_TOOL_INPUT_CHARS},
+ *                    so the UI can render an EXPANDABLE "Read {file}" / "Bash <cmd>" view.
+ *  - `tool_result` — a tool finished; `preview` (optional) is a bounded snippet of its
+ *                    output ({@link MAX_TOOL_RESULT_CHARS}), `ok` the success flag
+ *                    (`is_error: false` → `ok: true`), and `tool` (optional) the name
+ *                    of the tool it came from (correlated via the tool_use_id map).
+ *  - `init`        — the turn established a session; carries the `sessionId`. Lets the UI
+ *                    start a fresh live bubble (and a consumer correlate by session id).
  *
  * Deliberately small + serializable so it maps 1:1 onto an SSE frame the chat (and,
- * later, my-vault-ui) subscribes to.
+ * later, my-vault-ui) subscribes to. The `input` / `preview` fields are ADDITIVE +
+ * optional: an existing consumer that only reads `kind`/`tool`/`text` keeps working,
+ * and one that doesn't know `tool_result` simply ignores the new kind.
  */
 export type InterimTurnEvent =
   | { kind: "init"; sessionId: string }
   | { kind: "text"; text: string }
-  | { kind: "tool"; tool: string };
+  | { kind: "tool"; tool: string; input?: string }
+  | { kind: "tool_result"; tool?: string; ok?: boolean; preview?: string };
 
 interface SystemInitEvent {
   type: "system";
@@ -110,11 +139,53 @@ interface AssistantContentBlock {
   text?: string;
   /** Present on a `{ type: "tool_use" }` block — the invoked tool's name. */
   name?: string;
+  /** Present on a `{ type: "tool_use" }` block — the tool's input arguments. */
+  input?: unknown;
+  /** Present on a `{ type: "tool_use" }` block — correlates with a later tool_result. */
+  id?: string;
 }
 interface AssistantEvent {
   type: "assistant";
   message?: { content?: AssistantContentBlock[] };
   session_id?: string;
+}
+/**
+ * One content block of a USER-role message — claude emits `tool_result` blocks here,
+ * one per completed `tool_use`. `content` is the result payload (a string, or an array
+ * of `{ type: "text", text }` parts), `tool_use_id` links it back to its tool_use, and
+ * `is_error` is the success flag.
+ */
+interface UserContentBlock {
+  type?: string;
+  tool_use_id?: string;
+  is_error?: boolean;
+  /** The result payload — a plain string, or content parts (`{ type, text }`). */
+  content?: unknown;
+}
+interface UserEvent {
+  type: "user";
+  message?: { content?: UserContentBlock[] };
+  session_id?: string;
+}
+
+/**
+ * Flatten a `tool_result` block's `content` into a plain preview string. claude
+ * emits it either as a bare string or as an array of content parts
+ * (`[{ type: "text", text: "…" }, …]`); join the text parts. Returns undefined when
+ * there's nothing renderable.
+ */
+function previewToolResultContent(content: unknown): string | undefined {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    const parts: string[] = [];
+    for (const part of content) {
+      if (part && typeof part === "object" && typeof (part as { text?: unknown }).text === "string") {
+        parts.push((part as { text: string }).text);
+      }
+    }
+    return parts.length > 0 ? parts.join("") : undefined;
+  }
+  return undefined;
 }
 interface AnyEvent {
   type?: string;
@@ -125,12 +196,23 @@ interface AnyEvent {
 /**
  * Fold ONE already-trimmed, non-empty NDJSON line into the running {@link ParsedTurn}
  * and, when an `onInterim` sink is given, emit the interim events the line carries
- * (assistant text chunks, tool_use names, the session-establishing init). Shared by
- * the blob parser and the streaming parser so both have identical final-result
- * semantics. Never throws: a non-`{` line or a JSON-parse failure (a truncated
- * partial line, hook plain text, any noise) is silently ignored.
+ * (assistant text chunks, tool_use names + inputs, tool_result previews, the
+ * session-establishing init). Shared by the blob parser and the streaming parser so
+ * both have identical final-result semantics. Never throws: a non-`{` line or a
+ * JSON-parse failure (a truncated partial line, hook plain text, any noise) is
+ * silently ignored.
+ *
+ * `toolNames` (when given) is a per-PARSE `tool_use_id → name` map: a `tool_use`
+ * block records its id→name so a later `tool_result` (which carries only the
+ * `tool_use_id`) can be labeled with the tool it came from. The caller owns it (one
+ * per parse) so it persists across lines.
  */
-function foldLine(line: string, turn: ParsedTurn, onInterim?: (e: InterimTurnEvent) => void): void {
+function foldLine(
+  line: string,
+  turn: ParsedTurn,
+  onInterim?: (e: InterimTurnEvent) => void,
+  toolNames?: Map<string, string>,
+): void {
   // Fast reject: NDJSON events are objects. A non-`{` line (hook plain text, a
   // partial line that got cut mid-token) can't be one — skip without a try/catch.
   if (line[0] !== "{") return;
@@ -170,8 +252,45 @@ function foldLine(line: string, turn: ParsedTurn, onInterim?: (e: InterimTurnEve
         if (block.type === "text" && typeof block.text === "string" && block.text.length > 0) {
           onInterim({ kind: "text", text: block.text });
         } else if (block.type === "tool_use" && typeof block.name === "string" && block.name.length > 0) {
-          onInterim({ kind: "tool", tool: block.name });
+          // Record id→name so a later tool_result (which only carries the id) can be
+          // labeled with this tool. Best-effort: a result without a recorded id just
+          // omits the `tool` label.
+          if (toolNames && typeof block.id === "string" && block.id) toolNames.set(block.id, block.name);
+          // Stringify + HARD-bound the input so the UI can render an expandable view
+          // (e.g. the Read path, the Bash command). Omit when there's no input or it
+          // can't be stringified (a circular/exotic value — never throw the parse).
+          let input: string | undefined;
+          if (block.input !== undefined) {
+            try {
+              const json = JSON.stringify(block.input);
+              if (typeof json === "string") input = truncate(json, MAX_TOOL_INPUT_CHARS);
+            } catch {
+              // unstringifiable input — drop the field, keep the tool event
+            }
+          }
+          onInterim(input !== undefined ? { kind: "tool", tool: block.name, input } : { kind: "tool", tool: block.name });
         }
+      }
+    }
+    return;
+  }
+
+  // USER events carry the tool_result blocks (claude reports each completed tool's
+  // output as a tool_result on a user-role message). Emit a bounded `tool_result`
+  // interim event per block, labeled with the originating tool via the id→name map.
+  // Sink-gated like the assistant path (a no-op for the blob parser).
+  if (obj.type === "user" && onInterim) {
+    const blocks = (obj as UserEvent).message?.content;
+    if (Array.isArray(blocks)) {
+      for (const block of blocks) {
+        if (block.type !== "tool_result") continue;
+        const event: { kind: "tool_result"; tool?: string; ok?: boolean; preview?: string } = { kind: "tool_result" };
+        const name = toolNames && typeof block.tool_use_id === "string" ? toolNames.get(block.tool_use_id) : undefined;
+        if (name !== undefined) event.tool = name;
+        if (typeof block.is_error === "boolean") event.ok = block.is_error === false;
+        const preview = previewToolResultContent(block.content);
+        if (preview !== undefined) event.preview = truncate(preview, MAX_TOOL_RESULT_CHARS);
+        onInterim(event);
       }
     }
     return;
@@ -204,10 +323,11 @@ function foldLine(line: string, turn: ParsedTurn, onInterim?: (e: InterimTurnEve
  */
 export function parseStreamJson(stdout: string): ParsedTurn {
   const turn: ParsedTurn = {};
+  const toolNames = new Map<string, string>();
   for (const rawLine of stdout.split("\n")) {
     const line = rawLine.trim();
     if (!line) continue;
-    foldLine(line, turn);
+    foldLine(line, turn, undefined, toolNames);
   }
   return turn;
 }
@@ -241,6 +361,8 @@ export async function parseStreamJsonStream(
 
   const reader = stream.getReader();
   const decoder = new TextDecoder();
+  // Per-parse tool_use_id → name map, so a tool_result can be labeled with its tool.
+  const toolNames = new Map<string, string>();
   let buf = "";
   try {
     for (;;) {
@@ -253,14 +375,14 @@ export async function parseStreamJsonStream(
       while ((nl = buf.indexOf("\n")) !== -1) {
         const line = buf.slice(0, nl).trim();
         buf = buf.slice(nl + 1);
-        if (line) foldLine(line, turn, onInterim);
+        if (line) foldLine(line, turn, onInterim, toolNames);
       }
     }
     // Flush any multi-byte tail the decoder is holding, then fold the final
     // unterminated line (a result line the pipe closed without a trailing \n).
     buf += decoder.decode();
     const tail = buf.trim();
-    if (tail) foldLine(tail, turn, onInterim);
+    if (tail) foldLine(tail, turn, onInterim, toolNames);
   } finally {
     reader.releaseLock();
   }

--- a/src/backends/stream-json.ts
+++ b/src/backends/stream-json.ts
@@ -323,11 +323,13 @@ function foldLine(
  */
 export function parseStreamJson(stdout: string): ParsedTurn {
   const turn: ParsedTurn = {};
-  const toolNames = new Map<string, string>();
+  // No sink + no toolNames map: foldLine's interim branches (which build/consult the
+  // map) are all gated on `onInterim`, so the blob path needs neither — final-result
+  // semantics are identical with or without them.
   for (const rawLine of stdout.split("\n")) {
     const line = rawLine.trim();
     if (!line) continue;
-    foldLine(line, turn, undefined, toolNames);
+    foldLine(line, turn);
   }
   return turn;
 }


### PR DESCRIPTION
## What

Enriches the daemon's live turn-events SSE (the "watch it work" stream) so a consumer can render an **expandable** view of what the agent is doing — tool calls WITH their inputs + a bounded result preview, alongside the streaming partial text. This enriches the **source** only; the surface render is separate.

Before, the interim events were minimal: a `tool` event carried the tool NAME only.

## The enrichment (`src/backends/stream-json.ts`)

`InterimTurnEvent` extended:

- **`tool` gains `input?`** — the `tool_use` block's `input` object `JSON.stringify`'d and **truncated to `MAX_TOOL_INPUT_CHARS = 2000`** (appends `…` when cut). Renders "Read {file_path}", "Bash <command>", etc.
- **new `tool_result` event** `{ tool?, ok?, preview? }` — parsed from the `tool_result` blocks that appear on the **USER-role** messages of the stream-json. `preview` truncated to `MAX_TOOL_RESULT_CHARS = 2000`; `ok` derived from the block's `is_error` (`false` → `ok: true`); `tool` labeled by mapping `tool_use_id → name` via a small per-parse `Map` (a `tool_use` records its id→name so the later result can be labeled with the tool it came from).
- `init` / `text` unchanged.

`foldLine` now takes an optional per-parse `toolNames` map (owned by each parser, so it persists across lines). The `tool_result` content is flattened from either a bare string or an array of `{ type, text }` content parts.

## Additive + backward-compatible

- `input` is **optional** — a consumer reading only `kind`/`tool`/`text` keeps working; a `tool_use` with no input emits the exact prior `{ kind: "tool", tool }` shape.
- `tool_result` is a **new kind** — a consumer that doesn't know it simply ignores it.
- The **blob parser** (`parseStreamJson`, no sink) is unaffected: the final `ParsedTurn` is byte-for-byte identical (interim emission is sink-gated).

## Sizes bounded HARD

Both `input` and `preview` are capped at 2000 chars so SSE frames stay small. The turn-events SSE is **`agent:read`-gated (operator-only, owner-operated)**, so tool inputs/results are **intentionally visible to the operator** (their own agent, their own work) — there is **no redaction beyond size-bounding**.

## Sink / SSE — no structural change

`buildTurnEventSink` + the `GET /api/channels/<ch>/turn-events` route already JSON-serialize the event generically (`routeToChannel`), and `TurnLifecycleEvent` is a union that **includes** `InterimTurnEvent` — so the richer event flows through untouched and serializes cleanly. Confirmed; no daemon edit needed.

## Tests (`src/backends/stream-json.test.ts`)

Added: tool input present + oversize-truncated + omitted-when-absent; tool_result labeled via the id→name map (string content + array content parts); oversize preview truncated; `is_error:true → ok:false`; orphan (unknown id) result still emits without a tool label; blob-parser ignores the new data. Updated the one prior assertion whose `tool_use` had `input: {}` (now rides as `input: "{}"`). All existing stream-json tests stay green.

## Gates

- `bun run typecheck` — clean
- `bun test ./src/` — **1052 pass / 0 fail** (stream-json file: 26 pass / 0 fail)

No version bump (governance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)