### PR TITLE
agent-ui: remove vestigial `interactive` display backend (#115) + #10 root-cause

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/agent",
-  "version": "0.2.3-rc.3",
+  "version": "0.2.3-rc.4",
   "description": "Vault-native agents for Claude Code — a #agent/definition note + an inbound message becomes a sandboxed claude turn; the reply is written back as a note. Messaging gateway on :1941.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -7,7 +7,7 @@
  * — Phase 4a — edit/delete a def + add/remove a def-vault.
  *
  *   - `GET /agent/api/agents`        — every agent across ALL backends
- *     (interactive / programmatic / channel), with live status.
+ *     (programmatic / channel), with live status.
  *   - `GET /agent/api/agent-defs`    — the vault-native `#agent/definition`
  *     records (the durable defs that instantiate agents).
  *   - `GET /agent/api/agent-vaults`  — the module-level def-vault list
@@ -149,8 +149,13 @@ function deleteJsonWithBody<T>(suffix: string, body: unknown): Promise<T> {
 // daemon emits them; the daemon uses camelCase for these endpoints).
 // ---------------------------------------------------------------------------
 
-/** The backend that drives an agent. The primary axis of the v2 view. */
-export type AgentBackend = "interactive" | "programmatic" | "channel";
+/**
+ * The backend that drives an agent. The primary axis of the v2 view. The
+ * `interactive` (tmux) backend was retired (#114) and can never be returned by
+ * the daemon, so it's gone from the display type too (#115). `"channel"` is the
+ * SPA's label for the daemon's `attached` backend.
+ */
+export type AgentBackend = "programmatic" | "channel";
 
 /** Execution-lifecycle mode — the top-level branch. Rides in `metadata.mode`. */
 export type AgentMode = "single-threaded" | "multi-threaded";

--- a/web/ui/src/routes/Agents.test.tsx
+++ b/web/ui/src/routes/Agents.test.tsx
@@ -138,11 +138,13 @@ describe("mergeAgents (all-backends merge)", () => {
       [
         agentRow({ name: "prog", backend: "programmatic", status: "idle" }),
         agentRow({ name: "chan", backend: "channel", channel: "chan", vault: "default", status: "queued:2" }),
-        agentRow({ name: "tmux", backend: "interactive" }),
+        // A def-less programmatic agent — live from a legacy /api/spawn spec.json,
+        // not a #agent/definition note (no `channel` surfaced, no backing def).
+        agentRow({ name: "solo", backend: "programmatic" }),
       ],
       [],
     );
-    expect(merged.map((m) => m.name)).toEqual(["chan", "prog", "tmux"]); // sorted
+    expect(merged.map((m) => m.name)).toEqual(["chan", "prog", "solo"]); // sorted
     const chan = merged.find((m) => m.name === "chan")!;
     expect(chan.backend).toBe("channel");
     expect(chan.status).toBe("queued:2");
@@ -235,11 +237,12 @@ describe("Agents view states", () => {
   });
 
   it("detail panel notes when an agent has no backing def", async () => {
-    listAgents.mockResolvedValue({ agents: [agentRow({ name: "tmux", backend: "interactive" })] });
+    // A def-less programmatic agent (legacy /api/spawn spec.json, no #agent/definition note).
+    listAgents.mockResolvedValue({ agents: [agentRow({ name: "solo", backend: "programmatic" })] });
     listAgentDefs.mockResolvedValue({ defs: [] });
     renderRoute();
 
-    fireEvent.click(await screen.findByTestId("agent-row-tmux"));
+    fireEvent.click(await screen.findByTestId("agent-row-solo"));
     const detail = await screen.findByTestId("agent-detail");
     expect(within(detail).getByTestId("detail-no-def")).toBeInTheDocument();
   });
@@ -275,10 +278,11 @@ describe("Agents view states", () => {
   });
 
   it("does NOT show edit/delete for an agent with no backing def", async () => {
-    listAgents.mockResolvedValue({ agents: [agentRow({ name: "tmux", backend: "interactive" })] });
+    // A def-less programmatic agent — no #agent/definition note to mutate.
+    listAgents.mockResolvedValue({ agents: [agentRow({ name: "solo", backend: "programmatic" })] });
     listAgentDefs.mockResolvedValue({ defs: [] });
     renderRoute();
-    fireEvent.click(await screen.findByTestId("agent-row-tmux"));
+    fireEvent.click(await screen.findByTestId("agent-row-solo"));
     await screen.findByTestId("agent-detail");
     expect(screen.queryByTestId("detail-actions")).not.toBeInTheDocument();
     expect(screen.queryByTestId("edit-agent")).not.toBeInTheDocument();
@@ -440,12 +444,14 @@ describe("Schedules — per-agent jobs in the detail panel (Phase 4b)", () => {
     expect(within(section).getByText("ok")).toBeInTheDocument();
   });
 
-  it("is ABSENT for a channel-less (interactive) agent", async () => {
-    listAgents.mockResolvedValue({ agents: [agentRow({ name: "tmux", backend: "interactive" })] });
+  it("is ABSENT for a channel-less agent (def-less programmatic, no wake channel surfaced)", async () => {
+    // listProgrammaticAgents surfaces no `channel` field, so a def-less programmatic
+    // agent is channel-less in the view → no schedules section (schedules need a channel).
+    listAgents.mockResolvedValue({ agents: [agentRow({ name: "solo", backend: "programmatic" })] });
     listAgentDefs.mockResolvedValue({ defs: [] });
     renderRoute();
 
-    fireEvent.click(await screen.findByTestId("agent-row-tmux"));
+    fireEvent.click(await screen.findByTestId("agent-row-solo"));
     await screen.findByTestId("agent-detail");
     expect(screen.queryByTestId("schedules-section")).not.toBeInTheDocument();
   });

--- a/web/ui/src/routes/Agents.tsx
+++ b/web/ui/src/routes/Agents.tsx
@@ -2,7 +2,7 @@
  * `/agents` — the unified Agents view (Agent UI v2, Phases 2–4a).
  *
  * The one agent-centric surface the v2 design calls for: a single list of
- * EVERY agent across ALL backends (interactive / programmatic / channel) with a
+ * EVERY agent across ALL backends (programmatic / channel) with a
  * detail panel, plus the "Def-vaults" section showing which vaults the module
  * reads `#agent/definition` notes from. It composes the three Phase-1 list
  * endpoints:
@@ -14,7 +14,7 @@
  *   - `GET /agent/api/agent-vaults` → the def-vault list
  *
  * The "all-backends merge" is the load-bearing v2 move (#102): the list shows
- * channel/programmatic/interactive agents in one table instead of separate
+ * channel/programmatic agents in one table instead of separate
  * pages. We dedupe defs that have no corresponding live agent so a def authored
  * but not yet instantiated still appears (as a def-only row), giving the
  * operator the full picture.
@@ -93,7 +93,7 @@ export interface MergedAgent {
   status?: string;
   /** The execution-lifecycle mode, when the agent is backed by a vault-native def. */
   mode?: AgentMode;
-  /** True when a live agent (interactive/programmatic/channel) exists. */
+  /** True when a live agent (programmatic/channel) exists. */
   live: boolean;
   /** The vault-native def, when one defines this agent. */
   def?: AgentDefRow;
@@ -139,7 +139,7 @@ export function mergeAgents(agents: AgentRow[], defs: AgentDefRow[]): MergedAgen
 function backendPillClass(backend: string): string {
   if (backend === "programmatic") return "pill backend-programmatic";
   if (backend === "channel") return "pill backend-channel";
-  return "pill backend-interactive";
+  return "pill";
 }
 
 function statusPillClass(status: string): string {
@@ -216,9 +216,9 @@ export function Agents() {
     <div>
       <h1>Agents</h1>
       <p className="lede">
-        Every agent across all backends, in one place — programmatic, channel, and
-        interactive. Read-only for now; the create flow and def-vault editor land in
-        later phases.
+        Every agent across all backends, in one place — programmatic and channel.
+        Read-only for now; the create flow and def-vault editor land in later
+        phases.
       </p>
 
       {state.kind === "error" ? (
@@ -326,7 +326,7 @@ export function Agents() {
 /**
  * The per-agent detail panel. Surfaces the def's system-prompt preview, mode,
  * wants, vault, and status. For a vault-native def (a row carrying a `noteId`) it
- * offers Edit + Delete; interactive / non-def agents have no def to edit, so those
+ * offers Edit + Delete; non-def agents have no def to edit, so those
  * actions are absent. `onChanged` refreshes the list after an edit; `onDeleted`
  * closes the panel + refreshes after a delete.
  */

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -289,10 +289,6 @@ tr.agent-row.selected {
   background: var(--warn-soft);
   border-color: transparent;
 }
-.pill.backend-interactive {
-  color: var(--fg-muted);
-  background: var(--bg-soft);
-}
 .pill.status-enabled,
 .pill.status-idle {
   color: var(--success);


### PR DESCRIPTION
Closes #115. Investigates #10 (verdict: upstream — see below + the [issue comment](https://github.com/ParachuteComputer/parachute-agent/issues/10#issuecomment-4826841254)).

## #115 — remove the vestigial `interactive` display backend

The `interactive` (tmux) backend was retired in #114, but the agent admin SPA still carried `interactive` as a **display** value. The daemon's `/api/agents` can only ever return `programmatic` (from `listProgrammaticAgents`) or `attached` (from `listAttachedAgents`) — never `interactive` — so it was dead display code. Removed:

- the `interactive` member of the SPA `AgentBackend` type (`web/ui/src/lib/api.ts`)
- the `backend-interactive` pill fallback in `backendPillClass` (`web/ui/src/routes/Agents.tsx`) → now the neutral base `.pill` (the removed `.pill.backend-interactive` CSS rule was redundant with the base `.pill` styling, so the render is unchanged)
- the `.pill.backend-interactive` CSS rule (`web/ui/src/styles.css`)
- stale doc-comments / the user-facing lede that listed `interactive` as a live backend

`"channel"` is untouched — it's the SPA's label for the daemon's `attached` backend.

### The non-def-agent test determination

The Agents tests used `backend:"interactive"` agentRows to stand in for a **non-def / channel-less** agent (the `detail-no-def`, edit/delete-absent, and schedules-absent cases). The question #115 poses: does a non-def agent still exist post-retirement?

**Yes — and the substitution keeps the tests meaningful.** A live **programmatic** agent created via the legacy `/api/spawn` path (a persisted `spec.json`, not a `#agent/definition` note) is: live, `backend: "programmatic"`, has **no backing def**, and surfaces **no `channel` field** (`listProgrammaticAgents` omits it). The three test cases are gated in `Agents.tsx` on `def`/`channel` presence — **not** on the backend value (`detail-no-def` ← `!def`; edit/delete ← `def?.noteId`; `schedules-section` ← `agent.channel`). So they switch to a def-less programmatic agent (`solo`) and exercise exactly the same branches. No coverage lost.

## #10 — `/mcp` "no MCP server configured with that name" — UPSTREAM, no fix here

Traced the registration path: the agent already registers the MCP server under the **bare** name (`.mcp.json` key `agent-<channel>` in `launch-session.sh`; `serverInfo.name "parachute-agent"` in `bridge.ts`) — which is why `/mcp` correctly shows it `· healthy`. The spurious `server:<name> · no MCP server configured with that name` line is Claude Code's **own** `/mcp` command iterating the `--dangerously-load-development-channels` flag values (which carry the `server:` prefix) and looking each up in the registry **without stripping `server:`**. That flag-parse → lookup → display pipeline is entirely owned by Claude Code; an MCP server author can't affect it. Verdict: cosmetic upstream bug — re-file against anthropics/claude-code, then close/relabel #10 here. Full root cause posted as a comment on #10.

## Follow-up filed
#150 — pre-existing latent bug surfaced in review: the SPA never normalizes the daemon's `attached` backend → `channel`, so a real channel agent renders with the plain fallback pill. This PR does **not** worsen it (the prior fallback was the equally-muted `backend-interactive`); filed separately rather than scope-creep this cleanup.

## Versioning + gates
Bump `0.2.3-rc.3` → `0.2.3-rc.4`.

- `bun run typecheck` (daemon) — pass (tsc 0 errors)
- `bun test ./src` — **1097 pass / 0 fail** (ECONNREFUSED lines are intentional negative-path test stderr)
- `web/ui` `bunx vitest run` — **138 pass / 0 fail**
- `web/ui` `bun run build` — pass (tsc -b + vite build + verify-base ok)
- `bunx biome check .` — exit 0 (2 pre-existing warnings in `src/transports/vault.test.ts`, a file not touched here; all 5 changed files clean)

Independent reviewer: LGTM, no critical issues; confirmed the daemon can't emit `interactive`, the `channel` label is preserved, and the test substitution preserves coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)