### PR TITLE
fix(release): add repository field for npm provenance → 0.2.2 (unblock publish)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/agent",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Vault-native agents for Claude Code — a #agent/definition note + an inbound message becomes a sandboxed claude turn; the reply is written back as a note. Messaging gateway on :1941.",
   "license": "AGPL-3.0",
   "type": "module",
@@ -40,5 +40,9 @@
   },
   "devDependencies": {
     "@types/bun": "latest"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ParachuteComputer/parachute-agent.git"
   }
 }


### PR DESCRIPTION
v0.2.1's trusted-publish signed provenance fine but npm **E422'd** it: package.json had no `repository.url` for provenance to match. Adds the `repository` field + bumps 0.2.1→0.2.2 (0.2.1 never landed — E404). Re-tagging v0.2.2 republishes with valid provenance + the SPA. Metadata-only; pack still ships web/ui/dist + +x bins.