### PR TITLE
agent: move browser SSE auth from ?token=<JWT> to a one-time ticket (#25)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,15 +154,29 @@ that as the token `iss`); the loopback fallback is dev-only. Hub-as-supervisor s
 starts the module; a manually-run daemon on an exposed box needs it in the environment.
 
 **Layer 2 — human↔UI (done).** The chat-UI traffic endpoints (`POST /api/channels/<name>/send`
-→ scope `agent:send`; `GET /ui/events` → scope `agent:read`) require a hub-issued JWT,
-validated the same way as Layer 1 (shared `requireScope` in `src/auth.ts`). The token comes from
-a hub endpoint — `GET <hub-origin>/admin/agent-token` (cookie-gated to the logged-in portal
-operator), returning `{ token, expires_at, scopes }` with `aud:agent` + `agent:read agent:send`,
-~10min TTL. The chat page fetches it on load (`credentials: "include"`) and attaches it: a Bearer
-header on the send POST, and a `?token=` query param on the `/ui/events` EventSource (which can't
-set headers). On a 401/SSE-error it re-fetches once and retries. `/ui`, `/health`, and
+→ scope `agent:send`; the browser SSE streams `GET /ui/events` + `GET /api/channels/<ch>/turn-events`
+→ scope `agent:read`) require a hub-issued JWT, validated the same way as Layer 1 (shared
+`requireScope` in `src/auth.ts`). The token comes from a hub endpoint —
+`GET <hub-origin>/admin/agent-token` (cookie-gated to the logged-in portal operator), returning
+`{ token, expires_at, scopes }` with `aud:agent` + `agent:read agent:send`, ~10min TTL. The chat
+page fetches it on load (`credentials: "include"`) and attaches it as a Bearer header on the send
+POST and the ticket mint. On a 401/SSE-error it re-fetches once and retries. `/ui`, `/health`, and
 `/.parachute/config[/schema]` stay OPEN — the page must load to bootstrap its token fetch, and the
 config listing is non-sensitive.
+
+**SSE one-time ticket (agent#25).** An `EventSource` can't set an `Authorization` header, so the
+browser SSE streams used to take the hub JWT as a `?token=<JWT>` query param — which leaks the
+credential into any access/proxy log, browser history, or network trace (mitigated before only by
+the ~10min TTL). They now authenticate with a **one-time ticket** instead: the page POSTs its
+bearer to `POST /api/ui/sse-ticket` (Bearer-gated on `agent:read`, `mintSseTicket` in `src/auth.ts`),
+which returns `{ ticket, expires_at }` — an opaque 256-bit base64url nonce held only server-side in
+a TTL'd map (`src/ui-ticket.ts`, ≤60s) carrying the minting token's validated scopes. The page then
+opens `…?ticket=<nonce>`; the SSE consume path (`requireSseTicket`) looks it up, **consumes it
+single-use** (deletes immediately → a replay 401s), and establishes the stream with the ticket's
+scopes (never widened past the JWT's). So the JWT never appears in a URL. Each EventSource mints its
+own ticket; an SSE error re-mints and reconnects. The legacy `?token=` SSE path was REMOVED (pre-1.0,
+no deprecation window). The `agent:admin` terminal WebSocket still uses `?token=` — a separate
+operator-gated mechanism, out of this change's scope.
 
 ## Vault integration (Stage 2) — channels backed by `#agent/message` notes
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/agent",
-  "version": "0.2.3-rc.4",
+  "version": "0.2.3-rc.5",
   "description": "Vault-native agents for Claude Code — a #agent/definition note + an inbound message becomes a sandboxed claude turn; the reply is written back as a note. Messaging gateway on :1941.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/src/auth-sse-ticket.test.ts
+++ b/src/auth-sse-ticket.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Tests for the SSE one-time-ticket auth helpers (agent#25): `mintSseTicket`
+ * (the Bearer-gated mint) + `requireSseTicket` (the single-use consume gate).
+ *
+ * These are the auth-layer wrappers over `ui-ticket.ts`. The store itself is
+ * tested in `ui-ticket.test.ts`; here we lock the AUTH contract:
+ *  - mint REQUIRES a valid bearer (no token → 401; under-scoped → 403) — an
+ *    unauthenticated mint would be an auth bypass;
+ *  - the minted ticket carries the presenting token's OWN scopes (no widening);
+ *  - a valid ticket consumes once on connect (single-use → 2nd connect 401);
+ *  - an absent ticket → 401; a ticket lacking the required scope → 403.
+ *
+ * `validateHubJwt` is stubbed (sentinel tokens → fixed scopes) so we exercise the
+ * gate logic without a live hub — same pattern as http-ui.test.ts.
+ */
+import { describe, test, expect, beforeEach, mock } from "bun:test";
+
+const READ_SEND_TOKEN = "read-send-token"; // agent:read + agent:send (the chat token)
+const NO_READ_TOKEN = "no-read-token"; // agent:write only — lacks agent:read
+mock.module("./hub-jwt.ts", () => ({
+  AGENT_AUDIENCE: "agent",
+  CHANNEL_AUDIENCE: "channel",
+  ACCEPTED_AUDIENCES: ["agent", "channel"],
+  async validateHubJwt(token: string) {
+    if (token === READ_SEND_TOKEN) {
+      return { sub: "op", scopes: ["agent:read", "agent:send"], aud: "agent" };
+    }
+    if (token === NO_READ_TOKEN) {
+      return { sub: "op", scopes: ["agent:write"], aud: "agent" };
+    }
+    throw new HubJwtError("invalid token");
+  },
+  HubJwtError: class HubJwtError extends Error {},
+  looksLikeJwt: (t: string) => t.split(".").length === 3,
+  resetJwksCache() {},
+  resetRevocationCache() {},
+}));
+class HubJwtError extends Error {}
+
+import { mintSseTicket, requireSseTicket, SCOPE_READ, SCOPE_ADMIN } from "./auth.ts";
+import { mintTicket, _resetTicketsForTest } from "./ui-ticket.ts";
+
+beforeEach(() => {
+  _resetTicketsForTest();
+});
+
+/** Build a mint Request carrying `token` as a Bearer (or none). */
+function mintReq(token?: string): { req: Request; url: URL } {
+  const req = new Request("http://x/api/ui/sse-ticket", {
+    method: "POST",
+    headers: token ? { authorization: `Bearer ${token}` } : {},
+  });
+  return { req, url: new URL(req.url) };
+}
+
+describe("mintSseTicket — REQUIRES a valid bearer (no unauthenticated mint)", () => {
+  test("no token → 401, no ticket issued", async () => {
+    const { req, url } = mintReq();
+    const res = await mintSseTicket(req, url, SCOPE_READ, mintTicket);
+    expect(res.status).toBe(401);
+    expect(((await res.json()) as { error: string }).error).toBe("unauthorized");
+  });
+
+  test("an invalid token → 401", async () => {
+    const { req, url } = mintReq("garbage");
+    const res = await mintSseTicket(req, url, SCOPE_READ, mintTicket);
+    expect(res.status).toBe(401);
+  });
+
+  test("a valid token MISSING the required scope → 403, no ticket", async () => {
+    const { req, url } = mintReq(NO_READ_TOKEN); // has agent:write, not agent:read
+    const res = await mintSseTicket(req, url, SCOPE_READ, mintTicket);
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { error: string }).error).toBe("insufficient_scope");
+  });
+
+  test("a token in the URL (`?token=`) does NOT authenticate the mint", async () => {
+    // The mint takes a Bearer header only — a query-param token must not mint.
+    const req = new Request(`http://x/api/ui/sse-ticket?token=${READ_SEND_TOKEN}`, {
+      method: "POST",
+    });
+    const res = await mintSseTicket(req, new URL(req.url), SCOPE_READ, mintTicket);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("mintSseTicket — success + scope fidelity", () => {
+  test("a valid bearer mints a ticket + ISO expiry", async () => {
+    const { req, url } = mintReq(READ_SEND_TOKEN);
+    const res = await mintSseTicket(req, url, SCOPE_READ, mintTicket);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ticket: string; expires_at: string };
+    expect(typeof body.ticket).toBe("string");
+    expect(body.ticket.length).toBeGreaterThan(20);
+    expect(Number.isNaN(Date.parse(body.expires_at))).toBe(false);
+  });
+
+  test("the minted ticket carries the TOKEN's own scopes — not widened", async () => {
+    const { req, url } = mintReq(READ_SEND_TOKEN); // scopes: read + send
+    const res = await mintSseTicket(req, url, SCOPE_READ, mintTicket);
+    const { ticket } = (await res.json()) as { ticket: string };
+    // The ticket must satisfy agent:read (what it was minted for)...
+    expect(requireSseTicket(new URL(`http://x/?ticket=${ticket}`), SCOPE_READ)).toBeNull();
+  });
+
+  test("the ticket does NOT carry a scope the token lacked (no privilege escalation)", async () => {
+    // Mint with a read+send token, then assert the resulting ticket can't satisfy
+    // agent:admin — even though we ask requireSseTicket for admin. The ticket only
+    // ever holds the minting token's scopes.
+    const { req, url } = mintReq(READ_SEND_TOKEN);
+    const res = await mintSseTicket(req, url, SCOPE_READ, mintTicket);
+    const { ticket } = (await res.json()) as { ticket: string };
+    const denied = requireSseTicket(new URL(`http://x/?ticket=${ticket}`), SCOPE_ADMIN);
+    expect(denied).not.toBeNull();
+    expect(denied!.status).toBe(403);
+  });
+});
+
+describe("requireSseTicket — single-use consume + scope check", () => {
+  test("a valid ticket authorizes once (returns null = proceed)", () => {
+    const { ticket } = mintTicket(["agent:read"]);
+    expect(requireSseTicket(new URL(`http://x/?ticket=${ticket}`), SCOPE_READ)).toBeNull();
+  });
+
+  test("a SECOND connect with the same ticket → 401 (single-use)", () => {
+    const { ticket } = mintTicket(["agent:read"]);
+    const url = new URL(`http://x/?ticket=${ticket}`);
+    expect(requireSseTicket(url, SCOPE_READ)).toBeNull(); // first connect OK
+    const denied = requireSseTicket(new URL(`http://x/?ticket=${ticket}`), SCOPE_READ);
+    expect(denied).not.toBeNull();
+    expect(denied!.status).toBe(401);
+  });
+
+  test("no ?ticket= → 401", () => {
+    const denied = requireSseTicket(new URL("http://x/?channel=dev"), SCOPE_READ);
+    expect(denied).not.toBeNull();
+    expect(denied!.status).toBe(401);
+  });
+
+  test("an expired ticket → 401", () => {
+    const { ticket } = mintTicket(["agent:read"], 0); // already expired
+    const denied = requireSseTicket(new URL(`http://x/?ticket=${ticket}`), SCOPE_READ);
+    expect(denied).not.toBeNull();
+    expect(denied!.status).toBe(401);
+  });
+
+  test("a ticket lacking the required scope → 403 (and is still consumed)", () => {
+    const { ticket } = mintTicket(["agent:write"]); // no agent:read
+    const denied = requireSseTicket(new URL(`http://x/?ticket=${ticket}`), SCOPE_READ);
+    expect(denied).not.toBeNull();
+    expect(denied!.status).toBe(403);
+  });
+
+  test("dual-accept: a legacy channel:read ticket satisfies agent:read", () => {
+    // Pre-rename tokens carry channel:* — the ticket carries them through, and the
+    // consume gate's grantsScope honors the legacy alias (matches requireScope).
+    const { ticket } = mintTicket(["channel:read"]);
+    expect(requireSseTicket(new URL(`http://x/?ticket=${ticket}`), SCOPE_READ)).toBeNull();
+  });
+});

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -7,13 +7,26 @@
  *   - Layer 1 (bridge / session↔channel): the bridge presents the token as an
  *     `Authorization: Bearer` header on `/events` + `/api/*`.
  *   - Layer 2 (human / chat UI): the page fetches a short-lived token from the
- *     hub (`/admin/agent-token`) and attaches it — as a Bearer header on the
- *     `send` POST, and as a `?token=` query param on the `/ui/events` SSE
- *     (EventSource can't set headers).
+ *     hub (`/admin/agent-token`) and attaches it as a Bearer header on the
+ *     `send` POST. For the browser SSE streams (`/ui/events`,
+ *     `/api/channels/<ch>/turn-events`) — which an `EventSource` can't set a
+ *     header on — the page does NOT put the JWT in the URL. Instead it mints a
+ *     one-time SSE TICKET (`POST /api/ui/sse-ticket`, Bearer-authenticated) and
+ *     opens `…?ticket=<nonce>`. See `requireSseTicket` below + `ui-ticket.ts`.
  *
- * `requireScope` accepts the token from EITHER source so one helper guards both
- * layers. The no-token path short-circuits before any JWKS fetch, keeping it
- * unit-testable without a live hub (same approach Layer 1 used).
+ * `requireScope` accepts the token from a Bearer header (and, for the
+ * agent:admin terminal WebSocket only, a `?token=` query param). The no-token
+ * path short-circuits before any JWKS fetch, keeping it unit-testable without a
+ * live hub (same approach Layer 1 used).
+ *
+ * WHY THE TICKET (agent#25). A full hub JWT in a `?token=` URL lands in any
+ * access/proxy log, browser history, or network trace — a credential leak
+ * mitigated before only by the token's short TTL. The browser SSE endpoints now
+ * trade the JWT for an opaque, single-use, ≤60s ticket (`requireSseTicket`); the
+ * JWT only ever travels in a `fetch` Bearer header. The legacy `?token=` SSE
+ * path was REMOVED (pre-1.0, no deprecation window). The terminal WebSocket
+ * (`agent:admin`) still uses `?token=` — a separate, operator-gated mechanism
+ * out of this change's scope.
  *
  * DUAL-ACCEPT (channel→agent rename transition,
  * `parachute-patterns/migrations/2026-06-17-channel-to-agent.md` rule 1). New
@@ -26,6 +39,7 @@
 
 import { validateHubJwt, HubJwtError } from "./hub-jwt.ts";
 import { extractBearer } from "@openparachute/scope-guard";
+import { consumeTicket } from "./ui-ticket.ts";
 
 /** Agent scopes, declared here so callers share one spelling. */
 export const SCOPE_READ = "agent:read" as const;
@@ -79,15 +93,18 @@ export function json(data: unknown, status = 200): Response {
 
 /**
  * Extract a presented token from a request: the `Authorization: Bearer` header
- * first (the bridge + the UI's POST), falling back to a `?token=` query param
- * (the SSE case — `EventSource` can't set headers). Returns null if neither is
- * present.
+ * first (the bridge, the UI's POST, the SSE-ticket mint), falling back to a
+ * `?token=` query param only when `allowQueryParam` is set. The ONLY caller that
+ * opts into the query param is the agent:admin terminal WebSocket
+ * (`new WebSocket()` can't set headers); the browser SSE streams moved to the
+ * one-time-ticket path (`requireSseTicket`) so a JWT never rides in a URL. Returns
+ * null if neither source is present.
  */
 export function extractToken(req: Request, url: URL, allowQueryParam = false): string | null {
   const bearer = extractBearer(req.headers.get("authorization"));
   if (bearer) return bearer;
-  // `?token=` is opt-in (the SSE case only). The bridge + the UI POST present a
-  // Bearer header, so they never enable it — keeps query-param tokens off every
+  // `?token=` is opt-in (the terminal WebSocket only). Every other caller presents
+  // a Bearer header, so they leave it false — keeping query-param JWTs off every
   // endpoint that doesn't strictly need them (and out of those access logs).
   if (allowQueryParam) {
     const q = url.searchParams.get("token");
@@ -99,9 +116,10 @@ export function extractToken(req: Request, url: URL, allowQueryParam = false): s
 /**
  * Guard an HTTP endpoint on a hub-issued JWT carrying `scope`. The token arrives
  * as an `Authorization: Bearer` header; pass `allowQueryParam: true` to also
- * accept a `?token=` query param (the SSE case only — `EventSource` can't set
- * headers). Bridge + UI-POST callers leave it false, so query-param tokens are
- * confined to the one endpoint that needs them.
+ * accept a `?token=` query param (the agent:admin terminal WebSocket only —
+ * `new WebSocket()` can't set headers). All other callers leave it false, so
+ * query-param JWTs are confined to that one endpoint. Browser SSE streams use
+ * `requireSseTicket` (the one-time ticket), not this.
  *
  * Returns `null` when the request is authorized (caller proceeds), or a
  * `Response` (401/403) the caller must return as-is.
@@ -137,4 +155,75 @@ export async function requireScope(
       401,
     );
   }
+}
+
+/**
+ * Mint endpoint for a one-time SSE ticket (agent#25). Authenticate the presented
+ * Bearer JWT for `scope` (the SAME validation `requireScope` runs — no-token →
+ * 401 pre-JWKS, bad/insufficient → 401/403), then issue a single-use, ≤60s
+ * opaque ticket carrying ONLY the token's validated scopes. The ticket — never
+ * the JWT — goes in the SSE URL. Returns the mint `Response` (200 `{ ticket,
+ * expires_at }`, or the gate's 401/403) for the caller to return as-is.
+ *
+ * `mintTicket` is injected (defaults to the real `ui-ticket.ts` store) so unit
+ * tests can assert what scopes get carried without reaching into the singleton.
+ * Critically, an UNAUTHENTICATED mint is impossible: the scope gate runs first
+ * and short-circuits before any ticket is created — minting without a valid
+ * bearer would be an auth bypass.
+ */
+export async function mintSseTicket(
+  req: Request,
+  url: URL,
+  scope: string,
+  mint: (scopes: readonly string[]) => { ticket: string; expiresAt: number },
+): Promise<Response> {
+  const token = extractToken(req, url); // Bearer header ONLY — never a query param.
+  if (!token) {
+    return json({ error: "unauthorized", message: "Bearer token required" }, 401);
+  }
+  let scopes: string[];
+  try {
+    const claims = await validateHubJwt(token);
+    if (!grantsScope(claims.scopes, scope)) {
+      return json(
+        { error: "insufficient_scope", message: `requires ${scope}`, granted: claims.scopes },
+        403,
+      );
+    }
+    // Carry the token's OWN validated scopes — never widen beyond what it holds.
+    scopes = claims.scopes;
+  } catch (err) {
+    return json(
+      { error: "unauthorized", message: err instanceof HubJwtError ? err.message : "invalid token" },
+      401,
+    );
+  }
+  const { ticket, expiresAt } = mint(scopes);
+  return json({ ticket, expires_at: new Date(expiresAt).toISOString() });
+}
+
+/**
+ * Guard a browser SSE endpoint on a one-time `?ticket=<nonce>` (agent#25 — the
+ * EventSource auth path that replaced the leaky `?token=<JWT>`). Look up + CONSUME
+ * the ticket (single-use: a second connect 401s), then assert the ticket's carried
+ * scopes include `scope` (the ticket can never authorize more than the JWT that
+ * minted it — `mintSseTicket` stored exactly that JWT's scopes). Returns `null`
+ * when authorized (caller opens the stream) or a 401 `Response` to return as-is.
+ *
+ * No JWKS fetch on this path — the JWT was validated at MINT time and its scopes
+ * captured in the ticket; consume is a pure in-memory lookup. So an absent /
+ * expired / already-used / under-scoped ticket all map to 401 with no network I/O.
+ */
+export function requireSseTicket(url: URL, scope: string): Response | null {
+  const consumed = consumeTicket(url.searchParams.get("ticket"));
+  if (!consumed) {
+    return json({ error: "unauthorized", message: "valid one-time SSE ticket required" }, 401);
+  }
+  if (!grantsScope(consumed.scopes, scope)) {
+    return json(
+      { error: "insufficient_scope", message: `ticket lacks ${scope}`, granted: consumed.scopes },
+      403,
+    );
+  }
+  return null;
 }

--- a/src/daemon.test.ts
+++ b/src/daemon.test.ts
@@ -206,8 +206,8 @@ describe("Phase 4c — retired pages redirect to the SPA; the data plane survive
   test("FOOTGUN GUARD — GET /ui/events STILL routes to the SSE handler (NOT redirected)", async () => {
     // The /ui page retired, but /ui/events is the message SSE the SPA Chat
     // subscribes to (owned by the http-ui transport's ingestHttp). It must NOT
-    // be swallowed by the `/ui` redirect. With no ?token= it 401s at the SSE
-    // gate — proving it reached the handler, not the 302 page route.
+    // be swallowed by the `/ui` redirect. With no ?ticket= it 401s at the SSE
+    // gate (agent#25) — proving it reached the handler, not the 302 page route.
     const res = await fetch(`${base}/ui/events?channel=ui1`, { redirect: "manual" });
     expect(res.status).toBe(401);
     expect(res.headers.get("content-type")).toContain("application/json");
@@ -362,7 +362,7 @@ describe("Layer 2 — http-ui UI endpoints require a token (401 with none)", () 
     expect(((await res.json()) as { error: string }).error).toBe("unauthorized");
   });
 
-  test("GET /ui/events with no ?token= → 401", async () => {
+  test("GET /ui/events with no ?ticket= → 401", async () => {
     const res = await fetch(`${base}/ui/events?channel=ui1`);
     expect(res.status).toBe(401);
     // Must short-circuit before the SSE stream opens.

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -85,6 +85,8 @@ import { ClientRegistry, sseFrame } from "./routing.ts";
 import { DeliveryState } from "./delivery-state.ts";
 import {
   requireScope,
+  mintSseTicket,
+  requireSseTicket,
   extractToken,
   json as authJson,
   SCOPE_READ,
@@ -93,6 +95,7 @@ import {
   SCOPE_ADMIN,
   SCOPE_TERMINAL,
 } from "./auth.ts";
+import { mintTicket } from "./ui-ticket.ts";
 import {
   createTerminalWsHandlers,
   type TerminalWsData,
@@ -1124,8 +1127,13 @@ function redirect(location: string): Response {
 // is `agent:write`.
 //
 // Layer 2 — human / chat UI — gates the http-ui transport's `send` (POST,
-// `agent:send`) + `/ui/events` SSE (`?token=` query, `agent:read`) inside
-// `http-ui.ts`'s ingestHttp using the same `requireScope`.
+// `agent:send`, Bearer) with `requireScope`. The browser SSE streams
+// (`/ui/events`, `/api/channels/<ch>/turn-events`, `agent:read`) gate on a
+// ONE-TIME ticket (`requireSseTicket`) instead of a `?token=<JWT>` query —
+// `EventSource` can't set a header, and a JWT in a URL leaks into access logs
+// (agent#25). The page mints the ticket at `POST /api/ui/sse-ticket` (Bearer,
+// agent:read) and opens `…?ticket=<nonce>`; the ticket is single-use + ≤60s and
+// carries only the minting token's scopes.
 //
 // Discovery + the page itself (/health, /.parachute/config[/schema], /ui) stay
 // OPEN — non-sensitive, and /ui must load to bootstrap its token fetch.
@@ -2745,8 +2753,21 @@ export function createFetchHandler(
       return json({ ok: true, reloaded: result });
     }
 
+    // One-time SSE ticket mint — POST /api/ui/sse-ticket (agent#25). The chat
+    // page can't put its hub JWT in an EventSource URL without leaking it into
+    // access logs, so it trades the JWT (presented HERE as a Bearer header — no
+    // leak) for a single-use, ≤60s opaque ticket it puts in the SSE URL instead.
+    // Bearer-gated on `agent:read` (the scope both browser SSE streams require);
+    // the minted ticket carries ONLY the token's own validated scopes, so it can
+    // never authorize more than the JWT did. An unauthenticated mint is impossible
+    // — `mintSseTicket` runs the scope gate before issuing anything. Returns
+    // `{ ticket, expires_at }`. Externally `<hub>/agent/api/ui/sse-ticket`.
+    if (req.method === "POST" && url.pathname === "/api/ui/sse-ticket") {
+      return mintSseTicket(req, url, SCOPE_READ, mintTicket);
+    }
+
     // Turn-event SSE — GET /api/channels/<ch>/turn-events (chat-facing; gated on
-    // `agent:read`, same scope as the transcript poll + /ui/events). The streaming
+    // a one-time SSE ticket carrying `agent:read`). The streaming
     // view (design 2026-06-16 build item #1): the chat subscribes here to watch a
     // PROGRAMMATIC turn work in real time — interim assistant text + tool_use, then a
     // done/error lifecycle event. EPHEMERAL by design: no backlog/replay (the durable
@@ -2758,11 +2779,12 @@ export function createFetchHandler(
     {
       const turnMatch = url.pathname.match(/^\/api\/channels\/([^/]+)\/turn-events$/);
       if (req.method === "GET" && turnMatch) {
-        // allowQueryParam=true: this SSE is consumed by a browser EventSource, which
-        // cannot set an Authorization header — it authenticates via ?token=. Without
-        // this the live-streaming view 401s in the browser and never connects. (The
-        // stdio-bridge /events SSE uses a Bearer header, so it doesn't need this.)
-        const denied = await requireScope(req, url, SCOPE_READ, true);
+        // Browser EventSource can't set an Authorization header, so this SSE
+        // authenticates via a one-time `?ticket=<nonce>` (agent#25) — minted by
+        // POST /api/ui/sse-ticket (Bearer-gated) and consumed single-use here. The
+        // hub JWT never rides in this URL. (The stdio-bridge /events SSE uses a
+        // Bearer header, so it never needed a query credential at all.)
+        const denied = requireSseTicket(url, SCOPE_READ);
         if (denied) return denied;
         const channelName = decodeURIComponent(turnMatch[1]!);
         const clientId = crypto.randomUUID();

--- a/src/transports/http-ui.test.ts
+++ b/src/transports/http-ui.test.ts
@@ -68,12 +68,19 @@ import { HttpUiTransport } from "./http-ui.ts";
 import type { TransportContext, InboundMessage } from "../transport.ts";
 import { ClientRegistry } from "../routing.ts";
 import { instantiateTransport } from "../registry.ts";
+import { mintTicket } from "../ui-ticket.ts";
 
 /** Authorization header carrying the sentinel valid token. */
 const AUTH = { authorization: "Bearer " + VALID_TOKEN } as const;
-/** Append the sentinel token as a `?token=` query param (the SSE auth path). */
-function withToken(path: string): string {
-  return path + (path.includes("?") ? "&" : "?") + "token=" + encodeURIComponent(VALID_TOKEN);
+/**
+ * Append a FRESH single-use SSE ticket as `?ticket=` (the SSE auth path —
+ * agent#25, replacing the leaky `?token=`). Mints a real ticket against the live
+ * `ui-ticket.ts` store carrying `agent:read`; each call mints its own so a stream
+ * that consumes one doesn't break the next opener.
+ */
+function withTicket(path: string): string {
+  const { ticket } = mintTicket(["agent:read"]);
+  return path + (path.includes("?") ? "&" : "?") + "ticket=" + encodeURIComponent(ticket);
 }
 
 /** A test context that records emitted inbound messages + permission verdicts. */
@@ -167,7 +174,7 @@ describe("HttpUiTransport — direct", () => {
     expect(ctx.emitted).toHaveLength(0);
   });
 
-  test("ingestHttp SSE WITHOUT a ?token= → 401 (Layer 2)", async () => {
+  test("ingestHttp SSE WITHOUT a ?ticket= → 401 (Layer 2)", async () => {
     const t = new HttpUiTransport();
     await t.start(fakeCtx("dev"));
     const req = new Request("http://x/ui/events?channel=dev");
@@ -175,6 +182,17 @@ describe("HttpUiTransport — direct", () => {
     expect(res).not.toBeNull();
     expect(res!.status).toBe(401);
     expect(res!.headers.get("content-type")).toContain("application/json");
+  });
+
+  test("ingestHttp SSE with a stale `?token=<JWT>` → 401 (legacy path removed)", async () => {
+    // The JWT-in-URL path is gone (agent#25). Even a token that WOULD validate as
+    // a Bearer no longer opens the stream via `?token=`.
+    const t = new HttpUiTransport();
+    await t.start(fakeCtx("dev"));
+    const req = new Request(`http://x/ui/events?channel=dev&token=${VALID_TOKEN}`);
+    const res = await t.ingestHttp(req, new URL(req.url));
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(401);
   });
 
   test("ingestHttp ignores a send for a DIFFERENT channel's path", async () => {
@@ -214,7 +232,7 @@ describe("HttpUiTransport — direct", () => {
     await t.start(fakeCtx("dev"));
 
     // Open the UI SSE stream via ingestHttp (authed via ?token=).
-    const sseReq = new Request("http://x" + withToken("/ui/events?channel=dev"));
+    const sseReq = new Request("http://x" + withTicket("/ui/events?channel=dev"));
     const sseRes = await t.ingestHttp(sseReq, new URL(sseReq.url));
     expect(sseRes).not.toBeNull();
     const reader = sseRes!.body!.getReader();
@@ -233,7 +251,7 @@ describe("HttpUiTransport — direct", () => {
   test("stop() clears UI clients", async () => {
     const t = new HttpUiTransport();
     await t.start(fakeCtx("dev"));
-    const sseReq = new Request("http://x" + withToken("/ui/events?channel=dev"));
+    const sseReq = new Request("http://x" + withTicket("/ui/events?channel=dev"));
     const sseRes = await t.ingestHttp(sseReq, new URL(sseReq.url));
     sseRes!.body!.getReader();
     await t.stop();
@@ -335,7 +353,7 @@ describe("HttpUiTransport — through a daemon-shaped server", () => {
    *  route is Layer-2-gated, so append the sentinel `?token=` for those; the
    *  bridge `/events` route in this harness is ungated (pass through as-is). */
   async function openSse(base: string, path: string) {
-    const url = path.startsWith("/ui/events") ? withToken(path) : path;
+    const url = path.startsWith("/ui/events") ? withTicket(path) : path;
     const res = await fetch(`${base}${url}`);
     const reader = res.body!.getReader();
     return {

--- a/src/transports/http-ui.ts
+++ b/src/transports/http-ui.ts
@@ -16,8 +16,9 @@
  *    to them (mirroring the daemon's `/events` SSE pattern for bridges).
  *
  * It owns two HTTP surfaces via `ingestHttp` (scoped to ITS OWN channel name):
- *   1. POST /api/channels/<name>/send   — body {text} → ctx.emit(...) → {ok:true}
- *   2. GET  /ui/events?channel=<name>    — SSE stream the browser subscribes to
+ *   1. POST /api/channels/<name>/send         — body {text} → ctx.emit(...) → {ok:true}
+ *   2. GET  /ui/events?channel=<name>&ticket=  — SSE stream the browser subscribes to
+ *      (one-time ticket auth — agent#25; the JWT never rides in this URL)
  * The static `/ui` chat page itself is global and served by the daemon, since
  * it's a channel picker across all http-ui channels.
  */
@@ -30,7 +31,7 @@ import type {
   PermissionArgs,
 } from "../transport.ts";
 import { sseFrame } from "../routing.ts";
-import { requireScope, json, SCOPE_SEND, SCOPE_READ } from "../auth.ts";
+import { requireScope, requireSseTicket, json, SCOPE_SEND, SCOPE_READ } from "../auth.ts";
 
 /** A connected browser SSE client (one per open chat page on this channel). */
 interface UiClient {
@@ -168,11 +169,12 @@ export class HttpUiTransport implements Transport {
       url.pathname === "/ui/events" &&
       url.searchParams.get("channel") === channel
     ) {
-      // Layer 2: gate on `agent:read`. EventSource can't set headers, so the
-      // token rides in as a `?token=` query param — the ONLY endpoint that opts
-      // into the query-param fallback (allowQueryParam: true). No-token → 401
-      // before the stream opens.
-      const denied = await requireScope(req, url, SCOPE_READ, true);
+      // Layer 2: EventSource can't set headers, so this gates on a one-time
+      // `?ticket=<nonce>` (agent#25) — minted by POST /api/ui/sse-ticket
+      // (Bearer-gated) and consumed single-use here, carrying `agent:read`. The
+      // hub JWT never appears in this URL (the leak the ticket closes). Absent /
+      // expired / already-used ticket → 401 before the stream opens.
+      const denied = requireSseTicket(url, SCOPE_READ);
       if (denied) return denied;
       const clientId = crypto.randomUUID();
       const clients = this.uiClients;

--- a/src/ui-kit.ts
+++ b/src/ui-kit.ts
@@ -376,9 +376,12 @@ export const SHELL_JS = `
     el.className = "app-status" + (kind ? " " + kind : "");
   }
   // Hub-minted agent token (cookie-gated to the logged-in operator). Cached on
-  // window.__token; pages attach it as a Bearer header and/or ?token= param.
-  // (Endpoint renamed /admin/channel-token → /admin/agent-token in the
-  // channel→agent rename; the hub 301-redirects the old path for old bookmarks.)
+  // window.__token; pages attach it as a Bearer header. (Browser SSE auth moved
+  // off the query-param token to a one-time ticket in agent#25, so the JWT never
+  // lands in a URL; this template is the retired server-rendered shell, superseded
+  // by the SPA.) Endpoint renamed /admin/channel-token to /admin/agent-token in
+  // the channel-to-agent rename; the hub 301-redirects the old path for old
+  // bookmarks.
   function fetchToken() {
     return fetch(window.location.origin + "/admin/agent-token", { credentials: "include" })
       .then(function (r) { if (!r.ok) throw new Error("token " + r.status); return r.json(); })

--- a/src/ui-ticket.test.ts
+++ b/src/ui-ticket.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Unit tests for the one-time SSE ticket store (agent#25) — the primitive that
+ * lets a browser EventSource authenticate WITHOUT putting the hub JWT in the URL.
+ *
+ * The security contract this locks:
+ *  - unguessable nonce (≥128 bits, base64url, URL-safe);
+ *  - single-use (a second consume of the same ticket fails);
+ *  - short TTL (an expired ticket fails);
+ *  - scope fidelity (consume returns exactly what mint stored — never widened).
+ *
+ * Pure in-memory store, no JWKS / no network. `_resetTicketsForTest` isolates cases.
+ */
+import { describe, test, expect, beforeEach } from "bun:test";
+import {
+  mintTicket,
+  consumeTicket,
+  pruneExpiredTickets,
+  _resetTicketsForTest,
+  _ticketCountForTest,
+  TICKET_TTL_MS,
+} from "./ui-ticket.ts";
+
+beforeEach(() => {
+  _resetTicketsForTest();
+});
+
+describe("mintTicket", () => {
+  test("returns an opaque base64url nonce with ≥128 bits of entropy", () => {
+    const { ticket } = mintTicket(["agent:read"]);
+    // base64url alphabet only (no +, /, =).
+    expect(ticket).toMatch(/^[A-Za-z0-9_-]+$/);
+    // 32 random bytes → ~43 base64url chars (well above the 22-char/128-bit floor).
+    expect(ticket.length).toBeGreaterThanOrEqual(22);
+  });
+
+  test("each mint is distinct (random nonce)", () => {
+    const a = mintTicket(["agent:read"]).ticket;
+    const b = mintTicket(["agent:read"]).ticket;
+    expect(a).not.toBe(b);
+  });
+
+  test("returns an absolute expiry ~TTL in the future", () => {
+    const before = Date.now();
+    const { expiresAt } = mintTicket(["agent:read"]);
+    expect(expiresAt).toBeGreaterThanOrEqual(before + TICKET_TTL_MS - 50);
+    expect(expiresAt).toBeLessThanOrEqual(Date.now() + TICKET_TTL_MS + 50);
+  });
+});
+
+describe("consumeTicket — single-use", () => {
+  test("a valid, unexpired ticket consumes once and returns its scopes", () => {
+    const { ticket } = mintTicket(["agent:read", "agent:send"]);
+    const got = consumeTicket(ticket);
+    expect(got).not.toBeNull();
+    expect(got!.scopes).toEqual(["agent:read", "agent:send"]);
+  });
+
+  test("a SECOND consume of the same ticket fails (single-use)", () => {
+    const { ticket } = mintTicket(["agent:read"]);
+    expect(consumeTicket(ticket)).not.toBeNull(); // first use OK
+    expect(consumeTicket(ticket)).toBeNull(); // replay → rejected
+  });
+
+  test("an unknown / never-minted ticket fails", () => {
+    expect(consumeTicket("not-a-real-ticket")).toBeNull();
+  });
+
+  test("a null/empty ticket fails", () => {
+    expect(consumeTicket(null)).toBeNull();
+    expect(consumeTicket(undefined)).toBeNull();
+    expect(consumeTicket("")).toBeNull();
+  });
+
+  test("consuming deletes the entry (store shrinks)", () => {
+    const { ticket } = mintTicket(["agent:read"]);
+    expect(_ticketCountForTest()).toBe(1);
+    consumeTicket(ticket);
+    expect(_ticketCountForTest()).toBe(0);
+  });
+});
+
+describe("consumeTicket — TTL", () => {
+  test("an expired ticket fails (TTL=0) AND is removed (no lingering entry)", () => {
+    const { ticket } = mintTicket(["agent:read"], 0); // already expired
+    expect(consumeTicket(ticket)).toBeNull();
+    // Even an expired hit deletes — a replayed expired ticket can't be retried.
+    expect(_ticketCountForTest()).toBe(0);
+  });
+
+  test("a ticket consumed within its TTL succeeds", () => {
+    const { ticket } = mintTicket(["agent:read"], 10_000);
+    expect(consumeTicket(ticket)).not.toBeNull();
+  });
+});
+
+describe("scope fidelity — no widening", () => {
+  test("consume returns EXACTLY the scopes mint stored, nothing more", () => {
+    const { ticket } = mintTicket(["agent:read"]);
+    const got = consumeTicket(ticket);
+    expect(got!.scopes).toEqual(["agent:read"]);
+    expect(got!.scopes).not.toContain("agent:send");
+    expect(got!.scopes).not.toContain("agent:admin");
+  });
+
+  test("mint copies the scope array (later caller mutation can't leak in)", () => {
+    const scopes = ["agent:read"];
+    const { ticket } = mintTicket(scopes);
+    scopes.push("agent:admin"); // mutate the caller's array AFTER minting
+    const got = consumeTicket(ticket);
+    expect(got!.scopes).toEqual(["agent:read"]); // the ticket kept its own copy
+  });
+});
+
+describe("pruneExpiredTickets", () => {
+  test("drops expired entries, keeps live ones", () => {
+    // Mint the live one FIRST, then the expired one — so the expired-mint's own
+    // opportunistic prune (which runs BEFORE inserting) doesn't drop our live
+    // entry, and both are present when we call pruneExpiredTickets directly.
+    const live = mintTicket(["agent:read"], 10_000).ticket;
+    mintTicket(["agent:read"], 0); // expired
+    expect(_ticketCountForTest()).toBe(2);
+    pruneExpiredTickets();
+    expect(_ticketCountForTest()).toBe(1);
+    expect(consumeTicket(live)).not.toBeNull();
+  });
+
+  test("mint opportunistically prunes so the store can't grow unbounded", () => {
+    mintTicket(["agent:read"], 0); // expired, never consumed
+    mintTicket(["agent:read"], 0); // expired, never consumed
+    // A fresh mint prunes the two dead entries first → only the new one remains.
+    mintTicket(["agent:read"], 10_000);
+    expect(_ticketCountForTest()).toBe(1);
+  });
+});

--- a/src/ui-ticket.ts
+++ b/src/ui-ticket.ts
@@ -1,0 +1,121 @@
+/**
+ * One-time SSE tickets for the browser EventSource auth path (Layer 2, human↔UI).
+ *
+ * THE LEAK THIS CLOSES. A browser `EventSource` can't set an `Authorization`
+ * header, so the agent SPA used to put the hub JWT directly in the SSE URL
+ * (`/ui/events?token=<JWT>`, `/api/channels/<ch>/turn-events?token=<JWT>`). A
+ * full bearer JWT in a URL lands in any access log, proxy log, browser history,
+ * or network trace — mitigated before only by the token's ~10min TTL. That's a
+ * credential-in-a-URL leak.
+ *
+ * THE FIX. Trade the JWT for an opaque, single-use, very-short-lived TICKET that
+ * goes in the URL instead. The SPA presents its bearer JWT to a normal
+ * authenticated endpoint (a Bearer header on a `fetch`, no leak), which mints a
+ * ticket: a crypto-random 256-bit nonce (base64url) stored ONLY server-side in
+ * this TTL'd map, carrying the validated scope(s)/audience of the presenting
+ * token. The SPA opens `/ui/events?ticket=<nonce>`; the SSE consume path looks
+ * the nonce up, CONSUMES it (deletes immediately — single-use), and establishes
+ * the stream with the ticket's scopes. The JWT never appears in a URL or log.
+ *
+ * SECURITY PROPERTIES (all load-bearing):
+ *  - Unguessable: 32 random bytes (256 bits) from `crypto.getRandomValues`,
+ *    base64url-encoded. Far above the issue's 128-bit floor.
+ *  - Single-use: `consume` DELETES the entry before returning, so a replayed
+ *    ticket (a second connect, or a stolen URL) finds nothing → 401.
+ *  - Short TTL: default 60s — just long enough to open the connection. An
+ *    expired entry is treated as absent (and lazily pruned).
+ *  - No scope widening: the ticket stores EXACTLY the scopes the minting token
+ *    presented (validated upstream by `requireScope` before `mint` is called).
+ *    The consume path asserts the required scope against the stored set, so a
+ *    ticket can never authorize more than the JWT that minted it.
+ *
+ * This is process-local in-memory state by design (mirrors the daemon's other
+ * in-process registries). The daemon is single-instance per machine; tickets
+ * live ≤60s and are cheap to lose on restart (the SPA just re-mints). A
+ * module-level singleton is used because the two consume paths live in different
+ * modules (`http-ui.ts`'s `ingestHttp` and the daemon's turn-events route) and
+ * both must hit the SAME store — `ingestHttp(req, url)` has no place to thread an
+ * instance through. `_resetTicketsForTest` isolates unit tests.
+ */
+
+/** A minted ticket's server-side record. Never leaves the process. */
+interface TicketRecord {
+  /** The validated scopes carried from the minting JWT (the ceiling — never widened). */
+  scopes: string[];
+  /** Epoch ms after which the ticket is expired (treated as absent). */
+  expiresAt: number;
+}
+
+/** Default ticket lifetime — long enough to open an EventSource, no longer. */
+export const TICKET_TTL_MS = 60_000;
+
+/** Nonce entropy: 32 bytes = 256 bits, well above the 128-bit floor. */
+const TICKET_BYTES = 32;
+
+/** The process-local ticket store. nonce → record. */
+const tickets = new Map<string, TicketRecord>();
+
+/** base64url-encode bytes (no padding) — URL-safe, no `+`/`/`/`=`. */
+function base64url(bytes: Uint8Array): string {
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/**
+ * Mint a single-use ticket carrying `scopes` (a COPY of the validated scopes from
+ * the presenting JWT — the caller must have already authenticated + scope-checked
+ * the token, so this never widens authority). Returns the opaque nonce + its
+ * absolute expiry. TTL defaults to {@link TICKET_TTL_MS}.
+ */
+export function mintTicket(scopes: readonly string[], ttlMs = TICKET_TTL_MS): {
+  ticket: string;
+  expiresAt: number;
+} {
+  pruneExpiredTickets();
+  const bytes = new Uint8Array(TICKET_BYTES);
+  crypto.getRandomValues(bytes);
+  const ticket = base64url(bytes);
+  const expiresAt = Date.now() + ttlMs;
+  tickets.set(ticket, { scopes: [...scopes], expiresAt });
+  return { ticket, expiresAt };
+}
+
+/**
+ * Consume a ticket: look it up, and if present + unexpired, DELETE it (single-use)
+ * and return its scopes. Returns `null` for an absent / expired / already-consumed
+ * ticket — the caller maps that to a 401. Deletion happens before return, so two
+ * concurrent consumes of the same nonce can't both succeed.
+ */
+export function consumeTicket(ticket: string | null | undefined): { scopes: string[] } | null {
+  if (!ticket) return null;
+  const rec = tickets.get(ticket);
+  if (!rec) return null;
+  // Single-use: remove FIRST, so even an expired hit can't be retried and a
+  // concurrent second consume finds nothing.
+  tickets.delete(ticket);
+  if (Date.now() >= rec.expiresAt) return null;
+  return { scopes: rec.scopes };
+}
+
+/**
+ * Drop every expired ticket. Called opportunistically on each mint so the map
+ * can't grow unbounded if some tickets are never consumed; not on a timer (no
+ * background work in a possibly-idle daemon). O(n) over a map that's tiny in
+ * practice (≤ a handful of live tickets at 60s TTL).
+ */
+export function pruneExpiredTickets(now = Date.now()): void {
+  for (const [k, rec] of tickets) {
+    if (now >= rec.expiresAt) tickets.delete(k);
+  }
+}
+
+/** Test seam: clear all tickets so unit tests start from a clean store. */
+export function _resetTicketsForTest(): void {
+  tickets.clear();
+}
+
+/** Test seam: the current live ticket count (asserts single-use deletion). */
+export function _ticketCountForTest(): number {
+  return tickets.size;
+}

--- a/web/ui/src/lib/api.test.ts
+++ b/web/ui/src/lib/api.test.ts
@@ -389,37 +389,38 @@ describe("chat — listChannels / listMessages / sendMessage (Phase 4d)", () => 
   });
 });
 
-describe("chat SSE URL builders (Phase 4d)", () => {
-  it("messageStreamUrl appends &token= under the agent mount (origin-relative)", () => {
-    // apiBase() is "/agent/api" in vitest → MOUNT "/agent".
-    expect(messageStreamUrl("eng", "jwt-abc")).toBe(
-      "/agent/ui/events?channel=eng&token=jwt-abc",
+describe("chat SSE URL builders (Phase 4d — one-time ticket auth, agent#25)", () => {
+  it("messageStreamUrl appends &ticket= under the agent mount (origin-relative)", () => {
+    // apiBase() is "/agent/api" in vitest → MOUNT "/agent". Auth rides as a
+    // one-time ticket — NOT the hub JWT — so it never leaks into an access log.
+    expect(messageStreamUrl("eng", "tkt-abc")).toBe(
+      "/agent/ui/events?channel=eng&ticket=tkt-abc",
     );
   });
 
-  it("messageStreamUrl encodes the channel + token", () => {
+  it("messageStreamUrl encodes the channel + ticket", () => {
     expect(messageStreamUrl("eng team", "a/b c")).toBe(
-      "/agent/ui/events?channel=eng%20team&token=a%2Fb%20c",
+      "/agent/ui/events?channel=eng%20team&ticket=a%2Fb%20c",
     );
   });
 
-  it("messageStreamUrl omits the token when null (unguarded dev daemon)", () => {
+  it("messageStreamUrl omits the ticket when null (unguarded dev daemon)", () => {
     expect(messageStreamUrl("eng", null)).toBe("/agent/ui/events?channel=eng");
   });
 
-  it("turnEventsUrl appends ?token= under the agent mount (origin-relative)", () => {
-    expect(turnEventsUrl("eng", "jwt-abc")).toBe(
-      "/agent/api/channels/eng/turn-events?token=jwt-abc",
+  it("turnEventsUrl appends ?ticket= under the agent mount (origin-relative)", () => {
+    expect(turnEventsUrl("eng", "tkt-abc")).toBe(
+      "/agent/api/channels/eng/turn-events?ticket=tkt-abc",
     );
   });
 
-  it("turnEventsUrl encodes the channel + token", () => {
+  it("turnEventsUrl encodes the channel + ticket", () => {
     expect(turnEventsUrl("eng team", "a/b")).toBe(
-      "/agent/api/channels/eng%20team/turn-events?token=a%2Fb",
+      "/agent/api/channels/eng%20team/turn-events?ticket=a%2Fb",
     );
   });
 
-  it("turnEventsUrl omits the token when null", () => {
+  it("turnEventsUrl omits the ticket when null", () => {
     expect(turnEventsUrl("eng", null)).toBe("/agent/api/channels/eng/turn-events");
   });
 });

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -729,19 +729,21 @@ export function connectSessionCommand(name: string, origin: string): string {
 //     sorted ascending by ts — vault.ts:1072).
 //   - POST /api/channels/<ch>/send             — write the inbound + wake the turn
 //     (`agent:send`; daemon.ts ~3437, body `{ text }`, returns `{ ok, id }`).
-//   - GET  /ui/events?channel=<ch>&token=<jwt> — the message SSE (inbound/outbound
-//     deltas; `agent:read`, query-param token — http-ui.ts:168). Events:
+//   - GET  /ui/events?channel=<ch>&ticket=<nonce> — the message SSE (inbound/
+//     outbound deltas; `agent:read` via a one-time ticket — http-ui.ts). Events:
 //     `reply` `{ id, text, files }`, `edit` `{ id, text }`, `permission` {...}.
-//   - GET  /api/channels/<ch>/turn-events?token=<jwt> — the PROGRAMMATIC turn
-//     streaming view (`agent:read`, query-param token — daemon.ts:3353). Event
+//   - GET  /api/channels/<ch>/turn-events?ticket=<nonce> — the PROGRAMMATIC turn
+//     streaming view (`agent:read` via a one-time ticket — daemon.ts). Event
 //     name `"turn"`; payload is the TurnLifecycleEvent union below.
 //
-// EventSource can't set an Authorization header, so the agent JWT rides as the
-// `token` QUERY PARAM (the `?token=` fallback the daemon opts these two SSE routes
-// into). The URLs are built ORIGIN-RELATIVE under the agent module mount
-// (`apiBase()` → `/agent/api`; MOUNT = drop the trailing `/api` → `/agent`) so
-// they resolve correctly BOTH daemon-direct and hub-proxied — mirroring how the
-// inline chat derives MOUNT from the page path (src/daemon.ts ~1194).
+// EventSource can't set an Authorization header. Rather than leak the hub JWT in
+// a `?token=` URL (it lands in access logs / history — agent#25), the chat mints a
+// one-time SSE TICKET (`POST /agent/api/ui/sse-ticket`, Bearer-authed —
+// `lib/auth.ts:getSseTicket`) and rides it as `?ticket=<nonce>`. The ticket is
+// single-use + ≤60s; the server consumes it on connect. The URLs are built
+// ORIGIN-RELATIVE under the agent module mount (`apiBase()` → `/agent/api`; MOUNT =
+// drop the trailing `/api` → `/agent`) so they resolve correctly BOTH daemon-direct
+// and hub-proxied — mirroring how the inline chat derives MOUNT from the page path.
 // ---------------------------------------------------------------------------
 
 /**
@@ -827,28 +829,30 @@ export function sendMessage(ch: string, text: string): Promise<SendMessageRespon
 }
 
 /**
- * Build the message-stream SSE URL: `<MOUNT>/ui/events?channel=<ch>&token=<jwt>`.
+ * Build the message-stream SSE URL: `<MOUNT>/ui/events?channel=<ch>&ticket=<nonce>`.
  * Origin-relative (under the agent mount) so it resolves daemon-direct AND
- * hub-proxied. The token rides as `&token=` (the URL already has `?channel=`),
- * matching the inline chat (src/daemon.ts:1496-1497). A falsy token is omitted —
- * an unguarded dev daemon may accept the stream without one.
+ * hub-proxied. Auth rides as a one-time `&ticket=` (agent#25) — NOT the hub JWT —
+ * so the credential never lands in a URL / access log. A falsy ticket is omitted
+ * (an unguarded dev daemon may accept the stream without one). Mint the ticket via
+ * `lib/auth.ts:getSseTicket` immediately before opening the stream.
  */
-export function messageStreamUrl(ch: string, token: string | null): string {
+export function messageStreamUrl(ch: string, ticket: string | null): string {
   const mount = apiBase().replace(/\/api$/, "");
   let url = `${mount}/ui/events?channel=${encodeURIComponent(ch)}`;
-  if (token) url += `&token=${encodeURIComponent(token)}`;
+  if (ticket) url += `&ticket=${encodeURIComponent(ticket)}`;
   return url;
 }
 
 /**
- * Build the turn-event SSE URL: `<MOUNT>/api/channels/<ch>/turn-events?token=<jwt>`.
+ * Build the turn-event SSE URL: `<MOUNT>/api/channels/<ch>/turn-events?ticket=<nonce>`.
  * Origin-relative (under the agent mount) so it resolves daemon-direct AND
- * hub-proxied. The token rides as `?token=` (the first param), matching the inline
- * chat (src/daemon.ts:1356-1357). A falsy token is omitted.
+ * hub-proxied. Auth rides as a one-time `?ticket=` (agent#25) — NOT the hub JWT.
+ * A falsy ticket is omitted. Mint the ticket via `getSseTicket` right before
+ * opening the stream (single-use — each connect needs its own).
  */
-export function turnEventsUrl(ch: string, token: string | null): string {
+export function turnEventsUrl(ch: string, ticket: string | null): string {
   const mount = apiBase().replace(/\/api$/, "");
   let url = `${mount}/api/channels/${encodeURIComponent(ch)}/turn-events`;
-  if (token) url += `?token=${encodeURIComponent(token)}`;
+  if (ticket) url += `?ticket=${encodeURIComponent(ticket)}`;
   return url;
 }

--- a/web/ui/src/lib/auth.ts
+++ b/web/ui/src/lib/auth.ts
@@ -140,7 +140,9 @@ export async function getSseTicket(): Promise<string | null> {
     return null;
   }
   if (res.status === 401) {
-    // The cached token was stale — drop it, re-mint once, retry the ticket.
+    // 401 = the cached JWT was stale/expired — drop it, re-mint once, retry. (A
+    // 403 means the token lacks agent:read; a fresh fetch wouldn't fix that, so we
+    // DON'T retry it — it falls through to the `!res.ok → null` below.)
     clearCachedToken();
     const fresh = await getAgentToken();
     if (!fresh) return null;

--- a/web/ui/src/lib/auth.ts
+++ b/web/ui/src/lib/auth.ts
@@ -108,6 +108,75 @@ export function clearCachedToken(): void {
   cached = null;
 }
 
+/**
+ * Mint a one-time SSE TICKET for the browser EventSource streams (agent#25).
+ *
+ * An `EventSource` can't set an `Authorization` header, so the chat used to put
+ * the hub JWT directly in the SSE URL (`?token=<JWT>`) — which leaks the
+ * credential into access logs / history / traces. Instead we POST the JWT (as a
+ * normal Bearer header — no leak) to `/agent/api/ui/sse-ticket`, which returns a
+ * single-use, ≤60s opaque ticket. The caller puts THAT in the SSE URL
+ * (`?ticket=<nonce>`); the server consumes it on connect. The ticket is NOT
+ * cached — it's single-use, so every connect (and every reconnect) mints a fresh
+ * one.
+ *
+ * Returns the ticket string, or `null` when the mint fails (no session / network
+ * / malformed) — the caller (Chat's `openStreams`) then opens no stream, and the
+ * usual re-auth-and-retry on SSE error re-mints. Mirrors `getAgentToken`'s
+ * tolerant failure shape (the SPA renders OPEN; a failed mint is an error state,
+ * not a hard redirect).
+ */
+export async function getSseTicket(): Promise<string | null> {
+  const token = await getAgentToken();
+  if (!token) return null;
+  let res: Response;
+  try {
+    res = await fetch(sseTicketEndpoint(), {
+      method: "POST",
+      headers: { accept: "application/json", authorization: `Bearer ${token}` },
+      credentials: "include",
+    });
+  } catch {
+    return null;
+  }
+  if (res.status === 401) {
+    // The cached token was stale — drop it, re-mint once, retry the ticket.
+    clearCachedToken();
+    const fresh = await getAgentToken();
+    if (!fresh) return null;
+    try {
+      res = await fetch(sseTicketEndpoint(), {
+        method: "POST",
+        headers: { accept: "application/json", authorization: `Bearer ${fresh}` },
+        credentials: "include",
+      });
+    } catch {
+      return null;
+    }
+  }
+  if (!res.ok) return null;
+  let body: { ticket?: string };
+  try {
+    body = (await res.json()) as typeof body;
+  } catch {
+    return null;
+  }
+  return body.ticket ?? null;
+}
+
+/**
+ * The SSE-ticket mint endpoint — under the AGENT module mount (`/agent/api/...`),
+ * NOT the hub origin root like the token mint. Derived from the SPA base the same
+ * way `lib/api.ts:apiBase` does (`/agent/app/` → `/agent/api`), falling back to
+ * the canonical path in stand-alone dev (the vite proxy forwards it).
+ */
+function sseTicketEndpoint(): string {
+  const base = import.meta.env.BASE_URL || "/";
+  const m = base.match(/^(.*\/)app\/?$/);
+  const apiBase = m ? `${m[1]}api` : "/agent/api";
+  return `${apiBase}/ui/sse-ticket`;
+}
+
 /** Test seam: replace the cached token directly. */
 export function _setCachedTokenForTest(token: string, expiresAt: number): void {
   cached = { token, expiresAt };

--- a/web/ui/src/routes/Chat.test.tsx
+++ b/web/ui/src/routes/Chat.test.tsx
@@ -30,14 +30,15 @@ vi.mock("../lib/api.ts", async (orig) => {
 });
 
 vi.mock("../lib/auth.ts", () => ({
-  getAgentToken: vi.fn(),
+  // Chat opens its SSE streams with a one-time TICKET (agent#25), not the JWT.
+  getSseTicket: vi.fn(),
   clearCachedToken: vi.fn(),
 }));
 
 const listChannels = vi.mocked(api.listChannels);
 const listMessages = vi.mocked(api.listMessages);
 const sendMessage = vi.mocked(api.sendMessage);
-const getAgentToken = vi.mocked(auth.getAgentToken);
+const getSseTicket = vi.mocked(auth.getSseTicket);
 const clearCachedToken = vi.mocked(auth.clearCachedToken);
 
 // ---- a minimal fake EventSource so the SSE paths are drivable in jsdom -------
@@ -92,7 +93,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   FakeEventSource.reset();
   vi.stubGlobal("EventSource", FakeEventSource as unknown as typeof EventSource);
-  getAgentToken.mockResolvedValue("jwt-tok");
+  getSseTicket.mockResolvedValue("tkt-1");
   listChannels.mockResolvedValue({ channels: [chanRow()] });
   listMessages.mockResolvedValue({ messages: [] });
   sendMessage.mockResolvedValue({ ok: true, id: "sent-1" });

--- a/web/ui/src/routes/Chat.tsx
+++ b/web/ui/src/routes/Chat.tsx
@@ -10,11 +10,13 @@
  *   - the durable transcript loaded on select via `GET /api/channels/<ch>/messages`
  *     (sorted ascending by ts, deduped by note id) — direction drives bubble side:
  *     `inbound` = "you" (right), `outbound` = "them" (left);
- *   - live updates over TWO EventSource streams, both authenticated by the agent JWT
- *     as a `?token=` query param (EventSource can't set headers):
- *       1. `/ui/events?channel=<ch>&token=` — message deltas (`reply` / `edit` /
+ *   - live updates over TWO EventSource streams, both authenticated by a one-time
+ *     SSE TICKET in the URL (agent#25 — EventSource can't set a header, and a JWT
+ *     in the URL would leak into access logs; each stream mints its own single-use
+ *     ticket via `lib/auth.ts:getSseTicket` right before connecting):
+ *       1. `/ui/events?channel=<ch>&ticket=` — message deltas (`reply` / `edit` /
  *          `permission` events);
- *       2. `/api/channels/<ch>/turn-events?token=` — the PROGRAMMATIC "watch it
+ *       2. `/api/channels/<ch>/turn-events?ticket=` — the PROGRAMMATIC "watch it
  *          work" stream (interim assistant `text` + `tool` chips, finalized on
  *          `done` / shown errored on `error`);
  *   - a send box (`POST /api/channels/<ch>/send`) with an optimistic echo,
@@ -47,7 +49,7 @@ import {
   sendMessage,
   turnEventsUrl,
 } from "../lib/api.ts";
-import { clearCachedToken, getAgentToken } from "../lib/auth.ts";
+import { clearCachedToken, getSseTicket } from "../lib/auth.ts";
 
 /** A rendered transcript line — either a real message or a local "system" notice. */
 interface Line {
@@ -141,10 +143,12 @@ export function Chat() {
 
   /**
    * Open both live streams for `ch`: the message stream (`/ui/events`) and — for a
-   * vault channel — the programmatic turn-event stream. Both authenticate via the
-   * `?token=` query param. On the message stream's error we re-mint once + reconnect
-   * (mirrors the inline chat's single-retry); the turn stream is best-effort progress
-   * (browser auto-reconnect, no manual re-auth dance).
+   * vault channel — the programmatic turn-event stream. Both authenticate via a
+   * one-time SSE TICKET in the URL (agent#25) — NOT the hub JWT, which would leak
+   * in an access log. Each EventSource needs its OWN single-use ticket, so we mint
+   * one per stream right before opening it. On a stream error we re-mint once +
+   * reconnect (mirrors the inline chat's single-retry); the turn stream is
+   * best-effort progress (browser auto-reconnect, no manual re-auth dance).
    */
   const openStreams = useCallback(
     async (ch: string) => {
@@ -155,29 +159,26 @@ export function Chat() {
       turnEs.current?.close();
       turnEs.current = null;
 
-      const token = await getAgentToken();
-      // If a channel switch / unmount happened during the token mint, this cycle is
-      // stale — bail before creating streams that would escape the cleanup.
-      if (gen !== connectGen.current) return;
-
       const transport = transportFor(ch);
 
       // Shared stream lifecycle: `onopen` marks the chat live + clears the retry latch;
-      // `onerror` re-mints the token ONCE (a stale/short-lived token 401s the stream)
-      // then reconnects, else falls back to the browser's auto-reconnect. Both streams
-      // share the same token, so either erroring re-mints + re-opens both.
+      // `onerror` re-mints a fresh ticket ONCE (a single-use ticket is spent on connect,
+      // and a stale auth would 401 it) then reconnects, else falls back to the browser's
+      // auto-reconnect. The re-run mints brand-new tickets for whichever streams reopen.
       const onStreamOpen = () => {
         sseRetried.current = false;
         setStatus({ text: `live - ${ch}`, kind: "live" });
       };
       const onStreamError = () => {
-        if (!sseRetried.current && token) {
+        if (!sseRetried.current) {
           sseRetried.current = true;
           setStatus({ text: "re-authenticating...", kind: "" });
           msgEs.current?.close();
           msgEs.current = null;
           turnEs.current?.close();
           turnEs.current = null;
+          // Drop the cached JWT so the ticket re-mint forces a fresh token if the
+          // old one had gone stale, then reconnect (which mints new tickets).
           clearCachedToken();
           void openStreams(ch);
           return;
@@ -193,7 +194,11 @@ export function Chat() {
       //    on every chat load. Interactive/http-ui is retired, so in practice this is
       //    rarely taken; it's kept for any lingering http-ui channel.
       if (transport === "http-ui") {
-      const ms = new EventSource(messageStreamUrl(ch, token));
+      // Mint this stream's own one-time ticket. Bail if the connect cycle went stale
+      // during the (async) mint, so a ticket-backed stream can't escape the cleanup.
+      const msgTicket = await getSseTicket();
+      if (gen !== connectGen.current) return;
+      const ms = new EventSource(messageStreamUrl(ch, msgTicket));
       ms.onopen = onStreamOpen;
       ms.addEventListener("reply", (e) => {
         try {
@@ -233,9 +238,13 @@ export function Chat() {
       //    the durable outbound arrives via reload-on-done). Carries the same onopen
       //    (marks live) + onerror (re-mint-once) as the message stream, so a vault
       //    channel — which has no message stream — still shows "live" and recovers from
-      //    a stale token.
+      //    a stale ticket.
       if (isVault(ch)) {
-        const ts = new EventSource(turnEventsUrl(ch, token));
+        // This stream's own one-time ticket (single-use — distinct from the message
+        // stream's). Bail if the connect cycle went stale during the async mint.
+        const turnTicket = await getSseTicket();
+        if (gen !== connectGen.current) return;
+        const ts = new EventSource(turnEventsUrl(ch, turnTicket));
         ts.onopen = onStreamOpen;
         ts.addEventListener("turn", (e) => {
           try {


### PR DESCRIPTION
Closes #25.

## The leak

The Layer-2 **browser** SSE endpoints authenticated by putting the hub JWT directly in the URL as `?token=<JWT>` — because a browser `EventSource` can't set an `Authorization` header. A full bearer JWT in a URL lands in any access/proxy log, browser history, or network trace; before, the only mitigation was the token's ~10min TTL. That's a credential-in-a-URL leak.

Two browser EventSource endpoints carried this (both `agent:read`), confirmed by tracing what the SPA opens via `?token=`:
- `GET /ui/events` (http-ui transport's message deltas)
- `GET /api/channels/<ch>/turn-events` (the programmatic "watch it work" stream — the PRIMARY stream for a vault channel)

Both are fixed. The Layer-1 stdio-bridge `/events` uses a real `Authorization: Bearer` header and was **not** touched. The `agent:admin` terminal WebSocket still uses `?token=` — a separate, operator-gated mechanism out of scope here.

## The ticket flow

Trade the JWT for an opaque, single-use, very-short-lived **ticket**:

1. **Mint** — `POST /api/ui/sse-ticket` (new), Bearer-gated on `agent:read` (the *same* validation `requireScope` runs). It mints a crypto-random **256-bit** (32-byte) base64url nonce, stored only server-side in a TTL'd map (`src/ui-ticket.ts`), carrying **the presenting token's own validated scopes**. Returns `{ ticket, expires_at }`. An unauthenticated mint is impossible — the scope gate runs before any ticket is issued (`mintSseTicket` in `src/auth.ts`).
2. **Consume on connect** — `…?ticket=<nonce>` → `requireSseTicket` looks the nonce up, **deletes it immediately (single-use)**, then asserts the carried scope. Absent / expired / already-used / under-scoped → 401/403. No JWKS fetch on this path (validated at mint time).
3. **SPA** — `getSseTicket()` (in `web/ui/src/lib/auth.ts`) POSTs the bearer (`credentials: "include"`, mirroring the existing token fetch) to mint a ticket; `Chat.tsx` opens each EventSource with its **own** single-use `?ticket=<nonce>`, and re-mints + reconnects on SSE error (mirrors the prior re-auth-and-retry).

## Endpoint shape chosen
`POST /api/ui/sse-ticket` (the issue's primary suggestion). It's under the agent module mount (`/agent/api/ui/sse-ticket` externally), Bearer-authed — distinct from the hub-origin-root `/admin/agent-token` JWT mint.

## Old `?token=` path: REMOVED
Per pre-1.0, no deprecation window. The browser SSE endpoints no longer accept `?token=<JWT>` at all (a stale-token test asserts the legacy path now 401s). `extractToken`'s `allowQueryParam` survives only for the terminal WebSocket.

## Scope carried
The ticket carries **exactly** the minting token's validated scopes (a copy taken at mint), so it can never authorize more than the JWT did. The chat token is `agent:read agent:send`; both SSE streams require `agent:read`, which the ticket satisfies. Dual-accept (legacy `channel:read`) is honored via the shared `grantsScope`.

## Security
- Unguessable: 256-bit `crypto.getRandomValues` nonce, base64url (above the 128-bit floor).
- Single-use: deleted before return — a second connect 401s; a stolen URL is spent.
- Short TTL: 60s default (just long enough to open the connection); expired = absent + pruned.
- No scope widening; the JWT never appears in a URL or log.

## Gates (all green)
- `bun run typecheck` — pass
- `bun test ./src` — **1125 pass / 0 fail**
- `cd web/ui && bunx vitest run` — **138 pass**; `bun run build` — pass
- `bunx biome check .` — no errors (2 pre-existing warnings in `vault.test.ts`, untouched by this PR)

### Tests added
- `src/ui-ticket.test.ts` — unguessable nonce, single-use (2nd consume null), TTL expiry, scope fidelity (no widening, array copied), prune.
- `src/auth-sse-ticket.test.ts` — mint requires auth (no token → 401; invalid → 401; under-scoped → 403; `?token=` in URL can't mint); minted ticket carries token's scopes / not a scope it lacked; consume single-use (2nd connect → 401); absent/expired → 401; under-scope → 403; dual-accept.
- Updated `http-ui` / `daemon` / SPA SSE tests to the ticket path (incl. a "stale `?token=` → 401, legacy removed" case).

Version: `0.2.3-rc.4` → `0.2.3-rc.5`. CLAUDE.md Auth §Layer-2 updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
