### PR TITLE
feat(agent): inbound file attachments → the programmatic turn (Phase 1)

### DIFF
--- a/src/backends/programmatic.test.ts
+++ b/src/backends/programmatic.test.ts
@@ -31,6 +31,7 @@ import {
   isSessionNotFoundError,
   safeAttachmentBasename,
   ATTACHMENT_STAGING_DIR,
+  ATTACHMENT_MAX_COUNT,
   TURN_MAX_ATTEMPTS,
   TURN_RETRY_BACKOFF_MS,
   type ProgrammaticBackendDeps,
@@ -1648,5 +1649,67 @@ describe("ProgrammaticBackend.deliver — inbound attachment staging", () => {
     expect(result.ok).toBe(true);
     expect(existsSync(join(sessionsDir, "eng", ATTACHMENT_STAGING_DIR))).toBe(false);
     expect(calls[0]!.argv[2]!).not.toContain("Attached files");
+  });
+
+  test("caps the number of staged attachments at ATTACHMENT_MAX_COUNT", async () => {
+    mkDirs("att-cap");
+    const { fn } = recordingSpawn({ stdout: successTurn("sess-C", "ok") });
+    // Build MAX_COUNT + 5 fetchable blobs + matching attachment refs.
+    const blobs: Record<string, string> = {};
+    const refs: InboundAttachment[] = [];
+    const total = ATTACHMENT_MAX_COUNT + 5;
+    for (let i = 0; i < total; i++) {
+      const p = `2026-06-24/f${i}.bin`;
+      blobs[p] = `B${i}`;
+      refs.push(att(p, "application/octet-stream"));
+    }
+    const { fetchFn, blobCalls } = mintAndBlobFetch(blobs);
+    const backend = new ProgrammaticBackend(baseDeps(fn, { fetchFn }));
+    const handle = await backend.start(specWithVault("eng"));
+
+    const result = await backend.deliver(handle, "many", createSession("sess-C"), undefined, refs);
+    expect(result.ok).toBe(true);
+
+    // Only the first MAX_COUNT were fetched + staged; the overflow was dropped.
+    expect(blobCalls).toHaveLength(ATTACHMENT_MAX_COUNT);
+    const stagingDir = join(sessionsDir, "eng", ATTACHMENT_STAGING_DIR);
+    expect(existsSync(join(stagingDir, `f0.bin`))).toBe(true);
+    expect(existsSync(join(stagingDir, `f${ATTACHMENT_MAX_COUNT - 1}.bin`))).toBe(true);
+    expect(existsSync(join(stagingDir, `f${ATTACHMENT_MAX_COUNT}.bin`))).toBe(false);
+  });
+
+  test("an agent that binds NO vault → attachments skipped (no token to fetch), turn still runs", async () => {
+    mkDirs("att-novault");
+    const { fn, calls } = recordingSpawn({ stdout: successTurn("sess-V", "no vault reply") });
+    // A fetch that 500s on any blob — proving we NEVER reach it (no vault → no fetch).
+    const { fetchFn, blobCalls } = mintAndBlobFetch({});
+    const backend = new ProgrammaticBackend(baseDeps(fn, { fetchFn }));
+    // Spec with channels but NO vault binding.
+    const handle = await backend.start({ name: "eng", channels: ["eng"] } as AgentSpec);
+
+    const result = await backend.deliver(handle, "file but no vault", createSession("sess-V"), undefined, [
+      att("2026-06-24/x.png", "image/png"),
+    ]);
+    expect(result.ok).toBe(true);
+    // No blob fetched, no staging dir, no prompt pointer — the turn ran with text only.
+    expect(blobCalls).toHaveLength(0);
+    expect(existsSync(join(sessionsDir, "eng", ATTACHMENT_STAGING_DIR))).toBe(false);
+    expect(calls[0]!.argv[2]!).not.toContain("Attached files");
+  });
+
+  test("all attachments failing → NO empty staging dir left behind", async () => {
+    mkDirs("att-allfail");
+    const { fn } = recordingSpawn({ stdout: successTurn("sess-F", "ok") });
+    const { fetchFn } = mintAndBlobFetch({}); // every blob 404s
+    const backend = new ProgrammaticBackend(baseDeps(fn, { fetchFn }));
+    const handle = await backend.start(specWithVault("eng"));
+
+    const result = await backend.deliver(handle, "all bad", createSession("sess-F"), undefined, [
+      att("2026-06-24/a.png", "image/png"),
+      att("2026-06-24/b.png", "image/png"),
+    ]);
+    expect(result.ok).toBe(true);
+    // No file staged → the lazy mkdir never fired → no empty attachments/ dir.
+    expect(existsSync(join(sessionsDir, "eng", ATTACHMENT_STAGING_DIR))).toBe(false);
   });
 });

--- a/src/backends/programmatic.test.ts
+++ b/src/backends/programmatic.test.ts
@@ -29,12 +29,15 @@ import {
   PROGRAMMATIC_BACKEND_KIND,
   isTransientTurnError,
   isSessionNotFoundError,
+  safeAttachmentBasename,
+  ATTACHMENT_STAGING_DIR,
   TURN_MAX_ATTEMPTS,
   TURN_RETRY_BACKOFF_MS,
   type ProgrammaticBackendDeps,
   type ProgrammaticSpawnFn,
 } from "./programmatic.ts";
 import type { TurnSession } from "./types.ts";
+import type { InboundAttachment } from "../transport.ts";
 import type { SandboxEngine } from "../sandbox/index.ts";
 import type { SandboxRuntimeConfig } from "@anthropic-ai/sandbox-runtime";
 import type { AgentSpec } from "../sandbox/types.ts";
@@ -1436,5 +1439,214 @@ describe("ProgrammaticBackend.deliver — session-expiry → fresh-create fallba
     if (!result.ok) expect(result.error).toContain("No conversation found");
     // EXACTLY one spawn — the guard prevented any fallback create.
     expect(calls).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// INBOUND FILE ATTACHMENTS (Phase 1) — the programmatic backend stages each
+// attached file into the agent's PRIVATE session workspace (under a SAFE
+// basename, no traversal) and appends a pointer line to the turn prompt so the
+// `claude -p` turn can Read it. Best-effort + isolated per-file.
+// ---------------------------------------------------------------------------
+
+/**
+ * A fetch fake that serves BOTH the mint hub (POST → a token) AND vault storage
+ * blobs (GET .../api/storage/<path> → bytes). `blobs` maps a storage path → the
+ * byte body to return; a path not in the map 404s.
+ */
+function mintAndBlobFetch(blobs: Record<string, string> = {}): {
+  fetchFn: typeof fetch;
+  blobCalls: Array<{ url: string; auth: string | undefined }>;
+} {
+  let n = 0;
+  const blobCalls: Array<{ url: string; auth: string | undefined }> = [];
+  const fetchFn = (async (url: string | URL | Request, init?: RequestInit) => {
+    const u = String(url);
+    const method = (init?.method ?? "GET").toUpperCase();
+    if (u.includes("/api/storage/")) {
+      const auth = (init?.headers as Record<string, string> | undefined)?.authorization;
+      blobCalls.push({ url: u, auth });
+      const enc = u.split("/api/storage/")[1] ?? "";
+      const path = decodeURIComponent(enc);
+      const body = blobs[path];
+      if (body === undefined) return new Response("not found", { status: 404 });
+      return new Response(body, { status: 200, headers: { "content-type": "application/octet-stream" } });
+    }
+    if (method === "POST") {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { scope: string };
+      n += 1;
+      return new Response(
+        JSON.stringify({ jti: `j${n}`, token: `TOK-${n}`, expires_at: "2026-09-01T00:00:00Z", scope: body.scope }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    return new Response("unexpected", { status: 500 });
+  }) as unknown as typeof fetch;
+  return { fetchFn, blobCalls };
+}
+
+function att(path: string, mimeType: string, filename?: string): InboundAttachment {
+  return { path, mimeType, filename: filename ?? path.split("/").pop()! };
+}
+
+describe("safeAttachmentBasename — path-traversal sanitization (security)", () => {
+  test("strips directory components + traversal markers to a plain basename", () => {
+    expect(safeAttachmentBasename("../../etc/passwd")).toBe("passwd");
+    expect(safeAttachmentBasename("/abs/path/report.png")).toBe("report.png");
+    expect(safeAttachmentBasename("a/b/c/note.md")).toBe("note.md");
+    expect(safeAttachmentBasename("..\\..\\windows\\system32\\cmd.exe")).toBe("cmd.exe");
+  });
+  test("collapses disallowed chars to underscore + strips leading dots", () => {
+    expect(safeAttachmentBasename(".hidden")).toBe("hidden");
+    expect(safeAttachmentBasename("a b.png")).toBe("a_b.png");
+  });
+  test("degenerate input → a stable non-empty default", () => {
+    expect(safeAttachmentBasename("")).toBe("file");
+    expect(safeAttachmentBasename("..")).toBe("file");
+    expect(safeAttachmentBasename("/")).toBe("file");
+    expect(safeAttachmentBasename("./")).toBe("file");
+  });
+});
+
+describe("ProgrammaticBackend.deliver — inbound attachment staging", () => {
+  test("stages each blob into the PRIVATE workspace under a safe basename + appends the prompt line", async () => {
+    mkDirs("att-stage");
+    const { fn, calls } = recordingSpawn({ stdout: successTurn("sess-A", "looked at the files") });
+    const { fetchFn, blobCalls } = mintAndBlobFetch({
+      "2026-06-24/abc.png": "PNGBYTES",
+      "2026-06-24/def.txt": "hello world",
+    });
+    const backend = new ProgrammaticBackend(baseDeps(fn, { fetchFn }));
+    const handle = await backend.start(specWithVault("eng"));
+
+    const result = await backend.deliver(
+      handle,
+      "what is in these",
+      createSession("sess-A"),
+      undefined,
+      [att("2026-06-24/abc.png", "image/png"), att("2026-06-24/def.txt", "text/plain")],
+    );
+    expect(result.ok).toBe(true);
+
+    // Both blobs fetched from the storage endpoint, Bearer the per-turn minted vault token.
+    expect(blobCalls).toHaveLength(2);
+    for (const c of blobCalls) {
+      expect(c.url).toContain("/vault/default/api/storage/");
+      expect(c.auth).toMatch(/^Bearer TOK-/);
+    }
+
+    // Both files staged into the PRIVATE session workspace's attachments/ subdir.
+    const stagingDir = join(sessionsDir, "eng", ATTACHMENT_STAGING_DIR);
+    expect(existsSync(join(stagingDir, "abc.png"))).toBe(true);
+    expect(existsSync(join(stagingDir, "def.txt"))).toBe(true);
+    expect(readFileSync(join(stagingDir, "abc.png"), "utf-8")).toBe("PNGBYTES");
+    expect(readFileSync(join(stagingDir, "def.txt"), "utf-8")).toBe("hello world");
+
+    // The staged paths are WITHIN the private workspace.
+    expect(join(stagingDir, "abc.png").startsWith(join(sessionsDir, "eng"))).toBe(true);
+
+    // The turn prompt (argv) carries the attachment pointer line with the staged
+    // absolute paths + mime types, appended after the original message.
+    const cmd = calls[0]!.argv[2]!;
+    expect(cmd).toContain("Attached files");
+    expect(cmd).toContain(join(stagingDir, "abc.png"));
+    expect(cmd).toContain("image/png");
+    expect(cmd).toContain(join(stagingDir, "def.txt"));
+    expect(cmd).toContain("text/plain");
+    expect(cmd).toContain("what is in these");
+  });
+
+  test("a malicious filename is staged as a SAFE basename inside the staging dir, never outside (security)", async () => {
+    mkDirs("att-traversal");
+    const { fn, calls } = recordingSpawn({ stdout: successTurn("sess-T", "ok") });
+    // The blob's STORAGE PATH (what we fetch) is benign; the FILENAME is the attack vector.
+    const { fetchFn } = mintAndBlobFetch({ "2026-06-24/legit.bin": "EVILBYTES" });
+    const backend = new ProgrammaticBackend(baseDeps(fn, { fetchFn }));
+    const handle = await backend.start(specWithVault("eng"));
+
+    const result = await backend.deliver(
+      handle,
+      "stage this",
+      createSession("sess-T"),
+      undefined,
+      [att("2026-06-24/legit.bin", "application/octet-stream", "../../../../tmp/pwned.sh")],
+    );
+    expect(result.ok).toBe(true);
+
+    const stagingDir = join(sessionsDir, "eng", ATTACHMENT_STAGING_DIR);
+    // Landed INSIDE the staging dir under a sanitized basename, NOT at /tmp/pwned.sh.
+    expect(existsSync(join(stagingDir, "pwned.sh"))).toBe(true);
+    expect(existsSync("/tmp/pwned.sh")).toBe(false);
+    const cmd = calls[0]!.argv[2]!;
+    expect(cmd).toContain(join(stagingDir, "pwned.sh"));
+    expect(cmd).not.toContain("/tmp/pwned.sh");
+  });
+
+  test("a malicious storage PATH (no separate filename) also sanitizes to a basename in the staging dir", async () => {
+    mkDirs("att-pathtraversal");
+    const { fn } = recordingSpawn({ stdout: successTurn("sess-P", "ok") });
+    // The path the daemon hands us IS the attack; we fetch it verbatim but stage by basename.
+    const traversal = "../../../../tmp/evil.sh";
+    const { fetchFn } = mintAndBlobFetch({ [traversal]: "X" });
+    const backend = new ProgrammaticBackend(baseDeps(fn, { fetchFn }));
+    const handle = await backend.start(specWithVault("eng"));
+
+    const result = await backend.deliver(handle, "x", createSession("sess-P"), undefined, [
+      { path: traversal, mimeType: "text/plain", filename: traversal },
+    ]);
+    expect(result.ok).toBe(true);
+    const stagingDir = join(sessionsDir, "eng", ATTACHMENT_STAGING_DIR);
+    expect(existsSync(join(stagingDir, "evil.sh"))).toBe(true);
+    expect(existsSync("/tmp/evil.sh")).toBe(false);
+  });
+
+  test("a single blob fetch failure is isolated — the other file stages + the turn runs", async () => {
+    mkDirs("att-isolated");
+    const { fn, calls } = recordingSpawn({ stdout: successTurn("sess-I", "partial") });
+    const { fetchFn } = mintAndBlobFetch({ "2026-06-24/good.png": "GOODBYTES" });
+    const backend = new ProgrammaticBackend(baseDeps(fn, { fetchFn }));
+    const handle = await backend.start(specWithVault("eng"));
+
+    const result = await backend.deliver(
+      handle,
+      "two files",
+      createSession("sess-I"),
+      undefined,
+      [att("2026-06-24/missing.png", "image/png"), att("2026-06-24/good.png", "image/png")],
+    );
+    expect(result.ok).toBe(true);
+
+    const stagingDir = join(sessionsDir, "eng", ATTACHMENT_STAGING_DIR);
+    expect(existsSync(join(stagingDir, "good.png"))).toBe(true);
+    expect(existsSync(join(stagingDir, "missing.png"))).toBe(false);
+    const cmd = calls[0]!.argv[2]!;
+    expect(cmd).toContain(join(stagingDir, "good.png"));
+    expect(cmd).not.toContain("missing.png");
+  });
+
+  test("NO attachments → identical behavior to today (no staging dir, no prompt change)", async () => {
+    mkDirs("att-none");
+    const { fn, calls } = recordingSpawn({ stdout: successTurn("sess-N", "plain reply") });
+    const backend = new ProgrammaticBackend(baseDeps(fn));
+    const handle = await backend.start(specWithVault("eng"));
+
+    const result = await backend.deliver(handle, "no files here", createSession("sess-N"));
+    expect(result.ok).toBe(true);
+    expect(existsSync(join(sessionsDir, "eng", ATTACHMENT_STAGING_DIR))).toBe(false);
+    const cmd = calls[0]!.argv[2]!;
+    expect(cmd).not.toContain("Attached files");
+    expect(cmd).toContain("no files here");
+  });
+
+  test("an empty attachments array → no staging, no prompt change", async () => {
+    mkDirs("att-empty");
+    const { fn, calls } = recordingSpawn({ stdout: successTurn("sess-E", "x") });
+    const backend = new ProgrammaticBackend(baseDeps(fn));
+    const handle = await backend.start(specWithVault("eng"));
+
+    const result = await backend.deliver(handle, "hello", createSession("sess-E"), undefined, []);
+    expect(result.ok).toBe(true);
+    expect(existsSync(join(sessionsDir, "eng", ATTACHMENT_STAGING_DIR))).toBe(false);
+    expect(calls[0]!.argv[2]!).not.toContain("Attached files");
   });
 });

--- a/src/backends/programmatic.ts
+++ b/src/backends/programmatic.ts
@@ -57,6 +57,7 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { AgentSpec } from "../sandbox/types.ts";
+import type { InboundAttachment } from "../transport.ts";
 import { normalizeChannel } from "../sandbox/types.ts";
 import type { SandboxEngine } from "../sandbox/index.ts";
 import {
@@ -91,6 +92,41 @@ import type {
 const AGENT_NAME_SLUG = /^[a-z0-9_-]+$/i;
 
 export const PROGRAMMATIC_BACKEND_KIND = "programmatic" as const;
+
+/** The staging subdir (under the PRIVATE session workspace) inbound files are written into. */
+export const ATTACHMENT_STAGING_DIR = "attachments" as const;
+/**
+ * Per-attachment byte ceiling for staging. Matches the vault's own 100MB upload cap
+ * (parachute-vault `/api/storage` POST), so we never refuse a file the vault accepted —
+ * but caps a runaway/over-large blob from filling the workspace.
+ */
+export const ATTACHMENT_MAX_BYTES = 100 * 1024 * 1024;
+/** Max number of attachments staged per turn — a sane bound on fan-out. */
+export const ATTACHMENT_MAX_COUNT = 20;
+
+/**
+ * Sanitize a (possibly untrusted, possibly path-ful) attachment filename/path to a SAFE
+ * BASENAME for staging — NO path traversal, NO directory components. `path`/`filename`
+ * come from VAULT DATA (not the operator), so this is the security boundary: we take the
+ * LAST path segment, drop any `..`/empty segments, strip NUL + leading dots, and replace
+ * every character outside `[A-Za-z0-9._-]` with `_`. The result can ONLY name a file
+ * DIRECTLY inside the staging dir — never escape it. Returns `"file"` for a degenerate
+ * input so a write target always exists. The caller additionally verifies the joined
+ * path stays under the staging dir (defense in depth).
+ */
+export function safeAttachmentBasename(name: string): string {
+  // Take the final segment across both slash flavors; this alone defeats `../../etc/x`
+  // (every `..` and the leading dirs are discarded — only the trailing segment survives).
+  const segments = name.split(/[/\\]+/);
+  let base = segments.length > 0 ? segments[segments.length - 1]! : "";
+  // Strip NUL bytes + control chars, collapse disallowed chars to `_`.
+  base = base.replace(/\0/g, "").replace(/[^A-Za-z0-9._-]/g, "_");
+  // No leading dots (no `.`, `..`, or hidden-file surprises).
+  base = base.replace(/^\.+/, "");
+  if (base.length === 0 || base === "." || base === "..") return "file";
+  // Bound the length so a pathological name can't blow up the path.
+  return base.slice(0, 200);
+}
 
 /**
  * The minimal subprocess shape the runner awaits — a slice of `Bun.spawn`'s return
@@ -372,7 +408,13 @@ export class ProgrammaticBackend implements AgentBackend {
    * resume it. The fallback fires AT MOST once (only on a resume turn; the create it
    * runs has `resume: false`, so it can never re-trigger).
    */
-  async deliver(handle: AgentHandle, message: string, session: TurnSession, onInterim?: InterimSink): Promise<DeliverResult> {
+  async deliver(
+    handle: AgentHandle,
+    message: string,
+    session: TurnSession,
+    onInterim?: InterimSink,
+    attachments?: InboundAttachment[],
+  ): Promise<DeliverResult> {
     const spec = handle.spec;
     if (!spec) {
       return { ok: false, error: `ProgrammaticBackend.deliver: handle for "${handle.name}" carries no spec` };
@@ -485,6 +527,26 @@ export class ProgrammaticBackend implements AgentBackend {
     const mcpConfigPath = join(workspace, ".mcp.json");
     writeFileSync(mcpConfigPath, mcpConfigJson, { mode: 0o600 });
 
+    // ── INBOUND FILE ATTACHMENTS (Phase 1) ─────────────────────────────────────────
+    // Stage each attached file into the agent's PRIVATE session workspace (under a SAFE
+    // basename — NO path traversal; the path/filename come from VAULT DATA), then append a
+    // pointer line to the turn message so the `claude -p` turn can `Read` them. The private
+    // workspace is already in the sandbox read scope (composeFilesystemView always allows
+    // `base.workspace`), so NO sandbox-policy change is needed. Staged into the PRIVATE dir
+    // (NEVER a shared `spec.workspace`) — mirroring how `.mcp.json`/`system-prompt.txt` stay
+    // per-agent even when the working dir is shared. Best-effort + isolated: a single
+    // attachment's fetch/stage failure logs + is SKIPPED (the turn still runs with the rest
+    // + the text). Absent/empty → no staging, no prompt change (today's behavior exactly).
+    let turnMessage = message;
+    if (attachments && attachments.length > 0) {
+      const staged = await this.stageAttachments(workspace, attachments, vaultArg);
+      if (staged.length > 0) {
+        const lines = staged.map((s) => `- ${s.absPath} (${s.mimeType})`);
+        turnMessage =
+          `${message}\n\n[Attached files — read them as needed:\n${lines.join("\n")}\n]`;
+      }
+    }
+
     // System prompt (design 2026-06-16-channel-system-prompt.md). When the spec
     // carries one, write it to a per-session file (0600) and pass the `-file` flag.
     // The flag is PER-INVOCATION (not persistent), so we (re)write the file + pass
@@ -560,7 +622,7 @@ export class ProgrammaticBackend implements AgentBackend {
       // just runs the turn with the supplied {@link TurnSession} — `--resume <id>` to
       // continue, `--session-id <id>` to create.
       const argv = buildProgrammaticClaudeArgs({
-        message,
+        message: turnMessage,
         mcpConfigPath,
         sessionId: turnSession.id,
         resumeSession: turnSession.resume,
@@ -690,6 +752,112 @@ export class ProgrammaticBackend implements AgentBackend {
       result = await attemptTurn({ id: fresh, resume: false });
     }
     return result;
+  }
+
+  /**
+   * Stage inbound file attachments into the agent's PRIVATE session workspace so the turn
+   * can `Read` them (Phase 1). For each attachment: FETCH the blob from the vault storage
+   * REST endpoint (`GET <vaultUrl>/vault/<name>/api/storage/<path>`, Bearer the per-turn
+   * minted vault token), then WRITE it to `<workspace>/attachments/<safeBasename>`. Returns
+   * the staged files' ABSOLUTE paths + mime types (for the prompt pointer line).
+   *
+   * SECURITY:
+   *  - The staged filename is a SAFE BASENAME ({@link safeAttachmentBasename}) — the vault
+   *    `path`/`filename` are UNTRUSTED data, so a malicious `../../etc/passwd` collapses to a
+   *    plain basename inside the staging dir. As defense in depth we ALSO verify the resolved
+   *    write target stays UNDER the staging dir and skip it otherwise.
+   *  - Staged ONLY into the PRIVATE session dir (`workspace`), NEVER a shared `spec.workspace`
+   *    — mirroring `.mcp.json`/`system-prompt.txt`.
+   *  - Per-attachment size cap ({@link ATTACHMENT_MAX_BYTES}, = the vault's 100MB upload
+   *    ceiling) + a total count cap ({@link ATTACHMENT_MAX_COUNT}).
+   *
+   * Best-effort + ISOLATED: a single attachment's fetch/write failure logs + is SKIPPED (the
+   * turn still runs with the rest + the text). When the spec binds NO vault, there is no
+   * per-turn vault token to authenticate the storage fetch → ALL are skipped with one log.
+   */
+  private async stageAttachments(
+    workspace: string,
+    attachments: InboundAttachment[],
+    vaultArg: { url: string; entry: { name: string; token: string } } | undefined,
+  ): Promise<Array<{ absPath: string; mimeType: string }>> {
+    if (!vaultArg) {
+      console.warn(
+        `parachute-agent: ${attachments.length} inbound attachment(s) but this agent binds no ` +
+          `vault — cannot fetch the bytes; running the turn with text only.`,
+      );
+      return [];
+    }
+    const fetchFn = this.deps.fetchFn ?? fetch;
+    const stagingDir = join(workspace, ATTACHMENT_STAGING_DIR);
+    // The canonical staging-dir prefix the write target must stay under (defense in depth).
+    const stagingPrefix = stagingDir.endsWith("/") ? stagingDir : `${stagingDir}/`;
+    mkdirSync(stagingDir, { recursive: true });
+
+    const staged: Array<{ absPath: string; mimeType: string }> = [];
+    const usedNames = new Set<string>();
+    const capped = attachments.slice(0, ATTACHMENT_MAX_COUNT);
+    if (attachments.length > ATTACHMENT_MAX_COUNT) {
+      console.warn(
+        `parachute-agent: ${attachments.length} inbound attachments exceeds the cap ` +
+          `(${ATTACHMENT_MAX_COUNT}); staging the first ${ATTACHMENT_MAX_COUNT}.`,
+      );
+    }
+
+    for (const att of capped) {
+      if (typeof att.path !== "string" || att.path.length === 0) continue;
+      // SAFE basename — defeats path traversal (the vault path/filename are untrusted).
+      let base = safeAttachmentBasename(att.filename || att.path);
+      // De-dup colliding basenames so a second `report.png` doesn't clobber the first.
+      if (usedNames.has(base)) {
+        let n = 2;
+        const dot = base.lastIndexOf(".");
+        const stem = dot > 0 ? base.slice(0, dot) : base;
+        const ext = dot > 0 ? base.slice(dot) : "";
+        while (usedNames.has(`${stem}-${n}${ext}`)) n++;
+        base = `${stem}-${n}${ext}`;
+      }
+      const target = join(stagingDir, base);
+      // Defense in depth: the join MUST stay inside the staging dir.
+      if (target !== stagingDir.replace(/\/$/, "") && !target.startsWith(stagingPrefix)) {
+        console.warn(
+          `parachute-agent: refusing to stage attachment "${att.path}" — resolved path ` +
+            `"${target}" escapes the staging dir; skipping.`,
+        );
+        continue;
+      }
+
+      try {
+        const url = `${vaultArg.url}/vault/${vaultArg.entry.name}/api/storage/${encodeURIComponent(att.path)}`;
+        const res = await fetchFn(url, {
+          headers: { authorization: `Bearer ${vaultArg.entry.token}` },
+        });
+        if (!res.ok) {
+          const detail = await res.text().catch(() => "");
+          console.warn(
+            `parachute-agent: fetch attachment blob "${att.path}" failed (${res.status}) ` +
+              `${detail} — skipping this file`.trim(),
+          );
+          continue;
+        }
+        const buf = Buffer.from(await res.arrayBuffer());
+        if (buf.byteLength > ATTACHMENT_MAX_BYTES) {
+          console.warn(
+            `parachute-agent: attachment "${att.path}" is ${buf.byteLength} bytes, over the ` +
+              `${ATTACHMENT_MAX_BYTES}-byte cap — skipping this file.`,
+          );
+          continue;
+        }
+        writeFileSync(target, buf, { mode: 0o600 });
+        usedNames.add(base);
+        staged.push({ absPath: target, mimeType: att.mimeType || "application/octet-stream" });
+      } catch (err) {
+        console.warn(
+          `parachute-agent: staging attachment "${att.path}" errored (skipping this file): ` +
+            `${(err as Error).message}`,
+        );
+      }
+    }
+    return staged;
   }
 
   /**

--- a/src/backends/programmatic.ts
+++ b/src/backends/programmatic.ts
@@ -791,7 +791,16 @@ export class ProgrammaticBackend implements AgentBackend {
     const stagingDir = join(workspace, ATTACHMENT_STAGING_DIR);
     // The canonical staging-dir prefix the write target must stay under (defense in depth).
     const stagingPrefix = stagingDir.endsWith("/") ? stagingDir : `${stagingDir}/`;
-    mkdirSync(stagingDir, { recursive: true });
+    // Create the staging dir LAZILY — only just before the first real write. So a turn where
+    // every attachment fails/skips leaves NO empty `attachments/` dir behind (the "no staging
+    // side effects unless a file actually staged" contract).
+    let stagingDirReady = false;
+    const ensureStagingDir = (): void => {
+      if (!stagingDirReady) {
+        mkdirSync(stagingDir, { recursive: true });
+        stagingDirReady = true;
+      }
+    };
 
     const staged: Array<{ absPath: string; mimeType: string }> = [];
     const usedNames = new Set<string>();
@@ -827,6 +836,9 @@ export class ProgrammaticBackend implements AgentBackend {
       }
 
       try {
+        // The storage path is `date/filename` — `encodeURIComponent` percent-encodes the
+        // slash to `%2F`; the vault storage route `decodeURIComponent`s it back before
+        // matching (vault routes.ts), so a single encoded segment is the correct form.
         const url = `${vaultArg.url}/vault/${vaultArg.entry.name}/api/storage/${encodeURIComponent(att.path)}`;
         const res = await fetchFn(url, {
           headers: { authorization: `Bearer ${vaultArg.entry.token}` },
@@ -839,6 +851,17 @@ export class ProgrammaticBackend implements AgentBackend {
           );
           continue;
         }
+        // Pre-flight on Content-Length so an over-cap blob is skipped WITHOUT buffering its
+        // whole body. Best-effort: a missing/garbage header falls through to the post-read
+        // check below (the real guard).
+        const declared = Number(res.headers.get("content-length"));
+        if (Number.isFinite(declared) && declared > ATTACHMENT_MAX_BYTES) {
+          console.warn(
+            `parachute-agent: attachment "${att.path}" declares ${declared} bytes, over the ` +
+              `${ATTACHMENT_MAX_BYTES}-byte cap — skipping this file.`,
+          );
+          continue;
+        }
         const buf = Buffer.from(await res.arrayBuffer());
         if (buf.byteLength > ATTACHMENT_MAX_BYTES) {
           console.warn(
@@ -847,6 +870,7 @@ export class ProgrammaticBackend implements AgentBackend {
           );
           continue;
         }
+        ensureStagingDir();
         writeFileSync(target, buf, { mode: 0o600 });
         usedNames.add(base);
         staged.push({ absPath: target, mimeType: att.mimeType || "application/octet-stream" });

--- a/src/backends/registry.ts
+++ b/src/backends/registry.ts
@@ -45,6 +45,7 @@
 import type { AgentSpec, AgentMode } from "../sandbox/types.ts";
 import { normalizeChannel } from "../sandbox/types.ts";
 import type { AgentBackend, AgentHandle, InterimTurnEvent, TurnSession } from "./types.ts";
+import type { InboundAttachment } from "../transport.ts";
 
 /**
  * The streaming-view sink (design 2026-06-16 build item #1): the daemon wires this
@@ -326,6 +327,13 @@ export interface QueuedMessage {
    * to a finite integer before it lands here; a missing/garbage value reads as 0.
    */
   delegationDepth?: number;
+  /**
+   * Files attached to this inbound message (Phase 1: inbound file attachments → the
+   * programmatic turn). Threaded transport → daemon → `deliver`; the programmatic
+   * backend stages each into the agent's private session workspace so the turn can
+   * `Read` it. Absent/empty → no attachments (today's behavior unchanged).
+   */
+  attachments?: InboundAttachment[];
 }
 
 /** A registered programmatic agent's live status (surfaced in /health + the list). */
@@ -805,8 +813,14 @@ export class ProgrammaticAgentRegistry {
         // Forward each interim event to the streaming-view sink (keyed by channel)
         // as the turn runs — the "watch it work" live progress. The sink swallows
         // its own throws (emitTurnEvent), so a dead live stream can't break the turn.
-        result = await this.backend.deliver(handle.backendHandle, msg.content, turnSession, (e) =>
-          this.emitTurnEvent(channel, e),
+        result = await this.backend.deliver(
+          handle.backendHandle,
+          msg.content,
+          turnSession,
+          (e) => this.emitTurnEvent(channel, e),
+          // Phase 1: inbound attachments → the programmatic backend stages them into the
+          // agent's private workspace so the turn can Read them. Absent/empty → no staging.
+          msg.attachments,
         );
       } catch (err) {
         // The backend contract is failure-as-VALUE, never a throw — but defend so a

--- a/src/backends/types.ts
+++ b/src/backends/types.ts
@@ -45,6 +45,9 @@
 
 import type { AgentSpec } from "../sandbox/types.ts";
 import type { InterimTurnEvent } from "./stream-json.ts";
+import type { InboundAttachment } from "../transport.ts";
+
+export type { InboundAttachment } from "../transport.ts";
 
 export type { InterimTurnEvent } from "./stream-json.ts";
 
@@ -192,8 +195,20 @@ export interface AgentBackend {
    * the turn behaves exactly as before; the final {@link DeliverResult} is the
    * durable record either way. (Only the programmatic backend streams today; an
    * interactive retrofit may ignore it.)
+   *
+   * `attachments` (optional, Phase 1) are files attached to the inbound message. The
+   * programmatic backend stages each into the agent's PRIVATE session workspace (under
+   * a safe basename) before the turn and appends a workspace-relative pointer to the
+   * prompt, so the `claude -p` turn can `Read` them. ADDITIVE — absent/empty → no
+   * staging, the turn behaves exactly as before.
    */
-  deliver(handle: AgentHandle, message: string, session: TurnSession, onInterim?: InterimSink): Promise<DeliverResult>;
+  deliver(
+    handle: AgentHandle,
+    message: string,
+    session: TurnSession,
+    onInterim?: InterimSink,
+    attachments?: InboundAttachment[],
+  ): Promise<DeliverResult>;
 
   /**
    * Tear the agent down. For the programmatic backend this is a NO-OP — there is no

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -323,6 +323,9 @@ export function contextFor(
           // the vault transport's ingestInbound). When `reply_to` is present, the drain
           // delivers a callback to that channel on turn completion. See callbackFieldsFromMeta.
           ...callbackFieldsFromMeta(msg.meta),
+          // Phase 1: carry inbound file attachments through to the turn (the programmatic
+          // backend stages them into the agent's private workspace so the turn can Read them).
+          ...(msg.attachments && msg.attachments.length > 0 ? { attachments: msg.attachments } : {}),
         });
         return;
       }
@@ -344,6 +347,9 @@ export function contextFor(
           // that arrives before its recipient agent is live must still trigger a callback
           // once the buffered turn runs on register() (the agent#121 replay path).
           ...callbackFieldsFromMeta(msg.meta),
+          // Phase 1: carry inbound attachments through the pending buffer too, so a turn
+          // that runs on register() still stages them.
+          ...(msg.attachments && msg.attachments.length > 0 ? { attachments: msg.attachments } : {}),
         });
         if (outcome === "queued") return;
         // outcome === "unknown" — not an expected programmatic channel. It may still be a
@@ -2583,7 +2589,17 @@ export function createFetchHandler(
       let body: {
         trigger?: string;
         event?: string;
-        note?: { id?: string; path?: string; content?: string; tags?: string[]; metadata?: Record<string, unknown> };
+        note?: {
+          id?: string;
+          path?: string;
+          content?: string;
+          tags?: string[];
+          metadata?: Record<string, unknown>;
+          // The vault `send: "json"` trigger payload includes the note's attachments
+          // inline (each `{ id, path, mimeType, ... }`) — the has-attachments signal +
+          // fast-path the transport uses to surface inbound files (Phase 1).
+          attachments?: Array<{ id?: string; path?: string; mimeType?: string }>;
+        };
       };
       try {
         body = (await req.json()) as typeof body;
@@ -2649,7 +2665,16 @@ export function createFetchHandler(
       // Idempotency: a duplicate trigger delivery for the same note must not
       // double-wake. First-seen → process; already-seen → ack without emitting.
       if (markSeen(note.id)) {
-        vt.ingestInbound({ id: note.id, content: note.content, tags: note.tags, metadata: note.metadata });
+        // Await — ingestInbound is async when the note carries attachments (it fetches
+        // the attachment list before emitting). The `note.attachments` inline list from
+        // the trigger payload is forwarded as the has-attachments signal (Phase 1).
+        await vt.ingestInbound({
+          id: note.id,
+          content: note.content,
+          tags: note.tags,
+          metadata: note.metadata,
+          ...(note.attachments ? { attachments: note.attachments } : {}),
+        });
       }
       // Never write back to the note — the v1 trigger handles its own
       // created/rendered_at markers vault-side.

--- a/src/programmatic-wiring.test.ts
+++ b/src/programmatic-wiring.test.ts
@@ -61,6 +61,7 @@ import {
 } from "./backends/registry.ts";
 import type { AgentBackend, AgentHandle, AgentStatus, DeliverResult } from "./backends/types.ts";
 import type { AgentSpec } from "./sandbox/types.ts";
+import type { InboundAttachment } from "./transport.ts";
 import { VaultTransport } from "./transports/vault.ts";
 import { persistSpec, sessionWorkspace } from "./spawn-agent.ts";
 import type { Channel } from "./registry.ts";
@@ -144,13 +145,19 @@ async function withTempStateDir<T>(fn: (dir: string) => Promise<T> | T): Promise
 /** A controllable fake backend (no `claude -p`). */
 class FakeBackend implements AgentBackend {
   readonly kind = "programmatic";
-  readonly calls: { channel: string; message: string }[] = [];
+  readonly calls: { channel: string; message: string; attachments?: InboundAttachment[] }[] = [];
   resultFor: (message: string) => DeliverResult = (m) => ({ ok: true, reply: "reply:" + m });
   async start(spec: AgentSpec): Promise<AgentHandle> {
     return { backend: this.kind, channel: spec.channels[0] as string, name: spec.name, spec };
   }
-  async deliver(handle: AgentHandle, message: string): Promise<DeliverResult> {
-    this.calls.push({ channel: handle.channel, message });
+  async deliver(
+    handle: AgentHandle,
+    message: string,
+    _session?: unknown,
+    _onInterim?: unknown,
+    attachments?: InboundAttachment[],
+  ): Promise<DeliverResult> {
+    this.calls.push({ channel: handle.channel, message, ...(attachments ? { attachments } : {}) });
     return this.resultFor(message);
   }
   async stop(): Promise<void> {}
@@ -749,6 +756,29 @@ describe("contextFor.emit threads reply_to → a callback end-to-end through the
     expect(cb.calls[0]!.meta.source_channel).toBe("worker");
     expect(cb.calls[0]!.meta.correlation_id).toBe("corr-xyz");
     expect(cb.calls[0]!.meta.delegation_depth).toBe("2"); // incoming "1" → 1, +1 hop.
+  });
+
+  test("an inbound emit carrying attachments → they thread through the QueuedMessage to deliver() (no longer dropped)", async () => {
+    const backend = new FakeBackend();
+    const out = recorder();
+    const programmatic = new ProgrammaticAgentRegistry({ backend, writeOutbound: out.fn });
+    await programmatic.register({ name: "worker", channels: ["worker"], backend: "programmatic" });
+    const ctx = contextFor(new ClientRegistry(), "worker", new DeliveryState(), programmatic);
+
+    const attachments: InboundAttachment[] = [
+      { path: "2026-06-24/pic.png", mimeType: "image/png", filename: "pic.png" },
+    ];
+    ctx.emit({
+      channel: "worker",
+      content: "with a file",
+      meta: { note_id: "inbound-att", source: "vault" },
+      source: "vault",
+      attachments,
+    });
+
+    await until(() => backend.calls.length === 1);
+    // The attachments were carried onto the QueuedMessage and handed to deliver().
+    expect(backend.calls[0]!.attachments).toEqual(attachments);
   });
 
   test("an inbound emit WITHOUT reply_to → no callback (the common path)", async () => {

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -12,6 +12,27 @@
 
 import type { AgentMode } from "./sandbox/types.ts";
 
+/**
+ * A reference to a file attached to an inbound message (Phase 1: inbound file
+ * attachments → the programmatic turn). The vault transport surfaces these from
+ * an `#agent/message/inbound` note's attachments; the programmatic backend stages
+ * the bytes into the agent's private session workspace so a `claude -p` turn can
+ * `Read` them. Structured (not flattened into `meta`, which is string-only) so the
+ * list rides cleanly transport → daemon → backend.
+ */
+export interface InboundAttachment {
+  /**
+   * The vault-internal storage path (e.g. `2026-06-24/<uuid>.png`), relative to the
+   * vault's assets dir. The bytes are fetched via `GET <vaultUrl>/vault/<name>/api/storage/<path>`.
+   * UNTRUSTED (vault data) — the backend sanitizes the staged filename, never the path.
+   */
+  path: string;
+  /** The MIME type (e.g. `image/png`) — surfaced to the turn so it knows the file kind. */
+  mimeType: string;
+  /** The basename of `path` (a display/staging hint). UNTRUSTED — the backend re-sanitizes. */
+  filename: string;
+}
+
 /** An inbound message, routed by the daemon to the bridges subscribed to `channel`. */
 export interface InboundMessage {
   /** The named channel this message arrived on. */
@@ -22,6 +43,12 @@ export interface InboundMessage {
   meta: Record<string, string>;
   /** The transport kind that produced this message (e.g. "telegram"). */
   source: string;
+  /**
+   * Files attached to this inbound message, if any (Phase 1). The programmatic
+   * backend stages each into the agent's private session workspace so the turn can
+   * read it. Absent/empty → no attachments (today's behavior unchanged).
+   */
+  attachments?: InboundAttachment[];
 }
 
 export interface ReplyArgs {

--- a/src/transports/vault.test.ts
+++ b/src/transports/vault.test.ts
@@ -1359,6 +1359,83 @@ describe("VaultTransport — ingestInbound", () => {
     expect(ctx.emitted).toHaveLength(0);
   });
 
+  test("SURFACES attachments on the emitted InboundMessage when the note carries them (Phase 1)", async () => {
+    // The webhook payload carries `note.attachments` inline (the has-attachments signal);
+    // ingestInbound then fetches the authoritative attachment list (REST) and surfaces the
+    // refs on the emitted message so the programmatic backend can stage them.
+    const calls: string[] = [];
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      calls.push(String(url));
+      // The attachment-list endpoint → a bare Attachment[] array (vault REST shape).
+      return new Response(
+        JSON.stringify([
+          { id: "a1", noteId: "note-att-1", path: "2026-06-24/pic.png", mimeType: "image/png", createdAt: "x" },
+          { id: "a2", noteId: "note-att-1", path: "2026-06-24/doc.pdf", mimeType: "application/pdf", createdAt: "x" },
+        ]),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    const t = new VaultTransport(baseConfig());
+    const ctx = fakeCtx("eng");
+    void t.start(ctx);
+    await t.ingestInbound({
+      id: "note-att-1",
+      content: "look at these",
+      tags: ["#agent/message", "#agent/message/inbound"],
+      metadata: { agent: "eng", direction: "inbound", sender: "aaron" },
+      // inline list from the trigger payload — the has-attachments SIGNAL.
+      attachments: [{ id: "a1", path: "2026-06-24/pic.png", mimeType: "image/png" }],
+    });
+
+    // It fetched the attachment-list endpoint with the channel's vault token.
+    expect(calls.some((u) => u.endsWith("/vault/default/api/notes/note-att-1/attachments"))).toBe(true);
+
+    expect(ctx.emitted).toHaveLength(1);
+    const m = ctx.emitted[0]!;
+    expect(m.content).toBe("look at these");
+    expect(m.attachments).toBeDefined();
+    expect(m.attachments).toHaveLength(2);
+    expect(m.attachments![0]).toEqual({ path: "2026-06-24/pic.png", mimeType: "image/png", filename: "pic.png" });
+    expect(m.attachments![1]).toEqual({ path: "2026-06-24/doc.pdf", mimeType: "application/pdf", filename: "doc.pdf" });
+  });
+
+  test("attachment-list fetch FAILURE is best-effort — the message is still emitted with text, no attachments", async () => {
+    globalThis.fetch = (async () => new Response("boom", { status: 500 })) as unknown as typeof fetch;
+    const t = new VaultTransport(baseConfig());
+    const ctx = fakeCtx("eng");
+    void t.start(ctx);
+    await t.ingestInbound({
+      id: "note-att-fail",
+      content: "still delivered",
+      tags: ["#agent/message", "#agent/message/inbound"],
+      metadata: { agent: "eng", direction: "inbound" },
+      attachments: [{ id: "a1", path: "2026-06-24/pic.png", mimeType: "image/png" }],
+    });
+    expect(ctx.emitted).toHaveLength(1);
+    expect(ctx.emitted[0]!.content).toBe("still delivered");
+    expect(ctx.emitted[0]!.attachments).toBeUndefined();
+  });
+
+  test("NO inline attachments → NO fetch, emits synchronously (today's behavior)", () => {
+    // Any fetch here would throw — proving the no-attachment path never reaches out.
+    globalThis.fetch = (async () => {
+      throw new Error("must not fetch");
+    }) as unknown as typeof fetch;
+    const t = new VaultTransport(baseConfig());
+    const ctx = fakeCtx("eng");
+    void t.start(ctx);
+    // Not awaited — emit must be synchronous (before any await) when there are no attachments.
+    void t.ingestInbound({
+      id: "note-plain",
+      content: "no files",
+      tags: ["#agent/message", "#agent/message/inbound"],
+      metadata: { agent: "eng", direction: "inbound" },
+    });
+    expect(ctx.emitted).toHaveLength(1);
+    expect(ctx.emitted[0]!.attachments).toBeUndefined();
+  });
+
   test("FLATTENS the agent-to-agent callback fields (reply_to/correlation_id/delegation_depth) into meta", () => {
     // The READ side of the callback round-trip: a SENDING agent stamps reply_to et al on the
     // inbound note's metadata; ingestInbound must surface them in `meta` so contextFor.emit's

--- a/src/transports/vault.test.ts
+++ b/src/transports/vault.test.ts
@@ -1312,7 +1312,7 @@ describe("VaultTransport — ingestInbound", () => {
     const ctx = fakeCtx("eng");
     // start synchronously enough for the test (start just stores ctx).
     void t.start(ctx);
-    t.ingestInbound({
+    void t.ingestInbound({
       id: "note-in-1",
       content: "hello session",
       tags: ["#agent/message", "#agent/message/inbound"],
@@ -1338,7 +1338,7 @@ describe("VaultTransport — ingestInbound", () => {
     const t = new VaultTransport(baseConfig());
     const ctx = fakeCtx("eng");
     void t.start(ctx);
-    t.ingestInbound({
+    void t.ingestInbound({
       id: "our-own-reply",
       content: "I am awake",
       tags: ["#agent/message", "#agent/message/outbound"],
@@ -1351,7 +1351,7 @@ describe("VaultTransport — ingestInbound", () => {
     const t = new VaultTransport(baseConfig());
     const ctx = fakeCtx("eng");
     void t.start(ctx);
-    t.ingestInbound({
+    void t.ingestInbound({
       id: "x",
       content: "y",
       metadata: { channel: "eng", direction: "outbound" },
@@ -1444,7 +1444,7 @@ describe("VaultTransport — ingestInbound", () => {
     const t = new VaultTransport(baseConfig());
     const ctx = fakeCtx("worker");
     void t.start(ctx);
-    t.ingestInbound({
+    void t.ingestInbound({
       id: "note-deleg-1",
       content: "do the sub-task",
       tags: ["#agent/message", "#agent/message/inbound"],
@@ -1688,7 +1688,7 @@ describe("VaultTransport — ensureSchema (tag-schema declaration on connect)", 
     await flush(); // let the fire-and-forget ensureSchema settle (it must not reject globally)
 
     // Transport still delivers inbound after a failed schema declaration.
-    t.ingestInbound({
+    void t.ingestInbound({
       id: "n1",
       content: "still works",
       tags: ["#agent/message", "#agent/message/inbound"],

--- a/src/transports/vault.ts
+++ b/src/transports/vault.ts
@@ -64,7 +64,18 @@ import type {
   ReplyArgs,
   ThreadRecord,
   CallbackMetadata,
+  InboundAttachment,
 } from "../transport.ts";
+
+/** The safe basename of a (possibly path-ful, possibly untrusted) string — the LAST
+ *  path segment, with traversal markers stripped. Used to derive a display `filename`
+ *  from an attachment `path`. The backend re-sanitizes before staging; this is just a
+ *  reasonable default for the surfaced hint. */
+function basenameOf(p: string): string {
+  // Split on both slash flavors, take the last non-empty segment, drop `..`.
+  const parts = p.split(/[/\\]+/).filter((s) => s.length > 0 && s !== "..");
+  return parts.length > 0 ? parts[parts.length - 1]! : "";
+}
 
 /** Config for a vault transport instance (from the channel registry entry). */
 export interface VaultTransportConfig {
@@ -94,6 +105,14 @@ export interface InboundNote {
   /** The note's tags — carries `#agent/message/{inbound,outbound}` for loop avoidance. */
   tags?: string[];
   metadata?: Record<string, unknown>;
+  /**
+   * The note's attachments, if the trigger payload carried them inline (vault's
+   * `send: "json"` webhook includes `note.attachments` — each `{ id, path, mimeType, ... }`).
+   * A FAST-PATH: when present + non-empty, `ingestInbound` uses these directly and skips
+   * the REST attachment-list fetch. When absent, `ingestInbound` does NOT fetch (the
+   * daemon always forwards the inline list when the note has one — Phase 1).
+   */
+  attachments?: Array<{ id?: string; path?: string; mimeType?: string }>;
 }
 
 /**
@@ -1645,6 +1664,67 @@ export class VaultTransport implements Transport {
   // -------------------------------------------------------------------------
 
   /**
+   * Fetch the attachment list for an inbound note from the vault REST API
+   * (`GET <vaultUrl>/vault/<vault>/api/notes/<id>/attachments`, Bearer the channel's
+   * existing vault token). Returns the surfaced {@link InboundAttachment} refs (one per
+   * vault attachment that carries a usable `path`), or `[]` on ANY failure (best-effort —
+   * a missing/unreachable attachment list must NEVER drop the inbound message; the turn
+   * still runs with the text). The note id is percent-encoded as one path segment.
+   *
+   * Phase 1: the bytes are NOT fetched here — the programmatic backend stages them from
+   * `<vaultUrl>/.../api/storage/<path>` into the agent's private workspace. This method
+   * only surfaces the refs (path/mimeType/filename).
+   */
+  async fetchInboundAttachments(noteId: string): Promise<InboundAttachment[]> {
+    const url = `${this.vaultUrl}/vault/${this.vault}/api/notes/${encodeURIComponent(noteId)}/attachments`;
+    let res: Response;
+    try {
+      res = await fetch(url, { headers: { authorization: `Bearer ${this.token}` } });
+    } catch (err) {
+      console.warn(
+        `parachute-agent: fetch attachments for inbound note ${noteId} errored (proceeding ` +
+          `with text only): ${(err as Error).message}`,
+      );
+      return [];
+    }
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "");
+      console.warn(
+        `parachute-agent: fetch attachments for inbound note ${noteId} failed (${res.status}) ` +
+          `${detail} — proceeding with text only`.trim(),
+      );
+      return [];
+    }
+    let raw: unknown;
+    try {
+      raw = await res.json();
+    } catch (err) {
+      console.warn(
+        `parachute-agent: fetch attachments for inbound note ${noteId} — bad JSON (proceeding ` +
+          `with text only): ${(err as Error).message}`,
+      );
+      return [];
+    }
+    // Tolerate a bare array OR an `{ attachments: [...] }` envelope.
+    const list: Array<{ path?: unknown; mimeType?: unknown; mime_type?: unknown }> = Array.isArray(raw)
+      ? (raw as typeof list)
+      : (((raw as { attachments?: unknown }).attachments as typeof list | undefined) ?? []);
+    const out: InboundAttachment[] = [];
+    for (const a of list) {
+      const path = typeof a.path === "string" ? a.path : "";
+      if (!path) continue; // no storage path → nothing to fetch later; skip.
+      const mimeType =
+        typeof a.mimeType === "string"
+          ? a.mimeType
+          : typeof a.mime_type === "string"
+            ? a.mime_type
+            : "application/octet-stream";
+      out.push({ path, mimeType, filename: basenameOf(path) });
+    }
+    return out;
+  }
+
+  /**
    * Deliver an inbound `#agent/message/inbound` note onto this channel: emit it
    * so the subscribed bridge / MCP session wakes. Called by the daemon's
    * `/api/vault/inbound` webhook after it has resolved the channel.
@@ -1652,8 +1732,17 @@ export class VaultTransport implements Transport {
    * Belt-and-suspenders over the trigger predicate: a note tagged outbound
    * (`#agent/message/outbound`) OR explicitly `direction: "outbound"` is IGNORED —
    * we never wake on our own reply, even if a mis-wired trigger delivers one.
+   *
+   * ATTACHMENTS (Phase 1). When the note carries attachments inline (the vault
+   * `send: "json"` trigger payload includes `note.attachments`), we fetch the
+   * authoritative attachment list (REST) and surface the refs on the emitted
+   * {@link InboundMessage.attachments} so the programmatic backend can stage the
+   * bytes for the turn. The fetch is best-effort: a failure logs + the message is
+   * still emitted with the text (never dropped). When the note has NO attachments
+   * inline, NO fetch happens and emit is SYNCHRONOUS (today's behavior unchanged) —
+   * the only async path is the attachments-present case.
    */
-  ingestInbound(note: InboundNote): void {
+  async ingestInbound(note: InboundNote): Promise<void> {
     if (!this.ctx) throw new Error("vault transport: not started");
     const meta = note.metadata ?? {};
     const tags = note.tags ?? [];
@@ -1667,6 +1756,18 @@ export class VaultTransport implements Transport {
     for (const [k, v] of Object.entries(meta)) {
       flatMeta[k] = typeof v === "string" ? v : String(v);
     }
+
+    // Only reach for the attachment list when the inline payload signals there ARE
+    // attachments — so the no-attachment path emits WITHOUT a network round-trip (and
+    // stays synchronous-before-await, preserving the existing fire-and-forget callers).
+    const hasInline =
+      Array.isArray(note.attachments) &&
+      note.attachments.some((a) => typeof a?.path === "string" && a.path.length > 0);
+    let attachments: InboundAttachment[] = [];
+    if (hasInline) {
+      attachments = await this.fetchInboundAttachments(note.id);
+    }
+
     this.ctx.emit({
       // `channel` here is the in-memory InboundMessage.channel TS field (NOT serialized
       // note metadata) — left as the channel name. The routing key rides in `meta.agent`.
@@ -1683,6 +1784,7 @@ export class VaultTransport implements Transport {
         direction: "inbound",
       },
       source: "vault",
+      ...(attachments.length > 0 ? { attachments } : {}),
     });
   }
 }


### PR DESCRIPTION
## What

Make the **default programmatic backend's `claude -p` turn able to READ files attached to an inbound agent message**. When a surface attaches a file to an inbound message, it's uploaded to the vault as an attachment on the `#agent/message/inbound` note. Until now the programmatic path was blind to those files. This closes that for the **vault transport + programmatic backend**. The Telegram/`attached` path and the zero-attachment path are unchanged.

## Why

Today the programmatic path drops attachments at four points: the daemon drops message `meta`/attachments before enqueue, the `QueuedMessage` has no attachment field, the backend never stages a file, and the vault transport surfaces no attachments. A user who attaches a screenshot/PDF to a programmatic agent gets a turn that can't see it.

## How it flows

1. **Vault transport** (`ingestInbound`) — the vault `send: "json"` trigger webhook already carries `note.attachments` inline. When present, `ingestInbound` (now async) fetches the authoritative attachment list (`GET …/api/notes/<id>/attachments`, Bearer the channel's existing vault token) and surfaces `InboundMessage.attachments` (`{ path, mimeType, filename }`). Best-effort: a fetch failure logs + emits the text anyway. **No inline attachments → no fetch, emit stays synchronous** (today's behavior).
2. **Daemon** (`contextFor.emit`) — threads `attachments` onto the `QueuedMessage` (both the live programmatic enqueue and the agent#121 pending buffer); the webhook handler awaits `ingestInbound` and forwards `note.attachments`.
3. **Registry** (`drain`) — hands `msg.attachments` to `backend.deliver(...)` (new optional 5th param).
4. **Programmatic backend** (`deliver` → `stageAttachments`) — for each attachment, FETCH the blob (`GET <vaultUrl>/vault/<name>/api/storage/<path>`, Bearer the per-turn minted vault token) and WRITE it to `<workspace>/attachments/<safeBasename>` in the agent's **private** session dir, then append an `[Attached files — read them as needed: …]` pointer line (absolute paths + mime types) to the turn prompt.

## Sandbox

**No sandbox-policy change needed.** The staging dir lives under the private session `workspace`, which is `base.workspace` in `composeFilesystemView` — always in the read+write surface. The turn can `Read` the staged files as-is.

## Security

- **Safe basename** — vault `path`/`filename` are untrusted; `safeAttachmentBasename` takes the last path segment, drops `..`/leading dots, collapses disallowed chars. `../../etc/passwd` → `passwd` inside the staging dir. Defense-in-depth under-dir check on the joined path.
- **Private-dir staging only** — never a shared `spec.workspace` (mirrors how `.mcp.json` / `system-prompt.txt` stay per-agent even when the working dir is shared). Files written `0600`.
- **Caps** — per-attachment 100MB (= the vault's own upload ceiling) + a 20-file count cap.
- **Best-effort + isolated** — a single attachment's fetch/stage failure logs + skips that file; the turn still runs with the rest + the text. No vault bound → all skipped (one log). Zero attachments → identical to today.

## Verification

- `bun run typecheck` — clean.
- Targeted suites (`vault.test.ts`, `programmatic.test.ts`, `programmatic-wiring.test.ts`, `daemon.test.ts`) — green.
- Full `bun test ./src/` — **1094 pass, 0 fail** (no launchctl/daemon-mutating tests in this repo).

New tests: vault transport surfaces attachments / best-effort on fetch failure / no-fetch on the no-attachment path; daemon carries attachments into the `QueuedMessage` → `deliver`; backend stages into the private workspace under a safe basename + appends the prompt line; path traversal (malicious filename AND malicious path) stays inside the staging dir; isolated per-file failure; no-attachment + empty-array unchanged; `safeAttachmentBasename` unit suite.

## Follow-up

**Phase 2 — outbound files** (an agent attaching a file to its reply) is the follow-up; not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)