### PR TITLE
fix(agent): close env-passthrough isolation/billing leak (sandbox env allowlist)

### DIFF
--- a/src/_parked/interactive-spawn.ts
+++ b/src/_parked/interactive-spawn.ts
@@ -41,6 +41,7 @@ import { normalizeChannel } from "../sandbox/types.ts";
 import type { SandboxEngine, WrappedCommand } from "../sandbox/index.ts";
 import {
   buildAgentChildEnv,
+  mergeSandboxLaunchEnv,
   resolveAgentCwd,
   seedAgentHome,
   sessionWorkspace,
@@ -282,11 +283,11 @@ export async function spawnAgent(
   const homeEnv = seedAgentHome(workspace, { mcpServers: mcpServerNames, projectRoot: cwd });
 
   const childEnv = buildAgentChildEnv(deps.parentEnv ?? process.env, claudeOauthToken, channelEnv);
-  const launchEnv: Record<string, string | undefined> = {
-    ...childEnv,
-    ...wrapped.env,
-    ...homeEnv,
-  };
+  // Scrub WINS: only allowlisted sandbox/proxy keys from `wrapped.env` (not the whole
+  // daemon `process.env` the engine returns) layer on top. See mergeSandboxLaunchEnv.
+  // (This file is the PARKED/retired interactive backend — kept in sync with the live
+  // programmatic backend's shared seam, not a live spawn path.)
+  const launchEnv = mergeSandboxLaunchEnv(childEnv, wrapped.env, homeEnv);
 
   await deps.tmux.newSession({
     name: session,

--- a/src/backends/programmatic.test.ts
+++ b/src/backends/programmatic.test.ts
@@ -126,12 +126,36 @@ function fakeEngine(): SandboxEngine & { initializedWith: SandboxRuntimeConfig |
       rec.initializedWith = cfg;
     },
     async wrapWithSandboxArgv(command: string) {
-      // Emulate the real shape: a bash -c wrapper carrying the command + proxy env.
+      // Emulate the REAL `wrapWithSandboxArgv` contract: a bash -c wrapper carrying
+      // the command, and `env` = the daemon's FULL `process.env` (on macOS/Linux the
+      // real engine returns `process.env` verbatim; the proxy vars are baked into the
+      // command string and ALSO present in process.env on Windows). The hand-made
+      // SMALL env the old fake returned could never catch the passthrough leak — the
+      // whole-`process.env`-spread that defeats buildAgentChildEnv's scrub. So the fake
+      // must include the daemon's ambient secrets it would carry in real life PLUS the
+      // proxy/sandbox vars, so a test can prove the leak is closed AND egress survives.
+      //
       // The "argv" the runner spawns is therefore `["/bin/bash","-c","SBX <command>"]`;
       // assertions parse `argv[2]` for the claude flags.
       return {
         argv: ["/bin/bash", "-c", `SBX ${command}`],
-        env: { SANDBOX_RUNTIME: "1", HTTPS_PROXY: "http://localhost:5555", TMPDIR: "/tmp/claude" },
+        env: {
+          // The daemon's ambient env (process.env) the real engine passes through —
+          // these MUST be scrubbed from the launch env (the isolation/billing leak).
+          ANTHROPIC_API_KEY: "sk-ant-DAEMON-AMBIENT-SHOULD-NOT-LEAK",
+          CLAUDE_API_KEY: "daemon-ambient-also-should-not-leak",
+          CLAUDE_CODE_OAUTH_TOKEN: "DAEMON-AMBIENT-WRONG-TOKEN-SHOULD-NOT-WIN",
+          SECRET_THING: "daemon-ambient-secret-should-not-leak",
+          PATH: "/daemon/bin",
+          // The load-bearing sandbox/proxy vars the egress floor depends on — these
+          // MUST survive into the launch env (allowlisted).
+          SANDBOX_RUNTIME: "1",
+          HTTP_PROXY: "http://localhost:5555",
+          HTTPS_PROXY: "http://localhost:5555",
+          NO_PROXY: "localhost,127.0.0.1",
+          TMPDIR: "/tmp/claude",
+          NODE_EXTRA_CA_CERTS: "/tmp/claude/ca.pem",
+        },
       };
     },
     async reset() {},
@@ -564,6 +588,46 @@ describe("ProgrammaticBackend.deliver — argv + env shape", () => {
     expect(env.CLAUDE_API_KEY).toBeUndefined();
     // the sandbox proxy env is layered on top
     expect(env.SANDBOX_RUNTIME).toBe("1");
+  });
+
+  test("REGRESSION (isolation/billing leak): the engine's returned env (= daemon process.env) is NOT spread onto the launch env — only allowlisted sandbox/proxy keys survive; the scrub wins", async () => {
+    // The real `wrapWithSandboxArgv` returns `env: process.env` (the FULL daemon env)
+    // on macOS/Linux. The fakeEngine now mirrors that — its returned env carries the
+    // daemon's ambient ANTHROPIC_API_KEY / CLAUDE_API_KEY / SECRET_THING / a WRONG
+    // CLAUDE_CODE_OAUTH_TOKEN. The old `{ ...childEnv, ...wrapped.env, ...homeEnv }`
+    // spread let those OVERRIDE the scrubbed childEnv → reaching the sandboxed turn
+    // (subscription-billing + secret-leak breach). mergeSandboxLaunchEnv allowlists
+    // wrapped.env, so the scrub stays authoritative.
+    mkDirs("env-leak-regression");
+    const { fn, calls } = recordingSpawn({ stdout: successTurn("s", "ok") });
+    const backend = new ProgrammaticBackend(baseDeps(fn));
+    const handle = await backend.start(specWithVault());
+    await backend.deliver(handle, "hello", freshSession());
+
+    const env = calls[0]!.env;
+
+    // 1. LEAK CLOSED: the daemon's ambient secrets the engine returned never reach
+    //    the launch env (neither the scrubbed childEnv nor the allowlist admits them).
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(env.CLAUDE_API_KEY).toBeUndefined();
+    expect(env.SECRET_THING).toBeUndefined();
+
+    // 2. MANAGED AUTH WINS: CLAUDE_CODE_OAUTH_TOKEN is the session's resolved token,
+    //    NOT the wrong daemon-ambient one the engine env carried (it's denylisted +
+    //    not allowlisted, so step 2 can never overwrite the scrub's value).
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe("OAUTH-CRED-PLACEHOLDER");
+
+    // 3. EGRESS PRESERVED: the load-bearing sandbox/proxy vars DO survive (allowlist),
+    //    so the egress proxy keeps working — the fix doesn't strangle the network.
+    expect(env.SANDBOX_RUNTIME).toBe("1");
+    expect(env.HTTP_PROXY).toBe("http://localhost:5555");
+    expect(env.HTTPS_PROXY).toBe("http://localhost:5555");
+    expect(env.NO_PROXY).toBe("localhost,127.0.0.1");
+    expect(env.NODE_EXTRA_CA_CERTS).toBe("/tmp/claude/ca.pem");
+
+    // 4. The daemon's ambient PATH from the engine env does NOT clobber the scrubbed
+    //    PATH (PATH isn't in the sandbox allowlist; childEnv's passthrough owns it).
+    expect(env.PATH).not.toBe("/daemon/bin");
   });
 
   test("the per-channel env injection (GH_TOKEN) reaches the child; a planted API key is dropped", async () => {

--- a/src/backends/programmatic.ts
+++ b/src/backends/programmatic.ts
@@ -61,6 +61,7 @@ import { normalizeChannel } from "../sandbox/types.ts";
 import type { SandboxEngine } from "../sandbox/index.ts";
 import {
   buildAgentChildEnv,
+  mergeSandboxLaunchEnv,
   resolveAgentCwd,
   seedAgentHome,
   sessionWorkspace,
@@ -583,11 +584,13 @@ export class ProgrammaticBackend implements AgentBackend {
         ...(this.deps.ripgrep ? { ripgrep: this.deps.ripgrep } : {}),
       });
 
-      const launchEnv: Record<string, string | undefined> = {
-        ...childEnv,
-        ...wrapped.env,
-        ...homeEnv,
-      };
+      // Compose the launch env so the SCRUB WINS: the scrubbed `childEnv` is
+      // authoritative; only the ALLOWLISTED sandbox/proxy keys from `wrapped.env`
+      // (NOT the whole daemon `process.env` the engine returns) + the home overrides
+      // layer on top. A bare `...wrapped.env` spread would re-admit the daemon's
+      // ambient ANTHROPIC_API_KEY/secrets and defeat buildAgentChildEnv's scrub —
+      // an isolation/billing leak. See mergeSandboxLaunchEnv.
+      const launchEnv = mergeSandboxLaunchEnv(childEnv, wrapped.env, homeEnv);
 
       // Run the turn, with a bounded retry on TRANSIENT upstream errors (API 529/overload,
       // 5xx, rate-limit, network). The argv is fixed (built above for THIS turn's session),

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -20,7 +20,10 @@
 // patch releases, and it is the load-bearing isolation engine. Treat a version
 // bump as an upgrade-gate: only raise the pin behind a green run of the sandbox
 // test suite (esp. the LIVE Seatbelt assertions in `live-seatbelt.test.ts`, which
-// prove the real boundary still holds against the new version).
+// prove the real boundary still holds against the new version). On a bump, also
+// re-check `SANDBOX_ENV_ALLOWLIST` (spawn-agent.ts) against the runtime's
+// `generateProxyEnvVars` — a new proxy/launch var the engine emits must be added
+// there or egress silently breaks on Windows (where those vars ride in the env dict).
 import { SandboxManager as RealSandboxManager } from "@anthropic-ai/sandbox-runtime";
 import type { SandboxRuntimeConfig } from "@anthropic-ai/sandbox-runtime";
 import type { AgentSpec, BaseBinds, SandboxPlatform } from "./types.ts";

--- a/src/spawn-agent.test.ts
+++ b/src/spawn-agent.test.ts
@@ -5,6 +5,8 @@ import { tmpdir } from "node:os";
 // SHARED spawn helpers (live tree).
 import {
   buildAgentChildEnv,
+  mergeSandboxLaunchEnv,
+  SANDBOX_ENV_ALLOWLIST,
   resolveAgentCwd,
   seedAgentHome,
   sessionWorkspace,
@@ -230,6 +232,68 @@ describe("buildAgentChildEnv — scrub, inject OAuth, NEVER ANTHROPIC_API_KEY", 
     const env = buildAgentChildEnv({ PATH: "/usr/bin" }, "tok");
     expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe("tok");
     expect(env.PATH).toBe("/usr/bin");
+  });
+});
+
+describe("mergeSandboxLaunchEnv — the scrub WINS over the engine's returned env", () => {
+  // The REAL `wrapWithSandboxArgv` returns `env: process.env` (the FULL daemon env) on
+  // macOS/Linux; on Windows it returns `{...process.env, ...proxy}`. So `wrapped.env` is
+  // essentially the whole daemon env. The old `{ ...childEnv, ...wrapped.env, ...homeEnv }`
+  // spread let that OVERRIDE the scrubbed childEnv — re-admitting the daemon's ambient
+  // ANTHROPIC_API_KEY/secrets into the sandboxed turn (isolation/billing leak).
+
+  const childEnv = buildAgentChildEnv({ PATH: "/usr/bin", HOME: "/h" }, "THE-OAUTH-TOKEN");
+  // A representative `wrapped.env` = the daemon's process.env + the sandbox/proxy vars.
+  const wrappedEnv = {
+    ANTHROPIC_API_KEY: "sk-ant-DAEMON-AMBIENT",
+    CLAUDE_API_KEY: "daemon-ambient",
+    CLAUDE_CODE_OAUTH_TOKEN: "WRONG-DAEMON-TOKEN",
+    SECRET_THING: "daemon-secret",
+    PATH: "/daemon/bin",
+    SANDBOX_RUNTIME: "1",
+    HTTP_PROXY: "http://localhost:5555",
+    HTTPS_PROXY: "http://localhost:5555",
+    NO_PROXY: "localhost,127.0.0.1",
+    NODE_EXTRA_CA_CERTS: "/tmp/claude/ca.pem",
+    TMPDIR: "/tmp/claude",
+  };
+  const homeEnv: Record<string, string> = { CLAUDE_CONFIG_DIR: "/sess/.claude" };
+
+  test("LEAK CLOSED: the daemon's ambient secrets in wrapped.env never reach the launch env", () => {
+    const env = mergeSandboxLaunchEnv(childEnv, wrappedEnv, homeEnv);
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(env.CLAUDE_API_KEY).toBeUndefined();
+    expect(env.SECRET_THING).toBeUndefined();
+  });
+
+  test("MANAGED AUTH WINS: CLAUDE_CODE_OAUTH_TOKEN is the scrubbed value, not the engine env's wrong one", () => {
+    const env = mergeSandboxLaunchEnv(childEnv, wrappedEnv, homeEnv);
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe("THE-OAUTH-TOKEN");
+  });
+
+  test("EGRESS PRESERVED: the allowlisted sandbox/proxy vars survive (the proxy keeps working)", () => {
+    const env = mergeSandboxLaunchEnv(childEnv, wrappedEnv, homeEnv);
+    expect(env.SANDBOX_RUNTIME).toBe("1");
+    expect(env.HTTP_PROXY).toBe("http://localhost:5555");
+    expect(env.HTTPS_PROXY).toBe("http://localhost:5555");
+    expect(env.NO_PROXY).toBe("localhost,127.0.0.1");
+    expect(env.NODE_EXTRA_CA_CERTS).toBe("/tmp/claude/ca.pem");
+  });
+
+  test("the scrubbed PATH wins (PATH is not in the sandbox allowlist)", () => {
+    const env = mergeSandboxLaunchEnv(childEnv, wrappedEnv, homeEnv);
+    expect(env.PATH).toBe("/usr/bin"); // childEnv's, not the engine env's /daemon/bin
+  });
+
+  test("homeEnv wins last (CLAUDE_CONFIG_DIR/XDG/TMP overrides)", () => {
+    const env = mergeSandboxLaunchEnv(childEnv, wrappedEnv, homeEnv);
+    expect(env.CLAUDE_CONFIG_DIR).toBe("/sess/.claude");
+  });
+
+  test("the allowlist never contains the Claude-auth trio (defense-in-depth)", () => {
+    expect(SANDBOX_ENV_ALLOWLIST.has("ANTHROPIC_API_KEY")).toBe(false);
+    expect(SANDBOX_ENV_ALLOWLIST.has("CLAUDE_API_KEY")).toBe(false);
+    expect(SANDBOX_ENV_ALLOWLIST.has("CLAUDE_CODE_OAUTH_TOKEN")).toBe(false);
   });
 });
 

--- a/src/spawn-agent.ts
+++ b/src/spawn-agent.ts
@@ -247,6 +247,100 @@ export function readPersistedSpec(workspace: string): AgentSpec | null {
 }
 
 /**
+ * The ONLY env keys we accept FROM the sandbox engine's returned `wrapped.env`.
+ *
+ * CRITICAL ISOLATION CONTRACT. `@anthropic-ai/sandbox-runtime`'s
+ * `wrapWithSandboxArgv` returns `env: process.env` on macOS/Linux (the proxy/sandbox
+ * vars are baked into the wrapped COMMAND STRING via an `env VAR=… sandbox-exec …`
+ * prefix / bwrap `--setenv`, NOT into the returned env) and `{...process.env, ...proxy}`
+ * on Windows (where the proxy vars DO ride in the returned env). So `wrapped.env` is
+ * essentially the WHOLE daemon env. If we spread it over the scrubbed `childEnv`, the
+ * daemon's ambient `ANTHROPIC_API_KEY` / any other secret would OVERRIDE the scrub and
+ * reach the sandboxed turn — defeating `buildAgentChildEnv` entirely (the
+ * subscription-billing + no-secret-leak guarantee). So we ALLOWLIST: from `wrapped.env`
+ * we keep ONLY these known sandbox/proxy keys (the exact set the runtime's
+ * `generateProxyEnvVars` + the Linux bwrap `--setenv` markers emit — needed so the
+ * egress proxy works, esp. on Windows where they ride in the returned env), and drop
+ * everything else. {@link DENYLISTED_ENV} is re-applied to whatever we keep as belt-
+ * and-suspenders so the Claude-auth trio can NEVER enter via this seam.
+ *
+ * Source of truth: `@anthropic-ai/sandbox-runtime` `sandbox-utils.generateProxyEnvVars`
+ * (`SANDBOX_RUNTIME`, `TMPDIR`, `CA_TRUST_VARS`, `NO_PROXY`/proxy/socks/git-ssh/docker/
+ * cloudsdk/grpc vars) + `linux-sandbox-utils` (`CLAUDE_CODE_HOST_*_PROXY_PORT`). Raise
+ * this set alongside the pinned-engine upgrade gate if the runtime adds a launch var.
+ */
+export const SANDBOX_ENV_ALLOWLIST: ReadonlySet<string> = new Set([
+  // Sandbox markers + the per-session temp dir.
+  "SANDBOX_RUNTIME",
+  "TMPDIR",
+  // CA trust stores (CA_TRUST_VARS) — when the proxy terminates TLS the child must
+  // trust the proxy-minted certs.
+  "NODE_EXTRA_CA_CERTS",
+  "SSL_CERT_FILE",
+  "CURL_CA_BUNDLE",
+  "REQUESTS_CA_BUNDLE",
+  "PIP_CERT",
+  "GIT_SSL_CAINFO",
+  "AWS_CA_BUNDLE",
+  "CARGO_HTTP_CAINFO",
+  "DENO_CERT",
+  // Proxy routing (upper + lower case) — the egress floor. Without these the
+  // sandboxed turn loses network on platforms that carry them in the returned env.
+  "NO_PROXY",
+  "no_proxy",
+  "HTTP_PROXY",
+  "http_proxy",
+  "HTTPS_PROXY",
+  "https_proxy",
+  "ALL_PROXY",
+  "all_proxy",
+  "FTP_PROXY",
+  "ftp_proxy",
+  "RSYNC_PROXY",
+  "GRPC_PROXY",
+  "grpc_proxy",
+  "DOCKER_HTTP_PROXY",
+  "DOCKER_HTTPS_PROXY",
+  "CLOUDSDK_PROXY_TYPE",
+  "CLOUDSDK_PROXY_ADDRESS",
+  "CLOUDSDK_PROXY_PORT",
+  // Git-over-SSH through the SOCKS/HTTP proxy.
+  "GIT_SSH_COMMAND",
+  // Linux bwrap host-proxy-port markers (debug/transparency).
+  "CLAUDE_CODE_HOST_HTTP_PROXY_PORT",
+  "CLAUDE_CODE_HOST_SOCKS_PROXY_PORT",
+]);
+
+/**
+ * Compose the FINAL launch env for a sandboxed turn so the SCRUB WINS.
+ *
+ * Layering (lowest → highest precedence):
+ *   1. `childEnv` — the scrubbed allowlist from {@link buildAgentChildEnv} (authoritative).
+ *   2. the sandbox/proxy ALLOWLIST drawn from `wrappedEnv` ({@link SANDBOX_ENV_ALLOWLIST}),
+ *      with {@link DENYLISTED_ENV} re-applied defensively — only known egress/sandbox
+ *      vars layer on, never the daemon's ambient `process.env` (the old `...wrappedEnv`
+ *      spread leaked it).
+ *   3. `homeEnv` — `seedAgentHome`'s CLAUDE_CONFIG_DIR/XDG/TMP overrides win last.
+ *
+ * `CLAUDE_CODE_OAUTH_TOKEN` (set last by `buildAgentChildEnv`) survives: it is not in the
+ * allowlist AND is denylisted, so step 2 can never overwrite it; step 3 doesn't set it.
+ */
+export function mergeSandboxLaunchEnv(
+  childEnv: Record<string, string>,
+  wrappedEnv: Record<string, string | undefined>,
+  homeEnv: Record<string, string>,
+): Record<string, string | undefined> {
+  const out: Record<string, string | undefined> = { ...childEnv };
+  for (const [k, v] of Object.entries(wrappedEnv)) {
+    if (typeof v !== "string" || v.length === 0) continue;
+    if (!SANDBOX_ENV_ALLOWLIST.has(k)) continue; // drop the daemon's ambient env
+    if (DENYLISTED_ENV.has(k)) continue; // never re-admit the Claude-auth trio here
+    out[k] = v;
+  }
+  return { ...out, ...homeEnv };
+}
+
+/**
  * Build the scrubbed child env for the sandboxed claude. Mirrors runner's
  * passthrough allowlist MINUS `ANTHROPIC_API_KEY` (and the `ANTHROPIC_*`/`CLAUDE_*`
  * wildcards, which would re-admit it) — the channel session runs on the
@@ -254,7 +348,10 @@ export function readPersistedSpec(workspace: string): AgentSpec | null {
  * `CLAUDE_CODE_OAUTH_TOKEN` is the session's auth.
  *
  * The sandbox engine's own env (proxy vars, sandbox markers) is layered on TOP of
- * this by the wrap step; this is the base the wrapper extends.
+ * this by {@link mergeSandboxLaunchEnv} — but as an ALLOWLIST
+ * ({@link SANDBOX_ENV_ALLOWLIST}), NOT the whole returned `wrapped.env` (which is the
+ * daemon's `process.env` and would re-admit the scrubbed secrets). This scrubbed env
+ * is authoritative; only known sandbox/proxy keys + the home overrides layer on top.
  *
  * SECURITY POSTURE — the per-channel env injection (`channelEnv`):
  *

--- a/src/spawn-agent.ts
+++ b/src/spawn-agent.ts
@@ -270,7 +270,10 @@ export function readPersistedSpec(workspace: string): AgentSpec | null {
  * this set alongside the pinned-engine upgrade gate if the runtime adds a launch var.
  */
 export const SANDBOX_ENV_ALLOWLIST: ReadonlySet<string> = new Set([
-  // Sandbox markers + the per-session temp dir.
+  // Sandbox markers + the per-session temp dir. NB: TMPDIR is allowlisted for the
+  // WINDOWS path (where it rides in the returned env dict); on macOS/Linux it's baked
+  // into the command string. Either way `homeEnv` (seedAgentHome's per-workspace tmp)
+  // is layered LAST in mergeSandboxLaunchEnv, so the session's own TMPDIR wins by design.
   "SANDBOX_RUNTIME",
   "TMPDIR",
   // CA trust stores (CA_TRUST_VARS) — when the proxy terminates TLS the child must


### PR DESCRIPTION
## What

Closes a **HIGH** isolation/billing leak in the sandboxed `claude -p` turn: the daemon's full ambient `process.env` (incl. any `ANTHROPIC_API_KEY` or other daemon secret) was reaching the sandboxed agent, defeating `buildAgentChildEnv`'s scrub.

## Why (location / issue / fix)

- **Location:** `src/backends/programmatic.ts` `launchEnv` construction (was `{ ...childEnv, ...wrapped.env, ...homeEnv }`).
- **Issue:** `@anthropic-ai/sandbox-runtime`'s `wrapWithSandboxArgv` returns `env: process.env` on macOS/Linux (the proxy vars are baked into the wrapped *command string*, not the returned env) and `{ ...process.env, ...proxy }` on Windows. So `wrapped.env` is essentially the whole daemon env. Spreading it **over** the scrubbed `childEnv` let `process.env` override the scrub — the deliberate omission of `ANTHROPIC_API_KEY`/`CLAUDE_API_KEY` (the subscription-billing guarantee) was a **no-op**, and any ambient daemon secret leaked into the turn.
- **Fix:** new centralized `mergeSandboxLaunchEnv` (`src/spawn-agent.ts`) re-layers so the **scrub wins**. From `wrapped.env` it merges only an **allowlist** (`SANDBOX_ENV_ALLOWLIST`) of the keys the sandbox runtime genuinely needs — the exact set `generateProxyEnvVars` + the Linux bwrap `--setenv` markers emit — never the whole `process.env`. `DENYLISTED_ENV` (the Claude-auth trio) is re-applied defensively to whatever is merged. `homeEnv` layers last; `CLAUDE_CODE_OAUTH_TOKEN` (set by `buildAgentChildEnv`) stays the session's managed auth.

Net: `childEnv` is authoritative; only known sandbox/proxy vars + the home overrides layer on top. Egress proxy vars are **preserved** (esp. on Windows where they ride in the returned env), so agents keep network.

## Allowlist (what's kept from `wrapped.env`, and why)

`SANDBOX_RUNTIME`, `TMPDIR`; the CA-trust vars (`NODE_EXTRA_CA_CERTS`, `SSL_CERT_FILE`, `CURL_CA_BUNDLE`, `REQUESTS_CA_BUNDLE`, `PIP_CERT`, `GIT_SSL_CAINFO`, `AWS_CA_BUNDLE`, `CARGO_HTTP_CAINFO`, `DENO_CERT`); the proxy routing vars (`NO_PROXY`/`HTTP_PROXY`/`HTTPS_PROXY`/`ALL_PROXY`/`FTP_PROXY`/`RSYNC_PROXY`/`GRPC_PROXY`/`DOCKER_*_PROXY`/`CLOUDSDK_PROXY_*` + lowercase variants); `GIT_SSH_COMMAND`; and the Linux bwrap markers `CLAUDE_CODE_HOST_HTTP_PROXY_PORT`/`CLAUDE_CODE_HOST_SOCKS_PROXY_PORT`. These are the egress floor; everything else from the daemon env is dropped. Source of truth pinned in a comment to the runtime's `generateProxyEnvVars` so it tracks the engine-upgrade gate.

## Parked spawner

`src/_parked/interactive-spawn.ts` (the retired interactive backend, **not** a live path) had the same vulnerable spread; switched to the shared helper too, to keep the seam consistent. No live behavior change there.

## Test fix (was vacuous)

The regression test's fake sandbox engine returned a small hand-made env, so it could never catch this leak. The fake now mirrors the **real** contract — returns an env that includes the daemon's `process.env` shape with a planted `ANTHROPIC_API_KEY` + `SECRET_THING` (and a wrong `CLAUDE_CODE_OAUTH_TOKEN`) plus the proxy/sandbox vars. New focused regression tests (`programmatic.test.ts` + a `mergeSandboxLaunchEnv` unit block in `spawn-agent.test.ts`) assert: launch env does **not** carry `ANTHROPIC_API_KEY`/`CLAUDE_API_KEY`/`SECRET_THING` (leak closed), **does** carry the resolved `CLAUDE_CODE_OAUTH_TOKEN` (managed auth wins), and **does** carry the load-bearing proxy/sandbox vars (egress preserved).

Verified the new regression test **fails** against the old spread (`Received: "sk-ant-DAEMON-AMBIENT-SHOULD-NOT-LEAK"`) and passes with the fix.

## Verification

- `bun run typecheck` — clean.
- `bun test src/backends/programmatic.test.ts src/spawn-agent.test.ts` — **120 pass, 0 fail** (472 expects).
- `bun test src/_parked/interactive-spawn.test.ts src/sandbox/sandbox.test.ts` — **21 pass, 0 fail**.

No rc bump (parachute-agent is bun-linked/experimental, no npm publish — matches #137/#138/#139).