### PR TITLE
feat(agent): outbound file attachments — turn writes outbox/ → vault attachments on the reply (Phase 2)

### DIFF
--- a/src/backends/programmatic.test.ts
+++ b/src/backends/programmatic.test.ts
@@ -20,7 +20,7 @@
  *  - stop() clears the resume id; status() is live.
  */
 import { describe, test, expect, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, readFileSync, statSync, existsSync } from "node:fs";
+import { mkdtempSync, rmSync, readFileSync, statSync, existsSync, mkdirSync, writeFileSync, symlinkSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -32,6 +32,9 @@ import {
   safeAttachmentBasename,
   ATTACHMENT_STAGING_DIR,
   ATTACHMENT_MAX_COUNT,
+  OUTBOX_DIR,
+  OUTBOX_MAX_COUNT,
+  buildOutboxInstruction,
   TURN_MAX_ATTEMPTS,
   TURN_RETRY_BACKOFF_MS,
   type ProgrammaticBackendDeps,
@@ -1711,5 +1714,205 @@ describe("ProgrammaticBackend.deliver — inbound attachment staging", () => {
     expect(result.ok).toBe(true);
     // No file staged → the lazy mkdir never fired → no empty attachments/ dir.
     expect(existsSync(join(sessionsDir, "eng", ATTACHMENT_STAGING_DIR))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OUTBOUND FILE ATTACHMENTS (Phase 2) — the backend tells the turn how to attach
+// (write into ./outbox/) + sweeps the PRIVATE session outbox/ after a SUCCESSFUL
+// turn, surfacing the files on the result for the daemon to upload + link onto the
+// outbound note. The outbox is RESET per-turn so files never bleed across turns.
+// ---------------------------------------------------------------------------
+
+/** The absolute outbox dir for an agent's private session workspace. */
+function outboxOf(name = "eng"): string {
+  return join(sessionsDir, name, OUTBOX_DIR);
+}
+
+/** Write a file into the agent's private outbox (creating the dir) — simulating what the
+ *  turn would do. Called from a spawnFn so it lands DURING the turn, before the sweep. */
+function seedOutbox(name: string, files: Record<string, string>): void {
+  const dir = outboxOf(name);
+  mkdirSync(dir, { recursive: true });
+  for (const [fname, body] of Object.entries(files)) {
+    writeFileSync(join(dir, fname), body);
+  }
+}
+
+describe("ProgrammaticBackend.deliver — outbound file attachments (outbox sweep)", () => {
+  test("the turn message always carries the outbox instruction naming the ABSOLUTE outbox dir", async () => {
+    mkDirs("outbox-instr");
+    const { fn, calls } = recordingSpawn({ stdout: successTurn("sess-O", "done") });
+    const backend = new ProgrammaticBackend(baseDeps(fn));
+    const handle = await backend.start(specWithVault("eng"));
+
+    const result = await backend.deliver(handle, "do a thing", createSession("sess-O"));
+    expect(result.ok).toBe(true);
+    const cmd = calls[0]!.argv[2]!;
+    expect(cmd).toContain("do a thing");
+    // The instruction names the ABSOLUTE private-session outbox dir (NOT a `./outbox/`
+    // relative hint), so the agent writes where the sweep actually reads — even when its
+    // cwd is a shared spec.workspace.
+    expect(cmd).toContain(buildOutboxInstruction(outboxOf("eng")));
+    expect(cmd).toContain(outboxOf("eng"));
+    expect(cmd).not.toContain("./outbox/");
+  });
+
+  test("files the turn writes into outbox/ are swept + surfaced on the result (safe basenames)", async () => {
+    mkDirs("outbox-sweep");
+    // The spawnFn seeds the outbox DURING the turn (before the post-turn sweep).
+    const calls: string[][] = [];
+    const fn: ProgrammaticSpawnFn = (argv) => {
+      calls.push(argv);
+      seedOutbox("eng", { "chart.png": "PNGDATA", "report.pdf": "PDFDATA" });
+      return {
+        stdout: new Response(successTurn("sess-S", "here you go")).body,
+        stderr: new Response("").body,
+        exited: Promise.resolve(0),
+      };
+    };
+    const backend = new ProgrammaticBackend(baseDeps(fn));
+    const handle = await backend.start(specWithVault("eng"));
+
+    const result = await backend.deliver(handle, "make files", createSession("sess-S"));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.outboxFiles).toBeDefined();
+    const names = (result.outboxFiles ?? []).map((f) => f.basename).sort();
+    expect(names).toEqual(["chart.png", "report.pdf"]);
+    // Absolute paths point INTO the private session outbox.
+    for (const f of result.outboxFiles ?? []) {
+      expect(f.absPath.startsWith(outboxOf("eng"))).toBe(true);
+      expect(existsSync(f.absPath)).toBe(true);
+    }
+  });
+
+  test("a FAILED turn never surfaces outbox files (swept only on success)", async () => {
+    mkDirs("outbox-fail");
+    const fn: ProgrammaticSpawnFn = () => {
+      // The turn wrote a file, but the turn ITSELF fails — we must not surface it.
+      seedOutbox("eng", { "orphan.png": "X" });
+      return {
+        stdout: new Response(
+          ndjson({ type: "result", subtype: "error_during_execution", is_error: true, session_id: "sess-FX" }),
+        ).body,
+        stderr: new Response("").body,
+        exited: Promise.resolve(1),
+      };
+    };
+    const backend = new ProgrammaticBackend(baseDeps(fn));
+    const handle = await backend.start(specWithVault("eng"));
+
+    const result = await backend.deliver(handle, "fail", createSession("sess-FX"));
+    expect(result.ok).toBe(false);
+    // No outboxFiles field on a failure result (type-level: only the success arm carries it).
+    expect((result as { outboxFiles?: unknown }).outboxFiles).toBeUndefined();
+  });
+
+  test("the outbox is RESET per-turn — a prior turn's leftover never bleeds into the next reply", async () => {
+    mkDirs("outbox-reset");
+    // Pre-seed a leftover file BEFORE the first turn (as if a prior turn left it).
+    seedOutbox("eng", { "stale.png": "OLD" });
+    // The turn does NOT write anything new → after the pre-turn reset the outbox is empty.
+    const { fn } = recordingSpawn({ stdout: successTurn("sess-R", "no files this time") });
+    const backend = new ProgrammaticBackend(baseDeps(fn));
+    const handle = await backend.start(specWithVault("eng"));
+
+    const result = await backend.deliver(handle, "reset please", createSession("sess-R"));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // The stale file was cleared at the start of the turn → no swept files.
+    expect(result.outboxFiles).toBeUndefined();
+    expect(existsSync(join(outboxOf("eng"), "stale.png"))).toBe(false);
+  });
+
+  test("NO outbox files → text-only reply (outboxFiles absent), unchanged behavior", async () => {
+    mkDirs("outbox-none");
+    const { fn } = recordingSpawn({ stdout: successTurn("sess-NN", "plain") });
+    const backend = new ProgrammaticBackend(baseDeps(fn));
+    const handle = await backend.start(specWithVault("eng"));
+
+    const result = await backend.deliver(handle, "nothing to attach", createSession("sess-NN"));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.reply).toBe("plain");
+    expect(result.outboxFiles).toBeUndefined();
+  });
+
+  test("subdirs + zero-byte (partial) files are skipped; only regular non-empty files sweep", async () => {
+    mkDirs("outbox-filter");
+    const fn: ProgrammaticSpawnFn = () => {
+      const dir = outboxOf("eng");
+      mkdirSync(join(dir, "a-subdir"), { recursive: true });
+      writeFileSync(join(dir, "empty.png"), ""); // zero-byte → skip.
+      writeFileSync(join(dir, "good.png"), "REAL");
+      return {
+        stdout: new Response(successTurn("sess-FT", "filtered")).body,
+        stderr: new Response("").body,
+        exited: Promise.resolve(0),
+      };
+    };
+    const backend = new ProgrammaticBackend(baseDeps(fn));
+    const handle = await backend.start(specWithVault("eng"));
+
+    const result = await backend.deliver(handle, "filter", createSession("sess-FT"));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const names = (result.outboxFiles ?? []).map((f) => f.basename);
+    expect(names).toEqual(["good.png"]);
+  });
+
+  test("a SYMLINK in the outbox is skipped — never dereferenced + uploaded (security defense in depth)", async () => {
+    mkDirs("outbox-symlink");
+    // A target file OUTSIDE the outbox the symlink points at.
+    const outsideDir = mkdtempSync(join(tmpdir(), "outbox-outside-"));
+    const secret = join(outsideDir, "secret.png");
+    writeFileSync(secret, "SECRETBYTES");
+    const fn: ProgrammaticSpawnFn = () => {
+      const dir = outboxOf("eng");
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, "real.png"), "REAL");
+      // A symlink inside the outbox pointing at the outside secret.
+      symlinkSync(secret, join(dir, "link.png"));
+      return {
+        stdout: new Response(successTurn("sess-LN", "ok")).body,
+        stderr: new Response("").body,
+        exited: Promise.resolve(0),
+      };
+    };
+    const backend = new ProgrammaticBackend(baseDeps(fn));
+    const handle = await backend.start(specWithVault("eng"));
+    try {
+      const result = await backend.deliver(handle, "symlink", createSession("sess-LN"));
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      // Only the real regular file was swept; the symlink was rejected.
+      expect((result.outboxFiles ?? []).map((f) => f.basename)).toEqual(["real.png"]);
+    } finally {
+      rmSync(outsideDir, { recursive: true, force: true });
+    }
+  });
+
+  test("caps the swept files at OUTBOX_MAX_COUNT", async () => {
+    mkDirs("outbox-cap");
+    const total = OUTBOX_MAX_COUNT + 5;
+    const fn: ProgrammaticSpawnFn = () => {
+      const files: Record<string, string> = {};
+      // Zero-pad so the sweep's lexical sort is stable + matches numeric order.
+      for (let i = 0; i < total; i++) files[`f${String(i).padStart(3, "0")}.png`] = `B${i}`;
+      seedOutbox("eng", files);
+      return {
+        stdout: new Response(successTurn("sess-CAP", "many")).body,
+        stderr: new Response("").body,
+        exited: Promise.resolve(0),
+      };
+    };
+    const backend = new ProgrammaticBackend(baseDeps(fn));
+    const handle = await backend.start(specWithVault("eng"));
+
+    const result = await backend.deliver(handle, "lots", createSession("sess-CAP"));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect((result.outboxFiles ?? []).length).toBe(OUTBOX_MAX_COUNT);
   });
 });

--- a/src/backends/programmatic.ts
+++ b/src/backends/programmatic.ts
@@ -54,7 +54,7 @@
  * it is handed.
  */
 
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, writeFileSync, readdirSync, lstatSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import type { AgentSpec } from "../sandbox/types.ts";
 import type { InboundAttachment } from "../transport.ts";
@@ -85,6 +85,7 @@ import type {
   DeliverResult,
   DeliverUsage,
   InterimSink,
+  OutboxFile,
   TurnSession,
 } from "./types.ts";
 
@@ -103,6 +104,35 @@ export const ATTACHMENT_STAGING_DIR = "attachments" as const;
 export const ATTACHMENT_MAX_BYTES = 100 * 1024 * 1024;
 /** Max number of attachments staged per turn — a sane bound on fan-out. */
 export const ATTACHMENT_MAX_COUNT = 20;
+
+/**
+ * OUTBOUND FILE ATTACHMENTS (Phase 2) — the symmetric inverse of inbound staging.
+ * The turn writes files into the PRIVATE session `outbox/` (named by ABSOLUTE path in the
+ * turn instruction, so it works regardless of the turn's cwd); after a SUCCESSFUL turn the
+ * backend sweeps the dir + surfaces the files so the daemon's outbound write uploads each
+ * to the vault + links it onto the outbound note.
+ */
+/** The subdir (under the PRIVATE session workspace) the turn writes outbound files into. */
+export const OUTBOX_DIR = "outbox" as const;
+/** Max number of outbox files swept per turn — the same fan-out bound as inbound staging. */
+export const OUTBOX_MAX_COUNT = 20;
+
+/**
+ * Build the instruction appended to the turn so the agent knows HOW to attach a file to
+ * its reply. It names the ABSOLUTE outbox dir (the PRIVATE session `outbox/`, the dir the
+ * sweep actually reads) — NOT a `./outbox/` relative hint, because the turn's cwd is
+ * `spec.workspace` (a shared dir) when one is set, so a relative path would land in the
+ * WRONG place and never be swept. Mirrors how inbound attachments are surfaced by absolute
+ * path. Kept short + imperative. `outboxDir` is the absolute path from `deliver`.
+ */
+export function buildOutboxInstruction(outboxDir: string): string {
+  return (
+    `To attach a file to your reply, write it into ${outboxDir} (create the dir if needed). ` +
+    "Files there are uploaded to the vault and attached to your reply. Allowed types: " +
+    "images (.png .jpg .jpeg .gif .webp), .pdf, audio (.wav .mp3 .m4a .ogg .webm), .mp4 " +
+    "— other types are skipped. Omit this if you have no file to attach."
+  );
+}
 
 /**
  * Sanitize a (possibly untrusted, possibly path-ful) attachment filename/path to a SAFE
@@ -547,6 +577,30 @@ export class ProgrammaticBackend implements AgentBackend {
       }
     }
 
+    // ── OUTBOUND FILE ATTACHMENTS (Phase 2) ─────────────────────────────────────────
+    // The symmetric inverse of inbound staging: tell the turn HOW to attach a file to its
+    // reply (write it into the ABSOLUTE outbox dir), then — after a SUCCESSFUL turn — sweep
+    // that dir + surface the files for the daemon's outbound write to upload + link onto the
+    // outbound note. The outbox is the PRIVATE session `outbox/` (NEVER a shared
+    // `spec.workspace`), and it is RESET to empty BEFORE the turn so a prior turn's files
+    // can't bleed into this one's reply. The instruction names the ABSOLUTE path (not a
+    // `./outbox/` relative hint) — the turn's cwd is the SHARED `spec.workspace` when one is
+    // set, so a relative path would write to the wrong dir and never be swept. We append the
+    // instruction to EVERY turn (cheap + idempotent — the dir is empty unless the agent
+    // writes to it). Only the vault transport acts on the swept files downstream; a non-vault
+    // channel simply ignores them.
+    const outboxDir = join(workspace, OUTBOX_DIR);
+    // Per-turn fresh: clear any leftover from a prior turn (best-effort; a stale dir must
+    // never block the turn). Recreated lazily by the agent if it attaches.
+    try {
+      rmSync(outboxDir, { recursive: true, force: true });
+    } catch {
+      // A failed pre-clean is non-fatal — the post-turn sweep filters by mtime-free read,
+      // but the bleed risk is bounded because a SUCCESSFUL turn always re-sweeps the current
+      // contents (a prior turn's files would only persist if THIS turn also failed to clean).
+    }
+    turnMessage = `${turnMessage}\n\n[${buildOutboxInstruction(outboxDir)}]`;
+
     // System prompt (design 2026-06-16-channel-system-prompt.md). When the spec
     // carries one, write it to a per-session file (0600) and pass the `-file` flag.
     // The flag is PER-INVOCATION (not persistent), so we (re)write the file + pass
@@ -692,11 +746,19 @@ export class ProgrammaticBackend implements AgentBackend {
               ? { totalCostUsd: parsed.totalCostUsd }
               : undefined;
 
+          // OUTBOUND FILE ATTACHMENTS (Phase 2): sweep the PRIVATE session `outbox/` for
+          // files the turn wrote, ONLY on success — surfaced on the result so the daemon's
+          // outbound write uploads + links them onto the outbound note. Best-effort: a sweep
+          // failure logs + yields no files (the text reply still posts). An outbox from a
+          // FAILED turn is never swept (it's discarded with the turn outcome).
+          const outboxFiles = this.sweepOutbox(outboxDir);
+
           return {
             ok: true,
             reply: parsed.reply ?? "",
             ...(parsed.sessionId ? { sessionId: parsed.sessionId } : {}),
             ...(usage ? { usage } : {}),
+            ...(outboxFiles.length > 0 ? { outboxFiles } : {}),
           };
         }
 
@@ -882,6 +944,74 @@ export class ProgrammaticBackend implements AgentBackend {
       }
     }
     return staged;
+  }
+
+  /**
+   * Sweep the agent's PRIVATE session `outbox/` for files the turn wrote, returning each
+   * as an {@link OutboxFile} (absolute path + a SAFE basename). Called ONLY after a
+   * SUCCESSFUL turn — the daemon's outbound write uploads each to the vault + links it onto
+   * the outbound note (Phase 2). Best-effort + bounded:
+   *  - the dir absent / unreadable → `[]` (no outbox = a text-only reply, today's behavior);
+   *  - SKIP subdirectories, symlinks, and zero-byte files (a partial/in-progress write);
+   *  - the basename is reduced to a SAFE basename ({@link safeAttachmentBasename}) — the
+   *    AGENT chose the filename, so it's untrusted (defense in depth; the vault upload
+   *    re-derives the storage name + validates the extension server-side too);
+   *  - capped at {@link OUTBOX_MAX_COUNT} (a sane fan-out bound, mirrors inbound staging).
+   *
+   * This does NOT delete the swept files — the whole `outbox/` is RESET at the START of the
+   * NEXT turn (the per-turn-fresh contract in {@link deliver}), and the session workspace is
+   * the agent's own private dir, so leftover files never leak across agents.
+   */
+  private sweepOutbox(outboxDir: string): OutboxFile[] {
+    let entries: string[];
+    try {
+      entries = readdirSync(outboxDir);
+    } catch {
+      // Absent (the common case — the agent attached nothing) or unreadable → no files.
+      return [];
+    }
+    // Stable order so a multi-file reply is deterministic (and the cap takes the first N).
+    entries.sort();
+    const swept: OutboxFile[] = [];
+    const usedNames = new Set<string>();
+    for (const name of entries) {
+      if (swept.length >= OUTBOX_MAX_COUNT) {
+        console.warn(
+          `parachute-agent: outbox has more than ${OUTBOX_MAX_COUNT} files; ` +
+            `attaching the first ${OUTBOX_MAX_COUNT}.`,
+        );
+        break;
+      }
+      const absPath = join(outboxDir, name);
+      let st;
+      try {
+        // `lstatSync` (does NOT follow symlinks) so a SYMLINK inside the outbox — even one
+        // pointing at a regular file OUTSIDE the outbox (e.g. /etc/hosts) — is rejected by
+        // the `isFile()` check below (a symlink is `isSymbolicLink()`, not `isFile()`), not
+        // dereferenced and uploaded. Defense in depth: the sandbox write-confinement already
+        // stops the agent creating such a symlink, but never read+upload through one.
+        st = lstatSync(absPath);
+      } catch {
+        continue; // a vanished entry / race — skip.
+      }
+      // Only REGULAR, NON-EMPTY files: skip subdirs, symlinks, special files, and a zero-byte
+      // (partial/in-progress) write so we never upload an empty blob or a symlink target.
+      if (!st.isFile() || st.size === 0) continue;
+      // The AGENT chose this filename — sanitize to a safe basename (defense in depth).
+      let base = safeAttachmentBasename(name);
+      // De-dup colliding sanitized names so two files don't collapse to one display name.
+      if (usedNames.has(base)) {
+        let n = 2;
+        const dot = base.lastIndexOf(".");
+        const stem = dot > 0 ? base.slice(0, dot) : base;
+        const ext = dot > 0 ? base.slice(dot) : "";
+        while (usedNames.has(`${stem}-${n}${ext}`)) n++;
+        base = `${stem}-${n}${ext}`;
+      }
+      usedNames.add(base);
+      swept.push({ absPath, basename: base });
+    }
+    return swept;
   }
 
   /**

--- a/src/backends/registry.test.ts
+++ b/src/backends/registry.test.ts
@@ -114,11 +114,19 @@ class FakeBackend implements AgentBackend {
   }
 }
 
-/** A recorder WriteOutbound — captures every posted reply. */
-function recorder(): { calls: { channel: string; reply: string; inReplyTo?: string }[]; fn: WriteOutbound } {
-  const calls: { channel: string; reply: string; inReplyTo?: string }[] = [];
-  const fn: WriteOutbound = async (channel, reply, inReplyTo) => {
-    calls.push({ channel, reply, ...(inReplyTo ? { inReplyTo } : {}) });
+/** A recorder WriteOutbound — captures every posted reply (incl. Phase-2 outbound files). */
+function recorder(): {
+  calls: { channel: string; reply: string; inReplyTo?: string; files?: string[] }[];
+  fn: WriteOutbound;
+} {
+  const calls: { channel: string; reply: string; inReplyTo?: string; files?: string[] }[] = [];
+  const fn: WriteOutbound = async (channel, reply, inReplyTo, _threadId, files) => {
+    calls.push({
+      channel,
+      reply,
+      ...(inReplyTo ? { inReplyTo } : {}),
+      ...(files ? { files } : {}),
+    });
   };
   return { calls, fn };
 }
@@ -329,6 +337,82 @@ describe("ProgrammaticAgentRegistry — inbound enqueue + outbound", () => {
     expect(rec.calls).toHaveLength(2);
     expect(rec.calls[0]!.reply).toContain("surprise throw");
     expect(rec.calls[1]!).toEqual({ channel: "eng", reply: "reply:second (ok)" });
+  });
+});
+
+describe("ProgrammaticAgentRegistry — OUTBOUND file attachments (Phase 2)", () => {
+  test("a turn's swept outbox files ride through writeOutbound as `files` alongside the reply text", async () => {
+    const backend = new FakeBackend();
+    backend.resultFor = (m, sid) => ({
+      ok: true,
+      reply: "here you go",
+      sessionId: sid,
+      outboxFiles: [
+        { absPath: "/ws/eng/outbox/chart.png", basename: "chart.png" },
+        { absPath: "/ws/eng/outbox/report.pdf", basename: "report.pdf" },
+      ],
+    });
+    const rec = recorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    await reg.register(specFor("eng"));
+
+    reg.enqueue("eng", { content: "make me a chart" });
+    await until(() => rec.calls.length === 1);
+
+    expect(rec.calls).toHaveLength(1);
+    expect(rec.calls[0]!.reply).toBe("here you go");
+    expect(rec.calls[0]!.files).toEqual([
+      "/ws/eng/outbox/chart.png",
+      "/ws/eng/outbox/report.pdf",
+    ]);
+  });
+
+  test("outbox files with NO reply text STILL write an outbound note (so the attachment has a note to hang off)", async () => {
+    const backend = new FakeBackend();
+    backend.resultFor = (m, sid) => ({
+      ok: true,
+      reply: "",
+      sessionId: sid,
+      outboxFiles: [{ absPath: "/ws/eng/outbox/only.png", basename: "only.png" }],
+    });
+    const rec = recorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    await reg.register(specFor("eng"));
+
+    reg.enqueue("eng", { content: "just the file please" });
+    await until(() => rec.calls.length === 1);
+
+    expect(rec.calls).toHaveLength(1);
+    expect(rec.calls[0]!.reply).toBe("");
+    expect(rec.calls[0]!.files).toEqual(["/ws/eng/outbox/only.png"]);
+  });
+
+  test("NO outbox files → text-only reply, `files` is undefined (unchanged behavior)", async () => {
+    const backend = new FakeBackend();
+    // The default resultFor returns no outboxFiles.
+    const rec = recorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    await reg.register(specFor("eng"));
+
+    reg.enqueue("eng", { content: "hi" });
+    await until(() => rec.calls.length === 1);
+
+    expect(rec.calls).toHaveLength(1);
+    expect(rec.calls[0]!.reply).toBe("reply:hi");
+    expect(rec.calls[0]!.files).toBeUndefined();
+  });
+
+  test("empty reply AND no outbox files → NO outbound note at all (clean chat)", async () => {
+    const backend = new FakeBackend();
+    backend.resultFor = (m, sid) => ({ ok: true, reply: "", sessionId: sid });
+    const rec = recorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    await reg.register(specFor("eng"));
+
+    reg.enqueue("eng", { content: "tool-only work" });
+    await until(() => backend.calls.length === 1);
+    await new Promise<void>((r) => setTimeout(r, 5));
+    expect(rec.calls).toHaveLength(0);
   });
 });
 

--- a/src/backends/registry.ts
+++ b/src/backends/registry.ts
@@ -98,6 +98,15 @@ export type WriteOutbound = (
    * deferred (those notes are externally written; see the PR notes).
    */
   threadId?: string,
+  /**
+   * OUTBOUND FILE ATTACHMENTS (Phase 2): local file paths the turn wrote into its private
+   * `outbox/` (swept by the backend). The daemon's wiring hands them to the transport's
+   * `reply({ files })`; only the VaultTransport acts on them (uploads each to vault storage
+   * + links it onto the just-written outbound note). Absent/empty → a text-only reply
+   * (today's behavior). Best-effort downstream: a single file's upload/link failure is
+   * skipped + logged; the reply text + accepted files still post.
+   */
+  files?: string[],
 ) => Promise<{ id?: string } | void>;
 
 /**
@@ -902,20 +911,29 @@ export class ProgrammaticAgentRegistry {
 
       // The outbound reply — the channel-transcript delivery (the chat bubble). It is
       // ADDITIVE to the primary thread-note record already written above (for BOTH modes).
-      // Empty reply → NO note (reviewer contract — `reply` can be ""): a turn that produced
-      // no text (e.g. tool-only work) leaves the chat clean.
+      // Empty reply AND no outbox files → NO note (reviewer contract — `reply` can be ""): a
+      // turn that produced no text and attached nothing (e.g. tool-only work) leaves the chat
+      // clean. But a turn that attached a FILE with no text DOES get an outbound note (empty
+      // body) so the attachment has a note to hang off (Phase 2).
       //
       // `sourceMessage` — the delivered outbound note id, captured for the callback's
       // `source_message` so an orchestrator can PULL the full reply text. Stays undefined
       // for an empty/tool-only turn (no note) — the callback still fires (status:ok), it
       // just has no reply note to point at (the orchestrator pulls from `source_thread`).
+      //
+      // OUTBOUND FILE ATTACHMENTS (Phase 2): the files the turn wrote into its private
+      // `outbox/` (swept by the backend onto `result.outboxFiles`) ride to the outbound seam
+      // → the transport's `reply({ files })`, which uploads + links each onto THIS outbound
+      // note. Map to absolute paths here (the daemon's reply-args carry `files: string[]`).
+      const outboxPaths = (result.outboxFiles ?? []).map((f) => f.absPath);
       let sourceMessage: string | undefined;
-      if (result.reply && result.reply.length > 0) {
+      if ((result.reply && result.reply.length > 0) || outboxPaths.length > 0) {
         const delivered = await this.deliverOutboundWithRetry(
           channel,
-          result.reply,
+          result.reply ?? "",
           msg.inReplyTo,
           turnThreadId,
+          outboxPaths.length > 0 ? outboxPaths : undefined,
         );
         if (delivered.ok) sourceMessage = delivered.noteId;
         if (!delivered.ok) {
@@ -1134,6 +1152,14 @@ export class ProgrammaticAgentRegistry {
     reply: string,
     inReplyTo?: string,
     threadId?: string,
+    /**
+     * OUTBOUND FILE ATTACHMENTS (Phase 2): local file paths the turn wrote into its
+     * private `outbox/`. Threaded to the outbound seam → the transport's `reply({ files })`
+     * (only the VaultTransport uploads + links them onto the note). Absent/empty → a
+     * text-only reply. A per-file upload/link failure is handled gracefully inside the
+     * transport (skip + log); it does NOT fail the reply, so it never triggers a retry here.
+     */
+    files?: string[],
   ): Promise<{ ok: true; noteId?: string } | { ok: false; error: string }> {
     let lastError = "";
     for (let attempt = 0; attempt <= OUTBOUND_MAX_RETRIES; attempt++) {
@@ -1141,7 +1167,7 @@ export class ProgrammaticAgentRegistry {
         // Capture the written note id (when the seam returns one) so the caller can
         // point a callback's `source_message` at the delivered reply. A void return →
         // no id (the callback then omits source_message — still fires).
-        const written = await this.writeOutbound(channel, reply, inReplyTo, threadId);
+        const written = await this.writeOutbound(channel, reply, inReplyTo, threadId, files);
         return { ok: true, ...(written && written.id ? { noteId: written.id } : {}) };
       } catch (err) {
         lastError = (err as Error).message;

--- a/src/backends/types.ts
+++ b/src/backends/types.ts
@@ -124,6 +124,21 @@ export interface DeliverUsage {
 }
 
 /**
+ * One file the turn wrote into its PRIVATE session workspace `outbox/` dir (Phase 2:
+ * outbound file attachments). Swept by the backend after a successful turn + surfaced
+ * on the {@link DeliverResult} so the daemon's outbound write uploads it to the vault
+ * + links it onto the outbound note. UNTRUSTED filename (the agent chose it) — the
+ * backend already reduced it to a safe basename, but the downstream vault upload
+ * re-derives the storage filename + validates the extension server-side.
+ */
+export interface OutboxFile {
+  /** Absolute path to the swept file on disk (inside the private session `outbox/`). */
+  absPath: string;
+  /** A SAFE basename (no path components, no traversal) — the display name + ext source. */
+  basename: string;
+}
+
+/**
  * The result of delivering one message — a discriminated union so a failure is
  * always observable inline (never a silent drop). On success the daemon turns
  * `reply` into an outbound `#agent/message/outbound` note (the wiring follow-up).
@@ -141,6 +156,16 @@ export type DeliverResult =
       sessionId?: string;
       /** Optional token/cost usage for observability. */
       usage?: DeliverUsage;
+      /**
+       * OUTBOUND FILE ATTACHMENTS (Phase 2): files the turn wrote into its PRIVATE
+       * session workspace `outbox/` dir. After a successful turn the backend sweeps
+       * that dir and surfaces the swept files here (absolute path + a safe basename);
+       * the daemon's outbound write uploads each to the vault + links it onto the
+       * outbound `#agent/message/outbound` note so a surface renders it. Absent/empty
+       * → a text-only reply (today's behavior). Surfaced ONLY on a successful turn
+       * (an outbox from a failed turn is discarded with the workspace).
+       */
+      outboxFiles?: OutboxFile[];
     }
   | {
       ok: false;
@@ -201,6 +226,12 @@ export interface AgentBackend {
    * a safe basename) before the turn and appends a workspace-relative pointer to the
    * prompt, so the `claude -p` turn can `Read` them. ADDITIVE — absent/empty → no
    * staging, the turn behaves exactly as before.
+   *
+   * OUTBOUND attachments (Phase 2) are the symmetric inverse: the backend tells the turn
+   * to write any reply attachments into its private `outbox/` dir, then — on a SUCCESSFUL
+   * turn — sweeps that dir and surfaces the files on the result's `outboxFiles`, which the
+   * daemon uploads to the vault + links onto the outbound note. ADDITIVE — no outbox files
+   * → an unchanged text-only reply.
    */
   deliver(
     handle: AgentHandle,

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -673,7 +673,7 @@ export function attachedQueueStoreFor(
  * fork the conversation).
  */
 export function buildWriteOutbound(channels: Map<string, Channel>): WriteOutbound {
-  return async (channel, reply, inReplyTo, threadId) => {
+  return async (channel, reply, inReplyTo, threadId, files) => {
     const ch = channels.get(channel);
     if (!ch) {
       throw new Error(`no live transport for channel "${channel}" — cannot post the reply`);
@@ -685,10 +685,16 @@ export function buildWriteOutbound(channels: Map<string, Channel>): WriteOutboun
     const meta: Record<string, string> = {};
     if (inReplyTo) meta.in_reply_to = inReplyTo;
     if (threadId) meta.thread = threadId;
+    // OUTBOUND FILE ATTACHMENTS (Phase 2): the local paths the turn wrote into its private
+    // `outbox/`. The VaultTransport's `reply()` uploads each to vault storage + links it
+    // onto the just-written outbound note (best-effort, per-file isolated — a disallowed/
+    // oversize file is skipped, the reply still posts). A non-vault transport (telegram)
+    // already handles `files` (uploads them as photos/docs); this is additive there.
     const sent = await ch.transport.reply({
       channel,
       text: reply,
       ...(Object.keys(meta).length > 0 ? { meta } : {}),
+      ...(files && files.length > 0 ? { files } : {}),
     });
     // Surface the written outbound note id so the agent-to-agent callback can point its
     // `source_message` at it (the orchestrator pulls the full reply from there). `reply()`

--- a/src/programmatic-wiring.test.ts
+++ b/src/programmatic-wiring.test.ts
@@ -836,3 +836,57 @@ describe("buildWriteCallback — own-it-don't-strand for an unknown reply_to cha
     expect(captured!.content).toContain("[callback]");
   });
 });
+
+describe("buildWriteOutbound — OUTBOUND file attachments forwarded to the transport (Phase 2)", () => {
+  const realFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  test("the swept outbox file paths flow through buildWriteOutbound → VaultTransport.reply → upload + link onto the outbound note", async () => {
+    // Stub global fetch: the note POST, the storage upload, and the attachments link.
+    const seen: { url: string; method: string }[] = [];
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const u = String(url);
+      const method = (init?.method ?? "GET").toUpperCase();
+      seen.push({ url: u, method });
+      if (u.endsWith("/api/notes") && method === "POST") {
+        return new Response(JSON.stringify({ id: "out-note-1" }), { status: 201 });
+      }
+      if (u.endsWith("/api/storage/upload")) {
+        return new Response(JSON.stringify({ path: "2026-06-25/x.png", mimeType: "image/png" }), { status: 201 });
+      }
+      if (u.includes("/attachments")) {
+        return new Response(JSON.stringify({ id: "att" }), { status: 201 });
+      }
+      return new Response("{}", { status: 200 }); // ensureSchema PUTs.
+    }) as unknown as typeof fetch;
+
+    const vt = new VaultTransport({ vault: "default", vaultUrl: "http://127.0.0.1:1940", token: "x" });
+    (vt as unknown as { ctx: unknown }).ctx = { channel: "eng", emit() {}, emitPermissionVerdict() {} };
+    const channels = new Map<string, Channel>([
+      ["eng", { name: "eng", transport: vt, entry: { name: "eng", transport: "vault" } }],
+    ]);
+
+    // A real local file the upload reads off disk.
+    const dir = mkdtempSync(join(tmpdir(), "wire-outbox-"));
+    try {
+      const { writeFileSync } = await import("node:fs");
+      const f = join(dir, "chart.png");
+      writeFileSync(f, "PNGBYTES");
+
+      const write = buildWriteOutbound(channels);
+      const res = await write("eng", "here's your chart", "inbound-7", "thread-9", [f]);
+      expect(res && (res as { id?: string }).id).toBe("out-note-1");
+
+      // The full chain ran: note POST → storage upload → attachments link.
+      expect(seen.some((c) => c.url.endsWith("/api/notes") && c.method === "POST")).toBe(true);
+      expect(seen.some((c) => c.url.endsWith("/api/storage/upload") && c.method === "POST")).toBe(true);
+      expect(
+        seen.some((c) => c.url.endsWith("/vault/default/api/notes/out-note-1/attachments") && c.method === "POST"),
+      ).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/transports/vault.test.ts
+++ b/src/transports/vault.test.ts
@@ -25,6 +25,9 @@
  */
 
 import { describe, test, expect, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { VaultTransport, AGENT_VAULT_TAG_SCHEMA, AGENT_THREAD_TAG, AGENT_JOB_TAG, InboundClaimConflictError, noteAgentKey } from "./vault.ts";
 import type { TransportContext, InboundMessage } from "../transport.ts";
 import { instantiateTransport } from "../registry.ts";
@@ -188,6 +191,187 @@ describe("VaultTransport — reply (outbound note write)", () => {
     const t = new VaultTransport(baseConfig());
     await t.start(fakeCtx("eng"));
     await expect(t.reply({ channel: "eng", text: "x" })).rejects.toThrow(/write reply failed/);
+  });
+});
+
+describe("VaultTransport — OUTBOUND file attachments (Phase 2: upload + link)", () => {
+  let tmp = "";
+  afterEach(() => {
+    if (tmp) rmSync(tmp, { recursive: true, force: true });
+    tmp = ""; // reset so the next test mkdtemps a FRESH dir (not the just-deleted one).
+  });
+  /** Create a temp file with the given bytes; returns its absolute path. */
+  function tmpFile(name: string, body: string): string {
+    if (!tmp) tmp = mkdtempSync(join(tmpdir(), "vault-outbox-"));
+    const p = join(tmp, name);
+    writeFileSync(p, body);
+    return p;
+  }
+
+  /**
+   * A fetch stub that routes the three POSTs the reply path makes:
+   *   - .../api/notes            → create the outbound note (id "note-OUT")
+   *   - .../api/storage/upload   → upload (configurable status + body per call index)
+   *   - .../<id>/attachments     → link (configurable status)
+   * Records each call so a test can assert the ordering + payloads.
+   */
+  function replyFetch(opts: {
+    uploadResponses?: Array<{ status: number; body: unknown }>;
+    linkStatus?: number;
+  }) {
+    const calls: { url: string; method: string; body?: string; isForm: boolean }[] = [];
+    let uploadIdx = 0;
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const u = String(url);
+      const method = (init?.method ?? "GET").toUpperCase();
+      const isForm = init?.body instanceof FormData;
+      calls.push({ url: u, method, body: isForm ? undefined : String(init?.body ?? ""), isForm });
+      if (u.endsWith("/api/notes") && method === "POST") {
+        return new Response(JSON.stringify({ id: "note-OUT" }), { status: 201 });
+      }
+      if (u.endsWith("/api/storage/upload") && method === "POST") {
+        const r = opts.uploadResponses?.[uploadIdx] ?? {
+          status: 201,
+          body: { path: `2026-06-25/up${uploadIdx}.png`, mimeType: "image/png" },
+        };
+        uploadIdx += 1;
+        return new Response(JSON.stringify(r.body), { status: r.status });
+      }
+      if (u.includes("/attachments") && method === "POST") {
+        return new Response(JSON.stringify({ id: "att-1" }), { status: opts.linkStatus ?? 201 });
+      }
+      // ensureSchema PUTs (from start) + anything else → ok.
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
+    return { calls };
+  }
+
+  test("uploads each outbox file to storage + links it onto the just-written outbound note", async () => {
+    const { calls } = replyFetch({
+      uploadResponses: [
+        { status: 201, body: { path: "2026-06-25/a.png", mimeType: "image/png" } },
+        { status: 201, body: { path: "2026-06-25/b.pdf", mimeType: "application/pdf" } },
+      ],
+    });
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+
+    const f1 = tmpFile("chart.png", "PNGBYTES");
+    const f2 = tmpFile("report.pdf", "PDFBYTES");
+    const result = await t.reply({ channel: "eng", text: "here", files: [f1, f2] });
+    expect(result.sent).toEqual(["note-OUT"]);
+
+    // The note POST came FIRST (so the attachments link to a real note id), then the two
+    // upload+link pairs.
+    const ordered = calls.filter(
+      (c) =>
+        c.url.endsWith("/api/notes") ||
+        c.url.endsWith("/api/storage/upload") ||
+        c.url.includes("/attachments"),
+    );
+    expect(ordered[0]!.url).toBe("http://127.0.0.1:1940/vault/default/api/notes");
+    const uploads = calls.filter((c) => c.url.endsWith("/api/storage/upload"));
+    const links = calls.filter((c) => c.url.includes("/attachments"));
+    expect(uploads).toHaveLength(2);
+    expect(uploads.every((c) => c.isForm)).toBe(true); // multipart
+    expect(links).toHaveLength(2);
+    // The link POSTs target the just-created note id + carry { path, mimeType } from upload.
+    expect(links[0]!.url).toBe("http://127.0.0.1:1940/vault/default/api/notes/note-OUT/attachments");
+    const linkBody = JSON.parse(links[0]!.body!) as { path: string; mimeType: string };
+    expect(linkBody).toEqual({ path: "2026-06-25/a.png", mimeType: "image/png" });
+  });
+
+  test("a disallowed-extension file (vault 400) is SKIPPED — the reply + other files still post", async () => {
+    const { calls } = replyFetch({
+      uploadResponses: [
+        { status: 400, body: { error: "File type .exe not allowed" } }, // rejected
+        { status: 201, body: { path: "2026-06-25/ok.png", mimeType: "image/png" } }, // accepted
+      ],
+    });
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+
+    const bad = tmpFile("evil.exe", "MZ...");
+    const good = tmpFile("ok.png", "PNG");
+    const result = await t.reply({ channel: "eng", text: "two files", files: [bad, good] });
+    // The reply note still posted (text is durable).
+    expect(result.sent).toEqual(["note-OUT"]);
+    // Both uploads attempted; only the ACCEPTED one gets linked (the 400 file is skipped).
+    expect(calls.filter((c) => c.url.endsWith("/api/storage/upload"))).toHaveLength(2);
+    const links = calls.filter((c) => c.url.includes("/attachments"));
+    expect(links).toHaveLength(1);
+    expect((JSON.parse(links[0]!.body!) as { path: string }).path).toBe("2026-06-25/ok.png");
+  });
+
+  test("an oversize file (vault 413) is SKIPPED gracefully — reply still posts, no link", async () => {
+    const { calls } = replyFetch({
+      uploadResponses: [{ status: 413, body: { error: "File too large (200MB). Max: 100MB" } }],
+    });
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+
+    const big = tmpFile("huge.mp4", "BIGDATA");
+    const result = await t.reply({ channel: "eng", text: "big one", files: [big] });
+    expect(result.sent).toEqual(["note-OUT"]); // reply still posted.
+    expect(calls.filter((c) => c.url.includes("/attachments"))).toHaveLength(0); // never linked.
+  });
+
+  test("a LINK failure (vault non-ok) is isolated — the reply still posts, other files unaffected", async () => {
+    const { calls } = replyFetch({
+      uploadResponses: [
+        { status: 201, body: { path: "2026-06-25/a.png", mimeType: "image/png" } },
+        { status: 201, body: { path: "2026-06-25/b.png", mimeType: "image/png" } },
+      ],
+      linkStatus: 500, // BOTH links fail — must not throw / break the reply.
+    });
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+
+    const f1 = tmpFile("a.png", "A");
+    const f2 = tmpFile("b.png", "B");
+    const result = await t.reply({ channel: "eng", text: "links fail", files: [f1, f2] });
+    expect(result.sent).toEqual(["note-OUT"]); // reply still posted (no throw).
+    // Both uploads + both link ATTEMPTS happened (each isolated).
+    expect(calls.filter((c) => c.url.endsWith("/api/storage/upload"))).toHaveLength(2);
+    expect(calls.filter((c) => c.url.includes("/attachments"))).toHaveLength(2);
+  });
+
+  test("a missing local file is skipped, not fatal — the reply still posts", async () => {
+    const { calls } = replyFetch({});
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+
+    const result = await t.reply({
+      channel: "eng",
+      text: "ghost file",
+      files: ["/no/such/file/anywhere.png"],
+    });
+    expect(result.sent).toEqual(["note-OUT"]);
+    // The file couldn't be read → no upload attempted.
+    expect(calls.filter((c) => c.url.endsWith("/api/storage/upload"))).toHaveLength(0);
+  });
+
+  test("a zero-byte file is skipped (no empty-blob upload)", async () => {
+    const { calls } = replyFetch({});
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+
+    const empty = tmpFile("empty.png", "");
+    const result = await t.reply({ channel: "eng", text: "empty", files: [empty] });
+    expect(result.sent).toEqual(["note-OUT"]);
+    expect(calls.filter((c) => c.url.endsWith("/api/storage/upload"))).toHaveLength(0);
+  });
+
+  test("NO files → unchanged reply: a single notes POST, no upload/link", async () => {
+    const { calls } = replyFetch({});
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+
+    const result = await t.reply({ channel: "eng", text: "text only" });
+    expect(result.sent).toEqual(["note-OUT"]);
+    expect(calls.filter((c) => c.url.endsWith("/api/notes"))).toHaveLength(1);
+    expect(calls.filter((c) => c.url.endsWith("/api/storage/upload"))).toHaveLength(0);
+    expect(calls.filter((c) => c.url.includes("/attachments"))).toHaveLength(0);
   });
 });
 

--- a/src/transports/vault.ts
+++ b/src/transports/vault.ts
@@ -240,6 +240,13 @@ const DEFAULT_VAULT_URL = "http://127.0.0.1:1940";
 const DEFAULT_PATH_PREFIX = "channel";
 
 /**
+ * OUTBOUND FILE ATTACHMENTS (Phase 2): max files uploaded + linked onto one outbound note.
+ * Defense in depth — the programmatic backend already caps the outbox sweep at the same
+ * bound, but the transport seam shouldn't trust an unbounded `args.files`.
+ */
+const OUTBOX_UPLOAD_MAX_COUNT = 20;
+
+/**
  * Thrown by {@link VaultTransport.setInboundStatus} when a compare-and-swap claim
  * (an `ifUpdatedAt` precondition) FAILED — the note changed since it was read, so
  * another writer won the race (agent#101). The vault returns **409** (`error_type:
@@ -783,7 +790,126 @@ export class VaultTransport implements Transport {
     } catch {
       // Non-JSON / empty body — keep the proposed id.
     }
+
+    // OUTBOUND FILE ATTACHMENTS (Phase 2): after the note exists (so attachments link to a
+    // real note id), upload each swept outbox file to vault storage + link it onto THIS
+    // outbound note. Best-effort + per-file isolated (a disallowed/oversize file is skipped
+    // + logged); the reply text already posted above. A no-files reply is unchanged.
+    if (args.files && args.files.length > 0) {
+      await this.uploadAndLinkFiles(noteId, args.files);
+    }
+
     return { sent: [noteId] };
+  }
+
+  /**
+   * OUTBOUND FILE ATTACHMENTS (Phase 2) — upload each local file to vault storage, then link
+   * it onto the just-written outbound note. The symmetric inverse of the programmatic
+   * backend's inbound staging (which FETCHES vault storage → workspace). The vault token this
+   * transport already holds (`this.token`, a `vault:<name>:write` JWT) authenticates both.
+   *
+   * The two-step contract (parachute-vault `routes.ts`):
+   *   1. UPLOAD bytes — `POST <vaultUrl>/vault/<name>/api/storage/upload` (multipart, field
+   *      `file`) → `201 { path, mimeType }`. The vault VALIDATES the extension server-side
+   *      (an allowlist: .wav .mp3 .m4a .ogg .webm .png .jpg .jpeg .gif .webp .pdf .mp4) and
+   *      caps size at 100MB. A disallowed extension → 400; over the cap → 413. We handle BOTH
+   *      GRACEFULLY: skip that file, log, continue — a single bad file NEVER fails the reply
+   *      (the note already posted) or the other files.
+   *   2. LINK — `POST <vaultUrl>/vault/<name>/api/notes/<noteId>/attachments` JSON `{ path,
+   *      mimeType }` (from the upload response) → `201`. A link failure also skips + logs.
+   *
+   * SECURITY/ROBUSTNESS:
+   *  - The filename uploaded is a SAFE BASENAME ({@link basenameOf}) — the agent chose the
+   *    outbox filename, so it's untrusted; the vault also re-derives the stored filename
+   *    (`<ts>-<uuid><ext>`) so traversal in the upload name can't reshape storage.
+   *  - Per-file isolated: each file's upload+link runs in its own try/catch; one failure
+   *    (network, 400, 413, missing file) is contained.
+   *  - Capped at {@link OUTBOX_UPLOAD_MAX_COUNT} (defense in depth; the backend already caps
+   *    the sweep, but the seam shouldn't trust an unbounded list).
+   *  - NEVER throws — the reply text is already durable; an upload failure must not flip the
+   *    reply to an error (the registry's retry/record logic keys on `reply()` throwing).
+   */
+  private async uploadAndLinkFiles(noteId: string, files: string[]): Promise<void> {
+    const capped = files.slice(0, OUTBOX_UPLOAD_MAX_COUNT);
+    if (files.length > OUTBOX_UPLOAD_MAX_COUNT) {
+      console.warn(
+        `vault transport: ${files.length} outbound files exceeds the cap ` +
+          `(${OUTBOX_UPLOAD_MAX_COUNT}); attaching the first ${OUTBOX_UPLOAD_MAX_COUNT}.`,
+      );
+    }
+    for (const filePath of capped) {
+      try {
+        // Read the bytes off disk. A missing/unreadable file (e.g. cleaned between sweep +
+        // write) is skipped — Bun.file().arrayBuffer() rejects, caught below.
+        const file = Bun.file(filePath);
+        const bytes = await file.arrayBuffer();
+        if (bytes.byteLength === 0) {
+          // A zero-byte (partial) file slipped past the sweep — skip rather than upload an
+          // empty blob.
+          console.warn(`vault transport: outbound file "${filePath}" is empty — skipping.`);
+          continue;
+        }
+        const filename = basenameOf(filePath) || "attachment";
+        const form = new FormData();
+        // The vault derives the mime + the stored filename from the (extension of the)
+        // uploaded filename; pass the SAFE basename so the extension is preserved for the
+        // server-side allowlist check + mime derivation.
+        form.append("file", new Blob([bytes]), filename);
+
+        const uploadUrl = `${this.vaultUrl}/vault/${this.vault}/api/storage/upload`;
+        const upRes = await fetch(uploadUrl, {
+          method: "POST",
+          headers: { authorization: `Bearer ${this.token}` },
+          body: form,
+        });
+        if (!upRes.ok) {
+          // 400 (disallowed extension) / 413 (too big) / any other → SKIP this file, keep
+          // the reply + the rest. The vault's body carries a human reason.
+          const detail = await upRes.text().catch(() => "");
+          console.warn(
+            `vault transport: uploading outbound file "${filename}" failed (${upRes.status}) ` +
+              `${detail} — skipping this attachment (reply already posted)`.trim(),
+          );
+          continue;
+        }
+        const uploaded = (await upRes.json().catch(() => null)) as
+          | { path?: string; mimeType?: string }
+          | null;
+        if (!uploaded || typeof uploaded.path !== "string" || !uploaded.path) {
+          console.warn(
+            `vault transport: upload of "${filename}" returned no path — skipping the link.`,
+          );
+          continue;
+        }
+        const mimeType = uploaded.mimeType || "application/octet-stream";
+
+        // LINK the uploaded asset onto the outbound note. `<noteId>` is the just-created
+        // note's id (the storage attachments route resolves a note by id OR path).
+        const linkUrl = `${this.vaultUrl}/vault/${this.vault}/api/notes/${encodeURIComponent(noteId)}/attachments`;
+        const linkRes = await fetch(linkUrl, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: `Bearer ${this.token}`,
+          },
+          body: JSON.stringify({ path: uploaded.path, mimeType }),
+        });
+        if (!linkRes.ok) {
+          const detail = await linkRes.text().catch(() => "");
+          console.warn(
+            `vault transport: linking attachment "${uploaded.path}" to note "${noteId}" ` +
+              `failed (${linkRes.status}) ${detail} — skipping this attachment`.trim(),
+          );
+          continue;
+        }
+      } catch (err) {
+        // Missing file / network fault / bad JSON — isolated, skipped, logged.
+        console.warn(
+          `vault transport: attaching outbound file "${filePath}" errored (skipping): ` +
+            `${(err as Error).message}`,
+        );
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
## What

Phase 2 of agent file attachments — the **symmetric inverse of Phase 1** (#142, inbound staging). A programmatic turn can now **attach file(s) to its reply**: files the turn writes into its PRIVATE session `outbox/` are uploaded to the vault and **linked as attachments onto the outbound `#agent/message/outbound` note**, so a surface renders them.

## Why

Phase 1 made the turn READ inbound vault attachments. Phase 2 closes the loop — the turn can PRODUCE files (a generated chart, a rendered PDF, an audio clip) and have them land on its reply, with no new MCP plumbing.

## Mechanism (outbox sweep)

1. **Tell the turn how to attach** — the backend appends an instruction to every turn naming the **absolute** outbox dir (the private session `outbox/`). Absolute, not `./outbox/`, so it works even when the turn's cwd is a shared `spec.workspace` (a relative hint would write to the wrong dir and never be swept).
2. **Per-turn fresh** — the outbox is reset before each turn so a prior turn's files never bleed into the next reply.
3. **Sweep on success** — after a SUCCESSFUL turn the backend sweeps the private `outbox/` and surfaces the files on `DeliverResult.outboxFiles` (regular non-empty files only; subdirs / symlinks / zero-byte skipped; capped at 20; safe basenames).
4. **Thread → upload → link** — the registry threads the swept paths through the widened `WriteOutbound` seam (new optional `files?` param) → the daemon forwards them to `transport.reply({ files })`. The VaultTransport's `reply()`, after creating the note (id known), uploads each via `POST .../api/storage/upload` then links via `POST .../api/notes/<id>/attachments`, Bearer the vault write token it already holds. An outbound note is written when there's reply text **or** outbox files (a file-only reply gets an empty-body note to hang the attachment off).

Only the **vault transport** acts on the swept files; the no-files path is unchanged.

## Safety (mirrors Phase 1)

- The vault enforces a **100MB cap + extension allowlist** server-side (`.wav .mp3 .m4a .ogg .webm .png .jpg .jpeg .gif .webp .pdf .mp4`). A disallowed-ext (**400**) / oversize (**413**) / network / link failure is **SKIPPED + logged per-file** — the reply text and the other files still post, and `reply()` **never throws** on an upload failure (a file with a disallowed extension does NOT fail the whole reply).
- Best-effort + isolated; sweep is the **private** session dir only (never a shared `spec.workspace`); agent-chosen filenames are treated as **untrusted** (sanitized to safe basenames + symlinks rejected via `lstat`; the vault re-derives the stored name too).
- **No outbox files → identical to today** (text-only reply).

## Verification

- `bun run typecheck` — clean.
- `bun test ./src` — **1117 pass, 0 fail**. New tests cover: backend sweep → result; registry threading + file-only-no-text → still-write-note + empty-no-files → no-note; vault upload+link ordering (note created first), 400/413/link-failure/missing-file/zero-byte graceful skip; per-turn reset (no bleed); count cap; symlink rejection; and an end-to-end run through `buildWriteOutbound → VaultTransport.reply` with a stubbed fetch.

## Notes

- Experimental preview / bun-linked — **no rc bump**.
- The widened `WriteOutbound` seam is back-compat: existing `async (channel, reply, inReplyTo) => {}` recorders remain valid (the new params are optional).

🤖 Generated with [Claude Code](https://claude.com/claude-code)