### PR TITLE
chore(hygiene): tarball cleanup (#145) + biome gate (#104) + test 401-noise opt-out (#32)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   gate:
-    name: typecheck + tests (src)
+    name: lint + typecheck + tests (src)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -22,6 +22,8 @@ jobs:
         with:
           bun-version: 1.3.14
       - run: bun install --frozen-lockfile
+      - name: lint (biome)
+        run: bun run lint
       - name: typecheck
         run: bun run typecheck
       - name: tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     name: typecheck + tests (src)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.14
@@ -31,7 +31,7 @@ jobs:
     name: web/ui (vitest)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.14

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "organizeImports": { "enabled": false },
+  "files": {
+    "ignore": [
+      "dist",
+      "node_modules",
+      "coverage",
+      "web/ui/dist",
+      "web/ui/node_modules",
+      ".claude"
+    ]
+  },
+  "formatter": {
+    "enabled": false,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "trailingCommas": "all",
+      "semicolons": "always"
+    }
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "a11y": {
+        "useSemanticElements": "off",
+        "useKeyWithClickEvents": "off"
+      },
+      "style": {
+        "noNonNullAssertion": "off",
+        "noUnusedTemplateLiteral": "off",
+        "useTemplate": "off",
+        "useNodejsImportProtocol": "off",
+        "useNumberNamespace": "off",
+        "useSelfClosingElements": "off",
+        "useImportType": "off"
+      },
+      "performance": {
+        "noDelete": "off"
+      },
+      "complexity": {
+        "useOptionalChain": "off",
+        "noUselessConstructor": "off",
+        "useLiteralKeys": "off"
+      },
+      "correctness": {
+        "useExhaustiveDependencies": "off"
+      },
+      "suspicious": {
+        "noExplicitAny": "warn",
+        "noAssignInExpressions": "off",
+        "noImplicitAnyLet": "off",
+        "noConfusingVoidType": "off"
+      }
+    }
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "@xterm/xterm": "5.5.0",
       },
       "devDependencies": {
+        "@biomejs/biome": "^1.9.4",
         "@types/bun": "latest",
       },
       "peerDependencies": {
@@ -21,6 +22,24 @@
   },
   "packages": {
     "@anthropic-ai/sandbox-runtime": ["@anthropic-ai/sandbox-runtime@0.0.54", "", { "dependencies": { "@pondwader/socks5-server": "^1.0.10", "commander": "^12.1.0", "node-forge": "^1.4.0", "shell-quote": "^1.8.4", "zod": "^3.24.1" }, "bin": { "srt": "dist/cli.js" } }, "sha512-zszEoq/z02SgJLlPFcoegqz2UonYbn3Gi//Hwza6KdUolg9HeGw/mPuO7Ybp4EzgLxG6ifA4KOrozErYKJuFag=="],
+
+    "@biomejs/biome": ["@biomejs/biome@1.9.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "1.9.4", "@biomejs/cli-darwin-x64": "1.9.4", "@biomejs/cli-linux-arm64": "1.9.4", "@biomejs/cli-linux-arm64-musl": "1.9.4", "@biomejs/cli-linux-x64": "1.9.4", "@biomejs/cli-linux-x64-musl": "1.9.4", "@biomejs/cli-win32-arm64": "1.9.4", "@biomejs/cli-win32-x64": "1.9.4" }, "bin": { "biome": "bin/biome" } }, "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@1.9.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@1.9.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@1.9.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@1.9.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@1.9.4", "", { "os": "linux", "cpu": "x64" }, "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@1.9.4", "", { "os": "linux", "cpu": "x64" }, "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@1.9.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@1.9.4", "", { "os": "win32", "cpu": "x64" }, "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.13", "", { "peerDependencies": { "hono": "^4" } }, "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/agent",
-  "version": "0.2.3-rc.2",
+  "version": "0.2.3-rc.3",
   "description": "Vault-native agents for Claude Code — a #agent/definition note + an inbound message becomes a sandboxed claude turn; the reply is written back as a note. Messaging gateway on :1941.",
   "license": "AGPL-3.0",
   "type": "module",
@@ -24,6 +24,8 @@
     "test:spa": "cd web/ui && bun run test",
     "test:all": "bun run test && bun run test:spa",
     "test:e2e": "bun e2e/llm/run.ts",
+    "lint": "biome check .",
+    "lint:fix": "biome check --write .",
     "typecheck": "tsc --noEmit",
     "build:spa": "cd web/ui && bun install --frozen-lockfile && bun run build",
     "prepack": "bun run build:spa"
@@ -39,6 +41,7 @@
     "typescript": "^5"
   },
   "devDependencies": {
+    "@biomejs/biome": "^1.9.4",
     "@types/bun": "latest"
   },
   "repository": {

--- a/src/.npmignore
+++ b/src/.npmignore
@@ -1,0 +1,17 @@
+# Trims dev-only cruft from the published tarball, for the `src` subtree.
+#
+# WHY NESTED (src/.npmignore) AND NOT A ROOT .npmignore: package.json declares a
+# `files` allowlist (["src", ".parachute", ...]). When `files` is present, npm uses it
+# as the authoritative include-list and a ROOT .npmignore is NOT consulted at all
+# (verified: npm 11 ignores it). A nested .npmignore INSIDE an included directory IS
+# honored, though — exactly the mechanism web/ui/.npmignore already relies on. So the
+# test/_parked excludes live here, scoped to src/.
+#
+#   - *.test.ts   — ~50 unit-test files, no value to consumers
+#   - _parked/    — the retired interactive-backend PTY spawner, parked not shipped
+#
+# Re-verify after any change with `npm pack --dry-run`: confirm web/ui/dist/ is present
+# and the src/daemon.ts + src/bridge.ts bins keep mode 755 (a 100644 bin breaks
+# supervised start).
+*.test.ts
+_parked/

--- a/src/daemon-config-api.test.ts
+++ b/src/daemon-config-api.test.ts
@@ -105,6 +105,7 @@ function buildServer(initial: Array<{ name: string; secret?: string | null }> = 
       vault: "default",
       vaultUrl: "http://127.0.0.1:1940",
       token: "x",
+      declareSchemaOnStart: false, // fake token — don't 401 the live vault (#32)
       // null → omit (JWT-only channel); undefined → default "s3cret".
       ...(secret === null ? {} : { webhookSecret: secret ?? "s3cret" }),
     });
@@ -360,7 +361,7 @@ describe("B — config-management API (agent:admin)", () => {
         body: JSON.stringify({
           name: "eng",
           transport: "vault",
-          config: { vault: "default", vaultUrl: "http://127.0.0.1:1940", token: "vault-jwt", webhookSecret: "sek" },
+          config: { vault: "default", vaultUrl: "http://127.0.0.1:1940", token: "vault-jwt", webhookSecret: "sek", declareSchemaOnStart: false },
         }),
       });
       expect(create.status).toBe(200);
@@ -416,7 +417,7 @@ describe("B — config-management API (agent:admin)", () => {
         body: JSON.stringify({
           name: "eng",
           transport: "vault",
-          config: { vault: "default", token: "x", webhookSecret: "new" },
+          config: { vault: "default", token: "x", webhookSecret: "new", declareSchemaOnStart: false },
         }),
       });
       expect(res.status).toBe(200);
@@ -544,7 +545,7 @@ describe("B — config-management API (agent:admin)", () => {
       await fetch(`${base}/api/channels`, {
         method: "POST",
         headers: { "content-type": "application/json", ...adminAuth },
-        body: JSON.stringify({ name: "eng", transport: "vault", config: { vault: "default", token: "x", webhookSecret: "sek" } }),
+        body: JSON.stringify({ name: "eng", transport: "vault", config: { vault: "default", token: "x", webhookSecret: "sek", declareSchemaOnStart: false } }),
       });
       const file = channelsFilePath(stateDir);
       expect((JSON.parse(readFileSync(file, "utf8")) as { channels: unknown[] }).channels).toHaveLength(1);

--- a/src/daemon-jobs-api.test.ts
+++ b/src/daemon-jobs-api.test.ts
@@ -55,7 +55,7 @@ const readAuth = { authorization: "Bearer " + READ_TOKEN } as const;
 function buildServer() {
   const registry = new ClientRegistry();
   const channels = new Map<string, Channel>();
-  const eng = new VaultTransport({ vault: "default", vaultUrl: "http://127.0.0.1:1940", token: "vtok" });
+  const eng = new VaultTransport({ vault: "default", vaultUrl: "http://127.0.0.1:1940", token: "vtok", declareSchemaOnStart: false });
   const ctx: TransportContext = { channel: "eng", emit() {}, emitPermissionVerdict() {} };
   void eng.start(ctx);
   channels.set("eng", { name: "eng", transport: eng, entry: { name: "eng", transport: "vault", config: { vault: "default" } } });

--- a/src/daemon.test.ts
+++ b/src/daemon.test.ts
@@ -388,6 +388,7 @@ describe("Vault inbound webhook — POST /api/vault/inbound", () => {
       vaultUrl: "http://127.0.0.1:1940",
       token: "x",
       webhookSecret: SECRET,
+      declareSchemaOnStart: false, // fake token — don't 401 the live vault (#32)
     });
     const emitted: InboundMessage[] = [];
     const ctx: TransportContext = {
@@ -477,8 +478,8 @@ describe("Vault inbound webhook — POST /api/vault/inbound", () => {
 
   test("channel-spoofing: a webhook for channel B presenting channel A's secret → 401, no emit", async () => {
     const registry = new ClientRegistry();
-    const eng = new VaultTransport({ vault: "default", vaultUrl: "http://127.0.0.1:1940", token: "x", webhookSecret: "eng-secret" });
-    const ops = new VaultTransport({ vault: "default", vaultUrl: "http://127.0.0.1:1940", token: "x", webhookSecret: "ops-secret" });
+    const eng = new VaultTransport({ vault: "default", vaultUrl: "http://127.0.0.1:1940", token: "x", webhookSecret: "eng-secret", declareSchemaOnStart: false });
+    const ops = new VaultTransport({ vault: "default", vaultUrl: "http://127.0.0.1:1940", token: "x", webhookSecret: "ops-secret", declareSchemaOnStart: false });
     const engEmits: InboundMessage[] = [];
     const opsEmits: InboundMessage[] = [];
     void eng.start({ channel: "eng", emit: (m) => engEmits.push(m), emitPermissionVerdict() {} });

--- a/src/transports/vault.test.ts
+++ b/src/transports/vault.test.ts
@@ -53,6 +53,13 @@ function baseConfig() {
     vaultUrl: "http://127.0.0.1:1940",
     token: "write-token-xyz",
     webhookSecret: "s3cret",
+    // Default OFF here: these are unit tests for reply/writeThread/transcript etc.
+    // that mock fetch for ONE specific URL and don't want start()'s fire-and-forget
+    // ensureSchema() PUT hitting the (unmocked) tag-schema path → benign 401 warn
+    // spam against the live vault (#32). The dedicated `ensureSchema` describe block
+    // calls `t.ensureSchema()` directly, and the one test that exercises the
+    // start()→ensureSchema fire-and-forget path overrides this back to `true`.
+    declareSchemaOnStart: false,
   };
 }
 
@@ -1683,7 +1690,9 @@ describe("VaultTransport — ensureSchema (tag-schema declaration on connect)", 
       throw new Error("vault unreachable");
     }) as unknown as typeof fetch;
 
-    const t = new VaultTransport(baseConfig());
+    // Override back to true — this test specifically exercises the
+    // start()→ensureSchema fire-and-forget non-fatal path (#32).
+    const t = new VaultTransport({ ...baseConfig(), declareSchemaOnStart: true });
     const ctx = fakeCtx("eng");
     await expect(t.start(ctx)).resolves.toBeUndefined();
     await flush(); // let the fire-and-forget ensureSchema settle (it must not reject globally)

--- a/src/transports/vault.ts
+++ b/src/transports/vault.ts
@@ -96,6 +96,17 @@ export interface VaultTransportConfig {
   webhookSecret?: string;
   /** Optional path prefix for written notes. Default `channel`. */
   notePathPrefix?: string;
+  /**
+   * Whether `start()` fires the best-effort `ensureSchema()` tag-schema upsert
+   * against the connected vault. Default `true` (back-compat — the daemon always
+   * declares the module's tag inheritance on connect). Tests that construct a
+   * transport with a fake token set this `false` so `start()` does NOT hit the
+   * live vault on 127.0.0.1:1940 (which 401s the fake token → ~one `console.warn`
+   * per schema entry of benign noise). The "tag both parent + child" write floor
+   * means a channel works regardless, so skipping the declaration is safe; it's
+   * only a setup optimization, not a runtime contract. See #32.
+   */
+  declareSchemaOnStart?: boolean;
 }
 
 /** The note shape the daemon hands `ingestInbound` (a subset of the trigger payload). */
@@ -605,6 +616,8 @@ export class VaultTransport implements Transport {
    */
   readonly webhookSecret?: string;
   private readonly pathPrefix: string;
+  /** See `VaultTransportConfig.declareSchemaOnStart`. Default `true`. */
+  private readonly declareSchemaOnStart: boolean;
 
   constructor(config: VaultTransportConfig) {
     if (!config.vault) {
@@ -621,6 +634,7 @@ export class VaultTransport implements Transport {
     this.token = config.token;
     this.webhookSecret = config.webhookSecret;
     this.pathPrefix = (config.notePathPrefix ?? DEFAULT_PATH_PREFIX).replace(/\/$/, "");
+    this.declareSchemaOnStart = config.declareSchemaOnStart ?? true;
   }
 
   /**
@@ -642,7 +656,11 @@ export class VaultTransport implements Transport {
     // "tag both parent + child" floor in the note writes is the fail-safe, so the
     // channel works even if this declaration never lands. Fire-and-forget — no
     // reason to delay the channel coming up on a schema upsert.
-    void this.ensureSchema();
+    //
+    // Suppressible via `declareSchemaOnStart: false` — tests with a fake token
+    // set this so `start()` doesn't 401 against the live vault (benign warn noise,
+    // #32). The write floor makes the declaration optional anyway.
+    if (this.declareSchemaOnStart) void this.ensureSchema();
   }
 
   // -------------------------------------------------------------------------

--- a/web/ui/.npmignore
+++ b/web/ui/.npmignore
@@ -1,14 +1,15 @@
 # Intentionally minimal — overrides web/ui/.gitignore for npm packing.
 #
-# Without this, npm (which has no root .npmignore) falls back to .gitignore
-# files for exclusion, and the sibling web/ui/.gitignore's `dist/` rule strips
-# the built SPA bundle (web/ui/dist/) out of the published tarball — even though
-# package.json's `files` allowlist explicitly lists it and the prepack hook
-# builds it for release. A nested .npmignore takes precedence over the nested
-# .gitignore for this subtree, so packing falls back to the `files` allowlist
-# (which ships web/ui/dist/). Keep this minimal: only the dev/test cruft that
-# must never publish.
+# Without this, npm falls back to .gitignore files for exclusion in this subtree,
+# and the sibling web/ui/.gitignore's `dist/` rule strips the built SPA bundle
+# (web/ui/dist/) out of the published tarball — even though package.json's `files`
+# allowlist explicitly lists it and the prepack hook builds it for release. A nested
+# .npmignore takes precedence over the nested .gitignore for this subtree, so packing
+# falls back to the `files` allowlist (which ships web/ui/dist/). The root .npmignore
+# does NOT touch this subtree's dist/. Keep this minimal: only the dev/test cruft that
+# must never publish (tsconfig.json is build-time config, no value to consumers).
 node_modules
 src
+tsconfig.json
 *.tsbuildinfo
 *.log


### PR DESCRIPTION
Focused repo-hygiene pass bundling three contained issues. Version bumped `0.2.3-rc.2` → `0.2.3-rc.3`.

## #145 — packaging cleanliness (published tarball)
- **`src/.npmignore`** (new) excludes `*.test.ts` + `_parked/`.
  - **Decision — nested, not root `.npmignore`:** the issue asked for a root `.npmignore`, but npm 11 **ignores a root `.npmignore` entirely when `package.json` has a `files` field** (verified empirically — tests/_parked still shipped). A nested `.npmignore` *inside* an included dir IS honored — the same mechanism the existing `web/ui/.npmignore` relies on. So the excludes live in `src/.npmignore`, scoped to the `src` subtree.
- **`web/ui/.npmignore`** — added `tsconfig.json`; refreshed the stale "(npm has no root .npmignore)" comment.
- **`ci.yml`** — `actions/checkout@v4` → `@v6` (both jobs); `release.yml` was already on v6.

### npm-pack verification (CRITICAL — real `npm pack`, modes from `tar -tvf`)
```
-rwxr-xr-x  package/src/bridge.ts        ← bin, mode 755 ✓
-rwxr-xr-x  package/src/daemon.ts        ← bin, mode 755 ✓
package/web/ui/dist/assets/index-5KEwEhfi.js   ← SPA bundle present ✓
package/web/ui/dist/assets/index-C-iWdFFV.css  ← present ✓
package/web/ui/dist/index.html                 ← present ✓
```
- tests in tarball: **0** (was ~50) ✓
- `_parked/` in tarball: **0** ✓
- `web/ui/tsconfig.json` in tarball: **0** ✓
- total files: **104 → 53**
- prepack still rebuilds `web/ui/dist` (verify-base passes).

## #104 — biome.json
- Added `biome.json` matching the sibling-repo shape (hub/surface/runner), plus `@biomejs/biome ^1.9.4` devDep + `lint`/`lint:fix` scripts so `bunx biome check .` / `bun run lint` resolve the pinned local binary.
- **Formatter + `organizeImports` OFF** — the codebase predates biome; enabling them would force a whole-repo reformat (86 line-wrap diffs), which the issue explicitly says to avoid.
- **Linter ON (`recommended`)** with the rules the existing code idiomatically uses relaxed: `noNonNullAssertion`, `useTemplate`, `noUnusedTemplateLiteral`, `useNodejsImportProtocol`, `useNumberNamespace`, `useSelfClosingElements`, `useImportType`, `noDelete`, `useOptionalChain`, `noUselessConstructor`, `useLiteralKeys`, `useExhaustiveDependencies`, `noAssignInExpressions`, `noImplicitAnyLet`, `noConfusingVoidType`, `a11y/useSemanticElements`, `a11y/useKeyWithClickEvents`; `noExplicitAny: warn` (matches siblings).
- `.claude` added to `files.ignore` (stray worktree artifact in some checkouts).
- **`bunx biome check .` → exit 0** (2 `noExplicitAny` warnings, non-failing — same posture as siblings).

## #32 — test hygiene (live-vault 401 noise)
- Added `VaultTransportConfig.declareSchemaOnStart` (default `true`, back-compat). `start()` skips the fire-and-forget `ensureSchema()` when `false`.
- Set `false` in the suites that build a `VaultTransport` with a fake token: `daemon.test.ts`, `daemon-config-api.test.ts` (incl. the config-API hot-add POST path, which threads the flag through the real `instantiateTransport`), `daemon-jobs-api.test.ts`, and `vault.test.ts`'s `baseConfig()`.
- The dedicated `ensureSchema` describe block calls `t.ensureSchema()` directly, and the one test that exercises the `start()→ensureSchema` non-fatal path overrides back to `true` — both kept working.
- **Live-vault `(401)` warn spam: 295 → 0.** The 21 remaining `ensureSchema` warns are the error-path tests asserting warn-not-throw against a **mocked** fetch (ECONNREFUSED/500/unreachable) — correct, intentional, kept.
- Did NOT blanket-stub global fetch (daemon tests need real fetch to their in-process server).

## Gates (all green)
- `bun run typecheck` → exit 0
- `bun test ./src` → **1097 pass / 0 fail**; live-vault 401 warns **0**
- `cd web/ui && bunx vitest run` → **138 pass / 8 files**
- `cd web/ui && bun run build` → ok (dist + verify-base)
- `bunx biome check .` → exit 0 (2 warnings)
- `bun install --frozen-lockfile` → no changes (CI-safe lockfile)

Closes #145, #104, #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)