### PR TITLE
feat(auth): step-up PIN for high-privilege agent-admin actions (#80)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,6 +178,26 @@ own ticket; an SSE error re-mints and reconnects. The legacy `?token=` SSE path 
 no deprecation window). The `agent:admin` terminal WebSocket still uses `?token=` — a separate
 operator-gated mechanism, out of this change's scope.
 
+**Step-up auth — PIN second factor on the dangerous actions (agent#80).** A single
+`agent:admin` session can do anything dangerous with no re-confirm — set/rotate credentials
+(→ exfiltrate vault/channel/Claude tokens), open a **terminal** (→ raw host shell), or spawn a
+`filesystem: full` agent (→ read the whole disk). So those actions require a **step-up token**
+IN ADDITION to `agent:admin`. The operator sets a PIN once (hashed+salted via `Bun.password`
+argon2id in `~/.parachute/agent/step-up.json`, mode 0600 — `src/step-up.ts`); `POST /api/step-up
+{ pin }` validates it (rate-limited, 5 wrong / 5 min lockout) and mints an opaque CSPRNG nonce
+(TTL ~5min, server-side TTL'd map, REUSABLE within its window — like `ui-ticket.ts` but not
+single-use). `POST /api/step-up/pin { newPin, currentPin? }` sets/rotates the PIN (rotation
+requires the current PIN). The gate (`requireStepUp` in `src/auth.ts`) is enforced SERVER-side
+on: **set-credentials** (`POST`/`DELETE` `/api/credentials/env` + `/api/credentials/claude[/:channel]`),
+the **terminal** WS (`authorizeTerminalUpgrade`), and the **`filesystem: "full"` spawn** path
+(ordinary sandboxed spawns stay frictionless). A gate miss returns `403 { error:
+"step_up_required", reason: "setup"|"token" }` — DISTINCT from a plain 401 (no/invalid bearer) —
+so the SPA prompts (first-time setup vs PIN entry) instead of re-authenticating. The token rides
+the `X-Step-Up-Token` header (or `?step_up=` for the terminal WS, which can't set a header). The
+SPA holds it in memory and attaches it transparently in `lib/api.ts:authedFetch` (re-prompt on
+expiry); the PIN is never logged or returned. The step-up token NEVER widens scope — it's a
+second factor on top of `agent:admin`, never a substitute.
+
 ## Vault integration (Stage 2) — channels backed by `#agent/message` notes
 
 A `vault` transport backs a channel with notes in a Parachute vault, so messages

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/agent",
-  "version": "0.2.3-rc.5",
+  "version": "0.2.3-rc.6",
   "description": "Vault-native agents for Claude Code — a #agent/definition note + an inbound message becomes a sandboxed claude turn; the reply is written back as a note. Messaging gateway on :1941.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/src/agent-defs.ts
+++ b/src/agent-defs.ts
@@ -389,6 +389,15 @@ export function parseAgentDef(note: {
   }
 
   // Filesystem read scope.
+  //
+  // NOTE (step-up, agent#80): `filesystem: "full"` is the dangerous, full-disk
+  // case. The step-up PIN gate is enforced on the HTTP spawn path only
+  // (`POST /api/agents` in daemon.ts). This VAULT-NATIVE path (a #agent/definition
+  // note with `filesystem: full`) is NOT step-up-gated — registering it requires
+  // `vault:write` to author the note, which is itself separately scope-gated, so a
+  // step-up challenge here would gate a capability the caller already had to hold a
+  // write credential to reach. If the threat model is ever revisited (e.g. less-
+  // trusted note authors), this is the gap to close.
   const filesystem = metaStr(meta.filesystem);
   if (filesystem !== undefined) {
     if (filesystem !== "workspace" && filesystem !== "full") {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -40,6 +40,7 @@
 import { validateHubJwt, HubJwtError } from "./hub-jwt.ts";
 import { extractBearer } from "@openparachute/scope-guard";
 import { consumeTicket } from "./ui-ticket.ts";
+import { isStepUpTokenValid, isStepUpConfigured } from "./step-up.ts";
 
 /** Agent scopes, declared here so callers share one spelling. */
 export const SCOPE_READ = "agent:read" as const;
@@ -226,4 +227,82 @@ export function requireSseTicket(url: URL, scope: string): Response | null {
     );
   }
   return null;
+}
+
+/**
+ * The header a request carries the step-up token on (agent#80). The terminal
+ * WebSocket — which `new WebSocket()` can't set a header on — uses the
+ * `?step_up=` query param instead (mirroring the `?token=` exception).
+ */
+export const STEP_UP_TOKEN_HEADER = "x-step-up-token";
+
+/** Extract a presented step-up token: the header first, then `?step_up=` when allowed. */
+export function extractStepUpToken(req: Request, url: URL, allowQueryParam = false): string | null {
+  const header = req.headers.get(STEP_UP_TOKEN_HEADER);
+  if (header && header.length > 0) return header;
+  if (allowQueryParam) {
+    const q = url.searchParams.get("step_up");
+    if (q && q.length > 0) return q;
+  }
+  return null;
+}
+
+/**
+ * SECOND-FACTOR gate (agent#80) for the genuinely dangerous `agent:admin` actions:
+ * set/rotate credentials, open a terminal, spawn a `filesystem: full` agent. The
+ * caller runs {@link requireScope}(`agent:admin`) FIRST; this asserts — IN ADDITION —
+ * a valid step-up token (the operator entered their PIN recently).
+ *
+ *   - Step-up NOT configured (no PIN set) → returns `{ ok: false, reason: "setup" }`.
+ *     The caller maps it to `403 { error: "step_up_required", reason: "setup" }` so
+ *     the UI runs its FIRST-TIME PIN-setup flow before the action.
+ *   - PIN configured + valid token → `{ ok: true }` (the action proceeds).
+ *   - PIN configured + missing/expired token → `{ ok: false, reason: "token" }` →
+ *     `403 { error: "step_up_required" }` so the UI PROMPTS for the PIN.
+ *
+ * The 403 is deliberately DISTINCT from `requireScope`'s 401 (no/invalid Bearer):
+ * a 401 means "re-authenticate", a 403 `step_up_required` means "enter your PIN".
+ * The step-up token NEVER widens scope — the request already passed `agent:admin`;
+ * this is purely a recency re-confirm on top.
+ *
+ * `allowQueryParam: true` accepts `?step_up=` for the terminal WebSocket only.
+ * Pure in-memory token check — no I/O on the gated request path, no secret logged.
+ */
+export function requireStepUp(
+  req: Request,
+  url: URL,
+  allowQueryParam = false,
+  opts?: { configured?: () => boolean; valid?: (token: string | null) => boolean },
+): { ok: true } | { ok: false; response: Response } {
+  const isConfigured = opts?.configured ?? (() => isStepUpConfigured());
+  const isValid = opts?.valid ?? ((t: string | null) => isStepUpTokenValid(t));
+  if (!isConfigured()) {
+    // No PIN yet — the UI must set one before this action can proceed.
+    return {
+      ok: false,
+      response: json(
+        {
+          error: "step_up_required",
+          reason: "setup",
+          message: "set a step-up PIN before performing this action",
+        },
+        403,
+      ),
+    };
+  }
+  const token = extractStepUpToken(req, url, allowQueryParam);
+  if (!isValid(token)) {
+    return {
+      ok: false,
+      response: json(
+        {
+          error: "step_up_required",
+          reason: "token",
+          message: "enter your step-up PIN to confirm this action",
+        },
+        403,
+      ),
+    };
+  }
+  return { ok: true };
 }

--- a/src/daemon-config-api.test.ts
+++ b/src/daemon-config-api.test.ts
@@ -67,6 +67,7 @@ import {
   describeChannelEnv,
 } from "./credentials.ts";
 import type { TransportContext, InboundMessage } from "./transport.ts";
+import { setStepUpPin, mintStepUpToken, _resetStepUpTokensForTest } from "./step-up.ts";
 
 const sendAuth = { authorization: "Bearer " + SEND_TOKEN } as const;
 const adminAuth = { authorization: "Bearer " + ADMIN_TOKEN } as const;
@@ -74,8 +75,15 @@ const readAuth = { authorization: "Bearer " + READ_TOKEN } as const;
 const legacySendAuth = { authorization: "Bearer " + LEGACY_SEND_TOKEN } as const;
 
 let stateDir: string;
+/**
+ * agent:admin Bearer + a valid step-up token (agent#80). The credential-store
+ * routes (D + E below) are step-up-gated; this header lets the store-behavior
+ * tests reach the handler. The dedicated step-up tests live in
+ * daemon-step-up.test.ts. Recomputed per test in `beforeEach`.
+ */
+let stepAdminAuth: Record<string, string>;
 
-beforeEach(() => {
+beforeEach(async () => {
   // Sandbox channels.json under a throwaway state dir — the config API resolves
   // STATE_DIR from PARACHUTE_AGENT_STATE_DIR (read once at daemon module load),
   // so set it BEFORE importing... but the module is already imported. Instead the
@@ -83,6 +91,11 @@ beforeEach(() => {
   // and the tests that touch the file assert under that path. Re-resolve per test.
   stateDir = mkdtempSync(join(tmpdir(), "agent-cfg-"));
   process.env.PARACHUTE_AGENT_STATE_DIR = stateDir;
+  // Step-up: configure a PIN + mint a token so the credential-store routes pass
+  // their step-up gate. The store under test is in this same temp dir.
+  _resetStepUpTokensForTest();
+  await setStepUpPin("4242", stateDir);
+  stepAdminAuth = { ...adminAuth, "x-step-up-token": mintStepUpToken().token };
 });
 
 afterEach(() => {
@@ -618,7 +631,7 @@ describe("D — Claude credential store API (agent:admin)", () => {
     try {
       const res = await fetch(`${base}/api/credentials/claude`, {
         method: "POST",
-        headers: { "content-type": "application/json", ...adminAuth },
+        headers: { "content-type": "application/json", ...stepAdminAuth },
         body: JSON.stringify({ token: "oat_DEFAULT-OPERATOR" }),
       });
       expect(res.status).toBe(200);
@@ -639,12 +652,12 @@ describe("D — Claude credential store API (agent:admin)", () => {
     try {
       await fetch(`${base}/api/credentials/claude`, {
         method: "POST",
-        headers: { "content-type": "application/json", ...adminAuth },
+        headers: { "content-type": "application/json", ...stepAdminAuth },
         body: JSON.stringify({ token: "oat_DEFAULT" }),
       });
       const res = await fetch(`${base}/api/credentials/claude/aaron-dev`, {
         method: "POST",
-        headers: { "content-type": "application/json", ...adminAuth },
+        headers: { "content-type": "application/json", ...stepAdminAuth },
         body: JSON.stringify({ token: "oat_AARON-OVERRIDE" }),
       });
       expect(res.status).toBe(200);
@@ -662,12 +675,12 @@ describe("D — Claude credential store API (agent:admin)", () => {
     try {
       await fetch(`${base}/api/credentials/claude`, {
         method: "POST",
-        headers: { "content-type": "application/json", ...adminAuth },
+        headers: { "content-type": "application/json", ...stepAdminAuth },
         body: JSON.stringify({ token: "oat_SECRET-DEFAULT" }),
       });
       await fetch(`${base}/api/credentials/claude/aaron-dev`, {
         method: "POST",
-        headers: { "content-type": "application/json", ...adminAuth },
+        headers: { "content-type": "application/json", ...stepAdminAuth },
         body: JSON.stringify({ token: "oat_SECRET-OVERRIDE" }),
       });
 
@@ -690,17 +703,17 @@ describe("D — Claude credential store API (agent:admin)", () => {
     try {
       await fetch(`${base}/api/credentials/claude`, {
         method: "POST",
-        headers: { "content-type": "application/json", ...adminAuth },
+        headers: { "content-type": "application/json", ...stepAdminAuth },
         body: JSON.stringify({ token: "oat_DEFAULT" }),
       });
       await fetch(`${base}/api/credentials/claude/aaron-dev`, {
         method: "POST",
-        headers: { "content-type": "application/json", ...adminAuth },
+        headers: { "content-type": "application/json", ...stepAdminAuth },
         body: JSON.stringify({ token: "oat_OVERRIDE" }),
       });
       const del = await fetch(`${base}/api/credentials/claude/aaron-dev`, {
         method: "DELETE",
-        headers: { ...adminAuth },
+        headers: { ...stepAdminAuth },
       });
       expect(del.status).toBe(200);
       expect(await del.json()).toMatchObject({ ok: true, channel: "aaron-dev", removed: true });
@@ -715,13 +728,13 @@ describe("D — Claude credential store API (agent:admin)", () => {
     try {
       const empty = await fetch(`${base}/api/credentials/claude`, {
         method: "POST",
-        headers: { "content-type": "application/json", ...adminAuth },
+        headers: { "content-type": "application/json", ...stepAdminAuth },
         body: JSON.stringify({ token: "" }),
       });
       expect(empty.status).toBe(400);
       const missing = await fetch(`${base}/api/credentials/claude`, {
         method: "POST",
-        headers: { "content-type": "application/json", ...adminAuth },
+        headers: { "content-type": "application/json", ...stepAdminAuth },
         body: JSON.stringify({}),
       });
       expect(missing.status).toBe(400);
@@ -789,7 +802,7 @@ describe("E — per-channel env-var store API (agent:admin)", () => {
     try {
       const res = await fetch(`${base}/api/credentials/env`, {
         method: "POST",
-        headers: { "content-type": "application/json", ...adminAuth },
+        headers: { "content-type": "application/json", ...stepAdminAuth },
         body: JSON.stringify({ name: "GH_TOKEN", value: "ghp_DEFAULT-SECRET" }),
       });
       expect(res.status).toBe(200);
@@ -809,12 +822,12 @@ describe("E — per-channel env-var store API (agent:admin)", () => {
     try {
       await fetch(`${base}/api/credentials/env`, {
         method: "POST",
-        headers: { "content-type": "application/json", ...adminAuth },
+        headers: { "content-type": "application/json", ...stepAdminAuth },
         body: JSON.stringify({ name: "GH_TOKEN", value: "ghp_DEFAULT" }),
       });
       const res = await fetch(`${base}/api/credentials/env`, {
         method: "POST",
-        headers: { "content-type": "application/json", ...adminAuth },
+        headers: { "content-type": "application/json", ...stepAdminAuth },
         body: JSON.stringify({ channel: "aaron-dev", name: "GH_TOKEN", value: "ghp_AARON" }),
       });
       expect(res.status).toBe(200);
@@ -833,7 +846,7 @@ describe("E — per-channel env-var store API (agent:admin)", () => {
       for (const name of ["ANTHROPIC_API_KEY", "CLAUDE_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"]) {
         const res = await fetch(`${base}/api/credentials/env`, {
           method: "POST",
-          headers: { "content-type": "application/json", ...adminAuth },
+          headers: { "content-type": "application/json", ...stepAdminAuth },
           body: JSON.stringify({ name, value: "x" }),
         });
         expect(res.status).toBe(400);
@@ -850,12 +863,12 @@ describe("E — per-channel env-var store API (agent:admin)", () => {
     try {
       await fetch(`${base}/api/credentials/env`, {
         method: "POST",
-        headers: { "content-type": "application/json", ...adminAuth },
+        headers: { "content-type": "application/json", ...stepAdminAuth },
         body: JSON.stringify({ name: "GH_TOKEN", value: "ghp_SECRET-DEFAULT" }),
       });
       await fetch(`${base}/api/credentials/env`, {
         method: "POST",
-        headers: { "content-type": "application/json", ...adminAuth },
+        headers: { "content-type": "application/json", ...stepAdminAuth },
         body: JSON.stringify({ channel: "aaron-dev", name: "CLOUDFLARE_API_TOKEN", value: "cf_SECRET" }),
       });
       const res = await fetch(`${base}/api/credentials/env`, { headers: { ...adminAuth } });
@@ -876,18 +889,18 @@ describe("E — per-channel env-var store API (agent:admin)", () => {
     try {
       await fetch(`${base}/api/credentials/env`, {
         method: "POST",
-        headers: { "content-type": "application/json", ...adminAuth },
+        headers: { "content-type": "application/json", ...stepAdminAuth },
         body: JSON.stringify({ name: "GH_TOKEN", value: "ghp_DEFAULT" }),
       });
       await fetch(`${base}/api/credentials/env`, {
         method: "POST",
-        headers: { "content-type": "application/json", ...adminAuth },
+        headers: { "content-type": "application/json", ...stepAdminAuth },
         body: JSON.stringify({ channel: "aaron-dev", name: "GH_TOKEN", value: "ghp_AARON" }),
       });
       // Delete the channel override (via body).
       const del = await fetch(`${base}/api/credentials/env`, {
         method: "DELETE",
-        headers: { "content-type": "application/json", ...adminAuth },
+        headers: { "content-type": "application/json", ...stepAdminAuth },
         body: JSON.stringify({ channel: "aaron-dev", name: "GH_TOKEN" }),
       });
       expect(del.status).toBe(200);
@@ -897,7 +910,7 @@ describe("E — per-channel env-var store API (agent:admin)", () => {
       // Delete the default too.
       const delDef = await fetch(`${base}/api/credentials/env`, {
         method: "DELETE",
-        headers: { "content-type": "application/json", ...adminAuth },
+        headers: { "content-type": "application/json", ...stepAdminAuth },
         body: JSON.stringify({ name: "GH_TOKEN" }),
       });
       expect(delDef.status).toBe(200);
@@ -913,13 +926,13 @@ describe("E — per-channel env-var store API (agent:admin)", () => {
     try {
       const noName = await fetch(`${base}/api/credentials/env`, {
         method: "POST",
-        headers: { "content-type": "application/json", ...adminAuth },
+        headers: { "content-type": "application/json", ...stepAdminAuth },
         body: JSON.stringify({ value: "x" }),
       });
       expect(noName.status).toBe(400);
       const noVal = await fetch(`${base}/api/credentials/env`, {
         method: "POST",
-        headers: { "content-type": "application/json", ...adminAuth },
+        headers: { "content-type": "application/json", ...stepAdminAuth },
         body: JSON.stringify({ name: "GH_TOKEN" }),
       });
       expect(noVal.status).toBe(400);

--- a/src/daemon-step-up.test.ts
+++ b/src/daemon-step-up.test.ts
@@ -1,0 +1,533 @@
+/**
+ * Step-up auth (PIN) HTTP surface + gating — agent#80, on the real daemon fetch
+ * handler.
+ *
+ * Covers:
+ *   A. PIN setup + exchange endpoints (`/api/step-up`, `/api/step-up/pin`):
+ *      first-time setup, rotation requires the current PIN, wrong PIN → 401 +
+ *      rate-limited lockout, the exchange mints a token, the PIN is never returned.
+ *   B. Gating — each dangerous endpoint 403s `step_up_required` WITHOUT a valid
+ *      step-up token and SUCCEEDS with one:
+ *        - POST/DELETE /api/credentials/claude[/:channel]
+ *        - POST/DELETE /api/credentials/env
+ *        - the terminal WS upgrade (authorizeTerminalUpgrade) via `?step_up=`
+ *        - POST /api/agents with `filesystem: "full"` (ordinary spawn is NOT gated)
+ *   C. The 403 step_up_required is DISTINCT from a 401 (no/invalid Bearer); a GET
+ *      status read is NOT gated.
+ *
+ * The hub JWT validator is stubbed (sentinel tokens → fixed scopes), mirroring
+ * daemon-config-api.test.ts, so the accept paths run without a live hub/JWKS. The
+ * step-up PIN store + token store are the REAL `step-up.ts` against a temp dir.
+ */
+import { describe, test, expect, mock, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { HubJwtError, looksLikeJwt } from "@openparachute/scope-guard";
+
+const ADMIN_TOKEN = "test-admin-token"; // agent:admin
+const READ_TOKEN = "test-read-token"; // agent:read only (insufficient)
+
+mock.module("./hub-jwt.ts", () => ({
+  AGENT_AUDIENCE: "agent",
+  CHANNEL_AUDIENCE: "channel",
+  async validateHubJwt(token: string) {
+    const base = { sub: "operator", aud: "agent", jti: undefined, clientId: undefined, vaultScope: undefined };
+    if (token === ADMIN_TOKEN) return { ...base, scopes: ["agent:read", "agent:send", "agent:admin"] };
+    if (token === READ_TOKEN) return { ...base, scopes: ["agent:read"] };
+    throw new HubJwtError("issuer", "invalid token");
+  },
+  HubJwtError,
+  looksLikeJwt,
+  getHubOrigin() {
+    return "http://127.0.0.1:1939";
+  },
+  resetJwksCache() {},
+  resetRevocationCache() {},
+}));
+
+import { createFetchHandler, authorizeTerminalUpgrade } from "./daemon.ts";
+import { ClientRegistry } from "./routing.ts";
+import type { Channel } from "./registry.ts";
+import { _resetStepUpTokensForTest, stepUpLimiter } from "./step-up.ts";
+
+const adminAuth = { authorization: "Bearer " + ADMIN_TOKEN } as const;
+const readAuth = { authorization: "Bearer " + READ_TOKEN } as const;
+
+let stateDir: string;
+
+beforeEach(() => {
+  stateDir = mkdtempSync(join(tmpdir(), "agent-stepup-http-"));
+  process.env.PARACHUTE_AGENT_STATE_DIR = stateDir;
+  _resetStepUpTokensForTest();
+  stepUpLimiter.reset();
+});
+
+afterEach(() => {
+  try {
+    rmSync(stateDir, { recursive: true, force: true });
+  } catch {}
+});
+
+function buildServer() {
+  const registry = new ClientRegistry();
+  const channels = new Map<string, Channel>();
+  const srv = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    idleTimeout: 0,
+    fetch: createFetchHandler(channels, registry),
+  });
+  return { srv, base: `http://127.0.0.1:${srv.port}`, channels, registry };
+}
+
+/** Set a PIN, then exchange it for a fresh step-up token. Returns the token. */
+async function setupAndExchange(base: string, pin = "4242"): Promise<string> {
+  const setRes = await fetch(`${base}/api/step-up/pin`, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...adminAuth },
+    body: JSON.stringify({ newPin: pin }),
+  });
+  expect(setRes.status).toBe(200);
+  const exRes = await fetch(`${base}/api/step-up`, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...adminAuth },
+    body: JSON.stringify({ pin }),
+  });
+  expect(exRes.status).toBe(200);
+  const body = (await exRes.json()) as { stepUpToken: string };
+  return body.stepUpToken;
+}
+
+// ===========================================================================
+// A. PIN setup + exchange
+// ===========================================================================
+describe("A — PIN setup + exchange", () => {
+  test("GET /api/step-up reports configured:false, then true after a PIN is set", async () => {
+    const { srv, base } = buildServer();
+    try {
+      let res = await fetch(`${base}/api/step-up`, { headers: adminAuth });
+      expect(res.status).toBe(200);
+      expect((await res.json()).configured).toBe(false);
+
+      res = await fetch(`${base}/api/step-up/pin`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ newPin: "4242" }),
+      });
+      expect(res.status).toBe(200);
+
+      res = await fetch(`${base}/api/step-up`, { headers: adminAuth });
+      expect((await res.json()).configured).toBe(true);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("the step-up endpoints require agent:admin (read-only → 403, no token → 401)", async () => {
+    const { srv, base } = buildServer();
+    try {
+      const noTok = await fetch(`${base}/api/step-up`, { method: "GET" });
+      expect(noTok.status).toBe(401);
+      const readTok = await fetch(`${base}/api/step-up`, { method: "GET", headers: readAuth });
+      expect(readTok.status).toBe(403);
+      const setRead = await fetch(`${base}/api/step-up/pin`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...readAuth },
+        body: JSON.stringify({ newPin: "4242" }),
+      });
+      expect(setRead.status).toBe(403);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("exchange before any PIN is configured → 409 step_up_not_configured", async () => {
+    const { srv, base } = buildServer();
+    try {
+      const res = await fetch(`${base}/api/step-up`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ pin: "4242" }),
+      });
+      expect(res.status).toBe(409);
+      expect((await res.json()).error).toBe("step_up_not_configured");
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("exchange with the correct PIN mints a token; the PIN is never returned", async () => {
+    const { srv, base } = buildServer();
+    try {
+      const token = await setupAndExchange(base, "4242");
+      expect(typeof token).toBe("string");
+      expect(token.length).toBeGreaterThanOrEqual(43);
+      // Re-run the exchange and inspect the raw body for any leak of the PIN.
+      const res = await fetch(`${base}/api/step-up`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ pin: "4242" }),
+      });
+      const raw = await res.text();
+      expect(raw.includes("4242")).toBe(false);
+      expect(raw).toContain("stepUpToken");
+      expect(raw).toContain("expires_at");
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("wrong PIN → 401 invalid_pin (and never echoes the PIN)", async () => {
+    const { srv, base } = buildServer();
+    try {
+      await fetch(`${base}/api/step-up/pin`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ newPin: "4242" }),
+      });
+      const res = await fetch(`${base}/api/step-up`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ pin: "0000" }),
+      });
+      expect(res.status).toBe(401);
+      const raw = await res.text();
+      expect(JSON.parse(raw).error).toBe("invalid_pin");
+      expect(raw.includes("0000")).toBe(false);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("rate-limit: 5 wrong PINs then locked out (429 with retry-after)", async () => {
+    const { srv, base } = buildServer();
+    try {
+      await fetch(`${base}/api/step-up/pin`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ newPin: "4242" }),
+      });
+      // 5 wrong attempts are admitted to the verify (all 401), the 6th is locked out.
+      for (let i = 0; i < 5; i++) {
+        const r = await fetch(`${base}/api/step-up`, {
+          method: "POST",
+          headers: { "content-type": "application/json", ...adminAuth },
+          body: JSON.stringify({ pin: "0000" }),
+        });
+        expect(r.status).toBe(401);
+      }
+      const sixth = await fetch(`${base}/api/step-up`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ pin: "0000" }),
+      });
+      expect(sixth.status).toBe(429);
+      expect(sixth.headers.get("retry-after")).toBeTruthy();
+      const body = (await sixth.json()) as { error: string; retry_after_seconds: number };
+      expect(body.error).toBe("rate_limited");
+      expect(body.retry_after_seconds).toBeGreaterThanOrEqual(1);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("a SUCCESSFUL PIN entry clears the lockout bucket", async () => {
+    const { srv, base } = buildServer();
+    try {
+      await fetch(`${base}/api/step-up/pin`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ newPin: "4242" }),
+      });
+      // 4 wrong, then a correct one — the bucket resets, so we don't hit 429.
+      for (let i = 0; i < 4; i++) {
+        await fetch(`${base}/api/step-up`, {
+          method: "POST",
+          headers: { "content-type": "application/json", ...adminAuth },
+          body: JSON.stringify({ pin: "0000" }),
+        });
+      }
+      const good = await fetch(`${base}/api/step-up`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ pin: "4242" }),
+      });
+      expect(good.status).toBe(200);
+      // Now several MORE wrong attempts don't immediately 429 (bucket was cleared).
+      const next = await fetch(`${base}/api/step-up`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ pin: "0000" }),
+      });
+      expect(next.status).toBe(401);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("rotation requires the current PIN (wrong/absent → 401; correct → 200)", async () => {
+    const { srv, base } = buildServer();
+    try {
+      await fetch(`${base}/api/step-up/pin`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ newPin: "4242" }),
+      });
+      // No currentPin → 401.
+      let res = await fetch(`${base}/api/step-up/pin`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ newPin: "9999" }),
+      });
+      expect(res.status).toBe(401);
+      // Wrong currentPin → 401.
+      res = await fetch(`${base}/api/step-up/pin`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ newPin: "9999", currentPin: "0000" }),
+      });
+      expect(res.status).toBe(401);
+      // Correct currentPin → 200 + the new PIN exchanges.
+      res = await fetch(`${base}/api/step-up/pin`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ newPin: "9999", currentPin: "4242" }),
+      });
+      expect(res.status).toBe(200);
+      const ex = await fetch(`${base}/api/step-up`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ pin: "9999" }),
+      });
+      expect(ex.status).toBe(200);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("a malformed newPin → 400", async () => {
+    const { srv, base } = buildServer();
+    try {
+      const res = await fetch(`${base}/api/step-up/pin`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ newPin: "12" }),
+      });
+      expect(res.status).toBe(400);
+    } finally {
+      srv.stop(true);
+    }
+  });
+});
+
+// ===========================================================================
+// B. Gating — dangerous endpoints require a step-up token
+// ===========================================================================
+describe("B — set-credentials gating (Claude token + env store)", () => {
+  test("POST /api/credentials/claude: no step-up → 403 step_up_required; with token → 200", async () => {
+    const { srv, base } = buildServer();
+    try {
+      // Before any PIN: 403 with reason "setup" (UI runs first-time setup).
+      let res = await fetch(`${base}/api/credentials/claude`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ token: "sk-x" }),
+      });
+      expect(res.status).toBe(403);
+      let body = (await res.json()) as { error: string; reason: string };
+      expect(body.error).toBe("step_up_required");
+      expect(body.reason).toBe("setup");
+
+      // After setup but WITHOUT a token: 403 with reason "token".
+      const stepToken = await setupAndExchange(base);
+      res = await fetch(`${base}/api/credentials/claude`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ token: "sk-x" }),
+      });
+      expect(res.status).toBe(403);
+      body = (await res.json()) as { error: string; reason: string };
+      expect(body.error).toBe("step_up_required");
+      expect(body.reason).toBe("token");
+
+      // WITH a valid step-up token: 200.
+      res = await fetch(`${base}/api/credentials/claude`, {
+        method: "POST",
+        headers: { "content-type": "application/json", "x-step-up-token": stepToken, ...adminAuth },
+        body: JSON.stringify({ token: "sk-x" }),
+      });
+      expect(res.status).toBe(200);
+      expect((await res.json()).ok).toBe(true);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("GET /api/credentials/claude (status read) is NOT step-up-gated", async () => {
+    const { srv, base } = buildServer();
+    try {
+      const res = await fetch(`${base}/api/credentials/claude`, { headers: adminAuth });
+      expect(res.status).toBe(200);
+      expect((await res.json()).defaultSet).toBe(false);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("POST + DELETE /api/credentials/claude/:channel are gated", async () => {
+    const { srv, base } = buildServer();
+    try {
+      const stepToken = await setupAndExchange(base);
+      // POST without token → 403.
+      let res = await fetch(`${base}/api/credentials/claude/eng`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ token: "sk-x" }),
+      });
+      expect(res.status).toBe(403);
+      expect((await res.json()).error).toBe("step_up_required");
+      // POST with token → 200.
+      res = await fetch(`${base}/api/credentials/claude/eng`, {
+        method: "POST",
+        headers: { "content-type": "application/json", "x-step-up-token": stepToken, ...adminAuth },
+        body: JSON.stringify({ token: "sk-x" }),
+      });
+      expect(res.status).toBe(200);
+      // DELETE without token → 403.
+      res = await fetch(`${base}/api/credentials/claude/eng`, { method: "DELETE", headers: adminAuth });
+      expect(res.status).toBe(403);
+      // DELETE with token → 200.
+      res = await fetch(`${base}/api/credentials/claude/eng`, {
+        method: "DELETE",
+        headers: { "x-step-up-token": stepToken, ...adminAuth },
+      });
+      expect(res.status).toBe(200);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("POST + DELETE /api/credentials/env are gated; GET is not", async () => {
+    const { srv, base } = buildServer();
+    try {
+      const stepToken = await setupAndExchange(base);
+      // GET (status) → 200 without a step-up token.
+      let res = await fetch(`${base}/api/credentials/env`, { headers: adminAuth });
+      expect(res.status).toBe(200);
+      // POST without token → 403.
+      res = await fetch(`${base}/api/credentials/env`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ name: "GH_TOKEN", value: "ghp_x" }),
+      });
+      expect(res.status).toBe(403);
+      // POST with token → 200.
+      res = await fetch(`${base}/api/credentials/env`, {
+        method: "POST",
+        headers: { "content-type": "application/json", "x-step-up-token": stepToken, ...adminAuth },
+        body: JSON.stringify({ name: "GH_TOKEN", value: "ghp_x" }),
+      });
+      expect(res.status).toBe(200);
+      // DELETE without token → 403.
+      res = await fetch(`${base}/api/credentials/env`, {
+        method: "DELETE",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ name: "GH_TOKEN" }),
+      });
+      expect(res.status).toBe(403);
+    } finally {
+      srv.stop(true);
+    }
+  });
+});
+
+describe("B — terminal WS gating (?step_up=)", () => {
+  function termReq(base: string, qs = "") {
+    return new Request(`${base}/terminal/myagent${qs}`, {
+      headers: { ...adminAuth, upgrade: "websocket" },
+    });
+  }
+
+  test("no step-up (PIN set, no token) → 403 step_up_required", async () => {
+    const { srv, base } = buildServer();
+    try {
+      await setupAndExchange(base); // sets a PIN
+      const req = termReq(base);
+      const decision = await authorizeTerminalUpgrade(req, new URL(req.url), new Map(), "myagent");
+      expect(decision.ok).toBe(false);
+      if (!decision.ok) {
+        expect(decision.response.status).toBe(403);
+        expect((await decision.response.json()).error).toBe("step_up_required");
+      }
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("with a valid ?step_up= token → authorized", async () => {
+    const { srv, base } = buildServer();
+    try {
+      const stepToken = await setupAndExchange(base);
+      const req = termReq(base, `?step_up=${encodeURIComponent(stepToken)}`);
+      const decision = await authorizeTerminalUpgrade(req, new URL(req.url), new Map(), "myagent");
+      expect(decision.ok).toBe(true);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("a bad Bearer still 401s BEFORE step-up is consulted (distinct from 403)", async () => {
+    const { srv, base } = buildServer();
+    try {
+      await setupAndExchange(base);
+      const req = new Request(`${base}/terminal/myagent`, {
+        headers: { authorization: "Bearer bogus", upgrade: "websocket" },
+      });
+      const decision = await authorizeTerminalUpgrade(req, new URL(req.url), new Map(), "myagent");
+      expect(decision.ok).toBe(false);
+      if (!decision.ok) expect(decision.response.status).toBe(401);
+    } finally {
+      srv.stop(true);
+    }
+  });
+});
+
+describe("B — filesystem:full spawn gating (sandboxed spawn NOT gated)", () => {
+  test("POST /api/agents { filesystem: 'full' } without step-up → 403", async () => {
+    const { srv, base } = buildServer();
+    try {
+      await setupAndExchange(base);
+      const res = await fetch(`${base}/api/agents`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ name: "danger", channels: ["c"], filesystem: "full" }),
+      });
+      expect(res.status).toBe(403);
+      expect((await res.json()).error).toBe("step_up_required");
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("an ORDINARY (workspace / default) spawn is NOT step-up-gated", async () => {
+    const { srv, base } = buildServer();
+    try {
+      await setupAndExchange(base);
+      // No step-up token. A default-filesystem spawn should pass the step-up gate
+      // (it may still 400 on a missing Claude credential, but NOT 403 step_up_required).
+      const res = await fetch(`${base}/api/agents`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ name: "safe", channels: ["c"], filesystem: "workspace" }),
+      });
+      expect(res.status).not.toBe(403);
+      if (res.status === 403) {
+        // Make the failure legible if this ever regresses.
+        expect((await res.json()).error).not.toBe("step_up_required");
+      }
+    } finally {
+      srv.stop(true);
+    }
+  });
+});

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -87,6 +87,8 @@ import {
   requireScope,
   mintSseTicket,
   requireSseTicket,
+  requireStepUp,
+  grantsScope,
   extractToken,
   json as authJson,
   SCOPE_READ,
@@ -95,6 +97,15 @@ import {
   SCOPE_ADMIN,
   SCOPE_TERMINAL,
 } from "./auth.ts";
+import {
+  isStepUpConfigured,
+  isValidPinFormat,
+  setStepUpPin,
+  verifyStepUpPin,
+  mintStepUpToken,
+  stepUpLimiter,
+  StepUpPinFormatError,
+} from "./step-up.ts";
 import { mintTicket } from "./ui-ticket.ts";
 import {
   createTerminalWsHandlers,
@@ -1190,6 +1201,12 @@ export async function authorizeTerminalUpgrade(
   const denied = await requireScope(req, url, SCOPE_TERMINAL, true);
   if (denied) return { ok: false, response: denied };
 
+  // STEP-UP required (agent#80): a terminal is a raw host shell — the single most
+  // dangerous capability. allowQueryParam: true so the WS presents the step-up
+  // token as `?step_up=` (it can't set the `X-Step-Up-Token` header).
+  const step = requireStepUp(req, url, true);
+  if (!step.ok) return { ok: false, response: step.response };
+
   // tmux session name convention: `<name>-agent`. Attach a viewer pty to THIS
   // session; the session itself is created by the spawn path.
   const session = `${agentName}-agent`;
@@ -1792,6 +1809,169 @@ export function createFetchHandler(
     }
 
     // ---------------------------------------------------------------------
+    // STEP-UP AUTH (PIN) — second factor for high-privilege actions (agent#80).
+    //
+    // The dangerous `agent:admin` actions (set credentials, open a terminal,
+    // spawn a `filesystem: full` agent) require a step-up token IN ADDITION to
+    // the `agent:admin` Bearer. This block is the PIN setup + exchange surface;
+    // the gating lives at each dangerous endpoint (via `requireStepUp`).
+    //
+    //   GET  /api/step-up          → { configured } — is a PIN set? (UI: setup vs prompt)
+    //   POST /api/step-up { pin }  → validate PIN (rate-limited) → { stepUpToken, expires_at }
+    //   POST /api/step-up/pin { newPin, currentPin? } → set/rotate the PIN
+    //
+    // All `agent:admin`-gated (the operator's cookie-minted Bearer). The PIN is
+    // hashed+salted server-side (step-up.ts); it is NEVER returned or logged.
+    // Externally hub strips `/agent`, so these are `<hub>/agent/api/step-up`.
+    // ---------------------------------------------------------------------
+    if (url.pathname === "/api/step-up" && req.method === "GET") {
+      const denied = await requireScope(req, url, SCOPE_ADMIN);
+      if (denied) return denied;
+      // Whether a PIN is configured — the UI branches setup-flow vs PIN-prompt.
+      return json({ configured: isStepUpConfigured() });
+    }
+
+    if (url.pathname === "/api/step-up" && req.method === "POST") {
+      // Exchange: validate the PIN, then mint a short-lived step-up token. The
+      // session must already hold `agent:admin` (this is a SECOND factor on top,
+      // never a substitute — the token carries no scope of its own).
+      let claims;
+      try {
+        const token = extractToken(req, url);
+        if (!token) return json({ error: "unauthorized", message: "Bearer token required" }, 401);
+        claims = await validateHubJwt(token);
+      } catch (err) {
+        return json(
+          { error: "unauthorized", message: err instanceof Error ? err.message : "invalid token" },
+          401,
+        );
+      }
+      if (!grantsScope(claims.scopes, SCOPE_ADMIN)) {
+        return json(
+          { error: "insufficient_scope", message: `requires ${SCOPE_ADMIN}`, granted: claims.scopes },
+          403,
+        );
+      }
+      // No PIN configured yet — there's nothing to exchange. Tell the UI to run
+      // its first-time setup (distinct from a wrong-PIN 401).
+      if (!isStepUpConfigured()) {
+        return json(
+          { error: "step_up_not_configured", message: "set a step-up PIN first (POST /api/step-up/pin)" },
+          409,
+        );
+      }
+      let body: { pin?: unknown };
+      try {
+        body = (await req.json()) as typeof body;
+      } catch {
+        return json({ error: "invalid JSON body" }, 400);
+      }
+      if (typeof body.pin !== "string" || body.pin.length === 0) {
+        return json({ error: "body.pin (non-empty string) is required" }, 400);
+      }
+      // Rate-limit BEFORE the (expensive, brute-forceable) argon2 verify, keyed by
+      // the operator subject — a stolen-cookie attacker can't grind the PIN. A
+      // DENIED attempt returns 429 (the limiter does not count it again).
+      const limited = stepUpLimiter.checkAndRecord(`step-up:${claims.sub}`);
+      if (!limited.allowed) {
+        return new Response(
+          JSON.stringify({
+            error: "rate_limited",
+            message: "too many PIN attempts — wait before retrying",
+            retry_after_seconds: limited.retryAfterSeconds,
+          }),
+          {
+            status: 429,
+            headers: {
+              "content-type": "application/json",
+              "retry-after": String(limited.retryAfterSeconds ?? 60),
+            },
+          },
+        );
+      }
+      const ok = await verifyStepUpPin(body.pin);
+      if (!ok) {
+        // Wrong PIN — 401. The attempt already counted toward the lockout above.
+        // Never echo the PIN back.
+        return json({ error: "invalid_pin", message: "incorrect PIN" }, 401);
+      }
+      // Correct PIN — clear the attempt bucket (a fresh window for the next time)
+      // and mint a reusable, short-TTL step-up token.
+      stepUpLimiter.clear(`step-up:${claims.sub}`);
+      const { token: stepUpToken, expiresAt } = mintStepUpToken();
+      return json({ stepUpToken, expires_at: new Date(expiresAt).toISOString() });
+    }
+
+    if (url.pathname === "/api/step-up/pin" && req.method === "POST") {
+      // Set (first time) or rotate the step-up PIN. agent:admin-gated; if a PIN
+      // already exists, the CURRENT PIN must be supplied + verified (rotation
+      // needs the old PIN, so a hijacked session can't silently replace it).
+      let claims;
+      try {
+        const token = extractToken(req, url);
+        if (!token) return json({ error: "unauthorized", message: "Bearer token required" }, 401);
+        claims = await validateHubJwt(token);
+      } catch (err) {
+        return json(
+          { error: "unauthorized", message: err instanceof Error ? err.message : "invalid token" },
+          401,
+        );
+      }
+      if (!grantsScope(claims.scopes, SCOPE_ADMIN)) {
+        return json(
+          { error: "insufficient_scope", message: `requires ${SCOPE_ADMIN}`, granted: claims.scopes },
+          403,
+        );
+      }
+      let body: { newPin?: unknown; currentPin?: unknown };
+      try {
+        body = (await req.json()) as typeof body;
+      } catch {
+        return json({ error: "invalid JSON body" }, 400);
+      }
+      if (!isValidPinFormat(body.newPin)) {
+        return json({ error: "body.newPin must be 4–12 digits" }, 400);
+      }
+      // Rotation: a PIN already exists → require + verify the current one (rate-limited).
+      // SHARES the exchange bucket (same `step-up:<sub>` key) on purpose: both verify
+      // the PIN, so an attacker can't get a fresh grind window by alternating endpoints.
+      if (isStepUpConfigured()) {
+        const limited = stepUpLimiter.checkAndRecord(`step-up:${claims.sub}`);
+        if (!limited.allowed) {
+          return new Response(
+            JSON.stringify({
+              error: "rate_limited",
+              message: "too many PIN attempts — wait before retrying",
+              retry_after_seconds: limited.retryAfterSeconds,
+            }),
+            {
+              status: 429,
+              headers: {
+                "content-type": "application/json",
+                "retry-after": String(limited.retryAfterSeconds ?? 60),
+              },
+            },
+          );
+        }
+        if (typeof body.currentPin !== "string" || !(await verifyStepUpPin(body.currentPin))) {
+          return json(
+            { error: "invalid_pin", message: "the current PIN is required to change it" },
+            401,
+          );
+        }
+        stepUpLimiter.clear(`step-up:${claims.sub}`);
+      }
+      try {
+        await setStepUpPin(body.newPin);
+      } catch (err) {
+        if (err instanceof StepUpPinFormatError) return json({ error: err.message }, 400);
+        return json({ error: `failed to set PIN: ${(err as Error).message}` }, 500);
+      }
+      // Echo back only the fact of the write — never the PIN.
+      return json({ ok: true, configured: true });
+    }
+
+    // ---------------------------------------------------------------------
     // Claude OAuth credential store (design §6) — the per-channel secret a
     // launched agent session runs on (`CLAUDE_CODE_OAUTH_TOKEN`). Same
     // `agent:admin` gate + 0600 file-store + redaction-on-read posture as the
@@ -1810,11 +1990,15 @@ export function createFetchHandler(
 
       if (req.method === "GET") {
         // Inspect WITHOUT leaking the secret: whether a default is set + which
-        // channels carry an override (names only).
+        // channels carry an override (names only). A status read — no step-up.
         return json(describeClaudeCredentials(defaultStateDir()));
       }
 
-      // POST — set the default / operator-level token.
+      // POST — set the default / operator-level token. STEP-UP required (agent#80):
+      // setting a credential can exfiltrate the operator's Claude token.
+      const step = requireStepUp(req, url);
+      if (!step.ok) return step.response;
+
       let credBody: { token?: unknown };
       try {
         credBody = (await req.json()) as typeof credBody;
@@ -1837,6 +2021,10 @@ export function createFetchHandler(
     if (credMatch && (req.method === "POST" || req.method === "DELETE")) {
       const denied = await requireScope(req, url, SCOPE_ADMIN);
       if (denied) return denied;
+      // STEP-UP required (agent#80): both set + remove of a per-channel Claude
+      // credential are high-privilege credential-store mutations.
+      const step = requireStepUp(req, url);
+      if (!step.ok) return step.response;
       const channel = decodeURIComponent(credMatch[1]!);
 
       if (req.method === "DELETE") {
@@ -1891,8 +2079,14 @@ export function createFetchHandler(
 
       if (req.method === "GET") {
         // Inspect WITHOUT leaking values: names per channel + the default layer.
+        // A status read — no step-up.
         return json(describeChannelEnv(defaultStateDir()));
       }
+
+      // STEP-UP required (agent#80): set/remove of an env secret (GH_TOKEN,
+      // CLOUDFLARE_API_TOKEN, …) is a credential-store mutation.
+      const step = requireStepUp(req, url);
+      if (!step.ok) return step.response;
 
       let envBody: { channel?: unknown; name?: unknown; value?: unknown };
       try {
@@ -1985,6 +2179,15 @@ export function createFetchHandler(
       } catch (err) {
         if (err instanceof SpawnRequestError) return json({ error: err.message }, 400);
         throw err;
+      }
+
+      // STEP-UP required (agent#80) ONLY for the dangerous filesystem case: a
+      // `filesystem: "full"` agent runs UNSANDBOXED with read access to the whole
+      // disk. Ordinary sandboxed (workspace-confined) spawns stay frictionless —
+      // gate just the high-blast-radius case.
+      if (spec.filesystem === "full") {
+        const step = requireStepUp(req, url);
+        if (!step.ok) return step.response;
       }
 
       // CHANNEL EXCLUSION: a channel routes inbound to at most one agent. Refuse a

--- a/src/step-up.test.ts
+++ b/src/step-up.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Unit tests for the step-up auth PRIMITIVE (agent#80, `src/step-up.ts`):
+ * PIN set/verify (hashed+salted, never plaintext), the step-up token store (TTL +
+ * REUSE-within-window), and the brute-force rate-limiter/lockout.
+ *
+ * These exercise the pure module against a throwaway state dir — no daemon, no hub.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, existsSync, readFileSync, statSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  STEP_UP_PIN_RE,
+  isValidPinFormat,
+  isStepUpConfigured,
+  setStepUpPin,
+  verifyStepUpPin,
+  stepUpFilePath,
+  StepUpPinFormatError,
+  mintStepUpToken,
+  isStepUpTokenValid,
+  revokeStepUpToken,
+  _resetStepUpTokensForTest,
+  _stepUpTokenCountForTest,
+  StepUpRateLimiter,
+  stepUpLimiter,
+} from "./step-up.ts";
+
+let stateDir: string;
+
+beforeEach(() => {
+  stateDir = mkdtempSync(join(tmpdir(), "agent-stepup-"));
+  _resetStepUpTokensForTest();
+  stepUpLimiter.reset();
+});
+
+afterEach(() => {
+  try {
+    rmSync(stateDir, { recursive: true, force: true });
+  } catch {}
+});
+
+// ---------------------------------------------------------------------------
+// PIN format + storage
+// ---------------------------------------------------------------------------
+describe("PIN format", () => {
+  test("accepts 4–12 digits", () => {
+    expect(isValidPinFormat("1234")).toBe(true);
+    expect(isValidPinFormat("123456789012")).toBe(true);
+    expect(STEP_UP_PIN_RE.test("4242")).toBe(true);
+  });
+  test("rejects too-short / too-long / non-digit / non-string", () => {
+    expect(isValidPinFormat("123")).toBe(false);
+    expect(isValidPinFormat("1234567890123")).toBe(false);
+    expect(isValidPinFormat("12ab")).toBe(false);
+    expect(isValidPinFormat("")).toBe(false);
+    expect(isValidPinFormat(1234 as unknown)).toBe(false);
+    expect(isValidPinFormat(null)).toBe(false);
+  });
+});
+
+describe("PIN set / verify", () => {
+  test("not configured before any set; configured after", async () => {
+    expect(isStepUpConfigured(stateDir)).toBe(false);
+    await setStepUpPin("4242", stateDir);
+    expect(isStepUpConfigured(stateDir)).toBe(true);
+  });
+
+  test("verify succeeds for the right PIN, fails for the wrong PIN", async () => {
+    await setStepUpPin("4242", stateDir);
+    expect(await verifyStepUpPin("4242", stateDir)).toBe(true);
+    expect(await verifyStepUpPin("0000", stateDir)).toBe(false);
+  });
+
+  test("verify returns false when no PIN is configured", async () => {
+    expect(await verifyStepUpPin("4242", stateDir)).toBe(false);
+  });
+
+  test("rotating the PIN: the old PIN stops verifying, the new one works", async () => {
+    await setStepUpPin("4242", stateDir);
+    await setStepUpPin("9999", stateDir);
+    expect(await verifyStepUpPin("4242", stateDir)).toBe(false);
+    expect(await verifyStepUpPin("9999", stateDir)).toBe(true);
+  });
+
+  test("setStepUpPin rejects a malformed PIN", async () => {
+    await expect(setStepUpPin("12", stateDir)).rejects.toBeInstanceOf(StepUpPinFormatError);
+    expect(isStepUpConfigured(stateDir)).toBe(false);
+  });
+
+  test("the PIN is stored HASHED+SALTED — never plaintext — at 0600", async () => {
+    await setStepUpPin("4242", stateDir);
+    const path = stepUpFilePath(stateDir);
+    expect(existsSync(path)).toBe(true);
+    const raw = readFileSync(path, "utf8");
+    // The plaintext PIN must NOT appear anywhere in the file.
+    expect(raw.includes("4242")).toBe(false);
+    // argon2id PHC string marker present (salt embedded).
+    expect(raw.includes("$argon2id$")).toBe(true);
+    // 0600 perms.
+    expect(statSync(path).mode & 0o777).toBe(0o600);
+  });
+
+  test("two sets of the SAME PIN produce DIFFERENT hashes (random salt)", async () => {
+    await setStepUpPin("4242", stateDir);
+    const first = readFileSync(stepUpFilePath(stateDir), "utf8");
+    await setStepUpPin("4242", stateDir);
+    const second = readFileSync(stepUpFilePath(stateDir), "utf8");
+    expect(first).not.toBe(second);
+    // Both still verify.
+    expect(await verifyStepUpPin("4242", stateDir)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Step-up token store — TTL + REUSE-within-window
+// ---------------------------------------------------------------------------
+describe("step-up token", () => {
+  test("a freshly minted token is valid", () => {
+    const { token } = mintStepUpToken();
+    expect(isStepUpTokenValid(token)).toBe(true);
+  });
+
+  test("an unknown / null / empty token is invalid", () => {
+    expect(isStepUpTokenValid("nope")).toBe(false);
+    expect(isStepUpTokenValid(null)).toBe(false);
+    expect(isStepUpTokenValid(undefined)).toBe(false);
+    expect(isStepUpTokenValid("")).toBe(false);
+  });
+
+  test("REUSABLE within its window — repeated checks all pass (unlike a single-use ticket)", () => {
+    const { token } = mintStepUpToken();
+    expect(isStepUpTokenValid(token)).toBe(true);
+    expect(isStepUpTokenValid(token)).toBe(true);
+    expect(isStepUpTokenValid(token)).toBe(true);
+    // Still in the store (not consumed).
+    expect(_stepUpTokenCountForTest()).toBe(1);
+  });
+
+  test("expires after its TTL (and is lazily pruned)", () => {
+    const { token, expiresAt } = mintStepUpToken(1000);
+    // Just before expiry → valid.
+    expect(isStepUpTokenValid(token, expiresAt - 1)).toBe(true);
+    // At/after expiry → invalid, and pruned.
+    expect(isStepUpTokenValid(token, expiresAt)).toBe(false);
+    expect(_stepUpTokenCountForTest()).toBe(0);
+  });
+
+  test("revoke makes a token immediately invalid", () => {
+    const { token } = mintStepUpToken();
+    revokeStepUpToken(token);
+    expect(isStepUpTokenValid(token)).toBe(false);
+  });
+
+  test("the token is an opaque high-entropy nonce (base64url, ≥ 43 chars)", () => {
+    const { token } = mintStepUpToken();
+    expect(token).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(token.length).toBeGreaterThanOrEqual(43); // 32 bytes base64url, no padding
+  });
+
+  test("two mints produce distinct tokens", () => {
+    const a = mintStepUpToken().token;
+    const b = mintStepUpToken().token;
+    expect(a).not.toBe(b);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rate-limiter / lockout
+// ---------------------------------------------------------------------------
+describe("step-up rate limiter (lockout)", () => {
+  test("allows up to maxAttempts, then locks out with a retry-after", () => {
+    const rl = new StepUpRateLimiter(3, 60_000);
+    const t0 = 1_000_000;
+    expect(rl.checkAndRecord("k", t0).allowed).toBe(true);
+    expect(rl.checkAndRecord("k", t0 + 1).allowed).toBe(true);
+    expect(rl.checkAndRecord("k", t0 + 2).allowed).toBe(true);
+    const denied = rl.checkAndRecord("k", t0 + 3);
+    expect(denied.allowed).toBe(false);
+    expect(denied.retryAfterSeconds).toBeGreaterThanOrEqual(1);
+  });
+
+  test("a denied attempt is NOT counted again — the window stays anchored", () => {
+    const rl = new StepUpRateLimiter(2, 60_000);
+    const t0 = 1_000_000;
+    rl.checkAndRecord("k", t0);
+    rl.checkAndRecord("k", t0 + 1);
+    // Flood of denials shouldn't push the reset further out.
+    const d1 = rl.checkAndRecord("k", t0 + 2);
+    const d2 = rl.checkAndRecord("k", t0 + 3);
+    expect(d1.allowed).toBe(false);
+    expect(d2.allowed).toBe(false);
+    // Reset is anchored to the FIRST admitted attempt + window.
+    expect(d2.retryAfterSeconds).toBe(60);
+  });
+
+  test("the window slides — old attempts age out and free the bucket", () => {
+    const rl = new StepUpRateLimiter(2, 60_000);
+    const t0 = 1_000_000;
+    rl.checkAndRecord("k", t0);
+    rl.checkAndRecord("k", t0 + 1);
+    expect(rl.checkAndRecord("k", t0 + 2).allowed).toBe(false);
+    // After the window passes, attempts are admitted again.
+    expect(rl.checkAndRecord("k", t0 + 60_001).allowed).toBe(true);
+  });
+
+  test("clear() resets a key's bucket (the success path)", () => {
+    const rl = new StepUpRateLimiter(2, 60_000);
+    const t0 = 1_000_000;
+    rl.checkAndRecord("k", t0);
+    rl.checkAndRecord("k", t0 + 1);
+    expect(rl.checkAndRecord("k", t0 + 2).allowed).toBe(false);
+    rl.clear("k");
+    expect(rl.checkAndRecord("k", t0 + 3).allowed).toBe(true);
+  });
+
+  test("keys are independent", () => {
+    const rl = new StepUpRateLimiter(1, 60_000);
+    const t0 = 1_000_000;
+    expect(rl.checkAndRecord("a", t0).allowed).toBe(true);
+    expect(rl.checkAndRecord("a", t0 + 1).allowed).toBe(false);
+    // A different key is unaffected.
+    expect(rl.checkAndRecord("b", t0 + 2).allowed).toBe(true);
+  });
+});

--- a/src/step-up.ts
+++ b/src/step-up.ts
@@ -1,0 +1,316 @@
+/**
+ * Step-up auth (PIN) for high-privilege agent-admin actions (agent#80).
+ *
+ * ## The risk this closes
+ *
+ * A single authenticated `agent:admin` session (the operator's hub cookie traded
+ * for an `agent:admin` Bearer) can today do ANYTHING dangerous with no re-confirm:
+ *   - set/rotate credentials (the Claude OAuth token + the generic env store)
+ *     → exfiltrate vault / channel / Claude tokens,
+ *   - open a TERMINAL → a raw host shell,
+ *   - spawn a `filesystem: full` (unsandboxed) agent → read the whole disk.
+ * "One session = total control over the operator's vault + tokens."
+ *
+ * ## The design (mirrors hub's admin-lock PIN, design `2026-06-17-admin-ui-lock.md`)
+ *
+ * A SECOND factor on top of `agent:admin`: an operator-set PIN, exchanged for a
+ * short-lived **step-up token**. The dangerous endpoints require BOTH a valid
+ * `agent:admin` Bearer AND a valid step-up token; everything else stays
+ * frictionless.
+ *
+ *   1. **PIN, set once by the operator** (`setStepUpPin`). Stored HASHED + SALTED
+ *      (`Bun.password.hash`, argon2id — salt is embedded in the PHC string) in
+ *      `~/.parachute/agent/step-up.json`, mode 0600. NEVER plaintext, NEVER logged,
+ *      NEVER returned. Setting/changing it requires the current `agent:admin`
+ *      session and, if a PIN already exists, the current PIN.
+ *   2. **Step-up exchange** (`mintStepUpToken` after `verifyStepUpPin`): an opaque
+ *      256-bit CSPRNG nonce, TTL ~5min, held server-side in a TTL'd map. REUSABLE
+ *      within its window (unlike the single-use SSE ticket) — one PIN entry buys a
+ *      short working window across several gated actions.
+ *   3. **Gate** (`requireStepUp` in `auth.ts`): the dangerous endpoints assert a
+ *      valid step-up token (header `X-Step-Up-Token`, or `?step_up=` for the
+ *      terminal WebSocket which can't set a header) in addition to `agent:admin`.
+ *      A missing/expired token → `403 { error: "step_up_required" }`, distinct from
+ *      a plain 401 (no/invalid Bearer), so the UI knows to PROMPT vs RE-AUTH.
+ *
+ * ## Security properties (all load-bearing)
+ *
+ *   - PIN hashed + salted (argon2id); never logged / returned. The hash never
+ *     leaves this module — the only readers are `verifyStepUpPin` + `setStepUpPin`.
+ *   - Rate-limited with LOCKOUT ({@link stepUpLimiter}): a compromised `agent:admin`
+ *     session can't brute-force the PIN. 5 wrong PINs / 5 min, mirroring hub's
+ *     `unlockLimiter`.
+ *   - Step-up token: opaque (256-bit nonce), short TTL, SERVER-SIDE only. It NEVER
+ *     widens scope — it's a second factor ON TOP of `agent:admin`, never a
+ *     substitute. A request still needs its own valid `agent:admin` Bearer.
+ *   - No secret in any log: neither the PIN nor the hash nor the token is ever
+ *     written to a log line.
+ *
+ * Process-local in-memory token state by design (mirrors `ui-ticket.ts` + the
+ * daemon's other in-process registries). The daemon is single-instance per
+ * machine; tokens live ≤5min and are cheap to lose on restart (the UI re-prompts).
+ */
+
+import { readFileSync, writeFileSync, existsSync, chmodSync, mkdirSync } from "fs";
+import { join } from "path";
+import { defaultStateDir } from "./registry.ts";
+
+// ---------------------------------------------------------------------------
+// PIN storage (argon2id hash in step-up.json, mode 0600)
+// ---------------------------------------------------------------------------
+
+/**
+ * PIN format: 4–12 digits. A numeric PIN is the phone-lock affordance (mirrors
+ * hub's `ADMIN_LOCK_PIN_RE`). The real defense is the rate-limiter + the fact the
+ * session is already `agent:admin`-authenticated — this is a second, convenience-
+ * grade re-confirm gate, not a high-entropy secret.
+ */
+export const STEP_UP_PIN_RE = /^[0-9]{4,12}$/;
+
+/** Whether a candidate string is a well-formed PIN (format check only). */
+export function isValidPinFormat(pin: unknown): pin is string {
+  return typeof pin === "string" && STEP_UP_PIN_RE.test(pin);
+}
+
+/** The on-disk `step-up.json` shape. Namespaced so a future field can coexist. */
+interface StepUpFile {
+  /** argon2id PHC hash of the operator PIN (salt embedded). Never plaintext. */
+  pinHash?: string;
+}
+
+/** Absolute path to the step-up.json store in a state dir. */
+export function stepUpFilePath(stateDir?: string): string {
+  return join(stateDir ?? defaultStateDir(), "step-up.json");
+}
+
+/** Read `step-up.json`. Returns `{}` when absent. */
+function readStepUpFile(stateDir?: string): StepUpFile {
+  const file = stepUpFilePath(stateDir);
+  if (!existsSync(file)) return {};
+  const parsed = JSON.parse(readFileSync(file, "utf8")) as StepUpFile;
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error(`step-up: ${file} must be a JSON object`);
+  }
+  return parsed;
+}
+
+/**
+ * Persist `step-up.json` 0600 — it holds the PIN hash. Creates the state dir if
+ * needed; `chmod`s 0600 unconditionally (writeFileSync's `mode` only applies on
+ * CREATE, so an existing file under a looser umask is tightened on every write) —
+ * the exact discipline `credentials.ts` / `registry.ts` keep for secrets.
+ */
+function writeStepUpFile(file: StepUpFile, stateDir?: string): void {
+  const dir = stateDir ?? defaultStateDir();
+  mkdirSync(dir, { recursive: true });
+  const path = stepUpFilePath(dir);
+  writeFileSync(path, JSON.stringify(file, null, 2) + "\n", { mode: 0o600 });
+  chmodSync(path, 0o600);
+}
+
+/** True iff a step-up PIN is configured (the feature is set up for this install). */
+export function isStepUpConfigured(stateDir?: string): boolean {
+  const h = readStepUpFile(stateDir).pinHash;
+  return typeof h === "string" && h.length > 0;
+}
+
+/** Thrown by {@link setStepUpPin} when the PIN format is rejected. */
+export class StepUpPinFormatError extends Error {
+  constructor() {
+    super("PIN must be 4–12 digits");
+    this.name = "StepUpPinFormatError";
+  }
+}
+
+/**
+ * Set (first-time) or rotate the step-up PIN. Hashes with argon2id
+ * (`Bun.password.hash` — salted, salt embedded in the PHC string). The CALLER
+ * must enforce that:
+ *   - the request is `agent:admin`-authenticated, and
+ *   - if a PIN ALREADY exists, the current PIN was verified first
+ *     ({@link verifyStepUpPin}) — rotating a PIN needs the old one.
+ * This function trusts that gating; it only validates format + writes the hash.
+ *
+ * Returns nothing. Throws {@link StepUpPinFormatError} on a malformed PIN.
+ */
+export async function setStepUpPin(newPin: string, stateDir?: string): Promise<void> {
+  if (!isValidPinFormat(newPin)) throw new StepUpPinFormatError();
+  const hash = await Bun.password.hash(newPin, "argon2id");
+  const file = readStepUpFile(stateDir);
+  file.pinHash = hash;
+  writeStepUpFile(file, stateDir);
+}
+
+/**
+ * Verify a submitted PIN against the stored hash. Returns false when no PIN is
+ * configured (defensive — callers gate on {@link isStepUpConfigured} first) or the
+ * hash is malformed. The CALLER must run the rate-limiter BEFORE this (a wrong PIN
+ * must count toward the lockout). The PIN is never logged.
+ */
+export async function verifyStepUpPin(pin: string, stateDir?: string): Promise<boolean> {
+  if (typeof pin !== "string" || pin.length === 0) return false;
+  const hash = readStepUpFile(stateDir).pinHash;
+  if (typeof hash !== "string" || hash.length === 0) return false;
+  try {
+    return await Bun.password.verify(pin, hash);
+  } catch {
+    // Corrupt / unparseable hash — fail closed.
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Step-up token store — opaque nonce, TTL'd, REUSABLE within its window
+// ---------------------------------------------------------------------------
+
+/**
+ * Default step-up token lifetime — 5 min (the issue's ~5min). Long enough for an
+ * operator to set a credential / open a terminal / spawn after one PIN entry,
+ * short enough that a stolen token (or a walk-away) is bounded.
+ */
+export const STEP_UP_TOKEN_TTL_MS = 5 * 60 * 1000;
+
+/** Nonce entropy: 32 bytes = 256 bits, matching the SSE ticket's floor. */
+const STEP_UP_TOKEN_BYTES = 32;
+
+/** A minted step-up token's server-side record. Never leaves the process. */
+interface StepUpTokenRecord {
+  /** Epoch ms after which the token is expired (treated as absent). */
+  expiresAt: number;
+}
+
+/** The process-local step-up token store. nonce → record. */
+const stepUpTokens = new Map<string, StepUpTokenRecord>();
+
+/** base64url-encode bytes (no padding) — URL-safe, no `+`/`/`/`=`. */
+function base64url(bytes: Uint8Array): string {
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function pruneExpiredStepUpTokens(now = Date.now()): void {
+  for (const [k, rec] of stepUpTokens) {
+    if (now >= rec.expiresAt) stepUpTokens.delete(k);
+  }
+}
+
+/**
+ * Mint a step-up token valid for `ttlMs` (default {@link STEP_UP_TOKEN_TTL_MS}).
+ * The CALLER must have already verified the PIN — this never authenticates. The
+ * token is opaque (no scope/claims rides in it); it is purely a "the PIN was
+ * entered recently" capability checked alongside the `agent:admin` Bearer.
+ * Returns the nonce + its absolute expiry.
+ */
+export function mintStepUpToken(ttlMs = STEP_UP_TOKEN_TTL_MS): {
+  token: string;
+  expiresAt: number;
+} {
+  pruneExpiredStepUpTokens();
+  const bytes = new Uint8Array(STEP_UP_TOKEN_BYTES);
+  crypto.getRandomValues(bytes);
+  const token = base64url(bytes);
+  const expiresAt = Date.now() + ttlMs;
+  stepUpTokens.set(token, { expiresAt });
+  return { token, expiresAt };
+}
+
+/**
+ * Whether a step-up token is currently valid. REUSABLE within its window (does NOT
+ * delete on read — unlike the single-use SSE ticket), so one PIN entry buys a short
+ * window across several gated actions. An absent / expired token returns false (and
+ * an expired one is lazily pruned). Pure in-memory lookup — no I/O, no secret log.
+ */
+export function isStepUpTokenValid(token: string | null | undefined, now = Date.now()): boolean {
+  if (!token) return false;
+  const rec = stepUpTokens.get(token);
+  if (!rec) return false;
+  if (now >= rec.expiresAt) {
+    stepUpTokens.delete(token);
+    return false;
+  }
+  return true;
+}
+
+/** Explicitly revoke a step-up token ("lock now"). Idempotent. */
+export function revokeStepUpToken(token: string | null | undefined): void {
+  if (token) stepUpTokens.delete(token);
+}
+
+/** Test seam: clear the in-memory token store. */
+export function _resetStepUpTokensForTest(): void {
+  stepUpTokens.clear();
+}
+
+/** Test seam: the live step-up token count. */
+export function _stepUpTokenCountForTest(): number {
+  return stepUpTokens.size;
+}
+
+// ---------------------------------------------------------------------------
+// PIN brute-force limiter (lockout) — mirrors hub's admin-lock unlockLimiter
+// ---------------------------------------------------------------------------
+
+/**
+ * 5 wrong PINs / 5-min sliding window before lockout. The step-up exchange is
+ * already `agent:admin`-gated, so the threat is a COMPROMISED session (stolen
+ * cookie → minted Bearer) grinding argon2id PIN verifications without bound. Keyed
+ * per-session (the validated token's subject) so an attacker can't get a fresh
+ * bucket by rotating something cheap. Same floor + posture as hub's `unlockLimiter`.
+ */
+export const STEP_UP_MAX_ATTEMPTS = 5;
+export const STEP_UP_WINDOW_MS = 5 * 60 * 1000;
+
+export interface RateLimitResult {
+  /** True if the attempt is admitted; the caller proceeds to the PIN check. */
+  allowed: boolean;
+  /** Seconds until the bucket frees up (only set when denied). Always >= 1. */
+  retryAfterSeconds?: number;
+}
+
+/**
+ * A small sliding-window rate limiter (the shape mirrors hub's `RateLimiter`,
+ * inlined here to keep the agent module dependency-free). Each key keeps the last
+ * N admitted attempt timestamps; on a new attempt we prune anything older than the
+ * window, count what remains, and allow/deny. `now` is injectable for tests.
+ */
+export class StepUpRateLimiter {
+  private readonly buckets = new Map<string, number[]>();
+
+  constructor(
+    private readonly maxAttempts: number,
+    private readonly windowMs: number,
+  ) {}
+
+  /**
+   * Record an attempt and return whether it's admitted. A DENIED attempt is NOT
+   * recorded (so a flood of denials can't push the reset further out). `now` is
+   * epoch ms (injectable).
+   */
+  checkAndRecord(key: string, now = Date.now()): RateLimitResult {
+    const cutoff = now - this.windowMs;
+    const pruned = (this.buckets.get(key) ?? []).filter((t) => t > cutoff);
+    if (pruned.length >= this.maxAttempts) {
+      const resetAtMs = (pruned[0] ?? now) + this.windowMs;
+      const retryAfterSeconds = Math.max(1, Math.ceil((resetAtMs - now) / 1000));
+      this.buckets.set(key, pruned);
+      return { allowed: false, retryAfterSeconds };
+    }
+    pruned.push(now);
+    this.buckets.set(key, pruned);
+    return { allowed: true };
+  }
+
+  /** Clear a key's bucket (called on a SUCCESSFUL PIN entry so it resets). */
+  clear(key: string): void {
+    this.buckets.delete(key);
+  }
+
+  /** Test seam: wipe all buckets. */
+  reset(): void {
+    this.buckets.clear();
+  }
+}
+
+/** The singleton PIN-attempt limiter (all step-up exchanges share one bucket map). */
+export const stepUpLimiter = new StepUpRateLimiter(STEP_UP_MAX_ATTEMPTS, STEP_UP_WINDOW_MS);

--- a/src/terminal-ui.ts
+++ b/src/terminal-ui.ts
@@ -164,6 +164,65 @@ ${SHELL_JS}
     });
   }
 
+  // --- step-up PIN (agent#80) --------------------------------------------
+  // A terminal is a raw host shell — the most dangerous capability — so the WS
+  // upgrade requires a STEP-UP TOKEN on top of the agent:admin Bearer. The WS
+  // can't set a header, so we present it as a step_up query param. We fetch the step-up
+  // status, prompt for the PIN (or set one first), exchange it for a short-TTL
+  // token, and cache it on window.__stepUp. Re-prompt on expiry / WS auth-fail.
+  // This page is server-rendered (no React) so the prompt is a native dialog.
+  function authedJson(suffix, init) {
+    init = init || {};
+    var headers = init.headers || {};
+    headers["accept"] = "application/json";
+    if (window.__token) headers["authorization"] = "Bearer " + window.__token;
+    init.headers = headers;
+    return fetch(MOUNT + "/api" + suffix, init);
+  }
+  function ensureStepUp() {
+    if (window.__stepUp && window.__stepUpExp && Date.now() < window.__stepUpExp - 5000) {
+      return Promise.resolve(window.__stepUp);
+    }
+    return authedJson("/step-up").then(function (r) {
+      return r.json();
+    }).then(function (s) {
+      if (!s.configured) {
+        var np = window.prompt("Set a step-up PIN (4-12 digits) — required to open a terminal:");
+        if (!np) return null;
+        var confirm = window.prompt("Confirm the PIN:");
+        if (confirm !== np) { showNotice("The PINs didn't match — try again.", true); return null; }
+        return authedJson("/step-up/pin", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ newPin: np }),
+        }).then(function (r) {
+          if (!r.ok) { showNotice("Could not set the PIN (must be 4-12 digits).", true); return null; }
+          return exchangePin(np);
+        });
+      }
+      var pin = window.prompt("Enter your step-up PIN to open a terminal:");
+      if (!pin) return null;
+      return exchangePin(pin);
+    });
+  }
+  function exchangePin(pin) {
+    return authedJson("/step-up", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ pin: pin }),
+    }).then(function (r) {
+      if (r.status === 401) { showNotice("Incorrect PIN.", true); return null; }
+      if (r.status === 429) { showNotice("Too many PIN attempts — wait a minute.", true); return null; }
+      if (!r.ok) { showNotice("Step-up failed (" + r.status + ").", true); return null; }
+      return r.json();
+    }).then(function (body) {
+      if (!body || !body.stepUpToken) return null;
+      window.__stepUp = body.stepUpToken;
+      window.__stepUpExp = body.expires_at ? new Date(body.expires_at).getTime() : Date.now() + 5 * 60000;
+      return window.__stepUp;
+    });
+  }
+
   // --- WebSocket relay ----------------------------------------------------
   // The path segment is the AGENT name — the daemon attaches to that agent's tmux
   // session (<name>-agent). NOT a channel.
@@ -172,6 +231,7 @@ ${SHELL_JS}
     var dims = "cols=" + term.cols + "&rows=" + term.rows;
     var u = proto + "//" + location.host + MOUNT + "/terminal/" + encodeURIComponent(agent) + "?" + dims;
     if (window.__token) u += "&token=" + encodeURIComponent(window.__token);
+    if (window.__stepUp) u += "&step_up=" + encodeURIComponent(window.__stepUp);
     return u;
   }
 
@@ -181,6 +241,19 @@ ${SHELL_JS}
     if (ws) { manualClose = true; try { ws.close(); } catch (_e) {} ws = null; }
     manualClose = false;
     clearNotice();
+    // Step-up FIRST — a terminal needs the PIN-minted token (agent#80). Only open
+    // the socket once we hold one; a cancelled prompt leaves the page idle.
+    setStatus("step-up…");
+    ensureStepUp().then(function (tok) {
+      if (!tok) { setStatus("step-up required", "err"); return; }
+      openSocket(agent);
+    }).catch(function () {
+      setStatus("step-up failed", "err");
+      showNotice("Could not complete step-up. Reload and try again.", true);
+    });
+  }
+
+  function openSocket(agent) {
     setStatus("connecting…");
     doFit();
     var socket = new WebSocket(wsUrl(agent));

--- a/src/terminal.test.ts
+++ b/src/terminal.test.ts
@@ -16,8 +16,14 @@
  * test.ts uses — accept paths run without a live hub/JWKS; the no-token reject
  * still hits the real short-circuit.
  */
-import { describe, test, expect, mock } from "bun:test";
+import { describe, test, expect, mock, beforeEach, afterEach } from "bun:test";
 import type { ServerWebSocket } from "bun";
+import { mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+/** Throwaway state dir for the step-up PIN store (set per terminal-auth test). */
+let stateDir: string;
 
 // Sentinel tokens → fixed scope sets. Mirrors daemon-config-api.test.ts so this
 // process-wide mock stays compatible. ADMIN_TOKEN carries agent:admin (==
@@ -63,6 +69,11 @@ import {
 } from "./terminal.ts";
 import { authorizeTerminalUpgrade } from "./daemon.ts";
 import type { Channel } from "./registry.ts";
+import {
+  setStepUpPin,
+  mintStepUpToken,
+  _resetStepUpTokensForTest,
+} from "./step-up.ts";
 
 // ===========================================================================
 // Fakes — a recording pty + a controllable ServerWebSocket.
@@ -432,7 +443,24 @@ describe("tmuxAttachEnv — forces a real TERM so `tmux attach` finds terminfo",
 // ===========================================================================
 // Daemon-side terminal auth — authorizeTerminalUpgrade (pure fn)
 // ===========================================================================
-describe("authorizeTerminalUpgrade — operator-gated agent:admin", () => {
+describe("authorizeTerminalUpgrade — operator-gated agent:admin + step-up (agent#80)", () => {
+  // A terminal needs a STEP-UP token (agent#80) on top of agent:admin. Configure a
+  // PIN in a throwaway state dir + mint a valid token; the `ok:true` cases pass it
+  // as `&step_up=`. STEP is recomputed per test so a prior test can't strand state.
+  let STEP = "";
+  beforeEach(async () => {
+    stateDir = mkdtempSync(join(tmpdir(), "agent-term-stepup-"));
+    process.env.PARACHUTE_AGENT_STATE_DIR = stateDir;
+    _resetStepUpTokensForTest();
+    await setStepUpPin("4242", stateDir);
+    STEP = mintStepUpToken().token;
+  });
+  afterEach(() => {
+    try {
+      rmSync(stateDir, { recursive: true, force: true });
+    } catch {}
+  });
+
   function channels(names: string[] = ["eng"]): Map<string, Channel> {
     const m = new Map<string, Channel>();
     for (const name of names) {
@@ -466,8 +494,18 @@ describe("authorizeTerminalUpgrade — operator-gated agent:admin", () => {
     if (!d.ok) expect(d.response.status).toBe(403);
   });
 
-  test("valid agent:admin token → ok, with the right tmux session + geometry", async () => {
-    const { req: r, url } = req(`?token=${ADMIN_TOKEN}&cols=120&rows=40`);
+  test("valid agent:admin token but NO step-up → reject (403 step_up_required)", async () => {
+    const { req: r, url } = req(`?token=${ADMIN_TOKEN}`);
+    const d = await authorizeTerminalUpgrade(r, url, channels(), "eng");
+    expect(d.ok).toBe(false);
+    if (!d.ok) {
+      expect(d.response.status).toBe(403);
+      expect((await d.response.json()).error).toBe("step_up_required");
+    }
+  });
+
+  test("valid agent:admin + step-up token → ok, with the right tmux session + geometry", async () => {
+    const { req: r, url } = req(`?token=${ADMIN_TOKEN}&step_up=${STEP}&cols=120&rows=40`);
     const d = await authorizeTerminalUpgrade(r, url, channels(), "eng");
     expect(d.ok).toBe(true);
     if (d.ok) {
@@ -478,11 +516,11 @@ describe("authorizeTerminalUpgrade — operator-gated agent:admin", () => {
     }
   });
 
-  test("legacy channel:admin token still authorizes (dual-accept back-compat)", async () => {
+  test("legacy channel:admin token (+ step-up) still authorizes (dual-accept back-compat)", async () => {
     // A token minted before the channel→agent rename carries channel:admin (and
     // aud:"channel"). requireScope's dual-accept (hasScope) must still authorize
     // the agent:admin-gated terminal until live tokens are re-minted.
-    const { req: r, url } = req(`?token=${LEGACY_ADMIN_TOKEN}&cols=100&rows=30`);
+    const { req: r, url } = req(`?token=${LEGACY_ADMIN_TOKEN}&step_up=${STEP}&cols=100&rows=30`);
     const d = await authorizeTerminalUpgrade(r, url, channels(), "eng");
     expect(d.ok).toBe(true);
     if (d.ok) {
@@ -493,7 +531,7 @@ describe("authorizeTerminalUpgrade — operator-gated agent:admin", () => {
   });
 
   test("geometry defaults (80×24) when cols/rows absent or out-of-range", async () => {
-    const { req: r, url } = req(`?token=${ADMIN_TOKEN}&cols=0&rows=abc`);
+    const { req: r, url } = req(`?token=${ADMIN_TOKEN}&step_up=${STEP}&cols=0&rows=abc`);
     const d = await authorizeTerminalUpgrade(r, url, channels(), "eng");
     expect(d.ok).toBe(true);
     if (d.ok) {
@@ -506,7 +544,7 @@ describe("authorizeTerminalUpgrade — operator-gated agent:admin", () => {
     // The terminal attaches to an AGENT (tmux <name>-agent), not a channel — so a
     // valid-slug name that isn't in the channel map is accepted (a non-existent
     // session just fails to attach downstream with a clean 1000, no 404 here).
-    const url = new URL(`http://127.0.0.1/terminal/weaver?token=${ADMIN_TOKEN}`);
+    const url = new URL(`http://127.0.0.1/terminal/weaver?token=${ADMIN_TOKEN}&step_up=${STEP}`);
     const r = new Request(url, { headers: { upgrade: "websocket" } });
     const d = await authorizeTerminalUpgrade(r, url, channels(["eng"]), "weaver");
     expect(d.ok).toBe(true);
@@ -515,7 +553,7 @@ describe("authorizeTerminalUpgrade — operator-gated agent:admin", () => {
 
   test("a path-traversal-shaped name is rejected by the slug guard → 400 (no escape into tmux -t)", async () => {
     const weird = "../../etc";
-    const url = new URL(`http://127.0.0.1/terminal/${encodeURIComponent(weird)}?token=${ADMIN_TOKEN}`);
+    const url = new URL(`http://127.0.0.1/terminal/${encodeURIComponent(weird)}?token=${ADMIN_TOKEN}&step_up=${STEP}`);
     const r = new Request(url, { headers: { upgrade: "websocket" } });
     const d = await authorizeTerminalUpgrade(r, url, channels(["eng"]), weird);
     expect(d.ok).toBe(false);

--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -20,6 +20,7 @@ import { Link, Route, Routes, useLocation } from "react-router-dom";
 import { Agents } from "./routes/Agents.tsx";
 import { Chat } from "./routes/Chat.tsx";
 import { CreateAgentRoute } from "./routes/CreateAgent.tsx";
+import { StepUpProvider, useStepUp } from "./StepUpModal.tsx";
 
 const WORDMARK = "Parachute Agent";
 
@@ -30,8 +31,17 @@ function subtitleFor(pathname: string): string {
 }
 
 export function App() {
+  return (
+    <StepUpProvider>
+      <AppShell />
+    </StepUpProvider>
+  );
+}
+
+function AppShell() {
   const { pathname } = useLocation();
   const subtitle = subtitleFor(pathname);
+  const { openSettings } = useStepUp();
 
   return (
     <div className="page">
@@ -43,6 +53,14 @@ export function App() {
         <NavSection to="/" label="Agents" exact />
         <NavSection to="/create" label="New agent" />
         <NavSection to="/chat" label="Chat" />
+        <button
+          type="button"
+          className="nav-link nav-link-button"
+          onClick={openSettings}
+          title="Set or change the step-up PIN that gates high-privilege actions"
+        >
+          Step-up PIN
+        </button>
       </nav>
 
       <Routes>

--- a/web/ui/src/StepUpModal.tsx
+++ b/web/ui/src/StepUpModal.tsx
@@ -1,0 +1,297 @@
+/**
+ * Step-up PIN modal + provider (agent#80).
+ *
+ * The dangerous `agent:admin` actions (set credentials, open a terminal, spawn a
+ * `filesystem: full` agent) require a step-up token, obtained by entering the
+ * operator's PIN. The daemon ENFORCES this server-side; this is the UI affordance.
+ *
+ * Two flows, driven by the daemon's `403 step_up_required` `reason`:
+ *   - `"setup"` — no PIN configured yet → FIRST-TIME setup (set + confirm a new PIN),
+ *     which then immediately exchanges it for a token so the gated action proceeds.
+ *   - `"token"` — a PIN exists → PROMPT for it, exchange for a token.
+ *
+ * The provider registers a prompt handler with `lib/step-up.ts`, so the data layer
+ * (`lib/api.ts:authedFetch`) can trigger it on any gated request with no
+ * per-call-site plumbing. The promise resolves to the minted token (action
+ * proceeds) or null (operator cancelled → the 403 surfaces normally).
+ *
+ * It also renders a standalone "Set / change step-up PIN" control consumers can
+ * mount in settings via {@link useStepUp}().openSettings().
+ */
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import {
+  registerStepUpPrompt,
+  exchangePin,
+  setPin,
+  getStepUpStatus,
+  type StepUpReason,
+} from "./lib/step-up.ts";
+import { HttpError } from "./lib/api.ts";
+
+type Mode = "prompt" | "setup" | "settings";
+
+interface OpenState {
+  mode: Mode;
+  /** Resolver for the data-layer prompt (null for the settings flow). */
+  resolve: ((token: string | null) => void) | null;
+}
+
+interface StepUpContextValue {
+  /** Open the "set / change PIN" settings flow (not tied to a gated request). */
+  openSettings: () => void;
+}
+
+const StepUpContext = createContext<StepUpContextValue | null>(null);
+
+/** Access the step-up controls (the settings opener). */
+export function useStepUp(): StepUpContextValue {
+  const ctx = useContext(StepUpContext);
+  if (!ctx) throw new Error("useStepUp must be used inside <StepUpProvider>");
+  return ctx;
+}
+
+export function StepUpProvider({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState<OpenState | null>(null);
+
+  // Register the data-layer prompt handler. On a 403 step_up_required, api.ts
+  // calls this; we open the modal and resolve when the operator submits/cancels.
+  useEffect(() => {
+    registerStepUpPrompt((reason: StepUpReason) => {
+      return new Promise<string | null>((resolve) => {
+        setOpen({ mode: reason === "setup" ? "setup" : "prompt", resolve });
+      });
+    });
+    return () => registerStepUpPrompt(null);
+  }, []);
+
+  const close = useCallback(
+    (token: string | null) => {
+      setOpen((cur) => {
+        cur?.resolve?.(token);
+        return null;
+      });
+    },
+    [],
+  );
+
+  const ctx = useMemo<StepUpContextValue>(
+    () => ({
+      openSettings: () => setOpen({ mode: "settings", resolve: null }),
+    }),
+    [],
+  );
+
+  return (
+    <StepUpContext.Provider value={ctx}>
+      {children}
+      {open && <StepUpDialog state={open} onClose={close} />}
+    </StepUpContext.Provider>
+  );
+}
+
+function StepUpDialog({ state, onClose }: { state: OpenState; onClose: (token: string | null) => void }) {
+  const { mode } = state;
+  const [pin, setPinValue] = useState("");
+  const [newPin, setNewPin] = useState("");
+  const [confirmPin, setConfirmPin] = useState("");
+  const [currentPin, setCurrentPin] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // Settings flow needs to know whether a PIN already exists (rotation vs first-set).
+  const [hasPin, setHasPin] = useState<boolean | null>(mode === "settings" ? null : mode !== "setup");
+  const firstInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    firstInputRef.current?.focus();
+  }, []);
+
+  // For the settings flow, resolve whether a PIN already exists.
+  useEffect(() => {
+    if (mode !== "settings") return;
+    let alive = true;
+    getStepUpStatus()
+      .then((s) => alive && setHasPin(s.configured))
+      .catch(() => alive && setHasPin(false));
+    return () => {
+      alive = false;
+    };
+  }, [mode]);
+
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Escape") onClose(null);
+    },
+    [onClose],
+  );
+
+  function friendly(err: unknown): string {
+    if (err instanceof HttpError) {
+      if (err.status === 401) return "Incorrect PIN.";
+      if (err.status === 429) return "Too many attempts — wait a minute and try again.";
+      if (err.status === 400) return "PIN must be 4–12 digits.";
+      return err.message || "Something went wrong.";
+    }
+    return err instanceof Error ? err.message : "Something went wrong.";
+  }
+
+  // --- the "prompt" flow: enter the existing PIN → exchange → resolve ---------
+  async function submitPrompt() {
+    setError(null);
+    setBusy(true);
+    try {
+      const token = await exchangePin(pin);
+      onClose(token);
+    } catch (err) {
+      setError(friendly(err));
+      setBusy(false);
+    }
+  }
+
+  // --- the "setup" flow (first-time, triggered by a gated action): set a new
+  //     PIN, then immediately exchange it so the action proceeds ----------------
+  async function submitSetup() {
+    setError(null);
+    if (newPin !== confirmPin) {
+      setError("The PINs don't match.");
+      return;
+    }
+    setBusy(true);
+    try {
+      await setPin(newPin);
+      const token = await exchangePin(newPin);
+      onClose(token);
+    } catch (err) {
+      setError(friendly(err));
+      setBusy(false);
+    }
+  }
+
+  // --- the "settings" flow: set or rotate the PIN (NOT tied to an action) -----
+  async function submitSettings() {
+    setError(null);
+    if (newPin !== confirmPin) {
+      setError("The PINs don't match.");
+      return;
+    }
+    setBusy(true);
+    try {
+      await setPin(newPin, hasPin ? currentPin : undefined);
+      onClose(null); // settings flow doesn't return a token
+    } catch (err) {
+      setError(friendly(err));
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="step-up-backdrop" role="presentation" onClick={() => onClose(null)}>
+      <div
+        className="step-up-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Step-up PIN"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={onKeyDown}
+      >
+        {mode === "prompt" && (
+          <>
+            <h2>Confirm with your PIN</h2>
+            <p className="step-up-sub">
+              This is a high-privilege action. Enter your step-up PIN to continue.
+            </p>
+            <PinField label="PIN" value={pin} onChange={setPinValue} inputRef={firstInputRef} />
+          </>
+        )}
+
+        {mode === "setup" && (
+          <>
+            <h2>Set a step-up PIN</h2>
+            <p className="step-up-sub">
+              High-privilege actions (set credentials, open a terminal, spawn a full-filesystem
+              agent) require a PIN. Set one now to continue.
+            </p>
+            <PinField label="New PIN (4–12 digits)" value={newPin} onChange={setNewPin} inputRef={firstInputRef} />
+            <PinField label="Confirm PIN" value={confirmPin} onChange={setConfirmPin} />
+          </>
+        )}
+
+        {mode === "settings" && (
+          <>
+            <h2>{hasPin ? "Change step-up PIN" : "Set step-up PIN"}</h2>
+            <p className="step-up-sub">
+              The step-up PIN gates high-privilege admin actions (set credentials, open a terminal,
+              spawn a full-filesystem agent) as a second factor on top of your login.
+            </p>
+            {hasPin && (
+              <PinField label="Current PIN" value={currentPin} onChange={setCurrentPin} inputRef={firstInputRef} />
+            )}
+            <PinField
+              label={hasPin ? "New PIN (4–12 digits)" : "New PIN (4–12 digits)"}
+              value={newPin}
+              onChange={setNewPin}
+              inputRef={hasPin ? undefined : firstInputRef}
+            />
+            <PinField label="Confirm PIN" value={confirmPin} onChange={setConfirmPin} />
+          </>
+        )}
+
+        {error && (
+          <p className="step-up-error" role="alert">
+            {error}
+          </p>
+        )}
+
+        <div className="step-up-actions">
+          <button type="button" className="secondary" onClick={() => onClose(null)} disabled={busy}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={
+              mode === "prompt" ? submitPrompt : mode === "setup" ? submitSetup : submitSettings
+            }
+            disabled={busy || (mode === "settings" && hasPin === null)}
+          >
+            {busy ? "Working…" : mode === "prompt" ? "Confirm" : "Save PIN"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PinField({
+  label,
+  value,
+  onChange,
+  inputRef,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  inputRef?: React.RefObject<HTMLInputElement | null>;
+}) {
+  return (
+    <label className="step-up-field">
+      <span>{label}</span>
+      <input
+        ref={inputRef}
+        type="password"
+        inputMode="numeric"
+        autoComplete="off"
+        value={value}
+        // Digits only, ≤12 — mirrors the daemon's PIN format.
+        onChange={(e) => onChange(e.target.value.replace(/[^0-9]/g, "").slice(0, 12))}
+      />
+    </label>
+  );
+}

--- a/web/ui/src/lib/api.test.ts
+++ b/web/ui/src/lib/api.test.ts
@@ -32,6 +32,7 @@ import {
   setAgentSecret,
   turnEventsUrl,
 } from "./api.ts";
+import { registerStepUpPrompt, setStepUpToken, _resetStepUpForTest } from "./step-up.ts";
 
 const getAgentToken = vi.mocked(auth.getAgentToken);
 const clearCachedToken = vi.mocked(auth.clearCachedToken);
@@ -168,6 +169,68 @@ describe("listAgents / listAgentDefs / listAgentVaults", () => {
       vi.fn(async () => new Response("", { status: 401 })),
     );
     await expect(listAgents()).rejects.toBeInstanceOf(HttpError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Step-up gate (agent#80): a `403 step_up_required` drives the prompt, then the
+// request retries once with the `X-Step-Up-Token` header attached.
+// ---------------------------------------------------------------------------
+describe("authedFetch — step-up gate (403 step_up_required)", () => {
+  beforeEach(() => {
+    _resetStepUpForTest();
+  });
+
+  it("prompts for the PIN, then retries once with X-Step-Up-Token; success", async () => {
+    // The prompt handler mints + caches a token (as the real exchange would).
+    registerStepUpPrompt(async () => {
+      setStepUpToken("step-tok", Date.now() + 300_000);
+      return "step-tok";
+    });
+    const fetchMock = fetchFn(async () => jsonResponse(403, { error: "step_up_required", reason: "token" }));
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(403, { error: "step_up_required", reason: "token" }))
+      .mockResolvedValueOnce(jsonResponse(200, { ok: true, scope: "default", name: "GH_TOKEN" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await setAgentSecret({ name: "GH_TOKEN", value: "ghp_x" });
+    expect(res.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // The first call had no step-up header; the retry carries the minted token.
+    expect(new Headers(fetchMock.mock.calls[0]![1]?.headers).get("x-step-up-token")).toBeNull();
+    expect(new Headers(fetchMock.mock.calls[1]![1]?.headers).get("x-step-up-token")).toBe("step-tok");
+  });
+
+  it("surfaces the 403 when the operator cancels the prompt (returns null)", async () => {
+    registerStepUpPrompt(async () => null);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse(403, { error: "step_up_required", reason: "token" })),
+    );
+    await expect(setAgentSecret({ name: "GH_TOKEN", value: "ghp_x" })).rejects.toMatchObject({
+      status: 403,
+    });
+  });
+
+  it("a PLAIN 403 (not step_up_required) surfaces normally — no prompt", async () => {
+    const handler = vi.fn();
+    registerStepUpPrompt(handler);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse(403, { error: "insufficient_scope" })),
+    );
+    await expect(setAgentSecret({ name: "GH_TOKEN", value: "ghp_x" })).rejects.toMatchObject({
+      status: 403,
+    });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("attaches a HELD step-up token up-front (no prompt needed)", async () => {
+    setStepUpToken("held-tok", Date.now() + 300_000);
+    const fetchMock = fetchFn(async () => jsonResponse(200, { ok: true, scope: "default", name: "GH_TOKEN" }));
+    vi.stubGlobal("fetch", fetchMock);
+    await setAgentSecret({ name: "GH_TOKEN", value: "ghp_x" });
+    expect(new Headers(fetchMock.mock.calls[0]![1]?.headers).get("x-step-up-token")).toBe("held-tok");
   });
 });
 

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -23,6 +23,13 @@
  * vite.config.ts forwards to the loopback daemon.
  */
 import { clearCachedToken, getAgentToken } from "./auth.ts";
+import {
+  STEP_UP_HEADER,
+  currentStepUpToken,
+  clearStepUpToken,
+  requestStepUpToken,
+  type StepUpReason,
+} from "./step-up.ts";
 
 /** Status code carried alongside the message so callers can branch numerically. */
 export class HttpError extends Error {
@@ -55,13 +62,39 @@ export function apiBase(): string {
  * the SPA mirror of `src/ui-kit.ts:authedFetch`. On a clean 401 we drop the
  * cached token, re-mint once, and retry; a persistent 401 surfaces as an
  * `HttpError`.
+ *
+ * STEP-UP (agent#80): a gated action (set credentials, terminal, full-fs spawn)
+ * needs a step-up token IN ADDITION to the Bearer. We attach any HELD token
+ * up-front, and on a `403 step_up_required` we drive the PIN-prompt modal
+ * (`requestStepUpToken`), then retry ONCE with the fresh `X-Step-Up-Token`. This
+ * keeps the gate transparent to every call site — no per-call-site PIN plumbing.
+ * `_stepUpRetried` guards against an infinite prompt loop.
  */
-async function authedFetch(path: string, init: RequestInit = {}): Promise<Response> {
+async function authedFetch(
+  path: string,
+  init: RequestInit = {},
+  _stepUpRetried = false,
+): Promise<Response> {
   const token = await getAgentToken();
   const headers = new Headers(init.headers);
   headers.set("accept", "application/json");
   if (token) headers.set("authorization", `Bearer ${token}`);
+  const step = currentStepUpToken();
+  if (step) headers.set(STEP_UP_HEADER, step);
   const res = await fetch(path, { ...init, headers });
+
+  // Step-up gate: prompt for the PIN, then retry once with the minted token.
+  if (res.status === 403 && !_stepUpRetried) {
+    const reason = await stepUpReasonOf(res);
+    if (reason) {
+      // A held token we *thought* was valid but the server rejected → drop it.
+      if (currentStepUpToken()) clearStepUpToken();
+      const fresh = await requestStepUpToken(reason);
+      if (!fresh) return res; // operator cancelled / no prompt → surface the 403
+      return authedFetch(path, init, true);
+    }
+  }
+
   if (res.status !== 401) return res;
   // Re-mint once and retry. The first mint may have been stale/absent.
   clearCachedToken();
@@ -70,7 +103,29 @@ async function authedFetch(path: string, init: RequestInit = {}): Promise<Respon
   const retryHeaders = new Headers(init.headers);
   retryHeaders.set("accept", "application/json");
   retryHeaders.set("authorization", `Bearer ${fresh}`);
+  const stepRetry = currentStepUpToken();
+  if (stepRetry) retryHeaders.set(STEP_UP_HEADER, stepRetry);
   return fetch(path, { ...init, headers: retryHeaders });
+}
+
+/**
+ * Peek a 403 body for the `step_up_required` signal + its reason WITHOUT consuming
+ * the caller's response (we clone). Returns the reason (`"setup"` | `"token"`) when
+ * it's a step-up 403, else null (a plain insufficient-scope 403 surfaces normally).
+ */
+async function stepUpReasonOf(res: Response): Promise<StepUpReason | null> {
+  try {
+    const body = (await res.clone().json()) as { error?: string; reason?: string };
+    if (body.error !== "step_up_required") return null;
+    // Only the two reasons the server emits drive a prompt. An unrecognized reason
+    // (a future server adding a third) surfaces the 403 normally rather than silently
+    // prompting for a PIN — fail safe, don't guess.
+    if (body.reason === "setup") return "setup";
+    if (body.reason === "token") return "token";
+    return null;
+  } catch {
+    return null;
+  }
 }
 
 /** Pull the server `error` (or text) off a non-2xx response for an HttpError. */

--- a/web/ui/src/lib/step-up.test.ts
+++ b/web/ui/src/lib/step-up.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Step-up client-state tests (agent#80, `lib/step-up.ts`):
+ *   - the in-memory token holder (current/set/clear + expiry buffer);
+ *   - `requestStepUpToken` driving the registered prompt handler;
+ *   - the API client calls (exchange / set-PIN / status) attach the Bearer.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./auth.ts", () => ({
+  getAgentToken: vi.fn(),
+  clearCachedToken: vi.fn(),
+}));
+
+import * as auth from "./auth.ts";
+import {
+  currentStepUpToken,
+  setStepUpToken,
+  clearStepUpToken,
+  registerStepUpPrompt,
+  requestStepUpToken,
+  exchangePin,
+  setPin,
+  getStepUpStatus,
+  _resetStepUpForTest,
+} from "./step-up.ts";
+
+const getAgentToken = vi.mocked(auth.getAgentToken);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  _resetStepUpForTest();
+  getAgentToken.mockResolvedValue("jwt-tok");
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+}
+
+/** A `fetch`-shaped mock so `mock.calls` carries typed [input, init?] tuples. */
+function fetchFn(impl: (input: string, init?: RequestInit) => Promise<Response>) {
+  return vi.fn<(input: string, init?: RequestInit) => Promise<Response>>(impl);
+}
+
+describe("token holder", () => {
+  it("returns null when nothing is held", () => {
+    expect(currentStepUpToken()).toBeNull();
+  });
+
+  it("returns a held token while it's well within its window", () => {
+    setStepUpToken("tok-1", Date.now() + 60_000);
+    expect(currentStepUpToken()).toBe("tok-1");
+  });
+
+  it("treats a token within the expiry buffer as gone", () => {
+    setStepUpToken("tok-2", Date.now() + 1_000); // < 5s buffer
+    expect(currentStepUpToken()).toBeNull();
+  });
+
+  it("clearStepUpToken drops it", () => {
+    setStepUpToken("tok-3", Date.now() + 60_000);
+    clearStepUpToken();
+    expect(currentStepUpToken()).toBeNull();
+  });
+});
+
+describe("requestStepUpToken", () => {
+  it("returns the cached token for a 'token' reason without prompting", async () => {
+    setStepUpToken("cached", Date.now() + 60_000);
+    const handler = vi.fn();
+    registerStepUpPrompt(handler);
+    expect(await requestStepUpToken("token")).toBe("cached");
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("drives the prompt when no token is cached", async () => {
+    const handler = vi.fn().mockResolvedValue("fresh");
+    registerStepUpPrompt(handler);
+    expect(await requestStepUpToken("token")).toBe("fresh");
+    expect(handler).toHaveBeenCalledWith("token");
+  });
+
+  it("always prompts for a 'setup' reason even if a token is cached", async () => {
+    setStepUpToken("cached", Date.now() + 60_000);
+    const handler = vi.fn().mockResolvedValue(null);
+    registerStepUpPrompt(handler);
+    await requestStepUpToken("setup");
+    expect(handler).toHaveBeenCalledWith("setup");
+  });
+
+  it("returns null when no prompt handler is registered", async () => {
+    expect(await requestStepUpToken("token")).toBeNull();
+  });
+});
+
+describe("API client", () => {
+  it("getStepUpStatus GETs /step-up with the Bearer", async () => {
+    const fetchMock = fetchFn(async () => jsonResponse(200, { configured: true }));
+    vi.stubGlobal("fetch", fetchMock);
+    const res = await getStepUpStatus();
+    expect(res.configured).toBe(true);
+    const [, init] = fetchMock.mock.calls[0]!;
+    expect((init as RequestInit).headers).toBeInstanceOf(Headers);
+    expect(((init as RequestInit).headers as Headers).get("authorization")).toBe("Bearer jwt-tok");
+  });
+
+  it("exchangePin posts the PIN and caches the returned token", async () => {
+    const expiresAt = new Date(Date.now() + 300_000).toISOString();
+    const fetchMock = fetchFn(async () => jsonResponse(200, { stepUpToken: "minted", expires_at: expiresAt }));
+    vi.stubGlobal("fetch", fetchMock);
+    const token = await exchangePin("4242");
+    expect(token).toBe("minted");
+    expect(currentStepUpToken()).toBe("minted");
+    const [, init] = fetchMock.mock.calls[0]!;
+    expect((init as RequestInit).method).toBe("POST");
+    expect((init as RequestInit).body).toBe(JSON.stringify({ pin: "4242" }));
+  });
+
+  it("exchangePin throws HttpError (401) on a wrong PIN", async () => {
+    vi.stubGlobal("fetch", fetchFn(async () => jsonResponse(401, { error: "invalid_pin" })));
+    await expect(exchangePin("0000")).rejects.toMatchObject({ status: 401 });
+  });
+
+  it("setPin posts newPin (+ currentPin when rotating)", async () => {
+    const fetchMock = fetchFn(async () => jsonResponse(200, { ok: true }));
+    vi.stubGlobal("fetch", fetchMock);
+    await setPin("9999", "4242");
+    const [, init] = fetchMock.mock.calls[0]!;
+    expect((init as RequestInit).body).toBe(JSON.stringify({ newPin: "9999", currentPin: "4242" }));
+  });
+
+  it("setPin omits currentPin on first-time set", async () => {
+    const fetchMock = fetchFn(async () => jsonResponse(200, { ok: true }));
+    vi.stubGlobal("fetch", fetchMock);
+    await setPin("9999");
+    const [, init] = fetchMock.mock.calls[0]!;
+    expect((init as RequestInit).body).toBe(JSON.stringify({ newPin: "9999" }));
+  });
+});

--- a/web/ui/src/lib/step-up.ts
+++ b/web/ui/src/lib/step-up.ts
@@ -1,0 +1,167 @@
+/**
+ * Step-up auth (PIN) client state for the agent SPA (agent#80).
+ *
+ * The dangerous `agent:admin` actions (set credentials, open a terminal, spawn a
+ * `filesystem: full` agent) require a SECOND factor: a short-lived **step-up
+ * token** the operator gets by entering their PIN. The daemon enforces it
+ * SERVER-SIDE — this module is just the client convenience:
+ *
+ *   - holds the active step-up token in MEMORY for the session (never
+ *     localStorage — same posture as the agent Bearer in `lib/auth.ts`);
+ *   - exposes the step-up API client calls (status / exchange / set-PIN);
+ *   - bridges the data layer (`lib/api.ts`) to the UI: when a gated request comes
+ *     back `403 step_up_required`, `authedFetch` calls {@link requestStepUpToken},
+ *     which a React provider has wired to a PIN-prompt modal. The modal exchanges
+ *     the PIN for a token, this module caches it, and the request retries with
+ *     `X-Step-Up-Token`.
+ *
+ * The token is REUSABLE within its ~5min window, so one PIN entry covers a short
+ * burst of gated actions; on expiry the next gated request re-prompts.
+ */
+
+import { apiBase, HttpError } from "./api.ts";
+import { getAgentToken, clearCachedToken } from "./auth.ts";
+
+/** The header the daemon reads the step-up token from. */
+export const STEP_UP_HEADER = "x-step-up-token";
+
+interface HeldToken {
+  token: string;
+  expiresAt: number; // epoch ms
+}
+
+/** In-memory step-up token (never persisted). */
+let held: HeldToken | null = null;
+
+/** Slack kept before treating a held token as expired. */
+const EXPIRY_BUFFER_MS = 5_000;
+
+/** The currently-valid step-up token, or null if none / expired. */
+export function currentStepUpToken(): string | null {
+  if (!held) return null;
+  if (held.expiresAt - Date.now() <= EXPIRY_BUFFER_MS) {
+    held = null;
+    return null;
+  }
+  return held.token;
+}
+
+/** Cache a freshly-exchanged token. */
+export function setStepUpToken(token: string, expiresAt: number): void {
+  held = { token, expiresAt };
+}
+
+/** Drop the held token (e.g. after a 403 with a token we thought was valid). */
+export function clearStepUpToken(): void {
+  held = null;
+}
+
+// ---------------------------------------------------------------------------
+// API client — the step-up endpoints (all agent:admin, Bearer via lib/auth).
+// ---------------------------------------------------------------------------
+
+/** Authenticated fetch with the agent Bearer + a single 401 re-mint-retry. Mirrors
+ *  `lib/api.ts:authedFetch` but does NOT attach a step-up token (these endpoints
+ *  are the step-up surface itself — they're never step-up-gated). */
+async function adminFetch(suffix: string, init: RequestInit = {}): Promise<Response> {
+  const token = await getAgentToken();
+  const headers = new Headers(init.headers);
+  headers.set("accept", "application/json");
+  if (token) headers.set("authorization", `Bearer ${token}`);
+  const res = await fetch(`${apiBase()}${suffix}`, { ...init, headers });
+  if (res.status !== 401) return res;
+  clearCachedToken();
+  const fresh = await getAgentToken();
+  if (!fresh) return res;
+  const retry = new Headers(init.headers);
+  retry.set("accept", "application/json");
+  retry.set("authorization", `Bearer ${fresh}`);
+  return fetch(`${apiBase()}${suffix}`, { ...init, headers: retry });
+}
+
+async function errorDetail(res: Response): Promise<string> {
+  try {
+    const body = (await res.json()) as { error?: string };
+    return body.error ?? "";
+  } catch {
+    return await res.text().catch(() => "");
+  }
+}
+
+/** `GET /api/step-up` → whether a PIN is configured (UI: setup vs prompt). */
+export async function getStepUpStatus(): Promise<{ configured: boolean }> {
+  const res = await adminFetch("/step-up");
+  if (!res.ok) throw new HttpError(res.status, (await errorDetail(res)) || `step-up status failed: ${res.status}`);
+  return (await res.json()) as { configured: boolean };
+}
+
+/**
+ * `POST /api/step-up { pin }` → exchange the PIN for a step-up token. On success
+ * caches it and returns it. Throws `HttpError` on a wrong PIN (401), lockout (429),
+ * or not-configured (409) so the modal can show the right message.
+ */
+export async function exchangePin(pin: string): Promise<string> {
+  const res = await adminFetch("/step-up", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ pin }),
+  });
+  if (!res.ok) {
+    throw new HttpError(res.status, (await errorDetail(res)) || `PIN exchange failed: ${res.status}`);
+  }
+  const body = (await res.json()) as { stepUpToken: string; expires_at: string };
+  const expiresAt = new Date(body.expires_at).getTime();
+  setStepUpToken(body.stepUpToken, expiresAt);
+  return body.stepUpToken;
+}
+
+/**
+ * `POST /api/step-up/pin { newPin, currentPin? }` → set (first time) or rotate the
+ * PIN. `currentPin` is required when a PIN already exists. Throws `HttpError`
+ * (400 bad format, 401 wrong current PIN, 429 lockout).
+ */
+export async function setPin(newPin: string, currentPin?: string): Promise<void> {
+  const res = await adminFetch("/step-up/pin", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ newPin, ...(currentPin ? { currentPin } : {}) }),
+  });
+  if (!res.ok) {
+    throw new HttpError(res.status, (await errorDetail(res)) || `set PIN failed: ${res.status}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The data-layer → UI bridge. A React provider registers a prompt handler; the
+// data layer calls `requestStepUpToken()` on a `403 step_up_required`.
+// ---------------------------------------------------------------------------
+
+/** `reason: "setup"` → run first-time PIN setup; `"token"` → prompt for the PIN. */
+export type StepUpReason = "setup" | "token";
+
+type PromptHandler = (reason: StepUpReason) => Promise<string | null>;
+
+let promptHandler: PromptHandler | null = null;
+
+/** Register the modal's prompt handler (called once by the provider on mount). */
+export function registerStepUpPrompt(handler: PromptHandler | null): void {
+  promptHandler = handler;
+}
+
+/**
+ * Obtain a step-up token: return the cached one if valid, else drive the UI prompt
+ * (which exchanges the PIN). Returns null when no prompt handler is registered or
+ * the operator cancels. Called by `lib/api.ts:authedFetch` on a 403 step_up_required.
+ */
+export async function requestStepUpToken(reason: StepUpReason): Promise<string | null> {
+  const cached = currentStepUpToken();
+  if (cached && reason === "token") return cached;
+  if (!promptHandler) return null;
+  return promptHandler(reason);
+}
+
+/** Test seam: reset all module state. */
+export function _resetStepUpForTest(): void {
+  held = null;
+  promptHandler = null;
+}

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -811,3 +811,88 @@ button.button-danger:disabled {
   flex: 0 0 auto;
   align-self: flex-end;
 }
+
+/* ---- Step-up PIN: the nav button + the modal (agent#80) ---- */
+.nav .nav-link-button {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  color: var(--fg-muted);
+  font-size: 0.95rem;
+  font-family: inherit;
+}
+.nav .nav-link-button:hover {
+  color: var(--fg);
+}
+.step-up-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(44, 42, 38, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  z-index: 1000;
+}
+.step-up-modal {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  box-shadow: 0 12px 40px rgba(44, 42, 38, 0.2);
+  padding: 1.5rem;
+  width: 100%;
+  max-width: 26rem;
+}
+.step-up-modal h2 {
+  margin: 0 0 0.5rem;
+  font-family: var(--font-serif);
+  font-size: 1.25rem;
+}
+.step-up-sub {
+  color: var(--fg-muted);
+  font-size: 0.9rem;
+  margin: 0 0 1rem;
+}
+.step-up-field {
+  display: block;
+  margin-bottom: 0.85rem;
+}
+.step-up-field > span {
+  display: block;
+  font-size: 0.85rem;
+  color: var(--fg-muted);
+  margin-bottom: 0.3rem;
+}
+.step-up-field input {
+  width: 100%;
+  padding: 0.5rem 0.6rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-family: var(--font-mono);
+  font-size: 1.1rem;
+  letter-spacing: 0.25em;
+  background: var(--bg);
+  color: var(--fg);
+  box-sizing: border-box;
+}
+.step-up-field input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-soft);
+}
+.step-up-error {
+  color: var(--error);
+  background: var(--error-soft);
+  border-radius: 6px;
+  padding: 0.5rem 0.6rem;
+  font-size: 0.85rem;
+  margin: 0 0 0.85rem;
+}
+.step-up-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.6rem;
+  margin-top: 0.5rem;
+}


### PR DESCRIPTION
Closes #80.

## The risk
A single authenticated `agent:admin` session could do anything dangerous with **no re-confirm**:
- **set/rotate credentials** → exfiltrate vault / channel / Claude tokens (incl. the new Claude-token UI from #148);
- open a **terminal** → a raw host shell;
- spawn a **`filesystem: full`** agent → read the whole disk.

"One session = total control over the operator's vault + tokens."

## The design (PIN second factor, mirrors hub's admin-lock PIN)
A **step-up token** required IN ADDITION to `agent:admin` on the dangerous actions; everything else stays frictionless.

- **PIN, set once by the operator** — stored **hashed + salted** (`Bun.password` argon2id) in `~/.parachute/agent/step-up.json`, mode **0600**. Never plaintext, never logged, never returned. First-time setup flow if none configured; rotating it requires the current PIN.
- **Step-up exchange** — `POST /api/step-up { pin }` (gated `agent:admin`) validates the PIN and mints an opaque **256-bit CSPRNG nonce**, TTL **~5 min**, held in a server-side TTL'd map. **Reusable within its window** (unlike the single-use SSE ticket) so one PIN entry covers a short burst of gated actions.
- **Rate-limit + lockout** — **5 wrong PINs / 5 min**, keyed by the operator subject, run **before** the argon2 verify (mirrors hub's `unlockLimiter`). A successful entry clears the bucket.
- `GET /api/step-up` → `{ configured }`; `POST /api/step-up/pin { newPin, currentPin? }` sets/rotates.

## What's gated (server-side, `requireStepUp` in `src/auth.ts`)
- **set-credentials** — `POST`/`DELETE` on `/api/credentials/env` AND `/api/credentials/claude[/:channel]` (the #148 Claude-token routes included). GET status reads are NOT gated.
- **terminal** — the WS upgrade (`authorizeTerminalUpgrade`); the token rides `?step_up=` (a `new WebSocket()` can't set a header).
- **unsandboxed / full-fs spawn** — the `POST /api/agents` path **only when `filesystem: "full"`**; ordinary sandboxed spawns stay frictionless.

A gate miss returns **`403 { error: "step_up_required", reason: "setup"|"token" }`** — deliberately **distinct from a plain 401** (no/invalid bearer) — so the UI knows to **prompt** (first-time setup vs PIN entry) rather than re-authenticate.

## Not gated (documented)
The **vault-native** `#agent/definition` spawn path (a note with `filesystem: full`) is NOT step-up-gated — authoring that note already requires a separately-scope-gated `vault:write` credential, so a step-up challenge there would gate a capability the caller already had to hold a write credential to reach. Commented in `agent-defs.ts`; the gap to close if the threat model ever widens to less-trusted note authors.

## UI
- A **PIN modal** triggered transparently on `step_up_required` (handled in `lib/api.ts:authedFetch` — held token attached up-front, 403 drives the prompt + a single retry with `X-Step-Up-Token`, loop-guarded). First-time setup (set + confirm) and PIN-entry flows.
- A **"Step-up PIN"** settings control in the nav (set / change).
- The step-up token is held in **memory only** (never localStorage), re-prompts on expiry.
- The server-rendered **terminal page** prompts via a native dialog (set+confirm on first use) and rides `?step_up=`.

## Security properties
PIN hashed+salted (never logged/returned); rate-limited with lockout; step-up token opaque + short-TTL + server-side + **scope-not-widening** (a second factor on top of `agent:admin`, never a substitute — the request still needs its own valid `agent:admin` bearer); gating enforced **server-side** (the UI prompt is not the gate); `401`-before-`403` ordering preserved (a bad bearer fails at `requireScope` first).

## Tests
- `src/step-up.test.ts` — PIN set/verify (hashed, never plaintext, random salt, 0600), token TTL + reuse-within-window, rate-limiter window/lockout/clear.
- `src/daemon-step-up.test.ts` — the exchange + set/rotate endpoints, wrong-PIN 401, lockout 429, and **each gated surface 403s `step_up_required` without a token and 200s with one** (Claude default + per-channel, env store, terminal WS, `filesystem:full` spawn; ordinary spawn NOT gated), PIN never echoed.
- `web/ui/src/lib/step-up.test.ts` + `lib/api.test.ts` — token holder, prompt bridge, the 403→prompt→retry-with-header flow, plain-403 passthrough.
- Retrofitted `daemon-config-api.test.ts` + `terminal.test.ts` to arm the new gate.

## Gates
- Backend: **1165 pass / 0 fail** (`bun run test` = typecheck + `bun test ./src`)
- SPA: **155 pass** (`bunx vitest run`), `bun run build` ok, SPA typecheck clean
- `bunx biome check .` — clean (2 pre-existing `any` warnings in `vault.test.ts`, untouched)
- Version: `0.2.3-rc.5` → **`0.2.3-rc.6`**

🤖 Generated with [Claude Code](https://claude.com/claude-code)