### PR TITLE
fix(tags): agent tag namespace #agent/* → bare agent/* (drop the accidental leading hash)

### DIFF
--- a/.parachute/module.json
+++ b/.parachute/module.json
@@ -52,7 +52,7 @@
         "module": "vault",
         "event": "note.created",
         "filter": {
-          "tags": ["#agent/message/inbound"],
+          "tags": ["agent/message/inbound"],
           "has_metadata": ["channel"],
           "missing_metadata": ["channel_inbound_rendered_at"]
         }
@@ -85,7 +85,7 @@
         "module": "vault",
         "event": "note.created",
         "filter": {
-          "tags": ["#agent/definition"]
+          "tags": ["agent/definition"]
         }
       },
       "sink": {
@@ -110,7 +110,7 @@
         "module": "vault",
         "event": "note.updated",
         "filter": {
-          "tags": ["#agent/definition"]
+          "tags": ["agent/definition"]
         }
       },
       "sink": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,7 +248,7 @@ Bearer `vault:<name>:write`).
      - name: channel_inbound
        events: ["created"]
        when:
-         tags: ["#agent/message/inbound"]
+         tags: ["agent/message/inbound"]
          has_metadata: ["agent"]
          missing_metadata: ["channel_inbound_rendered_at"]
        action:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/agent",
-  "version": "0.2.2",
+  "version": "0.2.3-rc.1",
   "description": "Vault-native agents for Claude Code — a #agent/definition note + an inbound message becomes a sandboxed claude turn; the reply is written back as a note. Messaging gateway on :1941.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/src/agent-defs.test.ts
+++ b/src/agent-defs.test.ts
@@ -375,8 +375,8 @@ describe("DefVaultClient", () => {
     const client = new DefVaultClient(binding);
     const notes = await client.listDefNotes();
     expect(urls).toHaveLength(1);
-    // `#agent/definition` → `%23agent%2Fdefinition` (both `#` and `/` encoded).
-    expect(urls[0]).toContain("tag=%23agent%2Fdefinition");
+    // `agent/definition` → `agent%2Fdefinition` (the `/` percent-encoded).
+    expect(urls[0]).toContain("tag=agent%2Fdefinition");
     expect(urls[0]).toContain("include_content=true");
     expect(auth).toBe("Bearer write-token");
     expect(notes.map((n) => n.id)).toEqual(["Agents/uni-dev", "Agents/researcher"]);
@@ -444,7 +444,7 @@ describe("DefVaultClient", () => {
     expect(created.id).toBe("Agents/newbot");
     expect(captured!.method).toBe("POST");
     expect(captured!.url).toContain("/vault/default/api/notes");
-    expect(captured!.body.tags).toEqual(["#agent/definition"]);
+    expect(captured!.body.tags).toEqual(["agent/definition"]);
     expect(captured!.body.content).toBe("P");
     expect((captured!.body.metadata as Record<string, string>).name).toBe("newbot");
     expect(captured!.body.path).toBe("Agents/newbot");
@@ -538,7 +538,7 @@ function vaultFetch(opts: {
       opts.patches?.push({ id, status: meta.status, pending: meta.pending });
       return new Response(null, { status: 200 });
     }
-    if (u.includes("/api/notes?") && u.includes("tag=%23agent%2Fdefinition")) {
+    if (u.includes("/api/notes?") && u.includes("tag=agent%2Fdefinition")) {
       return new Response(JSON.stringify(opts.defs ?? []), {
         status: 200,
         headers: { "content-type": "application/json" },
@@ -678,7 +678,7 @@ describe("AgentDefRegistry — lifecycle", () => {
       const u = String(url);
       const method = init?.method ?? "GET";
       if (method === "PATCH") return new Response(null, { status: 200 });
-      if (u.includes("/api/notes?") && u.includes("tag=%23agent%2Fdefinition")) {
+      if (u.includes("/api/notes?") && u.includes("tag=agent%2Fdefinition")) {
         return new Response(JSON.stringify(present), { status: 200, headers: { "content-type": "application/json" } });
       }
       return new Response("[]", { status: 200 });
@@ -714,7 +714,7 @@ describe("AgentDefRegistry — lifecycle", () => {
       const u = String(url);
       const method = init?.method ?? "GET";
       if (method === "PATCH") return new Response(null, { status: 200 });
-      if (u.includes("/api/notes?") && u.includes("tag=%23agent%2Fdefinition")) {
+      if (u.includes("/api/notes?") && u.includes("tag=agent%2Fdefinition")) {
         return new Response(JSON.stringify(current), { status: 200, headers: { "content-type": "application/json" } });
       }
       return new Response("[]", { status: 200 });
@@ -752,7 +752,7 @@ describe("AgentDefRegistry — lifecycle", () => {
     const fetchFn = (async (url: string | URL | Request) => {
       const u = String(url);
       if (u.includes("/vault/default/")) return new Response("boom", { status: 500 });
-      if (u.includes("/vault/research/") && u.includes("tag=%23agent%2Fdefinition")) {
+      if (u.includes("/vault/research/") && u.includes("tag=agent%2Fdefinition")) {
         return new Response(JSON.stringify([{ id: "r1", content: "role", metadata: { name: "r" } }]), {
           status: 200,
         });
@@ -1217,7 +1217,7 @@ describe("AgentDefRegistry — grant-GC reconcile (#96)", () => {
           );
         }
       }
-      if (u.includes("/api/notes?") && u.includes("tag=%23agent%2Fdefinition")) {
+      if (u.includes("/api/notes?") && u.includes("tag=agent%2Fdefinition")) {
         return new Response(JSON.stringify(present), { status: 200, headers: { "content-type": "application/json" } });
       }
       return new Response("[]", { status: 200 });
@@ -1309,7 +1309,7 @@ describe("AgentDefRegistry — grant-GC reconcile (#96)", () => {
         reconciled.push({ agent: body.agent, liveConnections: body.liveConnections });
         return new Response(JSON.stringify({ pruned: 0 }), { status: 200 });
       }
-      if (u.includes("/api/notes?") && u.includes("tag=%23agent%2Fdefinition")) {
+      if (u.includes("/api/notes?") && u.includes("tag=agent%2Fdefinition")) {
         return new Response(JSON.stringify(present), { status: 200, headers: { "content-type": "application/json" } });
       }
       return new Response("[]", { status: 200 });
@@ -1339,7 +1339,7 @@ describe("AgentDefRegistry — grant-GC reconcile (#96)", () => {
         reconciled.push({ agent: body.agent, liveConnections: body.liveConnections });
         return new Response(JSON.stringify({ pruned: 0 }), { status: 200 });
       }
-      if (u.includes("/api/notes?") && u.includes("tag=%23agent%2Fdefinition")) {
+      if (u.includes("/api/notes?") && u.includes("tag=agent%2Fdefinition")) {
         if (listShouldFail) return new Response("boom", { status: 500 });
         return new Response(JSON.stringify(present), { status: 200, headers: { "content-type": "application/json" } });
       }
@@ -1408,7 +1408,7 @@ function vaultFetchWithDelete(opts: {
       return new Response(status >= 400 ? "delete failed" : null, { status });
     }
     if (method === "PATCH") return new Response(null, { status: 200 });
-    if (u.includes("/api/notes?") && u.includes("tag=%23agent%2Fdefinition")) {
+    if (u.includes("/api/notes?") && u.includes("tag=agent%2Fdefinition")) {
       return new Response(JSON.stringify(opts.defs), {
         status: 200,
         headers: { "content-type": "application/json" },

--- a/src/agents.test.ts
+++ b/src/agents.test.ts
@@ -77,9 +77,9 @@ describe("buildSpecFromBody", () => {
     const spec = buildSpecFromBody({
       name: "a",
       channels: ["c"],
-      vault: { name: "default", access: "write", tags: ["#agent/message"] },
+      vault: { name: "default", access: "write", tags: ["agent/message"] },
     });
-    expect(spec.vault).toEqual({ name: "default", access: "write", tags: ["#agent/message"] });
+    expect(spec.vault).toEqual({ name: "default", access: "write", tags: ["agent/message"] });
   });
 
   test("rejects a bad filesystem / network value", () => {

--- a/src/backends/programmatic.test.ts
+++ b/src/backends/programmatic.test.ts
@@ -210,7 +210,7 @@ function specWithVault(name = "eng"): AgentSpec {
   return {
     name,
     channels: [name],
-    vault: { name: "default", access: "read", tags: ["#agent/message"] },
+    vault: { name: "default", access: "read", tags: ["agent/message"] },
   };
 }
 
@@ -222,7 +222,7 @@ function specWithSystemPrompt(
   return {
     name,
     channels: [name],
-    vault: { name: "default", access: "read", tags: ["#agent/message"] },
+    vault: { name: "default", access: "read", tags: ["agent/message"] },
     systemPrompt: prompt,
     ...(mode ? { systemPromptMode: mode } : {}),
   };
@@ -234,7 +234,7 @@ function specMultiThreaded(name = "eng"): AgentSpec {
     name,
     channels: [name],
     mode: "multi-threaded",
-    vault: { name: "default", access: "read", tags: ["#agent/message"] },
+    vault: { name: "default", access: "read", tags: ["agent/message"] },
   };
 }
 
@@ -735,7 +735,7 @@ function specWithWorkspace(workspace: string, name = "eng"): AgentSpec {
   return {
     name,
     channels: [name],
-    vault: { name: "default", access: "read", tags: ["#agent/message"] },
+    vault: { name: "default", access: "read", tags: ["agent/message"] },
     workspace,
   };
 }
@@ -773,7 +773,7 @@ describe("ProgrammaticBackend.deliver — workspace seam: cwd = workspace, secre
       const spec: AgentSpec = {
         name: "eng",
         channels: ["eng"],
-        vault: { name: "default", access: "read", tags: ["#agent/message"] },
+        vault: { name: "default", access: "read", tags: ["agent/message"] },
         workspace: workspaceDir,
         systemPrompt: "Work in the repo.",
       };

--- a/src/daemon-agent-defs-api.test.ts
+++ b/src/daemon-agent-defs-api.test.ts
@@ -309,7 +309,7 @@ describe("GET /api/agent-defs", () => {
     fake.seed({
       id: "Agents/uni-dev",
       content: "a".repeat(500), // long prompt → preview truncates to 200.
-      tags: ["#agent/definition"],
+      tags: ["agent/definition"],
       metadata: { name: "uni-dev", backend: "attached", mode: "multi-threaded" },
     });
     const { reg } = registryWithFakeVault({ fake });
@@ -351,7 +351,7 @@ describe("GET /api/agent-defs/:noteId (full def)", () => {
     fake.seed({
       id: "Agents/uni-dev",
       content: "F".repeat(500), // long body → list preview truncates; full returns all.
-      tags: ["#agent/definition"],
+      tags: ["agent/definition"],
       metadata: { name: "uni-dev", backend: "attached", mode: "multi-threaded", wants: "vault:research:read" },
     });
     const { reg } = registryWithFakeVault({ fake });
@@ -459,7 +459,7 @@ describe("POST /api/agent-defs", () => {
     // The note was written to the fake vault, tagged the def tag, body = prompt.
     const written = [...fake.notes.values()].find((n) => n.metadata.name === "newbot");
     expect(written).toBeDefined();
-    expect(written!.tags).toContain("#agent/definition");
+    expect(written!.tags).toContain("agent/definition");
     expect(written!.content).toBe("You are newbot.");
     expect(written!.metadata.backend).toBe("programmatic");
     // It instantiated LIVE (the per-note reload ran ensureChannel + register) — not
@@ -555,7 +555,7 @@ describe("POST /api/agent-defs", () => {
     fake.seed({
       id: "Agents/uni-dev",
       content: "p",
-      tags: ["#agent/definition"],
+      tags: ["agent/definition"],
       metadata: { name: "uni-dev", backend: "programmatic" },
     });
     const { reg } = registryWithFakeVault({ fake });
@@ -586,7 +586,7 @@ describe("PATCH /api/agent-defs/:noteId", () => {
     fake.seed({
       id: "Agents/uni-dev",
       content: "old prompt",
-      tags: ["#agent/definition"],
+      tags: ["agent/definition"],
       metadata: { name: "uni-dev", backend: "programmatic" },
     });
     const { reg, calls } = registryWithFakeVault({ fake });
@@ -657,7 +657,7 @@ describe("DELETE /api/agent-defs/:noteId", () => {
     fake.seed({
       id: "Agents/uni-dev",
       content: "p",
-      tags: ["#agent/definition"],
+      tags: ["agent/definition"],
       metadata: { name: "uni-dev", backend: "programmatic" },
     });
     const { reg, calls } = registryWithFakeVault({ fake });

--- a/src/daemon-agent-env-api.test.ts
+++ b/src/daemon-agent-env-api.test.ts
@@ -226,7 +226,7 @@ describe("GET /api/agents/<name>/env — composes all three sources + precedence
     fake.seed({
       id: "Agents/uni-dev",
       content: "You are uni-dev.",
-      tags: ["#agent/definition"],
+      tags: ["agent/definition"],
       metadata: { name: "uni-dev", backend: "programmatic", mode: "single-threaded", wants: "env:github" },
     });
     const grants = grantsClientWith({ github: githubGrantStatus });
@@ -308,7 +308,7 @@ describe("GET /api/agents/<name>/env — resilient when grants/hub unreachable",
     fake.seed({
       id: "Agents/uni-dev",
       content: "You are uni-dev.",
-      tags: ["#agent/definition"],
+      tags: ["agent/definition"],
       metadata: { name: "uni-dev", backend: "programmatic", mode: "single-threaded", wants: "env:github" },
     });
     // A grants client whose hub fetch always throws — registerGrant fails at instantiate,

--- a/src/daemon-config-api.test.ts
+++ b/src/daemon-config-api.test.ts
@@ -130,7 +130,7 @@ function inboundBody(noteId: string, channel = "eng") {
       id: noteId,
       path: `channel/${channel}/${noteId}`,
       content: "wake up session",
-      tags: ["#agent/message", "#agent/message/inbound"],
+      tags: ["agent/message", "agent/message/inbound"],
       metadata: { channel, direction: "inbound", sender: "aaron" },
     },
   });
@@ -596,7 +596,7 @@ describe("C — AGENT_VAULT_TRIGGER_TEMPLATE exposed via /.parachute/config", ()
       // re-registration updates the existing trigger in place. The TAG is
       // #agent/message and the webhook is on the /agent mount.
       expect(body.triggerTemplate.name).toBe("channel_inbound_<channel>");
-      expect(body.triggerTemplate.when.tags).toEqual(["#agent/message/inbound"]);
+      expect(body.triggerTemplate.when.tags).toEqual(["agent/message/inbound"]);
       // CONTRACT: the predicate keys on the `agent` routing key (was `channel`).
       expect(body.triggerTemplate.when.has_metadata).toEqual(["agent"]);
       // The rendered-at marker NAME is unchanged (cosmetic/internal).

--- a/src/daemon-jobs-api.test.ts
+++ b/src/daemon-jobs-api.test.ts
@@ -194,7 +194,7 @@ describe("POST /api/jobs — create + validation", () => {
       expect(body.job.noteId).toBe("Channels/eng/jobs/x"); // vault note id for addressing
       const post = calls.find((c) => c.url.endsWith("/api/notes") && c.init.method === "POST")!;
       const sent = JSON.parse(String(post.init.body));
-      expect(sent.tags).toEqual(["#agent/job"]);
+      expect(sent.tags).toEqual(["agent/job"]);
       expect(sent.content).toBe("do it"); // trimmed
       expect(sent.metadata.enabled).toBe("true");
       expect(sent.metadata.jobId).toBe("x");
@@ -224,7 +224,7 @@ describe("POST /api/jobs/:id/run — fire now", () => {
       // The injected note is INBOUND with the #agent/message tags.
       const inject = calls.find((c) => c.url.endsWith("/api/notes") && c.init.method === "POST")!;
       const sent = JSON.parse(String(inject.init.body));
-      expect(sent.tags).toEqual(["#agent/message", "#agent/message/inbound"]);
+      expect(sent.tags).toEqual(["agent/message", "agent/message/inbound"]);
       expect(sent.metadata.sender).toBe("runner:Channels/eng/jobs/x");
     } finally { srv.stop(true); }
   });

--- a/src/daemon.test.ts
+++ b/src/daemon.test.ts
@@ -413,7 +413,7 @@ describe("Vault inbound webhook — POST /api/vault/inbound", () => {
   function body(
     noteId: string,
     extraMeta: Record<string, unknown> = {},
-    tags: string[] = ["#agent/message", "#agent/message/inbound"],
+    tags: string[] = ["agent/message", "agent/message/inbound"],
   ) {
     return JSON.stringify({
       trigger: "channel-inbound",
@@ -546,7 +546,7 @@ describe("Vault inbound webhook — POST /api/vault/inbound", () => {
           note: {
             id: "agent-only-1",
             content: "wake up via agent key",
-            tags: ["#agent/message", "#agent/message/inbound"],
+            tags: ["agent/message", "agent/message/inbound"],
             // NO `channel` field — the routing key is carried ONLY under the new `agent` alias.
             metadata: { agent: "eng", direction: "inbound", sender: "aaron" },
           },
@@ -571,7 +571,7 @@ describe("Vault inbound webhook — POST /api/vault/inbound", () => {
           note: {
             id: "channel-only-1",
             content: "wake up via legacy channel key",
-            tags: ["#agent/message", "#agent/message/inbound"],
+            tags: ["agent/message", "agent/message/inbound"],
             // ONLY the legacy `channel` field — a pre-expand writer; must still route.
             metadata: { channel: "eng", direction: "inbound", sender: "aaron" },
           },
@@ -618,13 +618,13 @@ describe("Vault inbound webhook — POST /api/vault/inbound", () => {
     }
   });
 
-  test("#agent/message/outbound-tagged note is ack'd 200 but NOT emitted (belt-and-suspenders)", async () => {
+  test("agent/message/outbound-tagged note is ack'd 200 but NOT emitted (belt-and-suspenders)", async () => {
     const { srv, base, emitted } = buildVaultServer();
     try {
       const res = await fetch(`${base}/api/vault/inbound?secret=${SECRET}`, {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: body("ob-1", { direction: "outbound" }, ["#agent/message", "#agent/message/outbound"]),
+        body: body("ob-1", { direction: "outbound" }, ["agent/message", "agent/message/outbound"]),
       });
       expect(res.status).toBe(200);
       expect(emitted).toHaveLength(0);

--- a/src/jobs.test.ts
+++ b/src/jobs.test.ts
@@ -126,7 +126,7 @@ describe("VaultJobStore — vault-native CRUD", () => {
     const jobs = await store.listAll();
     // Only ONE vault transport in the map → queried exactly once (telegram is skipped).
     expect(urls.filter((u) => u.includes("/api/notes")).length).toBe(1);
-    expect(urls[0]).toContain("tag=%23agent%2Fjob");
+    expect(urls[0]).toContain("tag=agent%2Fjob");
     expect(jobs).toHaveLength(2);
     expect(jobs[0]).toMatchObject({
       id: "note-1",
@@ -190,7 +190,7 @@ describe("VaultJobStore — vault-native CRUD", () => {
     expect(saved.noteId).toBe("Channels/uni-dev/jobs/morning");
     expect(calls).toHaveLength(1);
     const body = JSON.parse(String(calls[0]!.init.body));
-    expect(body.tags).toEqual(["#agent/job"]);
+    expect(body.tags).toEqual(["agent/job"]);
     expect(body.path).toBe("Channels/uni-dev/jobs/morning");
     expect(body.metadata.jobId).toBe("morning"); // slug persisted for stable display
     expect(body.content).toBe("Run the morning weave");

--- a/src/mint-token.test.ts
+++ b/src/mint-token.test.ts
@@ -68,12 +68,12 @@ describe("mintScopedToken — happy path", () => {
       {
         scope: "vault:default:read",
         audience: "vault.default",
-        permissions: { scoped_tags: ["#agent/message"] },
+        permissions: { scoped_tags: ["agent/message"] },
       },
       depsWith(hub.fetchFn),
     );
     expect(hub.calls[0]!.body.audience).toBe("vault.default");
-    expect(hub.calls[0]!.body.permissions).toEqual({ scoped_tags: ["#agent/message"] });
+    expect(hub.calls[0]!.body.permissions).toEqual({ scoped_tags: ["agent/message"] });
   });
 });
 

--- a/src/module-manifest.test.ts
+++ b/src/module-manifest.test.ts
@@ -74,7 +74,7 @@ describe("module.json — modular-UI declaration", () => {
     expect(tmpl?.requestedBy).toBe("agent");
     expect(tmpl?.source?.module).toBe("vault");
     expect(tmpl?.source?.event).toBe("note.created");
-    expect(tmpl?.source?.filter?.tags).toContain("#agent/message/inbound");
+    expect(tmpl?.source?.filter?.tags).toContain("agent/message/inbound");
     expect(tmpl?.sink?.module).toBe("agent");
     expect(tmpl?.sink?.action).toBe("message.deliver");
     // It's PARAMETERIZED — the operator picks the vault + names the channel.
@@ -128,7 +128,7 @@ describe("module.json — modular-UI declaration", () => {
       expect(tmpl?.requestedBy).toBe("agent");
       expect(tmpl?.source?.module).toBe("vault");
       // Filters on the def tag — and ONLY that tag (no inbound-message keys).
-      expect(tmpl?.source?.filter?.tags).toEqual(["#agent/definition"]);
+      expect(tmpl?.source?.filter?.tags).toEqual(["agent/definition"]);
       expect(tmpl?.sink?.module).toBe("agent");
       expect(tmpl?.sink?.action).toBe("definition.reload");
       // Parameterized: the operator picks which def-vault. No channel param

--- a/src/programmatic-wiring.test.ts
+++ b/src/programmatic-wiring.test.ts
@@ -264,7 +264,7 @@ describe("inbound for a programmatic channel → deliver → outbound note", () 
         note: {
           id: noteId,
           content,
-          tags: ["#agent/message", "#agent/message/inbound"],
+          tags: ["agent/message", "agent/message/inbound"],
           metadata: { channel, direction: "inbound", sender: "aaron", ts: "2026-06-16T00:00:01Z" },
         },
       }),
@@ -356,7 +356,7 @@ describe("inbound for an EXPECTED-but-not-yet-registered channel → queued pend
         note: {
           id: noteId,
           content,
-          tags: ["#agent/message", "#agent/message/inbound"],
+          tags: ["agent/message", "agent/message/inbound"],
           metadata: { channel, direction: "inbound", sender: "aaron", ts: "2026-06-16T00:00:01Z" },
         },
       }),

--- a/src/spawn-agent-cli.test.ts
+++ b/src/spawn-agent-cli.test.ts
@@ -16,7 +16,7 @@ describe("parseArgs — name + channels + vault + egress + mounts → the right 
       "--channel",
       "ops:read",
       "--vault",
-      "default:read:#agent/message,#decision",
+      "default:read:agent/message,#decision",
       "--egress",
       "registry.npmjs.org,github.com",
       "--mount",
@@ -38,7 +38,7 @@ describe("parseArgs — name + channels + vault + egress + mounts → the right 
     expect(spec!.vault).toEqual({
       name: "default",
       access: "read",
-      tags: ["#agent/message", "#decision"],
+      tags: ["agent/message", "#decision"],
     });
 
     // Egress: additive host list, comma-split.

--- a/src/spawn-agent.test.ts
+++ b/src/spawn-agent.test.ts
@@ -448,7 +448,7 @@ describe("spawnAgent — full wiring with stubs (no real token)", () => {
     const spec: AgentSpec = {
       name: "aaron-dev",
       channels: ["aaron-dev"],
-      vault: { name: "default", access: "read", tags: ["#agent/message"] },
+      vault: { name: "default", access: "read", tags: ["agent/message"] },
       network: "restricted", // exercise the egress floor; scoped reads are the default (step 6)
     };
     const res = await spawnAgent(spec, baseDeps({ tmux, sandboxEngine: engine }));
@@ -570,13 +570,13 @@ describe("spawnAgent — full wiring with stubs (no real token)", () => {
     const spec: AgentSpec = {
       name: "weaver",
       channels: ["c"],
-      vault: { name: "default", access: "read", tags: ["#agent/message"] },
+      vault: { name: "default", access: "read", tags: ["agent/message"] },
     };
     await spawnAgent(spec, baseDeps({ fetchFn }));
     const vaultCall = calls.find((c) => String(c.scope).startsWith("vault:"));
     expect(vaultCall).toBeDefined();
     expect(vaultCall!.scope).toBe("vault:default:read");
-    expect(vaultCall!.permissions).toEqual({ scoped_tags: ["#agent/message"] });
+    expect(vaultCall!.permissions).toEqual({ scoped_tags: ["agent/message"] });
   });
 
   test("idempotent: an already-running session is a no-op", async () => {
@@ -674,7 +674,7 @@ describe("spawnAgent — full wiring with stubs (no real token)", () => {
     const spec: AgentSpec = {
       name: "weaver",
       channels: [{ name: "weave", access: "read" }],
-      vault: { name: "default", access: "read", tags: ["#agent/message"] },
+      vault: { name: "default", access: "read", tags: ["agent/message"] },
       network: "restricted",
       egress: ["registry.npmjs.org"],
     };

--- a/src/transports/vault.test.ts
+++ b/src/transports/vault.test.ts
@@ -117,10 +117,10 @@ describe("VaultTransport — reply (outbound note write)", () => {
     // a child-only-tagged note is invisible to a `tag:#agent/message` query), and
     // the directional child `#agent/message/outbound` is the trigger discriminator.
     // We WRITE only the `#agent/message*` tags.
-    expect(sent.tags).toEqual(["#agent/message", "#agent/message/outbound"]);
+    expect(sent.tags).toEqual(["agent/message", "agent/message/outbound"]);
     // Regression guard: the queryable parent tag MUST be present literally.
-    expect(sent.tags).toContain("#agent/message");
-    expect(sent.tags).toContain("#agent/message/outbound");
+    expect(sent.tags).toContain("agent/message");
+    expect(sent.tags).toContain("agent/message/outbound");
     // Write-discipline: the interim/legacy tags are gone (CONTRACT dropped them).
     expect(sent.tags).not.toContain("#agent-message");
     expect(sent.tags).not.toContain("#agent-message/outbound");
@@ -246,8 +246,8 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
     // LOOP SAFETY (HARD CONSTRAINT 4): the thread note carries the thread tag EXACTLY —
     // NOT a message tag + NOT the inbound child — so it can never wake a session.
     expect(sent.tags).toEqual([AGENT_THREAD_TAG]);
-    expect(sent.tags).not.toContain("#agent/message");
-    expect(sent.tags).not.toContain("#agent/message/inbound");
+    expect(sent.tags).not.toContain("agent/message");
+    expect(sent.tags).not.toContain("agent/message/inbound");
     // Indexed/queryable fields.
     expect(sent.metadata.status).toBe("ok");
     expect(sent.metadata.definition).toBe("Agents/digest");
@@ -1007,7 +1007,7 @@ describe("VaultTransport — loadTranscript (read the durable store)", () => {
         getUrls.push(u);
         capturedAuth = (init?.headers as Record<string, string> | undefined)?.authorization ?? "";
         // CONTRACT: a SINGLE `#agent/message` query (no interim/legacy union).
-        if (u.includes("tag=%23agent%2Fmessage")) {
+        if (u.includes("tag=agent%2Fmessage")) {
           // Return notes OUT of ts order (prove the ascending sort) + a note from a
           // DIFFERENT channel (prove the client-side channel filter excludes it).
           return new Response(
@@ -1015,19 +1015,19 @@ describe("VaultTransport — loadTranscript (read the durable store)", () => {
               {
                 id: "n-out",
                 content: "session reply",
-                tags: ["#agent/message", "#agent/message/outbound"],
+                tags: ["agent/message", "agent/message/outbound"],
                 metadata: { agent: "eng", direction: "outbound", sender: "session", ts: "2026-06-08T00:00:02Z", in_reply_to: "n-in" },
               },
               {
                 id: "n-other",
                 content: "different channel — must be excluded",
-                tags: ["#agent/message", "#agent/message/inbound"],
+                tags: ["agent/message", "agent/message/inbound"],
                 metadata: { agent: "other", direction: "inbound", sender: "x", ts: "2026-06-08T00:00:03Z" },
               },
               {
                 id: "n-in",
                 content: "hi session",
-                tags: ["#agent/message", "#agent/message/inbound"],
+                tags: ["agent/message", "agent/message/inbound"],
                 metadata: { agent: "eng", direction: "inbound", sender: "aaron", ts: "2026-06-08T00:00:01Z" },
               },
             ]),
@@ -1049,7 +1049,7 @@ describe("VaultTransport — loadTranscript (read the durable store)", () => {
     // `metadata=` operator filter (the routing-key field isn't indexed on a bare
     // vault; we filter client-side). Overfetches the tag so other channels don't
     // crowd us out.
-    const agentGets = getUrls.filter((u) => u.includes("tag=%23agent%2Fmessage"));
+    const agentGets = getUrls.filter((u) => u.includes("tag=agent%2Fmessage"));
     expect(agentGets).toHaveLength(1);
     // No interim/legacy queries are issued.
     expect(getUrls.some((u) => u.includes("tag=%23agent-message"))).toBe(false);
@@ -1076,12 +1076,12 @@ describe("VaultTransport — loadTranscript (read the durable store)", () => {
     globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
       const u = String(url);
       if (u.includes("/api/notes") && (init?.method ?? "GET") === "GET") {
-        if (u.includes("tag=%23agent%2Fmessage")) {
+        if (u.includes("tag=agent%2Fmessage")) {
           return new Response(
             JSON.stringify([1, 2, 3, 4].map((i) => ({
               id: "n" + i,
               content: "m" + i,
-              tags: ["#agent/message", "#agent/message/inbound"],
+              tags: ["agent/message", "agent/message/inbound"],
               metadata: { agent: "eng", direction: "inbound", sender: "aaron", ts: "2026-06-08T00:00:0" + i + "Z" },
             }))),
             { status: 200 },
@@ -1102,13 +1102,13 @@ describe("VaultTransport — loadTranscript (read the durable store)", () => {
     globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
       const u = String(url);
       if (u.includes("/api/notes") && (init?.method ?? "GET") === "GET") {
-        if (u.includes("tag=%23agent%2Fmessage")) {
+        if (u.includes("tag=agent%2Fmessage")) {
           return new Response(
             JSON.stringify([
               // Outbound child → direction inferred "outbound".
-              { id: "a", content: "x", tags: ["#agent/message", "#agent/message/outbound"], metadata: { agent: "eng", ts: "2026-06-08T00:00:01Z" } },
+              { id: "a", content: "x", tags: ["agent/message", "agent/message/outbound"], metadata: { agent: "eng", ts: "2026-06-08T00:00:01Z" } },
               // No direction signal at all → defaults to "inbound".
-              { id: "b", content: "y", tags: ["#agent/message", "#agent/message/inbound"], metadata: { agent: "eng", ts: "2026-06-08T00:00:02Z" } },
+              { id: "b", content: "y", tags: ["agent/message", "agent/message/inbound"], metadata: { agent: "eng", ts: "2026-06-08T00:00:02Z" } },
             ]),
             { status: 200 },
           );
@@ -1168,11 +1168,11 @@ describe("VaultTransport — writeInbound (the chat's send → wakes the session
     };
     expect(sent.content).toBe("wake up");
     // The INBOUND tag pair — the child is the trigger discriminator that wakes the session.
-    expect(sent.tags).toEqual(["#agent/message", "#agent/message/inbound"]);
-    expect(sent.tags).toContain("#agent/message");
-    expect(sent.tags).toContain("#agent/message/inbound");
+    expect(sent.tags).toEqual(["agent/message", "agent/message/inbound"]);
+    expect(sent.tags).toContain("agent/message");
+    expect(sent.tags).toContain("agent/message/inbound");
     // It must NOT carry the outbound tag (that would be a reply, never wake).
-    expect(sent.tags).not.toContain("#agent/message/outbound");
+    expect(sent.tags).not.toContain("agent/message/outbound");
     // Write-discipline: the legacy tag family is gone (CONTRACT dropped it).
     expect(sent.tags).not.toContain("#channel-message");
     // CONTRACT: the routing key under `metadata.agent` ONLY — no `channel`. The vault
@@ -1244,8 +1244,8 @@ describe("VaultTransport — writeCallback (agent-to-agent reply_to substrate)",
 
     expect(result.sent).toEqual(["callback-note-1"]);
     // The callback is an INBOUND note (so it wakes the sender via the normal vault trigger).
-    expect(sent!.tags).toEqual(["#agent/message", "#agent/message/inbound"]);
-    expect(sent!.tags).not.toContain("#agent/message/outbound");
+    expect(sent!.tags).toEqual(["agent/message", "agent/message/inbound"]);
+    expect(sent!.tags).not.toContain("agent/message/outbound");
     // The metadata contract — all present fields stamped.
     expect(sent!.metadata.callback).toBe("true");
     expect(sent!.metadata.status).toBe("ok");
@@ -1315,7 +1315,7 @@ describe("VaultTransport — ingestInbound", () => {
     void t.ingestInbound({
       id: "note-in-1",
       content: "hello session",
-      tags: ["#agent/message", "#agent/message/inbound"],
+      tags: ["agent/message", "agent/message/inbound"],
       metadata: { agent: "eng", direction: "inbound", sender: "aaron", ts: "2026-06-08T00:00:00Z" },
     });
     expect(ctx.emitted).toHaveLength(1);
@@ -1341,7 +1341,7 @@ describe("VaultTransport — ingestInbound", () => {
     void t.ingestInbound({
       id: "our-own-reply",
       content: "I am awake",
-      tags: ["#agent/message", "#agent/message/outbound"],
+      tags: ["agent/message", "agent/message/outbound"],
       metadata: { channel: "eng", direction: "outbound", sender: "session" },
     });
     expect(ctx.emitted).toHaveLength(0);
@@ -1382,7 +1382,7 @@ describe("VaultTransport — ingestInbound", () => {
     await t.ingestInbound({
       id: "note-att-1",
       content: "look at these",
-      tags: ["#agent/message", "#agent/message/inbound"],
+      tags: ["agent/message", "agent/message/inbound"],
       metadata: { agent: "eng", direction: "inbound", sender: "aaron" },
       // inline list from the trigger payload — the has-attachments SIGNAL.
       attachments: [{ id: "a1", path: "2026-06-24/pic.png", mimeType: "image/png" }],
@@ -1408,7 +1408,7 @@ describe("VaultTransport — ingestInbound", () => {
     await t.ingestInbound({
       id: "note-att-fail",
       content: "still delivered",
-      tags: ["#agent/message", "#agent/message/inbound"],
+      tags: ["agent/message", "agent/message/inbound"],
       metadata: { agent: "eng", direction: "inbound" },
       attachments: [{ id: "a1", path: "2026-06-24/pic.png", mimeType: "image/png" }],
     });
@@ -1429,7 +1429,7 @@ describe("VaultTransport — ingestInbound", () => {
     void t.ingestInbound({
       id: "note-plain",
       content: "no files",
-      tags: ["#agent/message", "#agent/message/inbound"],
+      tags: ["agent/message", "agent/message/inbound"],
       metadata: { agent: "eng", direction: "inbound" },
     });
     expect(ctx.emitted).toHaveLength(1);
@@ -1447,7 +1447,7 @@ describe("VaultTransport — ingestInbound", () => {
     void t.ingestInbound({
       id: "note-deleg-1",
       content: "do the sub-task",
-      tags: ["#agent/message", "#agent/message/inbound"],
+      tags: ["agent/message", "agent/message/inbound"],
       metadata: {
         channel: "worker",
         direction: "inbound",
@@ -1482,10 +1482,11 @@ describe("VaultTransport — ensureSchema (tag-schema declaration on connect)", 
 
     expect(calls).toHaveLength(AGENT_VAULT_TAG_SCHEMA.length);
 
-    // Namespace ROOT `#agent` — no parent_names, just a description. Plain `#` → `%23`.
+    // Namespace ROOT `agent` — no parent_names, just a description. A single bare
+    // segment needs no percent-encoding.
     const root = calls[0]!;
     expect(root.url).toBe(
-      "http://127.0.0.1:1940/vault/default/api/tags/%23agent",
+      "http://127.0.0.1:1940/vault/default/api/tags/agent",
     );
     expect(root.init.method).toBe("PUT");
     expect((root.init.headers as Record<string, string>).authorization).toBe(
@@ -1497,19 +1498,19 @@ describe("VaultTransport — ensureSchema (tag-schema declaration on connect)", 
     };
     expect("parent_names" in rootBody).toBe(false);
 
-    // Definition (NEW) — name carries `#` + `/`; rolls up to the namespace root.
+    // Definition (NEW) — name carries `/`; rolls up to the namespace root.
     const def = calls[1]!;
     expect(def.url).toBe(
-      "http://127.0.0.1:1940/vault/default/api/tags/%23agent%2Fdefinition",
+      "http://127.0.0.1:1940/vault/default/api/tags/agent%2Fdefinition",
     );
-    expect(decodeURIComponent(def.url.split("/api/tags/")[1]!)).toBe("#agent/definition");
+    expect(decodeURIComponent(def.url.split("/api/tags/")[1]!)).toBe("agent/definition");
     const defBody = JSON.parse(String(def.init.body)) as { parent_names?: string[] };
-    expect(defBody.parent_names).toEqual(["#agent"]);
+    expect(defBody.parent_names).toEqual(["agent"]);
 
     // Message parent (NEW) — rolls up to the namespace root.
     const parent = calls[2]!;
     expect(parent.url).toBe(
-      "http://127.0.0.1:1940/vault/default/api/tags/%23agent%2Fmessage",
+      "http://127.0.0.1:1940/vault/default/api/tags/agent%2Fmessage",
     );
     const parentBody = JSON.parse(String(parent.init.body)) as {
       description?: string;
@@ -1518,23 +1519,23 @@ describe("VaultTransport — ensureSchema (tag-schema declaration on connect)", 
     expect(parentBody.description).toBe(
       "A message in a Parachute channel (parent of /inbound + /outbound).",
     );
-    expect(parentBody.parent_names).toEqual(["#agent"]);
+    expect(parentBody.parent_names).toEqual(["agent"]);
 
-    // Inbound child (NEW) — name carries BOTH `#` and `/`. The vault route matches a
+    // Inbound child (NEW) — name carries `/`. The vault route matches a
     // single path segment (`[^/]+`) then decodeURIComponent's it, so the `/` MUST
     // be encoded as `%2F` (a bare slash would fail the single-segment match → 404).
     const inbound = calls[3]!;
     expect(inbound.url).toBe(
-      "http://127.0.0.1:1940/vault/default/api/tags/%23agent%2Fmessage%2Finbound",
+      "http://127.0.0.1:1940/vault/default/api/tags/agent%2Fmessage%2Finbound",
     );
     // Confirm the encoding decodes back to the literal tag name the vault stores.
     const encodedSegment = inbound.url.split("/api/tags/")[1]!;
-    expect(decodeURIComponent(encodedSegment)).toBe("#agent/message/inbound");
+    expect(decodeURIComponent(encodedSegment)).toBe("agent/message/inbound");
     const inboundBody = JSON.parse(String(inbound.init.body)) as {
       description?: string;
       parent_names?: string[];
     };
-    expect(inboundBody.parent_names).toEqual(["#agent/message"]);
+    expect(inboundBody.parent_names).toEqual(["agent/message"]);
     expect(inboundBody.description).toBe(
       "Human→session message; the vault trigger fires on this.",
     );
@@ -1542,19 +1543,19 @@ describe("VaultTransport — ensureSchema (tag-schema declaration on connect)", 
     // Outbound child (NEW) — same encoding, parent declared.
     const outbound = calls[4]!;
     expect(outbound.url).toBe(
-      "http://127.0.0.1:1940/vault/default/api/tags/%23agent%2Fmessage%2Foutbound",
+      "http://127.0.0.1:1940/vault/default/api/tags/agent%2Fmessage%2Foutbound",
     );
     expect(decodeURIComponent(outbound.url.split("/api/tags/")[1]!)).toBe(
-      "#agent/message/outbound",
+      "agent/message/outbound",
     );
     const outboundBody = JSON.parse(String(outbound.init.body)) as { parent_names?: string[] };
-    expect(outboundBody.parent_names).toEqual(["#agent/message"]);
+    expect(outboundBody.parent_names).toEqual(["agent/message"]);
 
     // Job (NEW) — rolls up to the namespace root.
     const job = calls[5]!;
-    expect(decodeURIComponent(job.url.split("/api/tags/")[1]!)).toBe("#agent/job");
+    expect(decodeURIComponent(job.url.split("/api/tags/")[1]!)).toBe("agent/job");
     const jobBody = JSON.parse(String(job.init.body)) as { parent_names?: string[] };
-    expect(jobBody.parent_names).toEqual(["#agent"]);
+    expect(jobBody.parent_names).toEqual(["agent"]);
   });
 
   test("schema declares ONLY the #agent/* namespace rollup (CONTRACT dropped interim + legacy, 7 entries)", async () => {
@@ -1564,29 +1565,29 @@ describe("VaultTransport — ensureSchema (tag-schema declaration on connect)", 
     // schema entries — exactly 7 entries, all under `#agent/*`.
     const names = AGENT_VAULT_TAG_SCHEMA.map((e) => e.name);
     expect(names).toEqual([
-      "#agent",
-      "#agent/definition",
-      "#agent/message",
-      "#agent/message/inbound",
-      "#agent/message/outbound",
-      "#agent/job",
-      "#agent/thread",
+      "agent",
+      "agent/definition",
+      "agent/message",
+      "agent/message/inbound",
+      "agent/message/outbound",
+      "agent/job",
+      "agent/thread",
     ]);
     // The interim/legacy families are gone entirely.
     expect(names).not.toContain("#agent-message");
     expect(names).not.toContain("#channel-message");
     // The namespace children all roll up to the `#agent` root (the human rollup).
     const byName = (n: string) => AGENT_VAULT_TAG_SCHEMA.find((e) => e.name === n)!;
-    expect(byName("#agent/definition").parent_names).toEqual(["#agent"]);
-    expect(byName("#agent/message").parent_names).toEqual(["#agent"]);
-    expect(byName("#agent/job").parent_names).toEqual(["#agent"]);
-    expect(byName("#agent/thread").parent_names).toEqual(["#agent"]);
-    expect(byName("#agent/message/inbound").parent_names).toEqual(["#agent/message"]);
-    expect(byName("#agent/message/outbound").parent_names).toEqual(["#agent/message"]);
+    expect(byName("agent/definition").parent_names).toEqual(["agent"]);
+    expect(byName("agent/message").parent_names).toEqual(["agent"]);
+    expect(byName("agent/job").parent_names).toEqual(["agent"]);
+    expect(byName("agent/thread").parent_names).toEqual(["agent"]);
+    expect(byName("agent/message/inbound").parent_names).toEqual(["agent/message"]);
+    expect(byName("agent/message/outbound").parent_names).toEqual(["agent/message"]);
     // `#agent/thread` declares INDEXED string fields so threads are operator-queryable —
     // "all failed threads" (status), "all threads of agent X" (definition), "all
     // multi-threaded threads" (mode). The three axes carry over from the run record VERBATIM.
-    expect(byName("#agent/thread").fields).toEqual({
+    expect(byName("agent/thread").fields).toEqual({
       // The canonical `agent` routing-key alias is declared indexed.
       agent: { type: "string", indexed: true },
       status: { type: "string", indexed: true },
@@ -1594,11 +1595,11 @@ describe("VaultTransport — ensureSchema (tag-schema declaration on connect)", 
       mode: { type: "string", indexed: true },
     });
     // `#agent/message` declares the indexed `agent` routing key.
-    expect(byName("#agent/message").fields).toEqual({
+    expect(byName("agent/message").fields).toEqual({
       agent: { type: "string", indexed: true },
     });
     // CONTRACT: `#agent/job` indexes the routing key under `agent` ONLY — no `channel`.
-    expect(byName("#agent/job").fields).toEqual({
+    expect(byName("agent/job").fields).toEqual({
       agent: { type: "string", indexed: true },
       enabled: { type: "string", indexed: true },
       lastStatus: { type: "string", indexed: true },
@@ -1691,7 +1692,7 @@ describe("VaultTransport — ensureSchema (tag-schema declaration on connect)", 
     void t.ingestInbound({
       id: "n1",
       content: "still works",
-      tags: ["#agent/message", "#agent/message/inbound"],
+      tags: ["agent/message", "agent/message/inbound"],
       metadata: { channel: "eng", direction: "inbound", sender: "aaron" },
     });
     expect(ctx.emitted).toHaveLength(1);
@@ -1741,7 +1742,7 @@ describe("VaultTransport — injectInbound (runner seam)", () => {
     expect(noteCalls).toHaveLength(1);
     const body = JSON.parse(String(noteCalls[0]!.init.body));
     // Inbound: BOTH the parent + the inbound child (the trigger discriminator).
-    expect(body.tags).toEqual(["#agent/message", "#agent/message/inbound"]);
+    expect(body.tags).toEqual(["agent/message", "agent/message/inbound"]);
     expect(body.content).toBe("Run the morning weave");
     expect(body.metadata.direction).toBe("inbound");
     expect(body.metadata.sender).toBe("runner:morning");
@@ -1789,7 +1790,7 @@ describe("VaultTransport — scheduled-job notes (vault-native store)", () => {
 
     const t = new VaultTransport(baseConfig());
     const jobs = await t.listJobNotes();
-    expect(urls[0]).toContain("tag=%23agent%2Fjob");
+    expect(urls[0]).toContain("tag=agent%2Fjob");
     expect(urls[0]).toContain("include_content=true");
     expect(jobs).toHaveLength(2);
     // id = the slug from metadata.jobId; noteId = the vault note id.
@@ -1825,7 +1826,7 @@ describe("VaultTransport — scheduled-job notes (vault-native store)", () => {
     expect(r.id).toBe("Channels/eng/jobs/m");
     const body = JSON.parse(String(calls[0]!.init.body));
     expect(body.path).toBe("Channels/eng/jobs/m");
-    expect(body.tags).toEqual(["#agent/job"]);
+    expect(body.tags).toEqual(["agent/job"]);
     expect(body.metadata.enabled).toBe("true");
     expect(body.metadata.jobId).toBe("m"); // slug persisted for stable display
     // CONTRACT: routing key under `metadata.agent` ONLY — no `channel`.

--- a/src/transports/vault.ts
+++ b/src/transports/vault.ts
@@ -261,11 +261,11 @@ export class InboundClaimConflictError extends Error {
 /** Parent tag (NEW, namespaced) — carried LITERALLY on every note WE write; query
  *  this + metadata.channel to see BOTH directions of a channel (the slash children
  *  are namespace, not inheritance). */
-const AGENT_MESSAGE_TAG = "#agent/message";
+const AGENT_MESSAGE_TAG = "agent/message";
 /** Inbound child (NEW) — the vault trigger fires on this exact tag (never matches outbound → no loop). */
-const AGENT_MESSAGE_INBOUND_TAG = "#agent/message/inbound";
+const AGENT_MESSAGE_INBOUND_TAG = "agent/message/inbound";
 /** Outbound child (NEW) — replies carry this; the trigger's exact-match predicate excludes it. */
-const AGENT_MESSAGE_OUTBOUND_TAG = "#agent/message/outbound";
+const AGENT_MESSAGE_OUTBOUND_TAG = "agent/message/outbound";
 
 /** Metadata key carrying the channel-queue claim status (design 2026-06-18). */
 const STATUS_META_KEY = "status";
@@ -369,7 +369,7 @@ function buildThreadSummaryBody(t: {
  * (it always queries the exact leaf tag); it exists for the nice human rollup, per
  * the design's namespacing decision.
  */
-export const AGENT_ROOT_TAG = "#agent";
+export const AGENT_ROOT_TAG = "agent";
 
 /**
  * Agent-definition tag — a vault-native agent IS a `#agent/definition` note (design
@@ -377,7 +377,7 @@ export const AGENT_ROOT_TAG = "#agent";
  * METADATA is the config (name, backend, workspace, isolation, the def-vault binding).
  * The module reads these notes from a def-vault and instantiates each as a live agent.
  */
-export const AGENT_DEFINITION_TAG = "#agent/definition";
+export const AGENT_DEFINITION_TAG = "agent/definition";
 
 /**
  * Scheduled-job tag — the runner's vault-native job store (design
@@ -386,7 +386,7 @@ export const AGENT_DEFINITION_TAG = "#agent/definition";
  * `#agent/message`. Introduced in Phase 2 as the flat `#agent-job`; moved into the
  * `#agent/*` namespace (`#agent/job`) by the vault-native-agents work (Phase 4a).
  */
-export const AGENT_JOB_TAG = "#agent/job";
+export const AGENT_JOB_TAG = "agent/job";
 /** Default path prefix under which job notes are written: `Channels/<ch>/jobs/<id>`. */
 const JOB_PATH_PREFIX = "Channels";
 
@@ -413,7 +413,7 @@ const JOB_PATH_PREFIX = "Channels";
  * The note carries `['#agent/thread']` EXACTLY — NOT a message tag, NOT the inbound
  * child — so it can never wake a session (no loop).
  */
-export const AGENT_THREAD_TAG = "#agent/thread";
+export const AGENT_THREAD_TAG = "agent/thread";
 /** Default path prefix under which thread notes are written: `Threads/<ch>/<leaf>`. */
 const THREAD_PATH_PREFIX = "Threads";
 
@@ -557,7 +557,7 @@ export const AGENT_VAULT_TRIGGER_TEMPLATE = {
   name: "channel_inbound_<channel>", // hub substitutes the channel name
   events: ["created"],
   when: {
-    tags: ["#agent/message/inbound"],
+    tags: ["agent/message/inbound"],
     has_metadata: ["agent"],
     missing_metadata: ["channel_inbound_rendered_at"],
   },
@@ -581,7 +581,7 @@ export const AGENT_DEF_VAULT_TRIGGER_TEMPLATE = {
   name: "agent_def_reload",
   events: ["created", "updated", "deleted"],
   when: {
-    tags: ["#agent/definition"],
+    tags: ["agent/definition"],
   },
   action: {
     webhook: "<hub-origin>/agent/api/vault/agent-def", // hub fills origin + the auth.bearer
@@ -657,11 +657,11 @@ export class VaultTransport implements Transport {
    * `decodeURIComponent`'d (parachute-vault `src/routes.ts` handleTags, the
    * "Routes with tag name" block + `routing.ts` `apiPath.startsWith("/tags")`).
    * Because the route matches a SINGLE path segment (`[^/]+`, no literal slash)
-   * and decodes it, the tag name — which contains BOTH `#` and `/`
-   * (`#agent/message/inbound`) — must be `encodeURIComponent`'d so the `#`
-   * becomes `%23` and the `/` becomes `%2F`; the route then decodes that back to
-   * the literal name. A bare `/` in the URL would fail the `[^/]+` match → 404,
-   * silently dropping the declaration. The PUT body is `{ description?, parent_names? }`.
+   * and decodes it, the tag name — which contains a `/`
+   * (`agent/message/inbound`) — must be `encodeURIComponent`'d so the `/` becomes
+   * `%2F`; the route then decodes that back to the literal name. A bare `/` in the
+   * URL would fail the `[^/]+` match → 404, silently dropping the declaration. The
+   * PUT body is `{ description?, parent_names? }`.
    *
    * Best-effort + non-fatal by contract: every failure is caught and `console.warn`'d,
    * never thrown — the tag-both write floor is the fallback.
@@ -669,8 +669,8 @@ export class VaultTransport implements Transport {
   async ensureSchema(): Promise<void> {
     for (const entry of AGENT_VAULT_TAG_SCHEMA) {
       try {
-        // Single-segment, percent-encoded name: `#agent/message/inbound` →
-        // `%23agent%2Fmessage%2Finbound`. The vault decodes it back to the literal.
+        // Single-segment, percent-encoded name: `agent/message/inbound` →
+        // `agent%2Fmessage%2Finbound`. The vault decodes it back to the literal.
         const url = `${this.vaultUrl}/vault/${this.vault}/api/tags/${encodeURIComponent(entry.name)}`;
         const body: {
           description?: string;
@@ -1099,7 +1099,7 @@ export class VaultTransport implements Transport {
    * namespace, not query inheritance, so we never key off them here.
    *
    *   GET <vaultUrl>/vault/<vault>/api/notes
-   *       ?tag=%23agent%2Fmessage             (the `#` + `/` MUST be percent-encoded)
+   *       ?tag=agent%2Fmessage             (the `/` MUST be percent-encoded)
    *       &include_content=true               (we need the bodies)
    *       &limit=<n>                          (default 200)
    *
@@ -1380,7 +1380,7 @@ export class VaultTransport implements Transport {
     // Overfetch (the tag query spans all channels) then keep this channel's items.
     const fetchLimit = Math.min(Math.max(limit * 4, 500), 2000);
     const params = new URLSearchParams();
-    params.set("tag", AGENT_MESSAGE_INBOUND_TAG); // → %23agent%2Fmessage%2Finbound
+    params.set("tag", AGENT_MESSAGE_INBOUND_TAG); // → agent%2Fmessage%2Finbound
     params.set("include_content", "true");
     params.set("limit", String(fetchLimit));
     // NEWEST-first at the vault (default order_by is `updated_at`) so a hard cap drops
@@ -1517,7 +1517,7 @@ export class VaultTransport implements Transport {
   async listJobNotes(opts?: { limit?: number }): Promise<JobNote[]> {
     const limit = opts?.limit ?? 500;
     const params = new URLSearchParams();
-    params.set("tag", AGENT_JOB_TAG); // → %23agent%2Fjob
+    params.set("tag", AGENT_JOB_TAG); // → agent%2Fjob
     params.set("include_content", "true");
     params.set("limit", String(limit));
     const url = `${this.vaultUrl}/vault/${this.vault}/api/notes?${params.toString()}`;

--- a/src/transports/vault.ts
+++ b/src/transports/vault.ts
@@ -1138,7 +1138,7 @@ export class VaultTransport implements Transport {
     // empty transcript).
     const fetchByTag = async (tag: string): Promise<RawNote[]> => {
       const params = new URLSearchParams();
-      params.set("tag", tag); // URLSearchParams encodes `#` → `%23`
+      params.set("tag", tag); // URLSearchParams encodes `/` → `%2F`
       params.set("include_content", "true");
       params.set("limit", String(fetchLimit));
       const url = `${this.vaultUrl}/vault/${this.vault}/api/notes?${params.toString()}`;
@@ -1508,7 +1508,7 @@ export class VaultTransport implements Transport {
 
   /**
    * List the scheduled-job notes in THIS channel's vault. Queries by the parent
-   * `#agent/job` tag (URLSearchParams encodes `#`→`%23`, `/`→`%2F`) and returns ALL job
+   * `#agent/job` tag (URLSearchParams encodes `/`→`%2F`) and returns ALL job
    * notes in the vault — the CALLER filters by `metadata.channel` (same index-free
    * pattern as loadTranscript; we don't assume a `channel` index exists). Throws
    * on a non-ok vault response so the API surfaces a clear error rather than a

--- a/web/ui/src/lib/hub.test.ts
+++ b/web/ui/src/lib/hub.test.ts
@@ -134,7 +134,7 @@ describe("ensureDefReloadConnections", () => {
     expect(create).toMatchObject({
       id: "agentdefs-create-research",
       requestedBy: "agent",
-      source: { module: "vault", vault: "research", filter: { tags: ["#agent/definition"] } },
+      source: { module: "vault", vault: "research", filter: { tags: ["agent/definition"] } },
       sink: { module: "agent", action: "definition.reload" },
     });
     expect(edit).toMatchObject({ id: "agentdefs-edit-research", source: { event: "note.updated" } });

--- a/web/ui/src/lib/hub.ts
+++ b/web/ui/src/lib/hub.ts
@@ -90,7 +90,7 @@ const CREATE_EVENT = "note.created";
 const EDIT_EVENT = "note.updated";
 
 /** The def-discriminator tag the trigger filters on (created/edited defs only). */
-const DEFINITION_TAG = "#agent/definition";
+const DEFINITION_TAG = "agent/definition";
 
 /**
  * The stable connection id for a def-reload connector. Per (vault, kind) and


### PR DESCRIPTION
## What

The agent module's vault tag constants literally embedded a leading `#` (`"#agent/message"`, `"#agent/definition"`, …) — an accident, not the ecosystem convention. A Parachute vault tag name is **bare** (`agent/message`); the `#` is only the Obsidian/Markdown *display* affordance. This flips every tag **string literal** the module writes / reads / triggers-on to the bare form.

**Paired with** the vault `#`-strip guard (parachute-vault PR #516, rc.14) and a `#agent/*` → `agent/*` **data migration the coordinator runs separately**. Merging this code has no live effect on a migrated vault until both land.

## Constant changes (`src/transports/vault.ts`)

| Constant | Before | After |
|---|---|---|
| `AGENT_MESSAGE_TAG` | `#agent/message` | `agent/message` |
| `AGENT_MESSAGE_INBOUND_TAG` | `#agent/message/inbound` | `agent/message/inbound` |
| `AGENT_MESSAGE_OUTBOUND_TAG` | `#agent/message/outbound` | `agent/message/outbound` |
| `AGENT_ROOT_TAG` | `#agent` | `agent` |
| `AGENT_DEFINITION_TAG` | `#agent/definition` | `agent/definition` |
| `AGENT_JOB_TAG` | `#agent/job` | `agent/job` |
| `AGENT_THREAD_TAG` | `#agent/thread` | `agent/thread` |

## Schema propagation

`AGENT_VAULT_TAG_SCHEMA` builds `name` + `parent_names` **from the constants**, so the 7-entry rollup flips automatically. Verified no hardcoded `#agent/*` string remains in the schema array. All note-write paths and `agent-defs.ts` consume the constants too (no change needed in `agent-defs.ts`).

## Trigger propagation (LOAD-BEARING)

These key the live wakeups; if they stayed `#`-prefixed after the data migrates to bare, the agent would stop reacting:

- `AGENT_VAULT_TRIGGER_TEMPLATE.when.tags` (the **inbound** trigger) `["#agent/message/inbound"]` → `["agent/message/inbound"]`
- `AGENT_DEF_VAULT_TRIGGER_TEMPLATE.when.tags` (the **def-reload** trigger) `["#agent/definition"]` → `["agent/definition"]`
- **`.parachute/module.json`** connection-template `filter.tags` (3 arrays the hub uses to register vault triggers): the `link-to-vault` inbound filter (`agent/message/inbound`) + the two def-reload connectors create/edit (`agent/definition`) → bare.
- **SPA** def-reload connector `web/ui/src/lib/hub.ts` `DEFINITION_TAG` (posted to `/admin/connections` as `filter.tags`) → bare.

## Grep-swept literals

Every CODE occurrence across `src/` + `web/ui/`: `"#agent…`, `'#agent…`, plus `%23agent%2F…` URL-encodings in test mock-matchers + the encode-form doc lines (the encoded form now drops the gone `%23`). **Doc-comment / error-message / npm-`description` PROSE keeps the `#` display form** per scope. **Legacy negative assertions** (`#agent-message`, `#channel-message`) left intact — they verify those forms are NOT written.

## Tests

- All `#agent/*` tag assertions → bare; loop-safety negatives flipped (`not.toContain("agent/message")`).
- Schema URL-encoding assertions drop the now-gone `%23` (`/api/tags/%23agent%2Fdefinition` → `/api/tags/agent%2Fdefinition`; mock matchers `tag=%23agent%2F…` → `tag=agent%2F…`).
- `spawn-agent-cli.test.ts`: the `--vault default:read:#agent/message,#decision` fixture input → bare `agent/message` so it round-trips under the new convention.

## Gates

- `tsc --noEmit` (root): **clean**
- `bun test ./src/`: **1097 pass / 0 fail** (3276 expect calls, 50 files)
- SPA `vitest run`: **130 pass / 0 fail** (8 files)
- SPA `tsc --noEmit`: **clean**
- `bun install --frozen-lockfile`: **clean** (root + `web/ui`)

## Version

`0.2.3-rc.1` (per-PR rc bump; `0.2.2` is `@latest`).

## Migration-scope note for the coordinator

The agent code **only ever writes/reads `#agent/*` (slash) tags**. There are **no** live `#agent-message*` (hyphen) or `#channel-message*` literals produced by this module — they appear only in historical prose and in negative test assertions confirming they are NOT written. So the data migration scope is `#agent/*` → `agent/*` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)