### PR TITLE
ui(agents): return to the surface after an MCP OAuth connect

### DIFF
--- a/web/ui/src/lib/hub.ts
+++ b/web/ui/src/lib/hub.ts
@@ -278,11 +278,21 @@ export interface GrantListing {
  * daemon-direct degradation), 401 to a sign-in hint. The grant `id` MUST come from
  * the daemon's def-API (`connections[].grantId`) — never derived client-side.
  */
-export async function approveAgentGrant(id: string, token?: string): Promise<GrantListing> {
+export async function approveAgentGrant(
+  id: string,
+  token?: string,
+  returnTo?: string,
+): Promise<GrantListing> {
+  const body: Record<string, string> = {};
+  if (token !== undefined) body.token = token;
+  // A ROOT-RELATIVE path (the hub's isSafeHubReturnTo rejects absolute URLs).
+  // The hub 302s back to it after the OAuth round-trip, so the operator lands
+  // back on this surface instead of a dead-end "close this tab" page.
+  if (returnTo) body.returnTo = returnTo;
   const res = await hubFetch(`/admin/grants/${encodeURIComponent(id)}/approve`, {
     method: "POST",
     headers: { "content-type": "application/json" },
-    body: JSON.stringify(token !== undefined ? { token } : {}),
+    body: JSON.stringify(body),
   });
   if (!res.ok) {
     throw new HubError(res.status, hubErrorMessage(res.status, await errorDetail(res)));

--- a/web/ui/src/routes/Agents.tsx
+++ b/web/ui/src/routes/Agents.tsx
@@ -146,6 +146,7 @@ function statusPillClass(status: string): string {
 export function Agents() {
   const [state, setState] = useState<LoadState>({ kind: "loading" });
   const [selected, setSelected] = useState<string | null>(null);
+  const [justConnected, setJustConnected] = useState(false);
 
   const load = useCallback(async () => {
     setState({ kind: "loading" });
@@ -178,6 +179,22 @@ export function Agents() {
     void load();
   }, [load]);
 
+  // After an MCP OAuth round-trip the hub 302s back here with `?mcp_connected=1`.
+  // Surface a brief confirmation + strip the param (the mount load() already
+  // refreshes the grant rows, so the now-connected MCP shows its new status).
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get("mcp_connected") !== "1") return;
+    setJustConnected(true);
+    params.delete("mcp_connected");
+    const q = params.toString();
+    window.history.replaceState(
+      null,
+      "",
+      window.location.pathname + (q ? `?${q}` : "") + window.location.hash,
+    );
+  }, []);
+
   const merged = useMemo(
     () => (state.kind === "ok" ? mergeAgents(state.agents, state.defs) : []),
     [state],
@@ -202,6 +219,15 @@ export function Agents() {
           {state.message}{" "}
           <button type="button" className="secondary" onClick={() => void load()}>
             Retry
+          </button>
+        </div>
+      ) : null}
+
+      {justConnected ? (
+        <div className="success-banner" role="status">
+          ✓ MCP server connected — it'll be available to the agent on its next run.{" "}
+          <button type="button" className="link" onClick={() => setJustConnected(false)}>
+            Dismiss
           </button>
         </div>
       ) : null}
@@ -844,7 +870,12 @@ export function ConnectionsSection({
     setConnecting(grantId);
     setRowError(null);
     try {
-      const listing = await approveAgentGrant(grantId);
+      // Where to land after the OAuth round-trip — a ROOT-RELATIVE path so the
+      // hub's same-origin guard accepts it and 302s back here (with
+      // `?mcp_connected=1`) instead of the dead-end "close this tab" page.
+      const returnTo =
+        window.location.pathname + window.location.search + window.location.hash;
+      const listing = await approveAgentGrant(grantId, undefined, returnTo);
       if (listing.authorizeUrl) {
         // Cross-origin remote consent — full-page nav, NOT react-router.
         window.location.assign(listing.authorizeUrl);

--- a/web/ui/src/routes/Connections.test.tsx
+++ b/web/ui/src/routes/Connections.test.tsx
@@ -135,7 +135,11 @@ describe("ConnectionsSection — Connect (cookie→hub approve)", () => {
     });
     render(<ConnectionsSection noteId="Agents/alpha" def={def} onChanged={() => {}} />);
     fireEvent.click(screen.getByTestId("connect-https://c/mcp"));
-    await waitFor(() => expect(approveAgentGrant).toHaveBeenCalledWith("g3"));
+    // Connect passes (grantId, no token, a root-relative returnTo) so the hub
+    // can 302 the operator back to this surface after the OAuth round-trip.
+    await waitFor(() =>
+      expect(approveAgentGrant).toHaveBeenCalledWith("g3", undefined, expect.any(String)),
+    );
     await waitFor(() => expect(assign).toHaveBeenCalledWith("https://c/oauth/authorize?x=1"));
     Object.defineProperty(window, "location", { configurable: true, value: realLocation });
   });

--- a/web/ui/src/routes/Connections.test.tsx
+++ b/web/ui/src/routes/Connections.test.tsx
@@ -138,7 +138,9 @@ describe("ConnectionsSection — Connect (cookie→hub approve)", () => {
     // Connect passes (grantId, no token, a root-relative returnTo) so the hub
     // can 302 the operator back to this surface after the OAuth round-trip.
     await waitFor(() =>
-      expect(approveAgentGrant).toHaveBeenCalledWith("g3", undefined, expect.any(String)),
+      // root-relative returnTo (starts with "/") — NOT an absolute URL, which the
+      // hub's same-origin guard would reject.
+      expect(approveAgentGrant).toHaveBeenCalledWith("g3", undefined, expect.stringMatching(/^\//)),
     );
     await waitFor(() => expect(assign).toHaveBeenCalledWith("https://c/oauth/authorize?x=1"));
     Object.defineProperty(window, "location", { configurable: true, value: realLocation });


### PR DESCRIPTION
## What
Pairs with hub **#684**. After OAuth-connecting a remote MCP, the operator was dropped on a dead-end "close this tab" page. Now the agent ops surface sends a `returnTo` so the hub 302s them **back to the surface**, with a confirmation.

- `hub.ts` `approveAgentGrant`: optional 3rd arg `returnTo` (sent only when present; non-breaking).
- `Agents.tsx` `onConnect`: passes a **root-relative** path (`pathname+search+hash`) — the hub's `isSafeHubReturnTo` rejects absolute URLs, so the relative form is required.
- `Agents.tsx`: on return the hub appends `?mcp_connected=1` → shows a `success-banner`, refreshes grant rows (the mount `load()`), and strips the param via `replaceState`.

## Compat
Graceful against an old hub (returnTo ignored → prior close-tab behavior). Paste-token path unchanged (no redirect).

## Verification
- `bunx vitest run` → 126 pass (the Connect test now asserts a `returnTo` is passed).
- `bun run build` ok; root `bun run typecheck` clean.
- No version bump (bun-linked/experimental, matches repo convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)