### PR TITLE
feat(agent): GET /api/agents/<name>/env + "Effective env" panel — see the env a turn runs with (names only)

### DIFF
--- a/src/daemon-agent-env-api.test.ts
+++ b/src/daemon-agent-env-api.test.ts
@@ -1,0 +1,338 @@
+/**
+ * Integration tests for GET /api/agents/<name>/env — the EFFECTIVE-ENV operability
+ * endpoint (see what env vars an agent's `claude -p` turn will run with, NAMES ONLY).
+ *
+ * The endpoint composes three tagged sources — `default` (operator env.default),
+ * `channel` (per-agent override env.channels[<agent>]), and `grant:<service>` (service
+ * env vars an APPROVED grant WOULD inject) — in precedence order channel > default >
+ * grant, marking shadowed lower-precedence entries `overridden:true`.
+ *
+ * Load-bearing assertions (the security posture):
+ *   - VALUES NEVER appear in the response (only names) — across all three layers.
+ *   - grant env names are derived WITHOUT a material fetch (the GrantsClient's
+ *     getMaterial is asserted NEVER called).
+ *   - resilient when the grants/hub is unreachable at instantiate (env layers + a
+ *     degraded grant status still come back; the read never 500s).
+ *
+ * Harness mirrors daemon-agent-defs-api.test.ts: the hub JWT validator is stubbed
+ * (sentinel tokens → fixed scopes); the def-vault REST is an in-memory fake; the state
+ * dir is sandboxed so the env-store writes never touch the operator's ~/.parachute.
+ */
+import { describe, test, expect, mock, beforeAll, afterAll, beforeEach } from "bun:test";
+import { HubJwtError, looksLikeJwt } from "@openparachute/scope-guard";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Sandbox the state dir — the route reads the env store via describeChannelEnv() →
+// defaultStateDir(); the tests seed it via setChannelEnvVar(). Pin to a throwaway dir
+// so we never touch the operator's real ~/.parachute/agent (feedback_sandbox_destructive_cli).
+let stateDir: string;
+let priorStateDir: string | undefined;
+beforeAll(() => {
+  priorStateDir = process.env.PARACHUTE_AGENT_STATE_DIR;
+  stateDir = mkdtempSync(join(tmpdir(), "agent-env-api-state-"));
+  process.env.PARACHUTE_AGENT_STATE_DIR = stateDir;
+});
+afterAll(() => {
+  if (priorStateDir === undefined) delete process.env.PARACHUTE_AGENT_STATE_DIR;
+  else process.env.PARACHUTE_AGENT_STATE_DIR = priorStateDir;
+  try {
+    rmSync(stateDir, { recursive: true, force: true });
+  } catch {}
+});
+
+const ADMIN_TOKEN = "test-admin-token";
+const READ_TOKEN = "test-read-token";
+mock.module("./hub-jwt.ts", () => ({
+  AGENT_AUDIENCE: "agent",
+  CHANNEL_AUDIENCE: "channel",
+  async validateHubJwt(token: string) {
+    const base = { sub: "test", aud: "agent", jti: undefined, clientId: undefined, vaultScope: undefined };
+    if (token === ADMIN_TOKEN) return { ...base, scopes: ["agent:read", "agent:send", "agent:admin"] };
+    if (token === READ_TOKEN) return { ...base, scopes: ["agent:read"] };
+    throw new HubJwtError("issuer", "invalid token");
+  },
+  HubJwtError,
+  looksLikeJwt,
+  resetJwksCache() {},
+  resetRevocationCache() {},
+}));
+
+import { createFetchHandler } from "./daemon.ts";
+import { ClientRegistry } from "./routing.ts";
+import { AgentDefRegistry, type InstantiateDeps } from "./agent-defs.ts";
+import { GrantsClient } from "./grants.ts";
+import {
+  setChannelEnvVar,
+  removeChannelEnvVar,
+  readCredentialsFile,
+} from "./credentials.ts";
+import type { Channel } from "./registry.ts";
+
+const adminAuth = { authorization: "Bearer " + ADMIN_TOKEN } as const;
+const readAuth = { authorization: "Bearer " + READ_TOKEN } as const;
+
+// ---------------------------------------------------------------------------
+// A FAKE def-vault REST (in-memory) — the registry's DefVaultClient drives it via an
+// injected fetchFn. Only the routes the registry calls (list / patch-status) matter.
+// ---------------------------------------------------------------------------
+interface FakeNote {
+  id: string;
+  content?: string;
+  tags?: string[];
+  metadata: Record<string, unknown>;
+}
+class FakeDefVault {
+  readonly notes = new Map<string, FakeNote>();
+  seed(note: FakeNote): void {
+    this.notes.set(note.id, note);
+  }
+  fetch = (async (input: URL | RequestInfo, init?: RequestInit) => {
+    const url = new URL(typeof input === "string" ? input : (input as Request).url);
+    const method = (init?.method ?? "GET").toUpperCase();
+    const m = url.pathname.match(/\/vault\/[^/]+\/api\/notes(?:\/(.+))?$/);
+    const noteId = m?.[1] ? decodeURIComponent(m[1]) : undefined;
+    const j = (body: unknown, status = 200) =>
+      new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+    if (method === "GET" && noteId === undefined) return j(Array.from(this.notes.values()));
+    if (method === "GET" && noteId !== undefined) {
+      const note = this.notes.get(noteId);
+      return note ? j(note) : j({ error: "not_found" }, 404);
+    }
+    if (method === "PATCH" && noteId !== undefined) {
+      const note = this.notes.get(noteId);
+      if (!note) return j({ error: "not_found" }, 404);
+      const body = JSON.parse(String(init?.body ?? "{}")) as { content?: string; metadata?: Record<string, unknown> };
+      if (body.content !== undefined) note.content = body.content;
+      if (body.metadata) note.metadata = { ...note.metadata, ...body.metadata };
+      return j(note);
+    }
+    return j({ error: "unhandled", method, path: url.pathname }, 500);
+  }) as unknown as typeof fetch;
+}
+
+/** No-op InstantiateDeps — instantiate runs (own-vault) without real channel/spawn I/O. */
+function noopDeps(): InstantiateDeps {
+  return {
+    ensureChannel: async () => {},
+    setupAndRegister: async () => {},
+    deregister: async () => true,
+    removeChannel: async () => true,
+  };
+}
+
+/**
+ * A GrantsClient over a controllable hub fetch. registerGrant returns a status we set
+ * per connection key (so a `wants:` connection resolves to `approved`/`pending`).
+ * getMaterial is FORBIDDEN — the read endpoint must never fetch material; if it does,
+ * the test fails loudly. Records the URLs hit so we can assert no `/material` call.
+ */
+function grantsClientWith(statusByKeyHint: Record<string, string>) {
+  const calls: string[] = [];
+  let materialFetched = false;
+  const fetchFn = (async (input: URL | RequestInfo, init?: RequestInit) => {
+    const url = new URL(typeof input === "string" ? input : (input as Request).url);
+    const method = (init?.method ?? "GET").toUpperCase();
+    calls.push(`${method} ${url.pathname}`);
+    const j = (body: unknown, status = 200) =>
+      new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+    if (url.pathname.endsWith("/material")) {
+      materialFetched = true;
+      return j({ error: "material must never be fetched by a names-only read" }, 500);
+    }
+    if (method === "PUT" && url.pathname === "/admin/grants") {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { agent: string; connection: { kind: string; target: string; inject?: string[] } };
+      // Re-derive the same key the registry will look up. For a service it's
+      // `<inject-joined>:<target>`; we key the hint by the bare service target for ease.
+      const status = statusByKeyHint[body.connection.target] ?? "pending";
+      return j({ id: `grant-${body.connection.target}`, agent: body.agent, connection: body.connection, status });
+    }
+    if (method === "GET" && url.pathname === "/admin/grants") return j({ grants: [] });
+    if (method === "POST" && url.pathname === "/admin/grants/reconcile") return j({ pruned: 0 });
+    return j({ error: "unhandled", method, path: url.pathname }, 500);
+  }) as unknown as typeof fetch;
+  const client = new GrantsClient({ hubOrigin: "http://hub.test", managerBearer: "mgr", fetchFn });
+  return { client, calls, get materialFetched() { return materialFetched; } };
+}
+
+function serverWith(channels: Map<string, Channel>, agentDefs?: AgentDefRegistry) {
+  const registry = new ClientRegistry();
+  const srv = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    idleTimeout: 0,
+    fetch: createFetchHandler(channels, registry, agentDefs ? { agentDefs } : {}),
+  });
+  return { srv, base: `http://127.0.0.1:${srv.port}` };
+}
+
+const emptyChannels = () => new Map<string, Channel>();
+
+// Clean the env store between tests so layer assertions are deterministic.
+function wipeEnvStore() {
+  const f = readCredentialsFile(stateDir);
+  for (const n of Object.keys(f.env?.default ?? {})) removeChannelEnvVar(null, n, stateDir);
+  for (const [ch, vars] of Object.entries(f.env?.channels ?? {})) {
+    for (const n of Object.keys(vars)) removeChannelEnvVar(ch, n, stateDir);
+  }
+}
+beforeEach(() => wipeEnvStore());
+
+// Secret sentinels — assert these VALUES never appear in any response body.
+const SECRET_VALUES = ["ghp_supersecret", "cf_supersecret", "default_secret_val", "grant_token_secret"];
+function assertNoSecretValues(bodyText: string) {
+  for (const v of SECRET_VALUES) expect(bodyText).not.toContain(v);
+}
+
+describe("GET /api/agents/<name>/env — auth + shape", () => {
+  test("no Authorization → 401 (admin-gated)", async () => {
+    const { srv, base } = serverWith(emptyChannels());
+    const res = await fetch(`${base}/api/agents/uni-dev/env`);
+    expect(res.status).toBe(401);
+    srv.stop();
+  });
+
+  test("a read-only token → 403 (admin scope required; authenticated but insufficient)", async () => {
+    const { srv, base } = serverWith(emptyChannels());
+    const res = await fetch(`${base}/api/agents/uni-dev/env`, { headers: readAuth });
+    expect(res.status).toBe(403);
+    srv.stop();
+  });
+
+  test("no def registered → env-store layers only + a note (never a 500)", async () => {
+    setChannelEnvVar(null, "DEFAULT_VAR", "default_secret_val", stateDir);
+    setChannelEnvVar("uni-dev", "CHANNEL_VAR", "ghp_supersecret", stateDir);
+    const { srv, base } = serverWith(emptyChannels()); // NO agentDefs wired.
+    const res = await fetch(`${base}/api/agents/uni-dev/env`, { headers: adminAuth });
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    assertNoSecretValues(text);
+    const body = JSON.parse(text) as { env: Array<{ name: string; source: string }>; note?: string };
+    expect(body.note).toBeDefined();
+    const names = body.env.map((e) => e.name).sort();
+    expect(names).toEqual(["CHANNEL_VAR", "DEFAULT_VAR"]);
+    expect(body.env.find((e) => e.name === "DEFAULT_VAR")!.source).toBe("default");
+    expect(body.env.find((e) => e.name === "CHANNEL_VAR")!.source).toBe("channel");
+    srv.stop();
+  });
+});
+
+describe("GET /api/agents/<name>/env — composes all three sources + precedence", () => {
+  /** Build a registry with one live def for `uni-dev` declaring `env:github`, with the
+   *  grant status the hub reports for it. Returns the registry + the grants probe. */
+  async function liveDefRegistry(githubGrantStatus: string) {
+    const fake = new FakeDefVault();
+    fake.seed({
+      id: "Agents/uni-dev",
+      content: "You are uni-dev.",
+      tags: ["#agent/definition"],
+      metadata: { name: "uni-dev", backend: "programmatic", mode: "single-threaded", wants: "env:github" },
+    });
+    const grants = grantsClientWith({ github: githubGrantStatus });
+    const reg = new AgentDefRegistry(noopDeps(), {
+      bindings: [{ vault: "default", vaultUrl: "http://127.0.0.1:1940", token: "vtok" }],
+      fetchFn: fake.fetch,
+      grants: grants.client,
+    });
+    await reg.loadAll(); // instantiate → registers the grant + resolves status (no material fetch).
+    return { reg, grants };
+  }
+
+  test("default + channel + approved-grant env merge, channel wins on collision, grant names derived WITHOUT material fetch, VALUES never returned", async () => {
+    // Seed the env store: a default-only var, a channel-only var, and a COLLISION on
+    // GITHUB_TOKEN (both the channel override AND the github grant target the same name).
+    setChannelEnvVar(null, "DEFAULT_VAR", "default_secret_val", stateDir);
+    setChannelEnvVar(null, "GITHUB_TOKEN", "default_secret_val", stateDir); // default layer also sets it
+    setChannelEnvVar("uni-dev", "CHANNEL_VAR", "ghp_supersecret", stateDir);
+    setChannelEnvVar("uni-dev", "GITHUB_TOKEN", "ghp_supersecret", stateDir); // channel override (wins)
+
+    const { reg, grants } = await liveDefRegistry("approved"); // github grant approved → injects GITHUB_TOKEN
+    const { srv, base } = serverWith(emptyChannels(), reg);
+    const res = await fetch(`${base}/api/agents/uni-dev/env`, { headers: adminAuth });
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    // SECURITY: no value ever leaks, from any of the three layers.
+    assertNoSecretValues(text);
+    expect(text).not.toContain('"value"');
+
+    const body = JSON.parse(text) as { env: Array<{ name: string; source: string; overridden?: boolean }>; note?: string };
+    expect(body.note).toBeUndefined(); // a def IS registered → no degraded note.
+
+    // CHANNEL_VAR — channel only.
+    const channelVar = body.env.filter((e) => e.name === "CHANNEL_VAR");
+    expect(channelVar).toHaveLength(1);
+    expect(channelVar[0]!.source).toBe("channel");
+    expect(channelVar[0]!.overridden).toBeUndefined();
+
+    // DEFAULT_VAR — default only.
+    const defaultVar = body.env.filter((e) => e.name === "DEFAULT_VAR");
+    expect(defaultVar).toHaveLength(1);
+    expect(defaultVar[0]!.source).toBe("default");
+
+    // GITHUB_TOKEN — set in ALL THREE layers; winner is channel, the other two shadowed.
+    const gh = body.env.filter((e) => e.name === "GITHUB_TOKEN");
+    expect(gh).toHaveLength(3);
+    const winner = gh.find((e) => !e.overridden)!;
+    expect(winner.source).toBe("channel"); // channel > default > grant
+    const shadowed = gh.filter((e) => e.overridden);
+    expect(shadowed.map((e) => e.source).sort()).toEqual(["default", "grant:github"]);
+
+    // The grant env NAME was derived (GITHUB_TOKEN, tagged grant:github) — and the
+    // grants client was NEVER asked for material (only PUT register at instantiate).
+    expect(grants.materialFetched).toBe(false);
+    expect(grants.calls.some((c) => c.includes("/material"))).toBe(false);
+    srv.stop();
+  });
+
+  test("a PENDING (not approved) grant does NOT contribute an env name", async () => {
+    const { reg, grants } = await liveDefRegistry("pending"); // github grant pending → no inject
+    const { srv, base } = serverWith(emptyChannels(), reg);
+    const res = await fetch(`${base}/api/agents/uni-dev/env`, { headers: adminAuth });
+    const body = (await res.json()) as { env: Array<{ name: string; source: string }> };
+    // No grant: layer at all (nothing approved), and no env-store vars seeded.
+    expect(body.env.filter((e) => e.source.startsWith("grant:"))).toHaveLength(0);
+    expect(body.env.find((e) => e.name === "GITHUB_TOKEN")).toBeUndefined();
+    expect(grants.materialFetched).toBe(false);
+    srv.stop();
+  });
+});
+
+describe("GET /api/agents/<name>/env — resilient when grants/hub unreachable", () => {
+  test("a def whose grant registration fails (hub down) still returns env-store layers, no 500", async () => {
+    // The env store has layers even though the hub is unreachable.
+    setChannelEnvVar(null, "DEFAULT_VAR", "default_secret_val", stateDir);
+    setChannelEnvVar("uni-dev", "CHANNEL_VAR", "ghp_supersecret", stateDir);
+
+    const fake = new FakeDefVault();
+    fake.seed({
+      id: "Agents/uni-dev",
+      content: "You are uni-dev.",
+      tags: ["#agent/definition"],
+      metadata: { name: "uni-dev", backend: "programmatic", mode: "single-threaded", wants: "env:github" },
+    });
+    // A grants client whose hub fetch always throws — registerGrant fails at instantiate,
+    // so the connection resolves as pending (not approved); the load still succeeds own-vault.
+    const downFetch = (async () => {
+      throw new Error("ECONNREFUSED hub down");
+    }) as unknown as typeof fetch;
+    const reg = new AgentDefRegistry(noopDeps(), {
+      bindings: [{ vault: "default", vaultUrl: "http://127.0.0.1:1940", token: "vtok" }],
+      fetchFn: fake.fetch,
+      grants: new GrantsClient({ hubOrigin: "http://hub.test", managerBearer: "mgr", fetchFn: downFetch }),
+    });
+    await reg.loadAll();
+
+    const { srv, base } = serverWith(emptyChannels(), reg);
+    const res = await fetch(`${base}/api/agents/uni-dev/env`, { headers: adminAuth });
+    expect(res.status).toBe(200); // NOT a 500.
+    const text = await res.text();
+    assertNoSecretValues(text);
+    const body = JSON.parse(text) as { env: Array<{ name: string; source: string }> };
+    // Env-store layers came back even with the hub down; no approved grant → no grant layer.
+    const names = body.env.map((e) => e.name).sort();
+    expect(names).toEqual(["CHANNEL_VAR", "DEFAULT_VAR"]);
+    expect(body.env.filter((e) => e.source.startsWith("grant:"))).toHaveLength(0);
+    srv.stop();
+  });
+});

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -67,6 +67,7 @@ import {
 } from "./def-vaults.ts";
 import { mintScopedToken, vaultScope } from "./mint-token.ts";
 import { GrantsClient } from "./grants.ts";
+import { resolveEffectiveEnv } from "./effective-env.ts";
 import { VaultJobStore, validateJob, vaultTransportFor, type Job } from "./jobs.ts";
 import { Runner, realTickDriver } from "./runner.ts";
 import { nextRunAfter } from "./cron.ts";
@@ -2050,6 +2051,45 @@ export function createFetchHandler(
       const denied = await requireScope(req, url, SCOPE_ADMIN);
       if (denied) return denied;
       return json({ vaults: listVaultNames() });
+    }
+
+    // ---------------------------------------------------------------------
+    // EFFECTIVE ENV — the env-var NAMES an agent's `claude -p` turn runs with
+    // (operability: see-what-env-a-turn-runs-with). NAMES ONLY, never values —
+    // the same redaction posture as GET /api/credentials/env (describeChannelEnv).
+    // Composed from three tagged sources, in precedence order channel > default >
+    // grant (mirrors resolveChannelEnv + buildAgentChildEnv's spawn-time merge):
+    //   - "default"         — the operator-level env.default layer
+    //   - "channel"         — the per-agent override layer (env.channels[<agent>])
+    //   - "grant:<service>" — service env vars an APPROVED grant WOULD inject at spawn,
+    //                          derived from the def's already-resolved connections via
+    //                          serviceEnvVar() — NO grant material is fetched.
+    // A lower-precedence entry shadowed by a higher one is marked overridden:true.
+    // RESILIENT: the env-store layers always resolve (a local file read); a missing
+    // def (agent not vault-native / idle registry) returns the env layers + a note,
+    // never a 500. admin-gated to match the rest of the agents surface.
+    //
+    //   GET /api/agents/<name>/env → { env: [{ name, source, overridden? }], note? }
+    //
+    // Externally hub strips `/agent`, so this is `<hub>/agent/api/agents/<name>/env`.
+    // Safe to add AFTER the single-segment `/api/agents/<name>` DELETE + `/restart`
+    // routes above: the `\/env$` suffix + GET-only method never collide with them.
+    // ---------------------------------------------------------------------
+    const envMatch = url.pathname.match(/^\/api\/agents\/([^/]+)\/env$/);
+    if (envMatch && req.method === "GET") {
+      const denied = await requireScope(req, url, SCOPE_ADMIN);
+      if (denied) return denied;
+      const name = decodeURIComponent(envMatch[1]!);
+      // Find the agent's live def by name (agent ≡ channel). Its `connections` carry the
+      // hub-resolved grant status (resolved at instantiate, NOT a live material fetch), so
+      // the grant-env names derive without any secret fetch. Absent → env-store layers only.
+      const def = agentDefs?.listDetailed().find((d) => d.name === name);
+      return json(
+        resolveEffectiveEnv(name, {
+          ...(def ? { connections: def.connections } : {}),
+          hasDef: Boolean(def),
+        }),
+      );
     }
 
     // ---------------------------------------------------------------------

--- a/src/effective-env.test.ts
+++ b/src/effective-env.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Unit tests for the PURE effective-env composition (effective-env.ts) — the
+ * precedence/overridden logic + the no-material grant-name derivation, isolated from
+ * the daemon route + any I/O. (The route integration lives in daemon-agent-env-api.test.ts.)
+ */
+import { describe, test, expect } from "bun:test";
+import {
+  approvedGrantEnvNames,
+  composeEffectiveEnv,
+  resolveEffectiveEnv,
+} from "./effective-env.ts";
+
+describe("approvedGrantEnvNames — names only, approved-service grants only, NO material", () => {
+  test("maps an approved service grant to its env-var name via serviceEnvVar", () => {
+    const out = approvedGrantEnvNames([{ kind: "service", target: "github", status: "approved" }]);
+    expect(out).toEqual([{ name: "GITHUB_TOKEN", source: "grant:github" }]);
+  });
+
+  test("a non-default service maps to <TARGET>_TOKEN", () => {
+    const out = approvedGrantEnvNames([{ kind: "service", target: "fireflies", status: "approved" }]);
+    expect(out).toEqual([{ name: "FIREFLIES_TOKEN", source: "grant:fireflies" }]);
+  });
+
+  test("ignores pending grants, vault grants, and mcp grants (none inject an env var)", () => {
+    const out = approvedGrantEnvNames([
+      { kind: "service", target: "github", status: "pending" }, // not approved
+      { kind: "vault", target: "research", status: "approved" }, // vault → MCP, not env
+      { kind: "mcp", target: "https://x/mcp", status: "approved" }, // remote MCP, not env
+      { kind: "service", target: "cloudflare", status: "approved" }, // the only env one
+    ]);
+    expect(out).toEqual([{ name: "CLOUDFLARE_API_TOKEN", source: "grant:cloudflare" }]);
+  });
+
+  test("undefined connections → empty", () => {
+    expect(approvedGrantEnvNames(undefined)).toEqual([]);
+  });
+});
+
+describe("composeEffectiveEnv — precedence channel > default > grant + overridden marking", () => {
+  const channelEnv = {
+    default: ["DEFAULT_VAR", "GITHUB_TOKEN"],
+    channels: { "uni-dev": ["CHANNEL_VAR", "GITHUB_TOKEN"] },
+  };
+  const connections = [{ kind: "service", target: "github", status: "approved" }];
+
+  test("a name set in all three layers → channel wins, default + grant marked overridden", () => {
+    const out = composeEffectiveEnv("uni-dev", channelEnv, connections);
+    const gh = out.filter((e) => e.name === "GITHUB_TOKEN");
+    expect(gh).toHaveLength(3);
+    const winner = gh.find((e) => !e.overridden)!;
+    expect(winner.source).toBe("channel");
+    expect(gh.filter((e) => e.overridden).map((e) => e.source).sort()).toEqual(["default", "grant:github"]);
+  });
+
+  test("single-layer names carry no overridden flag", () => {
+    const out = composeEffectiveEnv("uni-dev", channelEnv, connections);
+    expect(out.find((e) => e.name === "DEFAULT_VAR")).toEqual({ name: "DEFAULT_VAR", source: "default" });
+    expect(out.find((e) => e.name === "CHANNEL_VAR")).toEqual({ name: "CHANNEL_VAR", source: "channel" });
+  });
+
+  test("default beats grant when no channel override exists", () => {
+    const out = composeEffectiveEnv(
+      "uni-dev",
+      { default: ["GITHUB_TOKEN"], channels: {} },
+      connections,
+    );
+    const gh = out.filter((e) => e.name === "GITHUB_TOKEN");
+    expect(gh.find((e) => !e.overridden)!.source).toBe("default");
+    expect(gh.find((e) => e.overridden)!.source).toBe("grant:github");
+  });
+
+  test("an agent with no env-store entries + no connections → empty", () => {
+    expect(composeEffectiveEnv("nobody", { default: [], channels: {} }, undefined)).toEqual([]);
+  });
+
+  test("only the matching agent's channel layer is used (another agent's overrides are ignored)", () => {
+    const out = composeEffectiveEnv(
+      "uni-dev",
+      { default: [], channels: { other: ["OTHER_VAR"], "uni-dev": ["MINE"] } },
+      undefined,
+    );
+    expect(out.map((e) => e.name)).toEqual(["MINE"]);
+  });
+});
+
+describe("resolveEffectiveEnv — degraded note when no def, never returns values", () => {
+  test("hasDef:false → attaches a note + still returns env layers", () => {
+    const res = resolveEffectiveEnv("uni-dev", {
+      describeEnv: () => ({ default: ["DEFAULT_VAR"], channels: { "uni-dev": ["CHANNEL_VAR"] } }),
+      hasDef: false,
+    });
+    expect(res.note).toBeDefined();
+    expect(res.env.map((e) => e.name).sort()).toEqual(["CHANNEL_VAR", "DEFAULT_VAR"]);
+  });
+
+  test("hasDef:true → no note", () => {
+    const res = resolveEffectiveEnv("uni-dev", {
+      describeEnv: () => ({ default: [], channels: {} }),
+      connections: [{ kind: "service", target: "github", status: "approved" }],
+      hasDef: true,
+    });
+    expect(res.note).toBeUndefined();
+    expect(res.env).toEqual([{ name: "GITHUB_TOKEN", source: "grant:github" }]);
+  });
+
+  test("the shape carries NO `value` field on any entry", () => {
+    const res = resolveEffectiveEnv("uni-dev", {
+      describeEnv: () => ({ default: ["A"], channels: { "uni-dev": ["B"] } }),
+      connections: [{ kind: "service", target: "github", status: "approved" }],
+      hasDef: true,
+    });
+    for (const e of res.env) expect(Object.keys(e).sort()).not.toContain("value");
+  });
+});

--- a/src/effective-env.ts
+++ b/src/effective-env.ts
@@ -1,0 +1,184 @@
+/**
+ * Effective env-var NAME resolution for an agent's `claude -p` turn (operability —
+ * agent#audit "see what env a turn runs with"). The operability win: an operator can
+ * SEE, names-only, which env vars a programmatic turn will actually run with — the
+ * exact view that would have made the `FIREFLIES_API_TOKEN`-vs-`_KEY` mix-up obvious
+ * at a glance. NO VALUES, ever — this mirrors the redaction posture of
+ * {@link describeChannelEnv} (credentials.ts), which returns names and never secrets.
+ *
+ * THE THREE SOURCES (each entry is tagged with where it came from):
+ *   1. `"default"`        — the operator-level default layer (credentials.json `env.default`).
+ *   2. `"channel"`        — the per-agent override layer (`env.channels[<agent>]`; for a
+ *                            vault-native agent the channel key == the agent name).
+ *   3. `"grant:<service>"`— a service env var that an APPROVED grant WOULD inject at
+ *                            spawn (github → `GITHUB_TOKEN`). Derived from the def's
+ *                            already-resolved connection list (kind:"service",
+ *                            status:"approved") via {@link serviceEnvVar} — NO grant
+ *                            MATERIAL is fetched (this is a read endpoint; we list the
+ *                            NAMES that would be injected, never the secret token).
+ *
+ * PRECEDENCE (highest → lowest): channel > default > grant. This mirrors the spawn-time
+ * merge exactly:
+ *   - {@link resolveChannelEnv} merges `{ ...env.default, ...env.channels[ch] }` — the
+ *     channel layer wins over the default on a key collision.
+ *   - `buildAgentChildEnv` (spawn-agent.ts) is fed `{ ...grantEnv, ...channelEnv }` (see
+ *     the precedence comment in backends/programmatic.ts) — the channel/operator store
+ *     wins over a granted-service var on a collision.
+ * So a name present in multiple layers resolves to its HIGHEST-precedence source; the
+ * shadowed lower-precedence entries are still listed, marked `overridden: true`, so a
+ * "default has X but the channel also sets X" is visible.
+ *
+ * The Claude-auth denylist (`ANTHROPIC_API_KEY` / `CLAUDE_API_KEY` /
+ * `CLAUDE_CODE_OAUTH_TOKEN`) never appears here: the env-store setters reject it,
+ * `resolveChannelEnv` strips it, and `serviceEnvVar` can never map a grant onto it
+ * (the parse-time guard in grants.ts rejects such a service). `describeChannelEnv`
+ * surfaces only what the store actually holds, so a denylisted name can't ride in.
+ */
+
+import { describeChannelEnv } from "./credentials.ts";
+import { serviceEnvVar } from "./grants.ts";
+
+/** Where a resolved env-var NAME came from. `grant:<service>` names the service. */
+export type EnvSource = "default" | "channel" | `grant:${string}`;
+
+/** One resolved env-var NAME + its source. NEVER carries a value. */
+export interface EffectiveEnvEntry {
+  /** The env-var name (e.g. `GITHUB_TOKEN`). Never a value. */
+  name: string;
+  /** The layer this entry comes from (`default` | `channel` | `grant:<service>`). */
+  source: EnvSource;
+  /**
+   * True when this entry is SHADOWED by a higher-precedence layer that sets the same
+   * name — so a lower-precedence "also has X" is visible. Omitted (not `false`) on the
+   * winning entry to keep the wire shape lean.
+   */
+  overridden?: boolean;
+}
+
+/** The `GET /api/agents/<name>/env` response shape — NAMES ONLY, never values. */
+export interface EffectiveEnvResult {
+  /**
+   * Every resolved env-var name across the three sources, each tagged. A name set in
+   * more than one layer appears ONCE PER LAYER it's set in; the shadowed lower-precedence
+   * copies carry `overridden: true`. Sorted by name, then by precedence (winner first).
+   */
+  env: EffectiveEnvEntry[];
+  /**
+   * A non-fatal advisory (e.g. the grants layer couldn't be derived because no def is
+   * registered for this agent). Omitted when everything resolved cleanly. NEVER an error
+   * that 500s the read — the env-store layers always come back.
+   */
+  note?: string;
+}
+
+/** Precedence rank — HIGHER wins. channel > default > grant. */
+function rank(source: EnvSource): number {
+  if (source === "channel") return 3;
+  if (source === "default") return 2;
+  return 1; // grant:<service>
+}
+
+/**
+ * The approved-grant SERVICE env-var names an agent's def WOULD inject at spawn, each
+ * tagged `grant:<service>`. Derived purely from the def's ALREADY-RESOLVED connection
+ * list (the grant LIST/status the registry resolved at instantiate, echoed on
+ * {@link AgentDefDetail.connections}) — we read `connections` filtered to a `service`
+ * kind that the hub reports `approved`, and map the target through {@link serviceEnvVar}.
+ *
+ * NO grant MATERIAL is fetched here: a service grant injects its token under
+ * `serviceEnvVar(target)` (grants.ts `resolveInjectedGrants`), so the NAME is fully
+ * determined by the service target alone — the secret is irrelevant to a names-only view.
+ * Only `kind:"service"` grants inject an env var (vault/mcp grants inject an MCP server,
+ * not an env var), so we ignore those.
+ */
+export function approvedGrantEnvNames(
+  connections: ReadonlyArray<{ kind: string; target: string; status: string }> | undefined,
+): EffectiveEnvEntry[] {
+  if (!connections) return [];
+  const out: EffectiveEnvEntry[] = [];
+  for (const c of connections) {
+    if (c.kind !== "service" || c.status !== "approved") continue;
+    out.push({ name: serviceEnvVar(c.target), source: `grant:${c.target}` as EnvSource });
+  }
+  return out;
+}
+
+/**
+ * Compose the effective env-var NAME set for an agent from the three sources +
+ * precedence/overridden marking. PURE over its inputs (the env-store description + the
+ * def's connections) so it's unit-testable without a live hub/vault and never does I/O
+ * itself (the route resolves the inputs).
+ *
+ * `channelEnv` is the env-store description ({@link describeChannelEnv} output);
+ * `connections` is the agent's def connections (or undefined when no def is registered —
+ * then the grant layer is simply empty, the env-store layers still resolve).
+ *
+ * Per name, every layer that sets it contributes an entry; the highest-precedence one is
+ * the winner (no `overridden`), the rest carry `overridden: true`. Sorted by name, then
+ * winner-first within a name.
+ */
+export function composeEffectiveEnv(
+  agent: string,
+  channelEnv: { default: string[]; channels: Record<string, string[]> },
+  connections: ReadonlyArray<{ kind: string; target: string; status: string }> | undefined,
+): EffectiveEnvEntry[] {
+  const entries: EffectiveEnvEntry[] = [];
+  for (const name of channelEnv.default) entries.push({ name, source: "default" });
+  for (const name of channelEnv.channels[agent] ?? []) entries.push({ name, source: "channel" });
+  entries.push(...approvedGrantEnvNames(connections));
+
+  // Group by name; within a name, the highest-rank source wins (no `overridden`), the
+  // rest are marked shadowed. Stable: a name appears once per layer that sets it.
+  const byName = new Map<string, EffectiveEnvEntry[]>();
+  for (const e of entries) {
+    const arr = byName.get(e.name);
+    if (arr) arr.push(e);
+    else byName.set(e.name, [e]);
+  }
+  const result: EffectiveEnvEntry[] = [];
+  for (const [, group] of byName) {
+    group.sort((a, b) => rank(b.source) - rank(a.source));
+    group.forEach((e, i) => {
+      result.push(i === 0 ? { name: e.name, source: e.source } : { name: e.name, source: e.source, overridden: true });
+    });
+  }
+  result.sort((a, b) => a.name.localeCompare(b.name) || rank(b.source) - rank(a.source));
+  return result;
+}
+
+/**
+ * Resolve the full {@link EffectiveEnvResult} for an agent — the env-store layers (always
+ * available, read fresh from `credentials.json` via {@link describeChannelEnv}) plus the
+ * approved-grant service env names derived from the def's connections.
+ *
+ * RESILIENCE: the env-store layers ALWAYS resolve (a local file read). The grant layer
+ * depends on the def being registered — `connections` is undefined when no def is found
+ * (agent not vault-native, or the registry is idle); we still return the env-store layers
+ * and attach a `note` rather than failing. The grant status itself was already resolved at
+ * instantiate (no live hub call here), so a hub outage at READ time can't sink this view —
+ * it reflects the last-resolved grant status, names only.
+ */
+export function resolveEffectiveEnv(
+  agent: string,
+  opts: {
+    /** Override the env-store description (tests). Defaults to {@link describeChannelEnv}. */
+    describeEnv?: () => { default: string[]; channels: Record<string, string[]> };
+    /** The def's connections (kind/target/status). Undefined → no def registered. */
+    connections?: ReadonlyArray<{ kind: string; target: string; status: string }>;
+    /** True when a def IS registered for this agent (so an empty grant layer isn't flagged). */
+    hasDef: boolean;
+  },
+): EffectiveEnvResult {
+  const channelEnv = (opts.describeEnv ?? describeChannelEnv)();
+  const env = composeEffectiveEnv(agent, channelEnv, opts.connections);
+  if (!opts.hasDef) {
+    return {
+      env,
+      note:
+        `no vault-native #agent/definition found for "${agent}" — showing the env-store layers ` +
+        `only (operator default + per-agent override); approved-grant service env names are ` +
+        `unavailable without a registered def.`,
+    };
+  }
+  return { env };
+}

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -495,6 +495,44 @@ export function removeAgentSecret(body: {
 }
 
 // ---------------------------------------------------------------------------
+// Effective env — the env-var NAMES an agent's `claude -p` turn will actually run
+// with (operability: "see what env a turn runs with"). NAMES ONLY, never values —
+// mirrors `GET /api/credentials/env`'s redaction posture. Composed daemon-side from
+// three tagged sources (operator default + per-agent override + approved-grant
+// service env), in precedence order channel > default > grant, with shadowed
+// lower-precedence entries marked `overridden`. The grant names are derived from the
+// def's already-resolved connections — NO grant material is fetched.
+// ---------------------------------------------------------------------------
+
+/** Where a resolved env-var name comes from. `grant:<service>` names the service.
+ *  Mirrors `EnvSource` in `src/effective-env.ts`. */
+export type EnvSource = "default" | "channel" | `grant:${string}`;
+
+/** One resolved env-var NAME + its source. NEVER carries a value. Mirrors
+ *  `EffectiveEnvEntry` in `src/effective-env.ts`. */
+export interface EffectiveEnvEntry {
+  name: string;
+  source: EnvSource;
+  /** True when a higher-precedence layer shadows this same name (omitted on the winner). */
+  overridden?: boolean;
+}
+
+/** `GET /api/agents/<name>/env` response — names only, plus an optional advisory note
+ *  (e.g. no def registered → grant layer unavailable). Mirrors `EffectiveEnvResult`. */
+export interface AgentEnvResponse {
+  env: EffectiveEnvEntry[];
+  note?: string;
+}
+
+/**
+ * List the EFFECTIVE env-var NAMES an agent's turn runs with (the three tagged sources,
+ * precedence-resolved). The agent name is URL-encoded. NO values are ever returned.
+ */
+export function listAgentEnv(name: string): Promise<AgentEnvResponse> {
+  return getJson<AgentEnvResponse>(`/agents/${encodeURIComponent(name)}/env`);
+}
+
+// ---------------------------------------------------------------------------
 // Scheduled jobs (Agent UI v2 — Phase 4b). A job is "an automated human": send a
 // message to a vault-backed agent on a cron schedule (design 2026-06-17). The SPA
 // folds the per-agent schedule management into the agent detail panel; these wrap

--- a/web/ui/src/routes/Agents.test.tsx
+++ b/web/ui/src/routes/Agents.test.tsx
@@ -28,6 +28,7 @@ vi.mock("../lib/api.ts", async (orig) => {
     listAgentSecrets: vi.fn(),
     setAgentSecret: vi.fn(),
     removeAgentSecret: vi.fn(),
+    listAgentEnv: vi.fn(),
   };
 });
 
@@ -46,6 +47,7 @@ const deleteJob = vi.mocked(api.deleteJob);
 const listAgentSecrets = vi.mocked(api.listAgentSecrets);
 const setAgentSecret = vi.mocked(api.setAgentSecret);
 const removeAgentSecret = vi.mocked(api.removeAgentSecret);
+const listAgentEnv = vi.mocked(api.listAgentEnv);
 
 function agentRow(over: Partial<api.AgentRow> = {}): api.AgentRow {
   return {
@@ -108,6 +110,7 @@ beforeEach(() => {
   listAgentVaults.mockResolvedValue({ vaults: [] });
   listJobs.mockResolvedValue({ jobs: [] });
   listAgentSecrets.mockResolvedValue({ default: [], channels: {} });
+  listAgentEnv.mockResolvedValue({ env: [] });
 });
 
 afterEach(() => {
@@ -565,5 +568,80 @@ describe("Agents — per-agent secrets (#36)", () => {
     await waitFor(() =>
       expect(removeAgentSecret).toHaveBeenCalledWith({ channel: "alpha", name: "GH_TOKEN" }),
     );
+  });
+});
+
+describe("Effective env — the resolved env-var names in the detail panel", () => {
+  function openAgent() {
+    listAgents.mockResolvedValue({
+      agents: [agentRow({ name: "alpha", backend: "programmatic", channel: "alpha", vault: "default" })],
+    });
+    listAgentDefs.mockResolvedValue({ defs: [defRow({ name: "alpha", channel: "alpha" })] });
+  }
+
+  it("renders the resolved names with a source badge per layer (default / channel / grant), no values", async () => {
+    openAgent();
+    listAgentEnv.mockResolvedValue({
+      env: [
+        { name: "DEFAULT_VAR", source: "default" },
+        { name: "CHANNEL_VAR", source: "channel" },
+        { name: "GITHUB_TOKEN", source: "grant:github" },
+      ],
+    });
+    renderRoute();
+
+    fireEvent.click(await screen.findByTestId("agent-row-alpha"));
+    const section = await screen.findByTestId("effective-env-section");
+    // Each name appears with its source badge.
+    expect(within(section).getByTestId("effective-env-DEFAULT_VAR-default")).toBeInTheDocument();
+    expect(within(section).getByTestId("effective-env-CHANNEL_VAR-channel")).toBeInTheDocument();
+    expect(within(section).getByTestId("effective-env-GITHUB_TOKEN-grant:github")).toBeInTheDocument();
+    // The source badges render the source label.
+    expect(within(section).getByText("grant:github")).toBeInTheDocument();
+    expect(within(section).getByText("channel")).toBeInTheDocument();
+    // The call resolved THIS agent.
+    expect(listAgentEnv).toHaveBeenCalledWith("alpha");
+    // No value text leaks.
+    expect(within(section).queryByText(/ghp_|secret/i)).not.toBeInTheDocument();
+  });
+
+  it("marks a shadowed lower-precedence entry as overridden", async () => {
+    openAgent();
+    listAgentEnv.mockResolvedValue({
+      env: [
+        { name: "GITHUB_TOKEN", source: "channel" }, // winner
+        { name: "GITHUB_TOKEN", source: "grant:github", overridden: true }, // shadowed
+      ],
+    });
+    renderRoute();
+
+    fireEvent.click(await screen.findByTestId("agent-row-alpha"));
+    const section = await screen.findByTestId("effective-env-section");
+    // The grant entry is marked overridden; the channel winner is not.
+    expect(within(section).getByTestId("effective-env-overridden-GITHUB_TOKEN-grant:github")).toBeInTheDocument();
+    expect(within(section).queryByTestId("effective-env-overridden-GITHUB_TOKEN-channel")).not.toBeInTheDocument();
+  });
+
+  it("shows the empty state when nothing resolves", async () => {
+    openAgent();
+    listAgentEnv.mockResolvedValue({ env: [] });
+    renderRoute();
+
+    fireEvent.click(await screen.findByTestId("agent-row-alpha"));
+    expect(await screen.findByTestId("effective-env-empty")).toHaveTextContent(
+      "No env vars resolved for this agent.",
+    );
+  });
+
+  it("surfaces the degraded note when no def is registered", async () => {
+    openAgent();
+    listAgentEnv.mockResolvedValue({
+      env: [{ name: "DEFAULT_VAR", source: "default" }],
+      note: "no vault-native #agent/definition found for \"alpha\" — showing the env-store layers only.",
+    });
+    renderRoute();
+
+    fireEvent.click(await screen.findByTestId("agent-row-alpha"));
+    expect(await screen.findByTestId("effective-env-note")).toBeInTheDocument();
   });
 });

--- a/web/ui/src/routes/Agents.tsx
+++ b/web/ui/src/routes/Agents.tsx
@@ -49,9 +49,12 @@ import {
   removeAgentVault,
   runJob,
   type AgentSecretsResponse,
+  type AgentEnvResponse,
+  type EffectiveEnvEntry,
   DENYLISTED_ENV_NAMES,
   ENV_NAME_RE,
   listAgentSecrets,
+  listAgentEnv,
   setAgentSecret,
   removeAgentSecret,
 } from "../lib/api.ts";
@@ -456,6 +459,13 @@ export function AgentDetail({
       {agent.channel ? (
         <SecretsSection channel={agent.channel} backend={agent.backend} />
       ) : null}
+
+      {/* Effective env — the env-var NAMES (never values) this agent's `claude -p`
+          turn will actually run with, resolved across the operator default, the
+          per-agent override, and approved-grant service env. The top operability
+          read: "what env does a turn run with?" Keyed by the agent name; guarded on
+          a channel (symmetric with Secrets — a channel-less agent has no per-agent env). */}
+      {agent.channel ? <EffectiveEnvSection name={agent.name} /> : null}
 
       {/* Edit / delete — only for a vault-native def (a note we can mutate). */}
       {noteId ? (
@@ -1596,6 +1606,119 @@ function RadioRow(props: {
         <span className="radio-help">{props.help}</span>
       </span>
     </label>
+  );
+}
+
+/** The CSS pill class for an env source badge — grant gets the accent style, channel
+ *  the warn style (matching the backend pills), default a plain pill. */
+function envSourceBadgeClass(source: string): string {
+  if (source === "channel") return "pill backend-channel";
+  if (source.startsWith("grant:")) return "pill backend-programmatic";
+  return "pill";
+}
+
+/**
+ * The per-agent EFFECTIVE-ENV section (operability: "see what env a turn runs with").
+ * A read-only view over the daemon's `GET /api/agents/<name>/env` — the env-var NAMES
+ * (NEVER values) this agent's `claude -p` turn will actually run with, each with a
+ * source badge: `default` (operator-level), `channel` (this agent's override), or
+ * `grant:<svc>` (a service env an APPROVED hub grant injects). A name shadowed by a
+ * higher-precedence layer is shown with a subtle "overridden" marker, so a
+ * "default sets X but the channel overrides it" is visible at a glance — exactly the
+ * read that makes a `_TOKEN`-vs-`_KEY` mix-up obvious. NO values are ever fetched or
+ * rendered. Names-only mirrors the Secrets section's redaction posture.
+ */
+export function EffectiveEnvSection({ name }: { name: string }) {
+  type LoadState =
+    | { kind: "loading" }
+    | { kind: "error"; message: string }
+    | { kind: "ok"; env: EffectiveEnvEntry[]; note?: string };
+  const [state, setState] = useState<LoadState>({ kind: "loading" });
+
+  const load = useCallback(async () => {
+    setState({ kind: "loading" });
+    try {
+      const res: AgentEnvResponse = await listAgentEnv(name);
+      setState({ kind: "ok", env: res.env, ...(res.note ? { note: res.note } : {}) });
+    } catch (err) {
+      setState({ kind: "error", message: errMessage(err) });
+    }
+  }, [name]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  return (
+    <section className="detail-section" aria-label="Effective env" data-testid="effective-env-section">
+      <div className="section-head">
+        <h3>Effective env</h3>
+        <button type="button" className="secondary" data-testid="effective-env-refresh" onClick={() => void load()}>
+          Refresh
+        </button>
+      </div>
+      <p className="muted">
+        The env-var <strong>names</strong> this agent's sandboxed turn runs with, resolved across the
+        operator default, this agent's override, and approved-grant service env.{" "}
+        <strong>Names only</strong> — values are never shown. Precedence: channel &gt; default &gt; grant.
+      </p>
+
+      {state.kind === "loading" ? <div className="loading">Loading effective env…</div> : null}
+      {state.kind === "error" ? (
+        <div className="error-banner" role="alert" data-testid="effective-env-error">
+          {state.message}{" "}
+          <button type="button" className="secondary" onClick={() => void load()}>
+            Retry
+          </button>
+        </div>
+      ) : null}
+
+      {state.kind === "ok" ? (
+        <>
+          {state.note ? (
+            <p className="muted" data-testid="effective-env-note">
+              {state.note}
+            </p>
+          ) : null}
+          {state.env.length === 0 ? (
+            <div className="empty" data-testid="effective-env-empty">
+              No env vars resolved for this agent.
+            </div>
+          ) : (
+            <table>
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Source</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody>
+                {state.env.map((e, i) => (
+                  <tr
+                    key={`${e.name}-${e.source}-${i}`}
+                    className={e.overridden ? "cell-dim" : ""}
+                    data-testid={`effective-env-${e.name}-${e.source}`}
+                  >
+                    <td className="cell-name">{e.name}</td>
+                    <td>
+                      <span className={envSourceBadgeClass(e.source)}>{e.source}</span>
+                    </td>
+                    <td>
+                      {e.overridden ? (
+                        <span className="cell-dim" data-testid={`effective-env-overridden-${e.name}-${e.source}`}>
+                          overridden
+                        </span>
+                      ) : null}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </>
+      ) : null}
+    </section>
   );
 }
 


### PR DESCRIPTION
## What

Adds the top operability fix from the env audit: an operator can now **SEE** which env vars an agent's `claude -p` turn will actually run with — **NAMES ONLY, never values** (matching the redaction posture of `describeChannelEnv` in `src/credentials.ts`).

This is the read that would have made the recent `FIREFLIES_API_TOKEN`-vs-`_KEY` mix-up obvious at a glance.

### Daemon
`GET /api/agents/<name>/env` (gated on `agent:admin`, mirroring the other `/api/agents` endpoints) returns the effective resolved env-var NAME set, composed from three **tagged** sources:

| source | layer |
|---|---|
| `default` | operator-level `env.default` (credentials.json) |
| `channel` | per-agent override `env.channels[<agent>]` (channel key == agent name) |
| `grant:<service>` | service env an **APPROVED** grant WOULD inject — derived from the def's already-resolved connections via `serviceEnvVar()` (github → `GITHUB_TOKEN`) |

Response shape (names only): `{ env: [{ name, source, overridden? }], note? }`.

**Precedence** is `channel > default > grant`, mirroring the spawn-time merge exactly (`resolveChannelEnv` does `{...default, ...channel}`; `buildAgentChildEnv` is fed `{...grantEnv, ...channelEnv}` per the comment in `backends/programmatic.ts`). A name present in multiple layers resolves to its highest-precedence source; the shadowed lower-precedence entries are still listed, marked `overridden: true`, so a "default has X but channel also sets X" is visible.

Pure composition lives in the new `src/effective-env.ts`; the route is a thin wiring over it.

## Why / security posture

- **Values are NEVER returned** — the wire shape has no `value` field. A positive-control test seeds real secrets across all three layers and asserts they never appear in any response body.
- **Grant names derive WITHOUT a material fetch** — the route reads the pre-resolved connection status (`kind`/`target`/`status` off `AgentDefDetail.connections`, resolved at instantiate), never `GrantsClient.getMaterial`/`listGrants` at read time. The service env var name is fully determined by the service target string alone, so the secret is irrelevant. The integration test instruments the hub fetch and fails loudly if `/material` is ever hit.
- **Resilient** — the read can't 500 on a hub/grants outage: the env-store layers always resolve from the local credentials file; a missing def (agent not vault-native / idle registry) returns the env layers + a `note`.

## SPA

An **"Effective env"** section in the agent detail panel (`web/ui/src/routes/Agents.tsx`) lists the resolved names, each with a source badge (`default` / `channel` / `grant:<svc>`) and an "overridden" marker on shadowed entries. Empty state: "No env vars resolved for this agent." Reuses the Secrets/Connections aesthetic (`.detail-section`, `.pill`, `.cell-dim`). `listAgentEnv(name)` added to `web/ui/src/lib/api.ts` (reuses `authedFetch`).

## Verification

- `bun run typecheck` — clean (daemon + `web/ui`)
- `bun test ./src/effective-env.test.ts ./src/daemon-agent-env-api.test.ts ./src/credentials.test.ts ./src/grants.test.ts ./src/daemon-agent-defs-api.test.ts` — **145 pass / 0 fail**
- `cd web/ui && bunx vitest run` — **130 pass / 0 fail** (Agents suite 34, incl. 4 new effective-env cases)
- `cd web/ui && bun run build` — ok (tsc -b + vite build + verify-base)
- Did NOT run full `bun test ./src` (avoided launchctl/daemon-state suites); ran targeted suites + adjacent daemon API tests (84 pass).

Independent reviewer pass: LGTM, no critical issues; two nits folded inline (redundant `| string` union in the client type; guard the panel on `agent.channel` for symmetry with Secrets).

## Versioning

No rc bump — bun-linked/experimental preview, no npm publish (matches #137–#140).

🤖 Generated with [Claude Code](https://claude.com/claude-code)