### PR TITLE
chore(release): bump to 0.2.1 (ship the SPA) + tag-triggered npm release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,115 @@
+# Release workflow — triggered by pushing a semver tag.
+#
+# Tag conventions (matches parachute-patterns governance rule 2):
+#   - rc:     v<X>.<Y>.<Z>-rc.<N>   (e.g. v0.2.0-rc.1)
+#   - stable: v<X>.<Y>.<Z>          (e.g. v0.2.0)
+#
+# Release flow:
+#   1. Code-touching PR merges to main, bumping `version` in package.json
+#      (rc.N → rc.N+1 for the rc chain; or drop -rc.N suffix for stable).
+#   2. After merge, push a matching tag:
+#        git tag v$(grep '"version"' package.json | cut -d'"' -f4) && git push --tags
+#   3. CI runs tests, then publishes to npm (with provenance attestation,
+#      dist-tag = rc or latest).
+#
+# Operator setup (one-time — REQUIRED before the first CI publish works):
+#   - npmjs.com → package @openparachute/agent → Settings → Trusted Publishers
+#     → "Add a new publisher" → GitHub Actions
+#       org=ParachuteComputer, repo=parachute-agent, workflow=release.yml,
+#       environment=(blank)
+#   - No NPM_TOKEN secret needed — the workflow uses OIDC (Trusted Publishing).
+#   - The package @openparachute/agent already exists on npm (stale 0.1.2), so
+#     the trusted-publisher rule is added on the EXISTING package's settings.
+#
+# Why tag-triggered (not push-to-main):
+#   - tag = explicit release signal; main commits without a tag don't publish.
+#   - Preserves a deliberate gate (you push the tag when you mean to ship).
+#   - Tag-as-canonical means the tag itself is the audit trail of what was
+#     released and when.
+
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
+
+concurrency:
+  # Don't let two releases race on the same tag.
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3
+      - name: install deps
+        run: bun install --frozen-lockfile
+      - name: typecheck
+        run: bun run typecheck
+      - name: agent tests
+        # Matches package.json "test" script's bun:test surface
+        # (bun test ./src/). The web/ui SPA suite runs under vitest and is
+        # exercised separately (test:spa / the `spa` CI job); the release
+        # gate stays on the canonical bun:test surface that covers the
+        # daemon + bridge + backends.
+        run: bun test ./src/
+
+  publish-npm:
+    name: publish to npm
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Required for npm provenance attestation + Trusted Publishing OIDC.
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3
+      - uses: actions/setup-node@v6
+        with:
+          # Node 24 ships npm 11.5+ which has Trusted Publishing OIDC
+          # support built in. Node 20 LTS only has npm 10 and would
+          # silently fall back to token auth (failing without NPM_TOKEN).
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+      - name: install deps
+        run: bun install --frozen-lockfile
+      - name: verify package.json version matches tag
+        # Defense against tag-vs-package.json drift. If they don't match,
+        # we'd publish under the wrong version.
+        run: |
+          PKG_VERSION=$(bun -e "console.log(require('./package.json').version)")
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::package.json version ($PKG_VERSION) doesn't match tag ($TAG_VERSION)"
+            exit 1
+          fi
+      - name: publish
+        # Trusted Publishing: npm verifies the OIDC token from this workflow
+        # against the package's configured trusted publisher rule
+        # (org=ParachuteComputer, repo=parachute-agent, workflow=release.yml).
+        # No NPM_TOKEN secret needed; `id-token: write` permission above
+        # makes the OIDC token available to npm CLI.
+        #
+        # `npm publish` runs the package's `prepack` hook first, which builds
+        # the web/ui SPA into web/ui/dist/ — included via the package.json
+        # `files` allowlist so the bundle ships in the tarball.
+        run: |
+          # Detect rc vs stable from tag name. Tag pattern in `on:` above
+          # enforces the shape, so this is just disambiguation.
+          if [[ "$GITHUB_REF_NAME" =~ -rc\. ]]; then
+            DIST_TAG=rc
+          else
+            DIST_TAG=latest
+          fi
+          echo "publishing with dist-tag=$DIST_TAG"
+          npm publish --tag "$DIST_TAG" --access public --provenance

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/agent",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "description": "Vault-native agents for Claude Code — a #agent/definition note + an inbound message becomes a sandboxed claude turn; the reply is written back as a note. Messaging gateway on :1941.",
   "license": "AGPL-3.0",
   "type": "module",
@@ -8,6 +8,14 @@
     "parachute-agent": "src/daemon.ts",
     "parachute-agent-bridge": "src/bridge.ts"
   },
+  "files": [
+    "src",
+    ".parachute",
+    "scripts/spawn-agent.ts",
+    "tsconfig.json",
+    "web/ui/dist",
+    "README.md"
+  ],
   "scripts": {
     "daemon": "bun src/daemon.ts",
     "bridge": "bun src/bridge.ts",
@@ -16,7 +24,9 @@
     "test:spa": "cd web/ui && bun run test",
     "test:all": "bun run test && bun run test:spa",
     "test:e2e": "bun e2e/llm/run.ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "build:spa": "cd web/ui && bun install --frozen-lockfile && bun run build",
+    "prepack": "bun run build:spa"
   },
   "dependencies": {
     "@anthropic-ai/sandbox-runtime": "0.0.54",

--- a/web/ui/.npmignore
+++ b/web/ui/.npmignore
@@ -1,0 +1,14 @@
+# Intentionally minimal — overrides web/ui/.gitignore for npm packing.
+#
+# Without this, npm (which has no root .npmignore) falls back to .gitignore
+# files for exclusion, and the sibling web/ui/.gitignore's `dist/` rule strips
+# the built SPA bundle (web/ui/dist/) out of the published tarball — even though
+# package.json's `files` allowlist explicitly lists it and the prepack hook
+# builds it for release. A nested .npmignore takes precedence over the nested
+# .gitignore for this subtree, so packing falls back to the `files` allowlist
+# (which ships web/ui/dist/). Keep this minimal: only the dev/test cruft that
+# must never publish.
+node_modules
+src
+*.tsbuildinfo
+*.log


### PR DESCRIPTION
## Why

`@openparachute/agent` on npm is stuck at a stale **0.1.2** — a manual May-24 publish made **before** the channel→agent rename and the attachment work. Fresh-box `bun add -g @openparachute/agent` therefore pulls the broken old build. The repo had **no publish workflow** (`ci.yml` only tests), and `package.json` sat at **0.1.0** — *below* the stale npm 0.1.2, so it couldn't even be published over.

This PR makes a current build publishable.

## What

1. **Version `0.1.0` → `0.2.0`** — above the stale 0.1.2; the new minor marks the post-rename + attachments era. The first publish targets **`@latest`** (the broken thing fresh installs pull) to unstick them.
2. **`release.yml`** — copied from `parachute-vault` and adapted for this package: tag `v<X>.<Y>.<Z>` → `@latest`, `v<X>.<Y>.<Z>-rc.<N>` → `@rc` (matching vault's dist-tag logic). Gate = `bun install --frozen-lockfile` + `bun run typecheck` + `bun test ./src/`. Auth = npm **Trusted Publishing** (OIDC `id-token: write` + `npm publish --provenance`), same as vault — no `NPM_TOKEN` secret.
3. **`files` allowlist + `build:spa`/`prepack`** — so the published tarball ships the built web/ui SPA (`web/ui/dist/`) that the daemon serves at `/agent/app/`, mirroring vault/hub. `prepack` builds the SPA on every `npm publish`. Pack drops from **305 polluted files** (`.claude/worktrees`, design docs, e2e) to a clean **105**.
4. **`web/ui/.npmignore`** — the nested `web/ui/.gitignore`'s `dist/` rule was stripping the built SPA out of the tarball via npm's gitignore-fallback even though `files` lists it. A nested `.npmignore` restores `files`-governed inclusion.

## ⚠️ Operator action required before CI publish works

**npm Trusted Publishing must be configured for `@openparachute/agent` on npmjs.com** (the package already exists at the stale 0.1.2):
npmjs.com → package `@openparachute/agent` → Settings → Trusted Publishers → Add → GitHub Actions → org=`ParachuteComputer`, repo=`parachute-agent`, workflow=`release.yml`, environment=(blank). Until then the CI tag-publish step will fail.

The maintainer publishes the first 0.2.0 manually (this PR does **not** publish and pushes **no tag**).

## Verification

- **`bun run typecheck`**: exit 0 (clean).
- **`bun test ./src/`**: **1097 pass / 0 fail** (3276 expect() calls, 50 files). The `vault unreachable` / `502 nope` stderr lines are expected mock-failure output from passing tests. No live daemon touched — tests use `Bun.serve({ port: 0 })` ephemeral ports, not :1941.
- **`npm pack` (real tarball, runs prepack)** — verified in the packed tarball:
  - `src/daemon.ts` → `-rwxr-xr-x` (bin `parachute-agent`, **+x preserved**)
  - `src/bridge.ts` → `-rwxr-xr-x` (bin `parachute-agent-bridge`, **+x preserved**)
  - `web/ui/dist/index.html` + `assets/*.js` + `assets/*.css` present (SPA ships; `verify-base` confirms `/agent/app/`-prefixed asset URLs)
- `release.yml` validated as parseable YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)