### PR TITLE
feat(agent-ui): add + OAuth-connect a remote MCP server per agent (connections panel)

### DIFF
--- a/src/agent-defs.test.ts
+++ b/src/agent-defs.test.ts
@@ -860,6 +860,79 @@ describe("AgentDefRegistry — lifecycle", () => {
     expect(await reg.getFullDef("Agents/ghost")).toBeNull();
   });
 
+  test("listDetailed/getFullDef surface per-connection {key,status,grantId} from the hub grants", async () => {
+    const { deps } = recorderDeps();
+    // The hub grants client's fetch: PUT /admin/grants echoes a grant record with the
+    // hub-assigned id + current status (the id we surface — never derived client-side);
+    // POST .../reconcile is the grant-GC (no-op here). One mcp connection, one vault.
+    const grantFetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const u = String(url);
+      const method = init?.method ?? "GET";
+      if (method === "PUT" && u.endsWith("/admin/grants")) {
+        const { connection } = JSON.parse(String(init?.body)) as { connection: ConnectionSpec };
+        const key = connectionKey(connection);
+        // The mcp connection is awaiting consent; the vault one is approved.
+        const status = connection.kind === "mcp" ? "needs_consent" : "approved";
+        return new Response(
+          JSON.stringify({ id: `grant_${key}`, agent: "uni-dev", connection, status }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      if (method === "POST" && u.endsWith("/admin/grants/reconcile")) {
+        return new Response(JSON.stringify({ pruned: 0 }), { status: 200 });
+      }
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+    const grants = new GrantsClient({
+      hubOrigin: "http://127.0.0.1:1939",
+      managerBearer: "host-admin",
+      fetchFn: grantFetch,
+    });
+    const note = {
+      id: "Agents/uni-dev",
+      content: "role",
+      metadata: { name: "uni-dev", wants: "mcp:https://remote/mcp, vault:research:read" },
+    };
+    const fetchFn = vaultFetch({ defs: [note], byId: { "Agents/uni-dev": note } });
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn, grants });
+    await reg.loadAll();
+
+    const detail = reg.listDetailed().find((d) => d.name === "uni-dev")!;
+    const byKey = new Map(detail.connections.map((c) => [c.key, c]));
+    const mcp = byKey.get("mcp:https://remote/mcp")!;
+    expect(mcp).toMatchObject({
+      kind: "mcp",
+      target: "https://remote/mcp",
+      status: "needs_consent",
+      grantId: "grant_mcp:https://remote/mcp",
+    });
+    const vault = byKey.get("vault:research:read")!;
+    expect(vault).toMatchObject({ kind: "vault", status: "approved", grantId: "grant_vault:research:read" });
+    // The FULL def carries the same connections (so the edit view needs no second fetch).
+    const full = await reg.getFullDef("Agents/uni-dev");
+    expect(full!.connections.map((c) => c.key).sort()).toEqual(
+      ["mcp:https://remote/mcp", "vault:research:read"],
+    );
+  });
+
+  test("without a grants client, connections are surfaced display-only (status pending, no grant id)", async () => {
+    const { deps } = recorderDeps();
+    const note = {
+      id: "Agents/uni-dev",
+      content: "role",
+      metadata: { name: "uni-dev", wants: "mcp:https://remote/mcp" },
+    };
+    const fetchFn = vaultFetch({ defs: [note], byId: { "Agents/uni-dev": note } });
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn }); // no grants
+    await reg.loadAll();
+    const detail = reg.listDetailed().find((d) => d.name === "uni-dev")!;
+    expect(detail.connections).toEqual([
+      { key: "mcp:https://remote/mcp", kind: "mcp", target: "https://remote/mcp", status: "pending" },
+    ]);
+    // No grant id → the panel can't offer Connect (shows the degraded hint instead).
+    expect(detail.connections[0]!.grantId).toBeUndefined();
+  });
+
   test("soleVaultName resolves the single binding (the reload-webhook default)", () => {
     const { deps } = recorderDeps();
     const reg = new AgentDefRegistry(deps, { bindings: [binding] });

--- a/src/agent-defs.ts
+++ b/src/agent-defs.ts
@@ -90,6 +90,30 @@ export interface DefVaultBinding {
 export type AgentDefStatus = "enabled" | "pending" | "error";
 
 /**
+ * Per-connection grant info surfaced to the ops UI (the MCP/connections panel) so it
+ * can render a status pill + drive the cookie→hub "Connect" without re-deriving the
+ * hub's grant id client-side (that divergence class already bit this codebase — the
+ * id MUST come from the hub). One entry per declared `wants:` connection.
+ *
+ *   - `key`     — the stable {@link connectionKey} (matches a `wants` entry).
+ *   - `kind`    — `vault` | `service` | `mcp` (the panel only acts on `mcp` today).
+ *   - `target`  — the connection target (for `mcp`, the remote https URL).
+ *   - `status`  — the hub grant's lifecycle as the hub reports it
+ *     (`pending` | `approved` | `revoked` | `needs_consent`), or `pending` when no
+ *     grant could be resolved (no grants client / a registration error).
+ *   - `grantId` — the hub-assigned grant id (the Connect/approve key). Absent when no
+ *     grant was registered/resolved (then the UI can't offer Connect — it shows a
+ *     degraded hint instead).
+ */
+export interface ConnectionInfo {
+  key: string;
+  kind: "vault" | "service" | "mcp";
+  target: string;
+  status: string;
+  grantId?: string;
+}
+
+/**
  * The parse of one `#agent/definition` note: the canonical {@link AgentSpec} the
  * registry instantiates, plus the note bookkeeping (its id for PATCH, the declared
  * connections to surface, and any parse error).
@@ -727,6 +751,12 @@ interface LiveDef {
   pending: string[];
   /** Structured `wants:` connection keys (surfaced for the UI; never a secret). */
   wants: string[];
+  /**
+   * Per-connection grant info (key, kind, target, hub grant status, grant id) — the
+   * source the connections/MCP panel renders + drives Connect from. One entry per
+   * declared `wants:` connection. Never a secret (status + id only, no token).
+   */
+  connections: ConnectionInfo[];
   /** The model the programmatic backend runs turns on (from `metadata.model`); unset = CC default. */
   model?: string;
 }
@@ -755,6 +785,13 @@ export interface AgentDefDetail {
   systemPromptPreview: string;
   /** Structured `wants:` connection keys the agent declared (empty when own-vault only). */
   wants: string[];
+  /**
+   * Per-connection grant info (key, kind, target, hub grant status, grant id) — the
+   * connections/MCP panel renders status pills + drives the cookie→hub Connect from
+   * this. Additive (a back-compat field; older clients ignore it). One entry per
+   * declared `wants:` connection. NO secrets (status + id, never a token).
+   */
+  connections: ConnectionInfo[];
   /** The model the programmatic backend runs turns on (e.g. `opus`); undefined = CC default. */
   model?: string;
   /** The wake channel inbound routes to this agent on (== name). */
@@ -785,6 +822,12 @@ export interface AgentDefFull {
   mode: AgentMode;
   /** Structured `wants:` connection keys the agent declared (empty when own-vault only). */
   wants: string[];
+  /**
+   * Per-connection grant info (key, kind, target, hub grant status, grant id) — same
+   * additive field {@link AgentDefDetail} carries, so the edit view's connections panel
+   * can render status + drive Connect without a second fetch. NO secrets.
+   */
+  connections: ConnectionInfo[];
   /** The model the programmatic backend runs turns on (e.g. `opus`); undefined = CC default. */
   model?: string;
   /** The FULL system prompt — the whole note body (NOT truncated). */
@@ -919,6 +962,7 @@ export class AgentDefRegistry {
         pending: [...d.pending],
         systemPromptPreview: d.systemPromptPreview,
         wants: [...d.wants],
+        connections: d.connections.map((c) => ({ ...c })),
         ...(d.model ? { model: d.model } : {}),
         channel: d.name, // agent ≡ channel.
       }))
@@ -983,6 +1027,7 @@ export class AgentDefRegistry {
       pending: [...d.pending],
       systemPromptPreview: d.systemPromptPreview,
       wants: [...d.wants],
+      connections: d.connections.map((c) => ({ ...c })),
       ...(d.model ? { model: d.model } : {}),
       channel: d.name,
     };
@@ -1038,6 +1083,7 @@ export class AgentDefRegistry {
       vault: detail.vault,
       mode: detail.mode,
       wants: [...detail.wants],
+      connections: detail.connections.map((c) => ({ ...c })),
       ...(detail.model ? { model: detail.model } : {}),
       systemPrompt: typeof note.content === "string" ? note.content : "",
       status: detail.status,
@@ -1468,7 +1514,7 @@ export class AgentDefRegistry {
     // Otherwise fall back to the pure {@link resolveDefStatus} (pending if anything is
     // declared, enabled if nothing is). Either way the agent ALREADY ran its own-vault
     // setup above — an unapproved connection is absent at spawn, never a failure here.
-    const { status, pending } = await this.resolveStatusWithGrants(def);
+    const { status, pending, connections } = await this.resolveStatusWithGrants(def);
     const fullPrompt = def.spec.systemPrompt ?? "";
     const systemPromptPreview =
       fullPrompt.length > SYSTEM_PROMPT_PREVIEW_LEN
@@ -1484,6 +1530,7 @@ export class AgentDefRegistry {
       systemPromptPreview,
       pending: pending ?? [],
       wants: def.wants.map((c) => connectionKey(c)),
+      connections,
       ...(def.spec.model ? { model: def.spec.model } : {}),
     });
     // Track this note in the per-vault seen set (a confident, freshly-parsed read) so the
@@ -1559,33 +1606,67 @@ export class AgentDefRegistry {
    */
   private async resolveStatusWithGrants(
     def: ParsedAgentDef,
-  ): Promise<{ status: AgentDefStatus; pending?: string[] }> {
+  ): Promise<{ status: AgentDefStatus; pending?: string[]; connections: ConnectionInfo[] }> {
     if (!this.grants || def.wants.length === 0) {
-      // No hub wiring / no structured connections → the pure fallback.
-      return resolveDefStatus(def);
+      // No hub wiring / no structured connections → the pure fallback. The connections
+      // list is still surfaced (status `pending`, NO grant id) so the ops panel can
+      // list the agent's declared `mcp:` connections + show the degraded hint when
+      // there's nothing to Connect against (no grant could be resolved here).
+      const fallback = resolveDefStatus(def);
+      const connections: ConnectionInfo[] = def.wants.map((c) => ({
+        key: connectionKey(c),
+        kind: c.kind,
+        target: c.target,
+        status: "pending",
+      }));
+      return { ...fallback, connections };
     }
     const grants = this.grants;
     const statusByKey = new Map<string, string>();
+    // Per-connection grant info (id + status) for the ops panel — keyed by connectionKey
+    // so it lines up with the def's wants. The grant id comes FROM the hub (registerGrant
+    // is an idempotent upsert that echoes the existing grant's id + current status); we
+    // never derive it client-side (the hub's id-slug impl must not be duplicated).
+    const infoByKey = new Map<string, ConnectionInfo>();
     for (const conn of def.wants) {
+      const key = connectionKey(conn);
       try {
         const rec = await grants.registerGrant(def.name, conn);
-        statusByKey.set(connectionKey(conn), rec.status);
+        statusByKey.set(key, rec.status);
+        infoByKey.set(key, {
+          key,
+          kind: conn.kind,
+          target: conn.target,
+          status: rec.status,
+          ...(rec.id ? { grantId: rec.id } : {}),
+        });
       } catch (err) {
         // A failed registration → the connection counts as unapproved (absent from
         // statusByKey). Never fatal — the agent runs own-vault; the operator retries.
+        // Surface it with status `pending` + no grant id (the panel shows it un-Connectable).
+        infoByKey.set(key, { key, kind: conn.kind, target: conn.target, status: "pending" });
         console.warn(
-          `agent-defs: registering grant for "${def.name}" (${connectionKey(conn)}) failed ` +
+          `agent-defs: registering grant for "${def.name}" (${key}) failed ` +
             `(treating as pending): ${(err as Error).message}`,
         );
       }
     }
+    const connections = def.wants.map(
+      (c) =>
+        infoByKey.get(connectionKey(c)) ?? {
+          key: connectionKey(c),
+          kind: c.kind,
+          target: c.target,
+          status: "pending",
+        },
+    );
     const resolved = resolveConnectionStatus(def.wants, statusByKey);
     // Surface legacy `uses:` names alongside the structured pending keys (no grant flow).
     const pending = [...(resolved.pending ?? []), ...def.declaredConnections];
     if (resolved.status === "enabled" && pending.length === 0) {
-      return { status: "enabled" };
+      return { status: "enabled", connections };
     }
-    return { status: "pending", pending };
+    return { status: "pending", pending, connections };
   }
 
   /** Tear down the agent for a given (vault, noteId): deregister + drop its channel. */

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -184,6 +184,23 @@ export interface AgentsResponse {
 export type AgentDefStatus = "enabled" | "pending" | "error" | string;
 
 /**
+ * One declared connection's grant info — mirrors `ConnectionInfo` in
+ * `src/agent-defs.ts`. The connections/MCP panel renders a status pill from `status`
+ * and drives the cookie→hub "Connect" with `grantId` (which comes FROM the hub — the
+ * SPA never derives it). `status` is the hub grant lifecycle: `pending` | `approved` |
+ * `revoked` | `needs_consent` (or `pending` when no grant could be resolved). `grantId`
+ * is absent when no grant was registered (then Connect is unavailable — a degraded hint
+ * shows instead). NO secrets (status + id, never a token).
+ */
+export interface ConnectionInfoRow {
+  key: string;
+  kind: "vault" | "service" | "mcp";
+  target: string;
+  status: "pending" | "approved" | "revoked" | "needs_consent" | string;
+  grantId?: string;
+}
+
+/**
  * One entry from `GET /agent/api/agent-defs` — a vault-native
  * `#agent/definition` record. Mirrors `AgentDefDetail` in `src/agent-defs.ts`.
  */
@@ -202,6 +219,13 @@ export interface AgentDefRow {
   systemPromptPreview: string;
   /** Structured `wants:` connection keys (empty when own-vault only). */
   wants: string[];
+  /**
+   * Per-connection grant info (key, kind, target, hub grant status, grant id). The
+   * connections/MCP panel renders status pills + drives Connect from this. OPTIONAL —
+   * an older daemon (pre-this-field) omits it; the UI falls back to deriving display-only
+   * rows from `wants`/`pending` (no Connect, since the grant id is hub-owned). NO secrets.
+   */
+  connections?: ConnectionInfoRow[];
   /** The model the programmatic backend runs turns on (e.g. `opus`); absent = CC default. */
   model?: string;
   /** The wake channel inbound routes to this agent on (== name). */
@@ -303,6 +327,9 @@ export interface AgentDefFull {
   mode: AgentMode;
   /** Structured `wants:` connection keys (empty when own-vault only). */
   wants: string[];
+  /** Per-connection grant info (key, kind, target, hub grant status, grant id). OPTIONAL
+   *  — older daemons omit it. NO secrets. */
+  connections?: ConnectionInfoRow[];
   /** The model the programmatic backend runs turns on (e.g. `opus`); absent = CC default. */
   model?: string;
   /** The FULL system prompt — the whole note body (NOT truncated). */

--- a/web/ui/src/lib/hub.test.ts
+++ b/web/ui/src/lib/hub.test.ts
@@ -8,9 +8,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   type ConnectionRow,
+  approveAgentGrant,
   defReloadStatus,
   ensureDefReloadConnections,
   HubError,
+  isDaemonDirectOrigin,
   listConnections,
   teardownDefReloadConnections,
 } from "./hub.ts";
@@ -229,6 +231,93 @@ describe("teardownDefReloadConnections", () => {
       name: "HubError",
       status: 403,
     });
+  });
+});
+
+describe("approveAgentGrant", () => {
+  it("OAuth start (no token): POSTs an empty body, credentials:include, returns authorizeUrl", async () => {
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) =>
+      jsonResponse(200, {
+        id: "grant_abc",
+        agent: "uni-dev",
+        connection: { kind: "mcp", target: "https://remote/mcp" },
+        status: "pending",
+        authorizeUrl: "https://remote/oauth/authorize?x=1",
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const listing = await approveAgentGrant("grant_abc");
+    expect(listing.authorizeUrl).toBe("https://remote/oauth/authorize?x=1");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://hub.example/admin/grants/grant_abc/approve",
+      expect.objectContaining({ method: "POST", credentials: "include" }),
+    );
+    // No token → empty JSON body.
+    const init = fetchMock.mock.calls[0]![1] as RequestInit;
+    expect(JSON.parse(init.body as string)).toEqual({});
+  });
+
+  it("static bearer (with token): sends { token } and returns the approved listing (no redirect)", async () => {
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) =>
+      jsonResponse(200, {
+        id: "grant_abc",
+        agent: "uni-dev",
+        connection: { kind: "mcp", target: "https://remote/mcp" },
+        status: "approved",
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const listing = await approveAgentGrant("grant_abc", "static-bearer-tok");
+    expect(listing.status).toBe("approved");
+    expect(listing.authorizeUrl).toBeUndefined();
+    const init = fetchMock.mock.calls[0]![1] as RequestInit;
+    expect(JSON.parse(init.body as string)).toEqual({ token: "static-bearer-tok" });
+  });
+
+  it("URL-encodes the grant id and maps a 404 to the hub-proxied-URL hint (daemon-direct)", async () => {
+    const fetchMock = vi.fn(async () => new Response("", { status: 404 }));
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(approveAgentGrant("grant/with slash")).rejects.toThrow(/hub-proxied URL/);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://hub.example/admin/grants/grant%2Fwith%20slash/approve",
+      expect.anything(),
+    );
+  });
+
+  it("throws a HubError with the status on a 401", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("", { status: 401 })),
+    );
+    await expect(approveAgentGrant("grant_abc")).rejects.toMatchObject({
+      name: "HubError",
+      status: 401,
+    });
+  });
+});
+
+describe("isDaemonDirectOrigin", () => {
+  it("true on the agent daemon's loopback origin (cookie can't flow there)", () => {
+    vi.stubGlobal("window", {
+      location: { origin: "http://127.0.0.1:1941", hostname: "127.0.0.1", port: "1941" },
+    } as unknown as Window & typeof globalThis);
+    expect(isDaemonDirectOrigin()).toBe(true);
+  });
+
+  it("false on the hub-proxied origin (the cookie→hub Connect works)", () => {
+    vi.stubGlobal("window", {
+      location: { origin: "https://hub.example", hostname: "hub.example", port: "" },
+    } as unknown as Window & typeof globalThis);
+    expect(isDaemonDirectOrigin()).toBe(false);
+  });
+
+  it("false on a loopback HUB port (a local operator on the hub itself)", () => {
+    vi.stubGlobal("window", {
+      location: { origin: "http://127.0.0.1:1939", hostname: "127.0.0.1", port: "1939" },
+    } as unknown as Window & typeof globalThis);
+    expect(isDaemonDirectOrigin()).toBe(false);
   });
 });
 

--- a/web/ui/src/lib/hub.ts
+++ b/web/ui/src/lib/hub.ts
@@ -48,6 +48,32 @@ function hubOrigin(): string {
 }
 
 /**
+ * Whether the SPA is being served DAEMON-DIRECT (the agent daemon's own loopback
+ * origin, e.g. `http://127.0.0.1:1941/agent/app/`) rather than through the hub proxy
+ * (`<hub-origin>/agent/app/`). The cookie→hub "Connect" only works at the hub origin —
+ * served daemon-direct, the hub root paths (`/admin/grants/...`) resolve to the AGENT
+ * daemon, which doesn't serve them (→ 404), AND the operator cookie + CSRF Origin
+ * belt wouldn't accept the daemon's origin anyway. We surface a clear inline note
+ * up front instead of letting the operator hit a confusing error on Connect.
+ *
+ * Heuristic: the daemon binds loopback on the agent port (1941 default; the
+ * PARACHUTE_AGENT_PORT override is for non-standard installs). An exposed hub is
+ * NEVER served from `127.0.0.1`/`localhost` to a remote operator; a local operator
+ * on the hub's own loopback hits the HUB port (1939), not the agent's. So a loopback
+ * host on the agent port is the daemon-direct tell. Conservative: a false "looks
+ * daemon-direct" only HIDES the Connect button (the 60s-equivalent correctness is the
+ * grant still being registered); the authoritative signal remains the approve response
+ * (a 404 maps to the same hub-proxied-URL hint). Returns false in non-browser (SSR).
+ */
+export function isDaemonDirectOrigin(): boolean {
+  if (typeof window === "undefined") return false;
+  const { hostname, port } = window.location;
+  const loopback = hostname === "127.0.0.1" || hostname === "localhost" || hostname === "[::1]";
+  // The agent daemon's own port (the SPA is daemon-served only on the daemon's port).
+  return loopback && port === "1941";
+}
+
+/**
  * One connection as `GET /admin/connections` projects it (the fields we read;
  * the wire shape carries more). `source`/`sink` mirror the store records.
  */
@@ -195,6 +221,73 @@ export async function ensureDefReloadConnections(
     throw new HubError(firstStatus, hubErrorMessage(firstStatus, firstDetail || "provisioning failed"));
   }
   return { ok: failures.length === 0, failures };
+}
+
+// ===========================================================================
+// Agent-connector GRANTS — the cookie→hub "Connect" for an MCP server (4b-2).
+//
+// Adding the MCP server is a DAEMON op (PATCH the def's `wants:` to append
+// `mcp:<url>`; the daemon registers the pending grant via its host-admin bearer).
+// APPROVING it (the OAuth dance / static-bearer store) is OPERATOR-COOKIE-gated on
+// the hub — a host-admin Bearer CANNOT approve (isFirstAdmin only). So the browser
+// must call the hub's approve endpoint DIRECTLY with the operator cookie. This works
+// same-origin because the SPA is served at the hub origin (`<hub>/agent/app/`).
+//
+// We MIRROR the hub's proven client impl (parachute-hub web/ui Grants.tsx
+// `onConnectMcp`/`onApprove` + src/admin-agent-grants.ts `approveGrant`):
+//   POST <origin>/admin/grants/<id>/approve   (credentials: "include")
+//     - body `{}`         (no token) → OAuth: response carries `authorizeUrl`;
+//                          the caller full-page-redirects the browser there.
+//     - body `{ token }`  (static bearer) → store + approve immediately, no redirect.
+//   A `needs_consent` grant re-offers the SAME path (the "Reconnect" affordance).
+//
+// Degradation: served daemon-direct (`http://127.0.0.1:1941/agent/app/`,
+// cross-origin to the hub) the cookie won't flow and the CSRF belt rejects it — the
+// approve 404s (no such route on the daemon) / 401s. The 404 maps to the existing
+// "use the hub-proxied URL" hint, so the panel shows a clear message, not a confusing
+// raw error. The brief's `isHubOrigin()` helper gates the affordance up front.
+// ===========================================================================
+
+/**
+ * A grant in the hub's list/echo wire shape (NEVER carries the secret material).
+ * Mirrors `GrantListing` in parachute-hub web/ui/src/lib/api.ts. `authorizeUrl` is
+ * present ONLY on an `approveAgentGrant` OAuth start (no pasted token).
+ */
+export interface GrantListing {
+  id: string;
+  agent: string;
+  connection: { kind: "vault" | "service" | "mcp"; target: string };
+  status: "pending" | "approved" | "revoked" | "needs_consent";
+  reason?: string;
+  approvedAt?: string;
+  /** The remote-issuer consent URL — present only when starting an mcp OAuth flow. */
+  authorizeUrl?: string;
+}
+
+/**
+ * Approve (or start the OAuth flow for) an agent connector grant — the cookie→hub
+ * "Connect" / "Reconnect". `POST <origin>/admin/grants/<id>/approve` with the
+ * operator cookie (`credentials: "include"`); same-origin only (the hub's CSRF belt).
+ *
+ *   - NO `token` → START OAuth: the returned listing carries `authorizeUrl`; the
+ *     caller full-page-redirects the browser to the remote consent screen. The hub's
+ *     callback finishes server-side and flips the grant `approved`.
+ *   - WITH `token` → store a static bearer (non-OAuth MCP) + approve immediately.
+ *
+ * Throws `HubError` on a non-2xx — a 404 maps to the hub-proxied-URL hint (the
+ * daemon-direct degradation), 401 to a sign-in hint. The grant `id` MUST come from
+ * the daemon's def-API (`connections[].grantId`) — never derived client-side.
+ */
+export async function approveAgentGrant(id: string, token?: string): Promise<GrantListing> {
+  const res = await hubFetch(`/admin/grants/${encodeURIComponent(id)}/approve`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(token !== undefined ? { token } : {}),
+  });
+  if (!res.ok) {
+    throw new HubError(res.status, hubErrorMessage(res.status, await errorDetail(res)));
+  }
+  return (await res.json()) as GrantListing;
 }
 
 /**

--- a/web/ui/src/routes/Agents.tsx
+++ b/web/ui/src/routes/Agents.tsx
@@ -1126,6 +1126,7 @@ export function AddMcpForm({
 
       <fieldset className="field">
         <legend>Authentication</legend>
+        <p className="muted">You'll enter credentials in the next step &mdash; on the connection's row after it's added.</p>
         <RadioRow
           name="mcp-auth"
           value="oauth"

--- a/web/ui/src/routes/Agents.tsx
+++ b/web/ui/src/routes/Agents.tsx
@@ -33,6 +33,7 @@ import {
   type AgentMode,
   type AgentRow,
   type AgentVaultRow,
+  type ConnectionInfoRow,
   type JobRow,
   addAgentVault,
   createJob,
@@ -56,8 +57,11 @@ import {
 } from "../lib/api.ts";
 import {
   type ConnectionRow,
+  approveAgentGrant,
   defReloadStatus,
   ensureDefReloadConnections,
+  HubError,
+  isDaemonDirectOrigin,
   listConnections,
   teardownDefReloadConnections,
 } from "../lib/hub.ts";
@@ -395,6 +399,10 @@ export function AgentDetail({
                 ))}
               </div>
             </>
+          ) : null}
+
+          {noteId ? (
+            <ConnectionsSection noteId={noteId} def={def} onChanged={onChanged} />
           ) : null}
         </>
       ) : (
@@ -736,6 +744,428 @@ export function DeleteAgentConfirm({
       </div>
     </div>
   );
+}
+
+// ---------------------------------------------------------------------------
+// Connections / MCP servers (this PR). Add a remote MCP server to THIS agent +
+// authenticate it via OAuth (or a pasted static bearer) — in one place, without
+// bouncing to the hub admin grants page.
+//
+//   - LIST the agent's `mcp:` connections (from `def.connections`, falling back to
+//     deriving display-only rows from `wants`/`pending` for an older daemon) with a
+//     live status pill (Connected / Pending / Needs reconnect).
+//   - ADD: a URL + an auth choice (OAuth default | paste a static bearer). On submit
+//     we PATCH the def's `wants:` to APPEND `mcp:<url>` (preserving the existing
+//     wants), so the DAEMON re-parses + registers the pending grant (its reconcile-GC
+//     prunes any grant not in the live `wants:`, so we must go through the def, NOT
+//     PUT a grant directly).
+//   - CONNECT / RECONNECT: the cookie→hub approve (`approveAgentGrant`) — OAuth
+//     redirect (no token) or static-bearer store (with token). This needs the hub
+//     grant `id` (`connection.grantId`, from the daemon — never derived here).
+//
+// Degradation: the cookie→hub Connect only works at the hub origin. Served
+// daemon-direct (`http://127.0.0.1:1941/agent/app/`) the cookie won't flow + the
+// CSRF belt rejects it, so we detect that (`isDaemonDirectOrigin`) and show a clear
+// inline note instead of a confusing error. Adding the MCP (the def PATCH) still
+// works daemon-direct; only the Connect step needs the hub origin.
+// ---------------------------------------------------------------------------
+
+/** A status pill for a grant lifecycle, mapped to the shared pill classes + a label. */
+function GrantStatusPill({ status }: { status: string }) {
+  if (status === "approved") {
+    return <span className="pill status-enabled" data-testid="conn-status-approved">Connected</span>;
+  }
+  if (status === "needs_consent") {
+    return (
+      <span className="pill status-error" data-testid="conn-status-needs_consent">
+        Needs reconnect
+      </span>
+    );
+  }
+  if (status === "revoked") {
+    return <span className="pill status-error" data-testid="conn-status-revoked">Revoked</span>;
+  }
+  // pending (or any unknown) → awaiting approval.
+  return <span className="pill status-pending" data-testid="conn-status-pending">Pending</span>;
+}
+
+/**
+ * Derive the MCP connection rows to render. Prefer the daemon's `def.connections`
+ * (carries the hub grant id + live status — drives Connect); for an OLDER daemon that
+ * omits the field, fall back to display-only rows derived from `wants` (those whose key
+ * starts `mcp:`), with status inferred from `pending` (in `pending` → pending, else
+ * approved) and NO grant id (so Connect is unavailable — a hint shows instead).
+ */
+export function mcpConnectionRows(def: AgentDefRow): ConnectionInfoRow[] {
+  if (def.connections && def.connections.length > 0) {
+    return def.connections.filter((c) => c.kind === "mcp");
+  }
+  // Fallback: an older daemon. `wants` keys for an mcp connection are `mcp:<url>`.
+  const pending = new Set(def.pending);
+  return def.wants
+    .filter((w) => w.startsWith("mcp:") && /^mcp:https?:\/\//i.test(w))
+    .map((w) => ({
+      key: w,
+      kind: "mcp" as const,
+      target: w.slice("mcp:".length),
+      status: pending.has(w) ? "pending" : "approved",
+    }));
+}
+
+/**
+ * The per-agent Connections / MCP-servers section. `def` carries the current `wants`
+ * + per-connection grant info; `onChanged` refreshes the list after an add (so the new
+ * connection + its grant id appear). A Connect drives a full-page OAuth redirect, so
+ * there's no post-redirect refresh to wire — the hub callback returns the operator to
+ * its own page.
+ */
+export function ConnectionsSection({
+  noteId,
+  def,
+  onChanged,
+}: {
+  noteId: string;
+  def: AgentDefRow;
+  onChanged: () => void;
+}) {
+  const [addOpen, setAddOpen] = useState(false);
+  // The grant id currently mid-connect (so its button shows a spinner) / mid-paste.
+  const [connecting, setConnecting] = useState<string | null>(null);
+  const [pasteFor, setPasteFor] = useState<string | null>(null);
+  const [pasteToken, setPasteToken] = useState("");
+  const [rowError, setRowError] = useState<string | null>(null);
+
+  const rows = mcpConnectionRows(def);
+  // The cookie→hub Connect only works at the hub origin (the cookie + CSRF belt).
+  const daemonDirect = isDaemonDirectOrigin();
+
+  /** Start the OAuth dance (no token) → full-page redirect to the remote consent. */
+  async function onConnect(grantId: string) {
+    setConnecting(grantId);
+    setRowError(null);
+    try {
+      const listing = await approveAgentGrant(grantId);
+      if (listing.authorizeUrl) {
+        // Cross-origin remote consent — full-page nav, NOT react-router.
+        window.location.assign(listing.authorizeUrl);
+        return; // navigating away; keep the spinner.
+      }
+      // No authorizeUrl (e.g. the hub approved without a redirect) → refresh in place.
+      onChanged();
+    } catch (err) {
+      setRowError(connectErrMessage(err));
+    } finally {
+      setConnecting(null);
+    }
+  }
+
+  /** Store a pasted static bearer (no redirect) → approve immediately, then refresh. */
+  async function onPasteToken(grantId: string) {
+    const token = pasteToken.trim();
+    if (token.length === 0) return;
+    setConnecting(grantId);
+    setRowError(null);
+    try {
+      await approveAgentGrant(grantId, token);
+      setPasteFor(null);
+      setPasteToken("");
+      onChanged();
+    } catch (err) {
+      setRowError(connectErrMessage(err));
+    } finally {
+      setConnecting(null);
+    }
+  }
+
+  return (
+    <section className="detail-section" aria-label="Connections" data-testid="connections-section">
+      <div className="section-head">
+        <h3>Connections / MCP servers</h3>
+        <button
+          type="button"
+          className="secondary"
+          data-testid="add-mcp-toggle"
+          onClick={() => {
+            setAddOpen((o) => !o);
+            setRowError(null);
+          }}
+        >
+          {addOpen ? "Cancel" : "Add MCP server"}
+        </button>
+      </div>
+      <p className="muted">
+        Remote MCP servers this agent can reach. Add one, then connect it via OAuth (or
+        paste a static bearer). Each connection is operator-approved before it's granted.
+      </p>
+
+      {daemonDirect ? (
+        <div className="info-banner" role="status" data-testid="connections-daemon-direct">
+          Open this surface via your hub to connect MCP servers — the OAuth/approve step
+          needs the hub origin (you're on the loopback daemon).
+        </div>
+      ) : null}
+
+      {addOpen ? (
+        <AddMcpForm
+          noteId={noteId}
+          def={def}
+          onCancel={() => setAddOpen(false)}
+          onAdded={() => {
+            setAddOpen(false);
+            onChanged();
+          }}
+        />
+      ) : null}
+
+      {rowError ? (
+        <div className="error-banner" role="alert" data-testid="connections-row-error">
+          {rowError}
+        </div>
+      ) : null}
+
+      {rows.length === 0 ? (
+        <div className="empty" data-testid="connections-empty">
+          No MCP servers connected to this agent yet.
+        </div>
+      ) : (
+        <table>
+          <thead>
+            <tr>
+              <th>MCP server</th>
+              <th>Status</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((c) => {
+              const actionable = c.status !== "approved";
+              const canConnect = actionable && !!c.grantId && !daemonDirect;
+              return (
+                <tr key={c.key} data-testid={`connection-row-${c.target}`}>
+                  <td className="cell-name">
+                    <code>{c.target}</code>
+                  </td>
+                  <td>
+                    <GrantStatusPill status={c.status} />
+                  </td>
+                  <td>
+                    {!actionable ? (
+                      <span className="cell-dim">—</span>
+                    ) : pasteFor === c.grantId ? (
+                      <span className="confirm-inline">
+                        <input
+                          type="password"
+                          value={pasteToken}
+                          placeholder="bearer token"
+                          autoComplete="off"
+                          spellCheck={false}
+                          aria-label="Static bearer token"
+                          data-testid={`paste-token-input-${c.target}`}
+                          onChange={(e) => setPasteToken(e.target.value)}
+                        />
+                        <button
+                          type="button"
+                          disabled={connecting === c.grantId || pasteToken.trim().length === 0}
+                          data-testid={`paste-token-save-${c.target}`}
+                          onClick={() => void onPasteToken(c.grantId!)}
+                        >
+                          {connecting === c.grantId ? "Saving…" : "Save"}
+                        </button>
+                        <button
+                          type="button"
+                          className="cancel-link"
+                          onClick={() => {
+                            setPasteFor(null);
+                            setPasteToken("");
+                          }}
+                        >
+                          Cancel
+                        </button>
+                      </span>
+                    ) : (
+                      <span className="schedule-row-actions">
+                        <button
+                          type="button"
+                          disabled={!canConnect || connecting === c.grantId}
+                          data-testid={`connect-${c.target}`}
+                          title={
+                            daemonDirect
+                              ? "Open the agent app via your hub origin to connect."
+                              : !c.grantId
+                                ? "No grant registered yet — reload after the daemon registers it."
+                                : undefined
+                          }
+                          onClick={() => void onConnect(c.grantId!)}
+                        >
+                          {connecting === c.grantId
+                            ? "Connecting…"
+                            : c.status === "needs_consent"
+                              ? "Reconnect"
+                              : "Connect"}
+                        </button>
+                        {c.grantId && !daemonDirect ? (
+                          <button
+                            type="button"
+                            className="cancel-link"
+                            data-testid={`paste-token-${c.target}`}
+                            onClick={() => {
+                              setRowError(null);
+                              setPasteToken("");
+                              setPasteFor(c.grantId!);
+                            }}
+                          >
+                            Paste token
+                          </button>
+                        ) : null}
+                      </span>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
+    </section>
+  );
+}
+
+/** A friendly message off a Connect failure (HubError carries the hub's hint). */
+function connectErrMessage(err: unknown): string {
+  if (err instanceof HubError) return err.message;
+  return (err as Error).message;
+}
+
+/**
+ * The inline "Add MCP server" form: a URL + an auth choice (OAuth default | paste a
+ * static bearer). On submit we APPEND `mcp:<url>` to the def's existing `wants:` (so we
+ * don't drop the agent's other connections) and PATCH the def — the daemon re-parses
+ * `wants` and registers the pending grant. The auth choice is informational at THIS
+ * step (adding registers the grant either way); the actual OAuth-vs-token decision is
+ * made at the Connect step on the row. We carry it so the operator's intent is clear +
+ * the OAuth path is the default the row's primary button takes.
+ */
+export function AddMcpForm({
+  noteId,
+  def,
+  onCancel,
+  onAdded,
+}: {
+  noteId: string;
+  def: AgentDefRow;
+  onCancel: () => void;
+  onAdded: () => void;
+}) {
+  const [url, setUrl] = useState("");
+  const [auth, setAuth] = useState<"oauth" | "token">("oauth");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // A valid http(s) URL (the daemon's parseWants requires http(s) for a remote MCP).
+  const trimmed = url.trim();
+  const urlValid = /^https?:\/\/.+/i.test(trimmed) && isParseableUrl(trimmed);
+  // Already declared? (avoid a duplicate `mcp:` entry — the daemon would dedupe by key
+  // but a friendlier pre-submit guard.)
+  const alreadyAdded = def.wants.includes(`mcp:${trimmed}`);
+  const canAdd = urlValid && !alreadyAdded && !saving;
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!canAdd) return;
+    setSaving(true);
+    setError(null);
+    try {
+      // APPEND to the existing wants (preserve the agent's other connections). The
+      // wants keys round-trip through the daemon's parseWants as a comma string.
+      const next = [...def.wants, `mcp:${trimmed}`].join(", ");
+      await editAgentDef(noteId, { wants: next });
+      onAdded();
+    } catch (err) {
+      const message =
+        err instanceof HttpError
+          ? err.status === 401
+            ? "Not signed in to the hub — sign in to the portal, then reload."
+            : err.message
+          : (err as Error).message;
+      setError(message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <form className="inline-form" onSubmit={onSubmit} aria-label="Add MCP server" data-testid="add-mcp-form">
+      {error ? (
+        <div className="error-banner" role="alert" data-testid="add-mcp-error">
+          {error}
+        </div>
+      ) : null}
+
+      <div className="field">
+        <label htmlFor="mcp-url">MCP server URL</label>
+        <input
+          id="mcp-url"
+          type="text"
+          value={url}
+          placeholder="https://mcp.example.com/mcp"
+          autoComplete="off"
+          spellCheck={false}
+          onChange={(e) => setUrl(e.target.value)}
+        />
+        {trimmed.length > 0 && !urlValid ? (
+          <p className="field-error" data-testid="mcp-url-invalid">
+            Must be a full http(s) URL.
+          </p>
+        ) : null}
+        {alreadyAdded ? (
+          <p className="field-error" data-testid="mcp-url-duplicate">
+            This MCP server is already connected to the agent.
+          </p>
+        ) : null}
+      </div>
+
+      <fieldset className="field">
+        <legend>Authentication</legend>
+        <RadioRow
+          name="mcp-auth"
+          value="oauth"
+          checked={auth === "oauth"}
+          onChange={() => setAuth("oauth")}
+          label="OAuth"
+          help="Sign in to the MCP server in your browser (recommended). Connect on the row after adding."
+          testid="mcp-auth-oauth"
+        />
+        <RadioRow
+          name="mcp-auth"
+          value="token"
+          checked={auth === "token"}
+          onChange={() => setAuth("token")}
+          label="Paste a token"
+          help="For an MCP server with a static bearer token. Paste it on the row's “Paste token” after adding."
+          testid="mcp-auth-token"
+        />
+      </fieldset>
+
+      <div className="form-actions">
+        <button type="submit" disabled={!canAdd} data-testid="add-mcp-submit">
+          {saving ? "Adding…" : "Add MCP server"}
+        </button>
+        <button type="button" className="cancel-link" onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}
+
+/** True if `s` parses as a URL (defensive — the regex already gates the scheme). */
+function isParseableUrl(s: string): boolean {
+  try {
+    new URL(s);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/web/ui/src/routes/Connections.test.tsx
+++ b/web/ui/src/routes/Connections.test.tsx
@@ -1,0 +1,215 @@
+/**
+ * Connections / MCP-servers panel tests (this PR). Exercises the exported
+ * `ConnectionsSection` + `AddMcpForm` + `mcpConnectionRows` directly (no full-page
+ * wiring), mocking `../lib/api.ts` (the def PATCH) and `../lib/hub.ts` (the cookie→hub
+ * approve + the daemon-direct detector). Asserts:
+ *   - the row list + status pills (Connected / Pending / Needs reconnect);
+ *   - Add MCP → PATCH wants APPENDS `mcp:<url>` (preserving existing wants);
+ *   - Connect → `approveAgentGrant(grantId)` → full-page redirect to authorizeUrl;
+ *   - Paste-token → `approveAgentGrant(grantId, token)` (no redirect);
+ *   - daemon-direct degradation hides Connect + shows the inline hint.
+ */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as api from "../lib/api.ts";
+import * as hub from "../lib/hub.ts";
+import { AddMcpForm, ConnectionsSection, mcpConnectionRows } from "./Agents.tsx";
+
+vi.mock("../lib/api.ts", async (orig) => {
+  const actual = (await orig()) as typeof api;
+  return { ...actual, editAgentDef: vi.fn() };
+});
+vi.mock("../lib/hub.ts", async (orig) => {
+  const actual = (await orig()) as typeof hub;
+  return { ...actual, approveAgentGrant: vi.fn(), isDaemonDirectOrigin: vi.fn(() => false) };
+});
+
+const editAgentDef = vi.mocked(api.editAgentDef);
+const approveAgentGrant = vi.mocked(hub.approveAgentGrant);
+const isDaemonDirectOrigin = vi.mocked(hub.isDaemonDirectOrigin);
+
+function defRow(over: Partial<api.AgentDefRow> = {}): api.AgentDefRow {
+  return {
+    noteId: "Agents/alpha",
+    name: "alpha",
+    backend: "programmatic",
+    mode: "single-threaded",
+    vault: "default",
+    status: "pending",
+    pending: [],
+    systemPromptPreview: "You are a helpful agent.",
+    wants: [],
+    channel: "alpha",
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  isDaemonDirectOrigin.mockReturnValue(false);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("mcpConnectionRows", () => {
+  it("prefers def.connections (filtered to kind:mcp, carrying grant id + status)", () => {
+    const def = defRow({
+      connections: [
+        { key: "mcp:https://a/mcp", kind: "mcp", target: "https://a/mcp", status: "pending", grantId: "g1" },
+        { key: "vault:research:read", kind: "vault", target: "research", status: "approved", grantId: "g2" },
+      ],
+      wants: ["mcp:https://a/mcp", "vault:research:read"],
+    });
+    const rows = mcpConnectionRows(def);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ target: "https://a/mcp", grantId: "g1", status: "pending" });
+  });
+
+  it("falls back to wants (older daemon, no connections field) — display-only, no grant id", () => {
+    const def = defRow({
+      // connections omitted (older daemon)
+      wants: ["mcp:https://a/mcp", "vault:research:read"],
+      pending: ["mcp:https://a/mcp"],
+    });
+    const rows = mcpConnectionRows(def);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toEqual({
+      key: "mcp:https://a/mcp",
+      kind: "mcp",
+      target: "https://a/mcp",
+      status: "pending",
+    });
+    expect(rows[0]!.grantId).toBeUndefined();
+  });
+});
+
+describe("ConnectionsSection — render + status pills", () => {
+  it("lists mcp connections with the right pills and the empty state", () => {
+    const def = defRow({
+      connections: [
+        { key: "mcp:https://a/mcp", kind: "mcp", target: "https://a/mcp", status: "approved", grantId: "g1" },
+        { key: "mcp:https://b/mcp", kind: "mcp", target: "https://b/mcp", status: "needs_consent", grantId: "g2" },
+        { key: "mcp:https://c/mcp", kind: "mcp", target: "https://c/mcp", status: "pending", grantId: "g3" },
+      ],
+    });
+    render(<ConnectionsSection noteId="Agents/alpha" def={def} onChanged={() => {}} />);
+    expect(screen.getByTestId("conn-status-approved")).toHaveTextContent("Connected");
+    expect(screen.getByTestId("conn-status-needs_consent")).toHaveTextContent("Needs reconnect");
+    expect(screen.getByTestId("conn-status-pending")).toHaveTextContent("Pending");
+    // The needs_consent row's button reads "Reconnect"; the pending one "Connect".
+    expect(screen.getByTestId("connect-https://b/mcp")).toHaveTextContent("Reconnect");
+    expect(screen.getByTestId("connect-https://c/mcp")).toHaveTextContent("Connect");
+  });
+
+  it("shows the empty state when there are no mcp connections", () => {
+    render(<ConnectionsSection noteId="Agents/alpha" def={defRow()} onChanged={() => {}} />);
+    expect(screen.getByTestId("connections-empty")).toBeInTheDocument();
+  });
+});
+
+describe("ConnectionsSection — Connect (cookie→hub approve)", () => {
+  it("Connect → approveAgentGrant(grantId) → full-page redirect to authorizeUrl", async () => {
+    // jsdom's window.location.assign isn't configurable to spy on directly; swap the
+    // whole location object (restored after the test) and stub assign on it.
+    const assign = vi.fn();
+    const realLocation = window.location;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...realLocation, assign },
+    });
+    approveAgentGrant.mockResolvedValue({
+      id: "g3",
+      agent: "alpha",
+      connection: { kind: "mcp", target: "https://c/mcp" },
+      status: "pending",
+      authorizeUrl: "https://c/oauth/authorize?x=1",
+    });
+    const def = defRow({
+      connections: [
+        { key: "mcp:https://c/mcp", kind: "mcp", target: "https://c/mcp", status: "pending", grantId: "g3" },
+      ],
+    });
+    render(<ConnectionsSection noteId="Agents/alpha" def={def} onChanged={() => {}} />);
+    fireEvent.click(screen.getByTestId("connect-https://c/mcp"));
+    await waitFor(() => expect(approveAgentGrant).toHaveBeenCalledWith("g3"));
+    await waitFor(() => expect(assign).toHaveBeenCalledWith("https://c/oauth/authorize?x=1"));
+    Object.defineProperty(window, "location", { configurable: true, value: realLocation });
+  });
+
+  it("Paste token → approveAgentGrant(grantId, token) (no redirect) → onChanged", async () => {
+    approveAgentGrant.mockResolvedValue({
+      id: "g3",
+      agent: "alpha",
+      connection: { kind: "mcp", target: "https://c/mcp" },
+      status: "approved",
+    });
+    const onChanged = vi.fn();
+    const def = defRow({
+      connections: [
+        { key: "mcp:https://c/mcp", kind: "mcp", target: "https://c/mcp", status: "pending", grantId: "g3" },
+      ],
+    });
+    render(<ConnectionsSection noteId="Agents/alpha" def={def} onChanged={onChanged} />);
+    fireEvent.click(screen.getByTestId("paste-token-https://c/mcp"));
+    fireEvent.change(screen.getByTestId("paste-token-input-https://c/mcp"), {
+      target: { value: "static-bearer" },
+    });
+    fireEvent.click(screen.getByTestId("paste-token-save-https://c/mcp"));
+    await waitFor(() => expect(approveAgentGrant).toHaveBeenCalledWith("g3", "static-bearer"));
+    await waitFor(() => expect(onChanged).toHaveBeenCalled());
+  });
+});
+
+describe("ConnectionsSection — daemon-direct degradation", () => {
+  it("hides Connect + shows the hub-origin hint when served daemon-direct", () => {
+    isDaemonDirectOrigin.mockReturnValue(true);
+    const def = defRow({
+      connections: [
+        { key: "mcp:https://c/mcp", kind: "mcp", target: "https://c/mcp", status: "pending", grantId: "g3" },
+      ],
+    });
+    render(<ConnectionsSection noteId="Agents/alpha" def={def} onChanged={() => {}} />);
+    expect(screen.getByTestId("connections-daemon-direct")).toBeInTheDocument();
+    // The Connect button is present but disabled (can't approve cross-origin).
+    expect(screen.getByTestId("connect-https://c/mcp")).toBeDisabled();
+    // No paste-token affordance daemon-direct (it also needs the hub origin).
+    expect(screen.queryByTestId("paste-token-https://c/mcp")).toBeNull();
+  });
+});
+
+describe("AddMcpForm", () => {
+  it("APPENDs mcp:<url> to the existing wants and PATCHes the def", async () => {
+    editAgentDef.mockResolvedValue({ ok: true, def: defRow() });
+    const onAdded = vi.fn();
+    const def = defRow({ wants: ["vault:research:read"] });
+    render(<AddMcpForm noteId="Agents/alpha" def={def} onCancel={() => {}} onAdded={onAdded} />);
+    fireEvent.change(screen.getByLabelText("MCP server URL"), {
+      target: { value: "https://new/mcp" },
+    });
+    fireEvent.click(screen.getByTestId("add-mcp-submit"));
+    await waitFor(() =>
+      expect(editAgentDef).toHaveBeenCalledWith("Agents/alpha", {
+        wants: "vault:research:read, mcp:https://new/mcp",
+      }),
+    );
+    await waitFor(() => expect(onAdded).toHaveBeenCalled());
+  });
+
+  it("rejects a non-http(s) URL and a duplicate", () => {
+    const def = defRow({ wants: ["mcp:https://dup/mcp"] });
+    render(<AddMcpForm noteId="Agents/alpha" def={def} onCancel={() => {}} onAdded={() => {}} />);
+    const input = screen.getByLabelText("MCP server URL");
+
+    fireEvent.change(input, { target: { value: "notaurl" } });
+    expect(screen.getByTestId("mcp-url-invalid")).toBeInTheDocument();
+    expect(screen.getByTestId("add-mcp-submit")).toBeDisabled();
+
+    fireEvent.change(input, { target: { value: "https://dup/mcp" } });
+    expect(screen.getByTestId("mcp-url-duplicate")).toBeInTheDocument();
+    expect(screen.getByTestId("add-mcp-submit")).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## What

In the agent ops surface (the SPA at `web/ui/`, served at `<hub>/agent/app/`), let an operator **add a remote MCP server to a specific agent and authenticate it via OAuth (or paste a static bearer)** — all in one place, without bouncing to the hub admin grants page.

A new **"Connections / MCP servers"** section in the per-agent detail panel:
- Lists the agent's `mcp:` connections with a live **status pill** (Connected / Pending / Needs reconnect).
- **"Add MCP server"** — a URL input + an auth choice (**OAuth** default | **Paste token**). On submit it PATCHes the def's `wants:` to **append** `mcp:<url>` (preserving existing wants).
- **Connect / Reconnect** — the cookie→hub approve (OAuth redirect, or paste-token static bearer).
- Daemon-direct **degradation**: when opened on the loopback daemon (cross-origin to the hub) the section shows a clear inline note and disables Connect.

## Why

The OAuth machinery (the agent-connector "grants" system) already lives in the hub. This is a UI + thin daemon-API task that brings the whole add-and-authenticate flow into the agent surface. **No `parachute-hub` changes.**

## Architecture (as built)

- **Adding the MCP = append `mcp:<url>` to `wants:`** via the existing daemon `PATCH /api/agent-defs/<noteId>` (SPA `agent:admin` Bearer). We go through the def — NOT a direct `PUT /admin/grants` — because the daemon's reconcile-GC prunes any grant not in the live `wants:`; the daemon re-parses `wants` and registers the grant itself.
- **The OAuth "Connect" is operator-cookie-gated on the hub.** The browser calls the hub's approve endpoint **directly** with `credentials: "include"` (works same-origin because the SPA is served at the hub origin). A host-admin Bearer cannot approve, so we deliberately do NOT route Connect through the daemon.
- **Grant id + status surfaced to the SPA.** The daemon's `GET /api/agent-defs[/<id>]` now carries an **additive, back-compat** `connections: [{ key, kind, target, status, grantId? }]` field. The grant id comes **from the hub** (`registerGrant`'s echoed record) — never derived client-side (that divergence class already bit this codebase).

## Hub endpoints reused (verbatim — no hub edits)

| Endpoint | Body | Auth | Use |
|---|---|---|---|
| `PATCH <hub>/agent/api/agent-defs/<noteId>` | `{ wants }` | SPA `agent:admin` Bearer (daemon) | append `mcp:<url>` |
| `POST <hub>/admin/grants/<id>/approve` | `{}` (OAuth) / `{ token }` (static bearer) | operator cookie (`credentials:include`, CSRF same-origin belt) | the Connect/Reconnect approve |

Approve response: no token → `{ …, authorizeUrl }` → `window.location.assign(authorizeUrl)`; with token → static bearer (no redirect); `needs_consent` re-offers the same path ("Reconnect"). Mirrors `parachute-hub` `web/ui/src/routes/Grants.tsx` (`onConnectMcp`/`onApprove`) + `src/admin-agent-grants.ts` (`approveGrant`).

## Files changed

- `src/agent-defs.ts` — `ConnectionInfo` type; `connections` on `LiveDef`/`AgentDefDetail`/`AgentDefFull`; populate it in `resolveStatusWithGrants`/`instantiate`; emit in `listDetailed`/`liveDef`/`getFullDef`.
- `src/agent-defs.test.ts` — +2 tests (connections surfaced with grants; display-only fallback without a grants client).
- `web/ui/src/lib/hub.ts` — `approveAgentGrant(id, token?)` + `isDaemonDirectOrigin()`.
- `web/ui/src/lib/hub.test.ts` — +5 tests.
- `web/ui/src/lib/api.ts` — `ConnectionInfoRow` + additive optional `connections` on `AgentDefRow`/`AgentDefFull`.
- `web/ui/src/routes/Agents.tsx` — the `ConnectionsSection` + `AddMcpForm` + `mcpConnectionRows`, wired into the detail panel.
- `web/ui/src/routes/Connections.test.tsx` — 9 component/interaction tests.

## Verification

- Root `bun run typecheck` — clean.
- `bun test ./src` — **1056 pass, 0 fail**.
- `cd web/ui && bunx vitest run` — **126 pass** (8 files).
- `cd web/ui && bun run build` — ok (`verify-base` passes).
- **No version bump** — this module is bun-linked/experimental (`0.1.0`); CI is typecheck+tests only (no publish/rc convention), matching the repo's actual practice (recent feature PRs don't bump).

## Degradation note

The cookie-based Connect only works at the hub origin. Served daemon-direct (`http://127.0.0.1:1941/agent/app/`, cross-origin), the cookie won't flow and the CSRF belt rejects it; `isDaemonDirectOrigin()` detects this and the panel shows "Open this surface via your hub to connect MCP servers" + disables Connect. Adding the MCP (the def PATCH) still works daemon-direct; only the Connect step needs the hub origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)