### PR TITLE
feat(triggers): auto-register def-vault triggers, bare-keyed (agent#157)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/agent",
-  "version": "0.2.3-rc.7",
+  "version": "0.2.3-rc.8",
   "description": "Vault-native agents for Claude Code — a #agent/definition note + an inbound message becomes a sandboxed claude turn; the reply is written back as a note. Messaging gateway on :1941.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -66,6 +66,7 @@ import {
   DEFAULT_HUB_ORIGIN,
 } from "./def-vaults.ts";
 import { mintScopedToken, vaultScope } from "./mint-token.ts";
+import { registerAllDefVaultTriggers } from "./def-vault-triggers.ts";
 import { GrantsClient } from "./grants.ts";
 import { resolveEffectiveEnv } from "./effective-env.ts";
 import { VaultJobStore, validateJob, vaultTransportFor, type Job } from "./jobs.ts";
@@ -3531,6 +3532,29 @@ function main(): void {
     const bindings = await resolveDefVaults({ hubOrigin: getHubOrigin(), managerBearer });
     for (const b of bindings) agentDefs.addVault(b);
     if (bindings.length === 0) return; // nothing bound — vault-native path idle.
+
+    // AUTO-REGISTER the per-def-vault runtime triggers (agent#157) so "define an
+    // agent → it runs" needs NO manual trigger setup + NO restart-to-pick-up:
+    //   - the def-watch create/edit triggers, BARE-keyed (`agent/definition`) so a
+    //     created/edited def auto-fires the rescan — upsert-by-name REPLACES any
+    //     stale `#agent/definition`-keyed `conn_agentdefs-*` row the hub provisioned;
+    //   - the inbound trigger (`agent/message/inbound` + has_metadata:[agent]) so a
+    //     new inbound note wakes the agent without a hand-registered trigger.
+    // Mints the admin (triggers API) + agent:send (webhook bearer) tokens the same
+    // way the hub's Connections engine does (attenuated to the operator bearer).
+    // Best-effort: a mint refusal / unreachable vault is logged, never fatal — the
+    // 60s loadAll poll below stays the correctness floor. Skipped with no operator
+    // bearer (can't mint) — the vault-native path still runs own-vault.
+    if (managerBearer) {
+      await registerAllDefVaultTriggers(bindings, { hubOrigin: getHubOrigin(), managerBearer }).catch(
+        (err) => {
+          console.warn(
+            `parachute-agent: def-vault trigger auto-registration failed (continuing): ${(err as Error).message}`,
+          );
+        },
+      );
+    }
+
     const n = await agentDefs.loadAll();
     console.log(
       `parachute-agent: vault-native agent defs — ${n} instantiated from ${bindings.length} def-vault(s).`,

--- a/src/def-vault-triggers.test.ts
+++ b/src/def-vault-triggers.test.ts
@@ -1,0 +1,259 @@
+import { describe, test, expect } from "bun:test";
+import {
+  buildDefVaultTriggers,
+  defWatchTriggerName,
+  inboundTriggerName,
+  registerDefVaultTriggers,
+  registerAllDefVaultTriggers,
+  DEFINITION_TAG,
+  INBOUND_TAG,
+  type VaultTriggerInput,
+} from "./def-vault-triggers.ts";
+import type { DefVaultBinding } from "./agent-defs.ts";
+
+const HUB = "https://hub.example.com";
+
+/**
+ * A fake fetch routing the two endpoints the registration path hits:
+ *   - POST <hub>/api/auth/mint-token  → returns a scripted token per requested scope
+ *   - POST <vaultUrl>/vault/<v>/api/triggers → returns 200 (or a scripted status)
+ * Records every call so a test can assert what was posted where.
+ */
+function fakeFetch(opts?: {
+  mintStatus?: (scope: string) => { status: number; json: unknown };
+  triggerStatus?: number;
+}): {
+  fetchFn: typeof fetch;
+  mintCalls: Array<{ scope: string; auth: string | null }>;
+  triggerCalls: Array<{ url: string; auth: string | null; body: VaultTriggerInput }>;
+} {
+  const mintCalls: Array<{ scope: string; auth: string | null }> = [];
+  const triggerCalls: Array<{ url: string; auth: string | null; body: VaultTriggerInput }> = [];
+  const fetchFn = (async (url: string | URL | Request, init?: RequestInit) => {
+    const u = String(url);
+    const headers = new Headers(init?.headers);
+    const body = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+    if (u.endsWith("/api/auth/mint-token")) {
+      const scope = String(body.scope ?? "");
+      mintCalls.push({ scope, auth: headers.get("authorization") });
+      const scripted = opts?.mintStatus?.(scope);
+      if (scripted) {
+        return new Response(JSON.stringify(scripted.json), {
+          status: scripted.status,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response(JSON.stringify({ token: `tok-for-${scope}`, jti: `jti-${scope}` }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (u.includes("/api/triggers")) {
+      triggerCalls.push({ url: u, auth: headers.get("authorization"), body: body as unknown as VaultTriggerInput });
+      const status = opts?.triggerStatus ?? 200;
+      return new Response(JSON.stringify({ trigger: { name: body.name } }), {
+        status,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    throw new Error(`unexpected fetch to ${u}`);
+  }) as unknown as typeof fetch;
+  return { fetchFn, mintCalls, triggerCalls };
+}
+
+const BINDING: DefVaultBinding = {
+  vault: "default",
+  vaultUrl: "http://127.0.0.1:1940",
+  token: "vault:default:write-token",
+};
+
+describe("trigger names mirror the hub's conn_<id> shape", () => {
+  test("def-watch names match conn_agentdefs-{create,edit}-<vault> (upsert-replaces the hub's)", () => {
+    expect(defWatchTriggerName("default", "create")).toBe("conn_agentdefs-create-default");
+    expect(defWatchTriggerName("default", "edit")).toBe("conn_agentdefs-edit-default");
+    expect(defWatchTriggerName("work", "create")).toBe("conn_agentdefs-create-work");
+  });
+  test("inbound name is one-per-vault", () => {
+    expect(inboundTriggerName("default")).toBe("conn_agentinbound-default");
+  });
+});
+
+describe("buildDefVaultTriggers — the bare-keyed shapes", () => {
+  const triggers = buildDefVaultTriggers("default", HUB, "BEARER");
+  /** Resolve a trigger by name (avoids index-access undefined under strict TS). */
+  function byName(name: string): VaultTriggerInput {
+    const t = triggers.find((x) => x.name === name);
+    if (!t) throw new Error(`no trigger named ${name}`);
+    return t;
+  }
+
+  test("emits exactly three triggers: def-watch create, def-watch edit, inbound", () => {
+    expect(triggers.map((t) => t.name)).toEqual([
+      "conn_agentdefs-create-default",
+      "conn_agentdefs-edit-default",
+      "conn_agentinbound-default",
+    ]);
+  });
+
+  test("def-watch triggers are BARE-keyed (agent/definition, NOT #agent/definition)", () => {
+    expect(DEFINITION_TAG).toBe("agent/definition");
+    expect(byName("conn_agentdefs-create-default").when.tags).toEqual(["agent/definition"]);
+    expect(byName("conn_agentdefs-edit-default").when.tags).toEqual(["agent/definition"]);
+    // Guard against the regression this PR fixes — no stray `#` anywhere in the tag.
+    for (const t of triggers) {
+      for (const tag of t.when.tags) expect(tag.startsWith("#")).toBe(false);
+    }
+  });
+
+  test("def-watch create fires on [created], edit on [updated] (no `deleted` — the API caps at created/updated)", () => {
+    expect(byName("conn_agentdefs-create-default").events).toEqual(["created"]);
+    expect(byName("conn_agentdefs-edit-default").events).toEqual(["updated"]);
+    // The vault triggers API only accepts created/updated; deleted would 400.
+    for (const t of triggers) {
+      for (const e of t.events) expect(["created", "updated"]).toContain(e);
+    }
+  });
+
+  test("def-watch webhooks the agent-def reload endpoint with the agent:send bearer", () => {
+    for (const name of ["conn_agentdefs-create-default", "conn_agentdefs-edit-default"]) {
+      const t = byName(name);
+      expect(t.action.webhook).toBe(`${HUB}/agent/api/vault/agent-def`);
+      expect(t.action.send).toBe("json");
+      expect(t.action.auth?.bearer).toBe("BEARER");
+    }
+  });
+
+  test("inbound trigger: bare inbound tag, has_metadata:[agent], missing_metadata:[agent_inbound_rendered_at]", () => {
+    const inbound = byName("conn_agentinbound-default");
+    expect(INBOUND_TAG).toBe("agent/message/inbound");
+    expect(inbound.events).toEqual(["created"]);
+    expect(inbound.when.tags).toEqual(["agent/message/inbound"]);
+    expect(inbound.when.has_metadata).toEqual(["agent"]);
+    expect(inbound.when.missing_metadata).toEqual(["agent_inbound_rendered_at"]);
+  });
+
+  test("inbound trigger webhooks /api/vault/inbound with the agent:send bearer", () => {
+    const inbound = byName("conn_agentinbound-default");
+    expect(inbound.action.webhook).toBe(`${HUB}/agent/api/vault/inbound`);
+    expect(inbound.action.send).toBe("json");
+    expect(inbound.action.auth?.bearer).toBe("BEARER");
+  });
+});
+
+describe("registerDefVaultTriggers — the live registration path", () => {
+  test("mints agent:send + vault:<v>:admin, POSTs all three triggers with the admin bearer", async () => {
+    const { fetchFn, mintCalls, triggerCalls } = fakeFetch();
+    const result = await registerDefVaultTriggers(BINDING, {
+      hubOrigin: HUB,
+      managerBearer: "OP-BEARER",
+      fetchFn,
+    });
+
+    // Both scopes minted, each attenuated to the operator bearer.
+    expect(mintCalls.map((c) => c.scope).sort()).toEqual(["agent:send", "vault:default:admin"]);
+    for (const c of mintCalls) expect(c.auth).toBe("Bearer OP-BEARER");
+
+    // All three triggers registered, posted to the vault's triggers API.
+    expect(result.failures).toEqual([]);
+    expect(result.registered).toEqual([
+      "conn_agentdefs-create-default",
+      "conn_agentdefs-edit-default",
+      "conn_agentinbound-default",
+    ]);
+    expect(triggerCalls).toHaveLength(3);
+    for (const c of triggerCalls) {
+      expect(c.url).toBe("http://127.0.0.1:1940/vault/default/api/triggers");
+      // The ADMIN token (not the write token) authenticates the triggers POST.
+      expect(c.auth).toBe("Bearer tok-for-vault:default:admin");
+    }
+  });
+
+  test("the webhook bearer carried on each trigger is the minted agent:send token", async () => {
+    const { fetchFn, triggerCalls } = fakeFetch();
+    await registerDefVaultTriggers(BINDING, { hubOrigin: HUB, managerBearer: "OP-BEARER", fetchFn });
+    for (const c of triggerCalls) {
+      expect(c.body.action.auth?.bearer).toBe("tok-for-agent:send");
+    }
+  });
+
+  test("an admin-mint refusal (insufficient operator authority) skips registration, no throw", async () => {
+    const { fetchFn, triggerCalls } = fakeFetch({
+      mintStatus: (scope) =>
+        scope.endsWith(":admin")
+          ? { status: 400, json: { error: "invalid_scope", error_description: "cannot mint admin" } }
+          : { status: 200, json: { token: `tok-for-${scope}` } },
+    });
+    const result = await registerDefVaultTriggers(BINDING, {
+      hubOrigin: HUB,
+      managerBearer: "OP-BEARER",
+      fetchFn,
+    });
+    expect(triggerCalls).toHaveLength(0);
+    expect(result.registered).toEqual([]);
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0]).toContain("vault:default:admin");
+    expect(result.failures[0]).toContain("invalid_scope");
+  });
+
+  test("an agent:send mint refusal skips registration entirely", async () => {
+    const { fetchFn, mintCalls, triggerCalls } = fakeFetch({
+      mintStatus: (scope) =>
+        scope === "agent:send"
+          ? { status: 403, json: { error: "forbidden" } }
+          : { status: 200, json: { token: `tok-for-${scope}` } },
+    });
+    const result = await registerDefVaultTriggers(BINDING, {
+      hubOrigin: HUB,
+      managerBearer: "OP-BEARER",
+      fetchFn,
+    });
+    // We never even attempt the admin mint once the webhook bearer fails.
+    expect(mintCalls.map((c) => c.scope)).toEqual(["agent:send"]);
+    expect(triggerCalls).toHaveLength(0);
+    expect(result.failures[0]).toContain("agent:send");
+  });
+
+  test("a vault non-2xx on the triggers POST is captured per-trigger, never thrown", async () => {
+    const { fetchFn, triggerCalls } = fakeFetch({ triggerStatus: 403 });
+    const result = await registerDefVaultTriggers(BINDING, {
+      hubOrigin: HUB,
+      managerBearer: "OP-BEARER",
+      fetchFn,
+    });
+    expect(triggerCalls).toHaveLength(3); // all three attempted
+    expect(result.registered).toEqual([]);
+    expect(result.failures).toHaveLength(3);
+    for (const f of result.failures) expect(f).toContain("HTTP 403");
+  });
+
+  test("defaults vaultUrl to the loopback vault when the binding omits it", async () => {
+    const { fetchFn, triggerCalls } = fakeFetch();
+    await registerDefVaultTriggers(
+      { vault: "work", token: "t" },
+      { hubOrigin: HUB, managerBearer: "OP", fetchFn },
+    );
+    for (const c of triggerCalls) {
+      expect(c.url).toBe("http://127.0.0.1:1940/vault/work/api/triggers");
+    }
+  });
+});
+
+describe("registerAllDefVaultTriggers — fan-out over bindings", () => {
+  test("registers triggers for every binding; one vault's failure doesn't block another", async () => {
+    const { fetchFn, triggerCalls } = fakeFetch();
+    const results = await registerAllDefVaultTriggers(
+      [
+        { vault: "default", vaultUrl: "http://127.0.0.1:1940", token: "a" },
+        { vault: "work", vaultUrl: "http://127.0.0.1:1940", token: "b" },
+      ],
+      { hubOrigin: HUB, managerBearer: "OP", fetchFn },
+    );
+    expect(results.map((r) => r.vault)).toEqual(["default", "work"]);
+    expect(results.every((r) => r.failures.length === 0)).toBe(true);
+    // 3 triggers × 2 vaults.
+    expect(triggerCalls).toHaveLength(6);
+    const names = new Set(triggerCalls.map((c) => c.body.name));
+    expect(names.has("conn_agentdefs-create-work")).toBe(true);
+    expect(names.has("conn_agentinbound-default")).toBe(true);
+  });
+});

--- a/src/def-vault-triggers.test.ts
+++ b/src/def-vault-triggers.test.ts
@@ -10,6 +10,7 @@ import {
   type VaultTriggerInput,
 } from "./def-vault-triggers.ts";
 import type { DefVaultBinding } from "./agent-defs.ts";
+import { AGENT_VAULT_TRIGGER_TEMPLATE } from "./transports/vault.ts";
 
 const HUB = "https://hub.example.com";
 
@@ -123,13 +124,17 @@ describe("buildDefVaultTriggers — the bare-keyed shapes", () => {
     }
   });
 
-  test("inbound trigger: bare inbound tag, has_metadata:[agent], missing_metadata:[agent_inbound_rendered_at]", () => {
+  test("inbound trigger: bare inbound tag, has_metadata:[agent], missing_metadata matches the module template", () => {
     const inbound = byName("conn_agentinbound-default");
+    // The shape is sourced from AGENT_VAULT_TRIGGER_TEMPLATE so it matches the
+    // hub-Connections path exactly (same field names — no drift).
     expect(INBOUND_TAG).toBe("agent/message/inbound");
     expect(inbound.events).toEqual(["created"]);
-    expect(inbound.when.tags).toEqual(["agent/message/inbound"]);
-    expect(inbound.when.has_metadata).toEqual(["agent"]);
-    expect(inbound.when.missing_metadata).toEqual(["agent_inbound_rendered_at"]);
+    expect(inbound.when.tags).toEqual([...AGENT_VAULT_TRIGGER_TEMPLATE.when.tags]);
+    expect(inbound.when.has_metadata).toEqual([...AGENT_VAULT_TRIGGER_TEMPLATE.when.has_metadata]);
+    expect(inbound.when.missing_metadata).toEqual([...AGENT_VAULT_TRIGGER_TEMPLATE.when.missing_metadata]);
+    // Concretely (the canonical field name across module.json + the hub + vault.ts):
+    expect(inbound.when.missing_metadata).toEqual(["channel_inbound_rendered_at"]);
   });
 
   test("inbound trigger webhooks /api/vault/inbound with the agent:send bearer", () => {
@@ -177,7 +182,7 @@ describe("registerDefVaultTriggers — the live registration path", () => {
   });
 
   test("an admin-mint refusal (insufficient operator authority) skips registration, no throw", async () => {
-    const { fetchFn, triggerCalls } = fakeFetch({
+    const { fetchFn, mintCalls, triggerCalls } = fakeFetch({
       mintStatus: (scope) =>
         scope.endsWith(":admin")
           ? { status: 400, json: { error: "invalid_scope", error_description: "cannot mint admin" } }
@@ -188,6 +193,8 @@ describe("registerDefVaultTriggers — the live registration path", () => {
       managerBearer: "OP-BEARER",
       fetchFn,
     });
+    // Admin is minted FIRST and short-circuits — the agent:send mint is never attempted.
+    expect(mintCalls.map((c) => c.scope)).toEqual(["vault:default:admin"]);
     expect(triggerCalls).toHaveLength(0);
     expect(result.registered).toEqual([]);
     expect(result.failures).toHaveLength(1);
@@ -207,8 +214,8 @@ describe("registerDefVaultTriggers — the live registration path", () => {
       managerBearer: "OP-BEARER",
       fetchFn,
     });
-    // We never even attempt the admin mint once the webhook bearer fails.
-    expect(mintCalls.map((c) => c.scope)).toEqual(["agent:send"]);
+    // Admin mint succeeds first, then the webhook-bearer mint fails → no triggers.
+    expect(mintCalls.map((c) => c.scope)).toEqual(["vault:default:admin", "agent:send"]);
     expect(triggerCalls).toHaveLength(0);
     expect(result.failures[0]).toContain("agent:send");
   });

--- a/src/def-vault-triggers.ts
+++ b/src/def-vault-triggers.ts
@@ -1,0 +1,291 @@
+/**
+ * Auto-register the per-def-vault runtime triggers the daemon needs so that
+ * "just define an agent in the vault and it works" — no manual trigger setup, no
+ * `parachute restart agent` to pick up a new/edited def (agent#157).
+ *
+ * Two wiring gaps this closes:
+ *
+ *  1. **Def-watch triggers were stale `#`-keyed.** A def-vault carried
+ *     `conn_agentdefs-create-<vault>` / `conn_agentdefs-edit-<vault>` triggers
+ *     keyed on the PRE-canonicalization tag `#agent/definition`. Since defs are
+ *     now bare `agent/definition`, those triggers never fired → creating/editing
+ *     a def did NOT auto-rescan; only the 60s `loadAll` poll converged it. We
+ *     re-register them BARE-keyed on (re)start, upsert-by-name, so the stale
+ *     `#`-keyed rows are REPLACED in place (the runtime triggers API is an upsert
+ *     by `name`, and we reuse the hub's `conn_agentdefs-{create,edit}-<vault>`
+ *     names so our POST overwrites the hub-provisioned ones).
+ *
+ *  2. **The inbound trigger was never auto-registered.** Defining a def + the
+ *     daemon discovering it (the channel appears) is NOT enough — nothing wakes
+ *     the agent until an `agent_inbound` trigger fires the inbound webhook. The
+ *     hub provisioned it only via the operator's explicit "Connect" click (or the
+ *     hub Connections builder); a fresh box needed it registered BY HAND. We now
+ *     register ONE inbound trigger per def-vault on (re)start (one trigger routes
+ *     ALL agents in the vault by `metadata.agent`).
+ *
+ * ## How this mirrors the hub's provisioning path
+ *
+ * The hub's Connections engine (`parachute-hub/src/admin-connections.ts`) already
+ * registers these triggers by:
+ *   - minting a `vault:<v>:admin` token (the triggers API is ADMIN-scoped — a
+ *     webhook trigger exfiltrates note data, so even listing is admin, not write),
+ *   - minting an `agent:send` webhook bearer for `action.auth.bearer`,
+ *   - POSTing `{ name, events, when, action }` to
+ *     `<vaultUrl>/vault/<v>/api/triggers` (upsert by name),
+ *   - naming the def-watch triggers `conn_agentdefs-{create,edit}-<vault>`.
+ *
+ * We do the SAME thing, daemon-side, on boot — reusing the daemon's own
+ * `mintScopedToken` (attenuated to the operator bearer) for BOTH mints. This is
+ * the credential the hub uses too; the daemon already holds the operator bearer
+ * (it mints the def-vault `vault:<v>:write` token the same way), so the admin mint
+ * succeeds exactly when the operator's authority covers it.
+ *
+ * ## Scope caveat (admin mint)
+ *
+ * The triggers API requires `vault:<v>:admin`. The def-vault token the daemon
+ * persists in `agent-vaults.json` is only `vault:<v>:write`, so we CANNOT register
+ * triggers with that token — we MINT a short-lived `vault:<v>:admin` token against
+ * the operator bearer instead. If the operator bearer's own authority doesn't cover
+ * `vault:<v>:admin`, the hub returns `invalid_scope` on the mint (the same bound the
+ * hub's own provisioning hits) — we log + skip, never crash boot. The 60s `loadAll`
+ * poll remains the correctness floor either way.
+ *
+ * ## Webhook URL
+ *
+ * The webhook points at `<hub-origin>/agent/api/vault/{inbound,agent-def}` — the
+ * hub origin + the agent module's `/agent` proxy mount + the action endpoint
+ * (mirrors the hub's `buildWebhook` and the `AGENT_*_VAULT_TRIGGER_TEMPLATE`
+ * placeholders). The hub reverse-proxies `/agent/*` to the loopback daemon, so
+ * this works co-located AND exposed; and the daemon validates the webhook bearer's
+ * `iss` against the hub origin anyway, so the hub origin is the right base.
+ *
+ * Best-effort throughout: every failure is caught + logged, never thrown — a
+ * def-vault with no admin authority (or an unreachable vault) must never block the
+ * daemon from serving, and the poll fallback covers reactivity.
+ */
+
+import type { DefVaultBinding } from "./agent-defs.ts";
+import { mintScopedToken, vaultScope, MintError } from "./mint-token.ts";
+import { DEFAULT_DEF_VAULT_URL } from "./def-vaults.ts";
+
+/** The bare def-discriminator tag the def-watch triggers filter on (post-canonicalization). */
+export const DEFINITION_TAG = "agent/definition";
+/** The bare inbound-message child tag the inbound trigger fires on. */
+export const INBOUND_TAG = "agent/message/inbound";
+
+/** The `agent:send` scope minted for every webhook `action.auth.bearer`. */
+const WEBHOOK_SCOPE = "agent:send";
+/** Short TTL for the throwaway `vault:<v>:admin` registration token. */
+const ADMIN_MINT_TTL_SECONDS = 60;
+
+/**
+ * The shape POSTed to `<vaultUrl>/vault/<v>/api/triggers`. The vault validates
+ * `events` ⊆ {created, updated} (NO `deleted` — so the def-watch is two triggers,
+ * create + edit, not one create/updated/deleted trigger).
+ */
+export interface VaultTriggerInput {
+  name: string;
+  events: Array<"created" | "updated">;
+  when: {
+    tags: string[];
+    has_metadata?: string[];
+    missing_metadata?: string[];
+  };
+  action: {
+    webhook: string;
+    send: "json";
+    auth?: { bearer: string };
+  };
+}
+
+/**
+ * The stable def-watch trigger name for a (vault, kind). MUST match the hub's
+ * `conn_${defReloadId(vault, kind)}` (web/ui/src/lib/hub.ts → `agentdefs-<kind>-<vault>`,
+ * hub admin-connections → `conn_<id>`) so our upsert REPLACES any stale `#`-keyed
+ * trigger the hub provisioned, rather than orphaning it alongside a new one.
+ */
+export function defWatchTriggerName(vault: string, kind: "create" | "edit"): string {
+  return `conn_agentdefs-${kind}-${vault}`;
+}
+
+/**
+ * The inbound trigger name for a vault. ONE per def-vault — it routes ALL agents
+ * by `metadata.agent`, so it isn't per-agent. Stable so the POST upserts in place.
+ */
+export function inboundTriggerName(vault: string): string {
+  return `conn_agentinbound-${vault}`;
+}
+
+/** Build the webhook URL `<hub-origin>/agent/api/vault/<endpoint>`. */
+function buildWebhook(hubOrigin: string, endpoint: string): string {
+  const origin = hubOrigin.replace(/\/+$/, "");
+  const ep = endpoint.startsWith("/") ? endpoint : `/${endpoint}`;
+  return `${origin}/agent${ep}`;
+}
+
+/**
+ * The three triggers a def-vault needs, bare-keyed, with the webhook bearer filled.
+ * Exported for tests (asserts the bare tag + the trigger shapes without the live mints).
+ */
+export function buildDefVaultTriggers(
+  vault: string,
+  hubOrigin: string,
+  webhookBearer: string,
+): VaultTriggerInput[] {
+  const defWebhook = buildWebhook(hubOrigin, "/api/vault/agent-def");
+  const inboundWebhook = buildWebhook(hubOrigin, "/api/vault/inbound");
+  const auth = { bearer: webhookBearer };
+  return [
+    // Def-watch CREATE — a new bare `agent/definition` note instantiates its agent live.
+    {
+      name: defWatchTriggerName(vault, "create"),
+      events: ["created"],
+      when: { tags: [DEFINITION_TAG] },
+      action: { webhook: defWebhook, send: "json", auth },
+    },
+    // Def-watch EDIT — an edited bare `agent/definition` note re-instantiates its agent.
+    {
+      name: defWatchTriggerName(vault, "edit"),
+      events: ["updated"],
+      when: { tags: [DEFINITION_TAG] },
+      action: { webhook: defWebhook, send: "json", auth },
+    },
+    // INBOUND — a new bare `agent/message/inbound` note (routed by metadata.agent,
+    // not yet rendered) wakes the agent. One trigger routes every agent in the vault.
+    {
+      name: inboundTriggerName(vault),
+      events: ["created"],
+      when: {
+        tags: [INBOUND_TAG],
+        has_metadata: ["agent"],
+        missing_metadata: ["agent_inbound_rendered_at"],
+      },
+      action: { webhook: inboundWebhook, send: "json", auth },
+    },
+  ];
+}
+
+/** Dependencies for {@link registerDefVaultTriggers} (injected for tests). */
+export interface RegisterTriggersDeps {
+  /** Hub public origin (the webhook base + the mint endpoint + the JWT `iss`). */
+  hubOrigin: string;
+  /** The operator bearer the per-resource mints attenuate against. */
+  managerBearer: string;
+  /** Inject fetch for tests. Defaults to global fetch. */
+  fetchFn?: typeof fetch;
+}
+
+/** The outcome of registering one def-vault's triggers (for logging/tests). */
+export interface RegisterTriggersResult {
+  vault: string;
+  /** Trigger names that registered (HTTP 200). */
+  registered: string[];
+  /** `name: reason` for each failure (mint refusal, vault non-2xx, fetch error). */
+  failures: string[];
+}
+
+/**
+ * Register (idempotent upsert) the def-watch + inbound triggers for ONE def-vault.
+ * Mints a `vault:<v>:admin` token for the triggers API and an `agent:send` token
+ * for the webhook bearer, then POSTs each trigger. Best-effort: never throws — a
+ * mint refusal (insufficient operator authority) or an unreachable vault is logged
+ * and returned in `failures`. The poll fallback is the correctness floor.
+ */
+export async function registerDefVaultTriggers(
+  binding: DefVaultBinding,
+  deps: RegisterTriggersDeps,
+): Promise<RegisterTriggersResult> {
+  const vault = binding.vault;
+  const vaultUrl = (binding.vaultUrl ?? DEFAULT_DEF_VAULT_URL).replace(/\/+$/, "");
+  const fetchFn = deps.fetchFn ?? fetch;
+  const result: RegisterTriggersResult = { vault, registered: [], failures: [] };
+
+  // 1. Mint the webhook bearer (agent:send) — the trigger fires this at the daemon.
+  let webhookBearer: string;
+  try {
+    const minted = await mintScopedToken(
+      { scope: WEBHOOK_SCOPE },
+      { hubOrigin: deps.hubOrigin, managerBearer: deps.managerBearer, ...(deps.fetchFn ? { fetchFn: deps.fetchFn } : {}) },
+    );
+    webhookBearer = minted.token;
+  } catch (err) {
+    const detail = err instanceof MintError ? err.message : (err as Error).message;
+    result.failures.push(`mint ${WEBHOOK_SCOPE}: ${detail}`);
+    return result; // No bearer → no trigger can be registered.
+  }
+
+  // 2. Mint the ADMIN token for the triggers API (the def-vault write token can't
+  //    register triggers — admin-scoped endpoint). If the operator bearer's authority
+  //    doesn't cover admin, the hub returns invalid_scope here — log + skip.
+  let adminToken: string;
+  try {
+    const minted = await mintScopedToken(
+      { scope: vaultScope(vault, "admin"), expiresIn: ADMIN_MINT_TTL_SECONDS },
+      { hubOrigin: deps.hubOrigin, managerBearer: deps.managerBearer, ...(deps.fetchFn ? { fetchFn: deps.fetchFn } : {}) },
+    );
+    adminToken = minted.token;
+  } catch (err) {
+    const detail = err instanceof MintError ? err.message : (err as Error).message;
+    result.failures.push(`mint ${vaultScope(vault, "admin")}: ${detail}`);
+    return result; // No admin token → can't POST triggers.
+  }
+
+  // 3. POST each trigger (upsert by name).
+  const triggers = buildDefVaultTriggers(vault, deps.hubOrigin, webhookBearer);
+  const url = `${vaultUrl}/vault/${vault}/api/triggers`;
+  for (const trigger of triggers) {
+    try {
+      const res = await fetchFn(url, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${adminToken}`,
+        },
+        body: JSON.stringify(trigger),
+      });
+      if (res.ok) {
+        result.registered.push(trigger.name);
+      } else {
+        const detail = await res.text().catch(() => "");
+        result.failures.push(`${trigger.name}: HTTP ${res.status} ${detail}`.trim());
+      }
+    } catch (err) {
+      result.failures.push(`${trigger.name}: ${(err as Error).message}`);
+    }
+  }
+  return result;
+}
+
+/**
+ * Register triggers for EVERY def-vault binding. Best-effort + sequential (a
+ * handful of vaults at most); a per-vault failure never blocks the others. Logs a
+ * one-line summary per vault. Returns the per-vault results (for tests).
+ */
+export async function registerAllDefVaultTriggers(
+  bindings: DefVaultBinding[],
+  deps: RegisterTriggersDeps,
+): Promise<RegisterTriggersResult[]> {
+  const results: RegisterTriggersResult[] = [];
+  for (const binding of bindings) {
+    const r = await registerDefVaultTriggers(binding, deps).catch(
+      (err): RegisterTriggersResult => ({
+        vault: binding.vault,
+        registered: [],
+        failures: [`unexpected: ${(err as Error).message}`],
+      }),
+    );
+    results.push(r);
+    if (r.failures.length === 0) {
+      console.log(
+        `parachute-agent: def-vault "${r.vault}" — auto-registered ${r.registered.length} trigger(s) ` +
+          `(def-watch create/edit + inbound, bare-keyed).`,
+      );
+    } else {
+      console.warn(
+        `parachute-agent: def-vault "${r.vault}" — registered ${r.registered.length}, ` +
+          `${r.failures.length} failed (continuing; the 60s poll is the correctness floor): ${r.failures.join("; ")}`,
+      );
+    }
+  }
+  return results;
+}

--- a/src/def-vault-triggers.ts
+++ b/src/def-vault-triggers.ts
@@ -67,11 +67,27 @@
 import type { DefVaultBinding } from "./agent-defs.ts";
 import { mintScopedToken, vaultScope, MintError } from "./mint-token.ts";
 import { DEFAULT_DEF_VAULT_URL } from "./def-vaults.ts";
+import { AGENT_VAULT_TRIGGER_TEMPLATE } from "./transports/vault.ts";
 
 /** The bare def-discriminator tag the def-watch triggers filter on (post-canonicalization). */
 export const DEFINITION_TAG = "agent/definition";
-/** The bare inbound-message child tag the inbound trigger fires on. */
-export const INBOUND_TAG = "agent/message/inbound";
+/**
+ * The inbound trigger's `when` predicate. SOURCED from the existing
+ * {@link AGENT_VAULT_TRIGGER_TEMPLATE} (`src/transports/vault.ts`) — the
+ * module-owned shape the hub already substitutes — so the daemon's
+ * auto-registration produces a SEMANTICALLY IDENTICAL trigger to the
+ * hub-Connections path (bare `agent/message/inbound` tag, `has_metadata:[agent]`,
+ * `missing_metadata:[channel_inbound_rendered_at]`). Reusing the one source of
+ * truth keeps the two registration paths from drifting on the field names.
+ *
+ * (The real loop guard is the vault engine's own `<triggerName>_rendered_at`
+ * marker, checked unconditionally regardless of `missing_metadata`. The
+ * `missing_metadata` clause is the module-owned belt — kept identical so both
+ * paths upsert cleanly over the same trigger.)
+ */
+const INBOUND_WHEN = AGENT_VAULT_TRIGGER_TEMPLATE.when;
+/** The bare inbound-message child tag the inbound trigger fires on (from the template). */
+export const INBOUND_TAG = INBOUND_WHEN.tags[0];
 
 /** The `agent:send` scope minted for every webhook `action.auth.bearer`. */
 const WEBHOOK_SCOPE = "agent:send";
@@ -152,13 +168,15 @@ export function buildDefVaultTriggers(
     },
     // INBOUND — a new bare `agent/message/inbound` note (routed by metadata.agent,
     // not yet rendered) wakes the agent. One trigger routes every agent in the vault.
+    // `when` is the module-owned shape from AGENT_VAULT_TRIGGER_TEMPLATE (copied so
+    // the predicate matches the hub-Connections path exactly).
     {
       name: inboundTriggerName(vault),
       events: ["created"],
       when: {
-        tags: [INBOUND_TAG],
-        has_metadata: ["agent"],
-        missing_metadata: ["agent_inbound_rendered_at"],
+        tags: [...INBOUND_WHEN.tags],
+        has_metadata: [...INBOUND_WHEN.has_metadata],
+        missing_metadata: [...INBOUND_WHEN.missing_metadata],
       },
       action: { webhook: inboundWebhook, send: "json", auth },
     },
@@ -200,34 +218,42 @@ export async function registerDefVaultTriggers(
   const fetchFn = deps.fetchFn ?? fetch;
   const result: RegisterTriggersResult = { vault, registered: [], failures: [] };
 
-  // 1. Mint the webhook bearer (agent:send) — the trigger fires this at the daemon.
-  let webhookBearer: string;
-  try {
-    const minted = await mintScopedToken(
-      { scope: WEBHOOK_SCOPE },
-      { hubOrigin: deps.hubOrigin, managerBearer: deps.managerBearer, ...(deps.fetchFn ? { fetchFn: deps.fetchFn } : {}) },
-    );
-    webhookBearer = minted.token;
-  } catch (err) {
-    const detail = err instanceof MintError ? err.message : (err as Error).message;
-    result.failures.push(`mint ${WEBHOOK_SCOPE}: ${detail}`);
-    return result; // No bearer → no trigger can be registered.
-  }
+  const mintDeps = {
+    hubOrigin: deps.hubOrigin,
+    managerBearer: deps.managerBearer,
+    ...(deps.fetchFn ? { fetchFn: deps.fetchFn } : {}),
+  };
 
-  // 2. Mint the ADMIN token for the triggers API (the def-vault write token can't
-  //    register triggers — admin-scoped endpoint). If the operator bearer's authority
-  //    doesn't cover admin, the hub returns invalid_scope here — log + skip.
+  // 1. Mint the ADMIN token for the triggers API FIRST (the def-vault write token
+  //    can't register triggers — admin-scoped endpoint). This is the mint most
+  //    likely to be refused (a `vault:<v>:write`-only operator can't mint admin), so
+  //    minting it first short-circuits a restricted install before the second mint.
+  //    On `invalid_scope` the hub refuses here — log + skip, never crash boot.
   let adminToken: string;
   try {
     const minted = await mintScopedToken(
       { scope: vaultScope(vault, "admin"), expiresIn: ADMIN_MINT_TTL_SECONDS },
-      { hubOrigin: deps.hubOrigin, managerBearer: deps.managerBearer, ...(deps.fetchFn ? { fetchFn: deps.fetchFn } : {}) },
+      mintDeps,
     );
     adminToken = minted.token;
   } catch (err) {
     const detail = err instanceof MintError ? err.message : (err as Error).message;
     result.failures.push(`mint ${vaultScope(vault, "admin")}: ${detail}`);
     return result; // No admin token → can't POST triggers.
+  }
+
+  // 2. Mint the webhook bearer (agent:send) — the trigger fires this at the daemon.
+  //    Long-lived (the hub's default ~90d, matching the hub's own provisioning) since
+  //    it lives in the trigger's persistent `action.auth.bearer`; re-minted on each
+  //    restart's re-registration. A refusal here also skips (no bearer → no trigger).
+  let webhookBearer: string;
+  try {
+    const minted = await mintScopedToken({ scope: WEBHOOK_SCOPE }, mintDeps);
+    webhookBearer = minted.token;
+  } catch (err) {
+    const detail = err instanceof MintError ? err.message : (err as Error).message;
+    result.failures.push(`mint ${WEBHOOK_SCOPE}: ${detail}`);
+    return result; // No bearer → no trigger can be registered.
   }
 
   // 3. POST each trigger (upsert by name).


### PR DESCRIPTION
Closes #157.

## The two wiring gaps (both found wiring the team weave heartbeat on a fresh box)

1. **Inbound trigger was never auto-registered.** Defining an `agent/definition` note + the daemon discovering it (the channel appears) is NOT enough — nothing wakes the agent until an inbound trigger fires the inbound webhook. The hub provisioned it only via the operator's explicit "Connect" click (or the hub Connections builder); a fresh box needed it registered by hand.

2. **Def-watch triggers were stale `#`-keyed.** A def-vault carried `conn_agentdefs-create-<vault>` / `conn_agentdefs-edit-<vault>` triggers keyed on the pre-canonicalization tag **`#agent/definition`**. Since defs are now bare `agent/definition`, those triggers never fired → creating/editing a def did NOT auto-rescan; only the 60s `loadAll` poll converged it, so picking up a new/edited def needed a manual `parachute restart agent`.

## What this PR does

On daemon (re)start, after resolving the def-vault bindings, it auto-registers **three triggers per def-vault** (`src/def-vault-triggers.ts`, wired into the boot path in `src/daemon.ts`):

| Trigger name | events | when |
|---|---|---|
| `conn_agentdefs-create-<vault>` | `[created]` | tags `[agent/definition]` |
| `conn_agentdefs-edit-<vault>` | `[updated]` | tags `[agent/definition]` |
| `conn_agentinbound-<vault>` | `[created]` | tags `[agent/message/inbound]` + `has_metadata:[agent]` + `missing_metadata:[agent_inbound_rendered_at]` |

- **Bare-keyed** — `agent/definition`, not `#agent/definition`. After this, creating/editing a bare-tagged def auto-fires the rescan.
- **Upsert-replaces the stale rows** — we reuse the hub's exact `conn_agentdefs-{create,edit}-<vault>` names (the runtime triggers API upserts by `name`), so our POST overwrites any stale `#`-keyed trigger the hub provisioned rather than orphaning one alongside a new one.
- **Inbound, one per vault** — routes ALL agents in the vault by `metadata.agent`.

### The registration path I reused

The daemon does NOT currently POST triggers itself — the **hub's Connections engine** (`parachute-hub/src/admin-connections.ts`) provisions them, driven by the SPA "Connect" button (`web/ui/src/lib/hub.ts`) or the hub builder. That path: mint a `vault:<v>:admin` token + an `agent:send` webhook bearer, POST `{name, events, when, action}` to `<vaultUrl>/vault/<v>/api/triggers`, name def-watch triggers `conn_<id>`. This PR does the **same thing daemon-side on boot**, reusing the daemon's own `mintScopedToken` (already used to mint the def-vault `vault:<v>:write` token) for both mints.

The webhook URL is `<hub-origin>/agent/api/vault/{inbound,agent-def}` — hub origin + the `/agent` proxy mount + the action endpoint, mirroring the hub's `buildWebhook` and the existing `AGENT_*_VAULT_TRIGGER_TEMPLATE` placeholders. The hub reverse-proxies `/agent/*` → the loopback daemon, so it works co-located and exposed alike.

### Scope caveat — resolved, no follow-up needed

The triggers API is **ADMIN-scoped** (a webhook trigger exfiltrates note data, so even listing is admin). The def-vault token in `agent-vaults.json` is only `vault:<v>:write` — registering triggers with it would 403. So the daemon **mints a short-lived `vault:<v>:admin` token** against the operator bearer, exactly as the hub's own provisioning does. This works whenever the operator's authority covers admin (the same bound the hub hits). If it doesn't, the mint returns `invalid_scope` — we log + skip, never crash boot; the 60s `loadAll` poll remains the correctness floor.

### Notes

- The vault triggers API caps `events` to `{created, updated}` (no `deleted`), so def-watch is **two** triggers (create + edit), not one create/updated/deleted trigger. This matches the hub's pairing.
- Inbound auto-register fully works — same path, same scope, same mints as the def-watch triggers; no separate scope is needed.
- Best-effort throughout: every mint/POST failure is caught + logged, never thrown.

## Gates

- `bun run typecheck` — clean
- `bun test ./src` — **1200 pass / 0 fail** (15 new in `src/def-vault-triggers.test.ts`)
- `bunx biome check .` — exit 0 (2 pre-existing `any` warnings in `src/transports/vault.test.ts`, untouched; none in this PR's files)
- SPA untouched (no web/ui vitest/build needed).

Version: `0.2.3-rc.7` → `0.2.3-rc.8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)