### PR TITLE
UI label + step-up follow-ups (#150, #154)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,7 +196,17 @@ so the SPA prompts (first-time setup vs PIN entry) instead of re-authenticating.
 the `X-Step-Up-Token` header (or `?step_up=` for the terminal WS, which can't set a header). The
 SPA holds it in memory and attaches it transparently in `lib/api.ts:authedFetch` (re-prompt on
 expiry); the PIN is never logged or returned. The step-up token NEVER widens scope — it's a
-second factor on top of `agent:admin`, never a substitute.
+second factor on top of `agent:admin`, never a substitute. (The PIN is 4–12 digits —
+convenience-grade, bounded by the 5-wrong/5-min lockout + the `agent:admin` barrier — by design.)
+
+> **Upgrade note (the step-up build).** Upgrading to the build that introduced step-up
+> (agent#80) makes the credential / terminal / full-filesystem-spawn actions require a step-up
+> PIN. On a fresh upgrade NO PIN is set yet, so the FIRST time you trigger one of those actions
+> the daemon returns `403 step_up_required` with `reason: "setup"` and the admin UI prompts you
+> to set a PIN (then immediately proceeds). If you script those endpoints directly (no UI),
+> you'll get the same `403 step_up_required (setup)` until you set a PIN via the admin UI (or
+> `POST /api/step-up/pin { newPin }`) and send the minted token as `X-Step-Up-Token`. Ordinary
+> sandboxed spawns + every read stay frictionless — only the three dangerous actions are gated.
 
 ## Vault integration (Stage 2) — channels backed by `#agent/message` notes
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/agent",
-  "version": "0.2.3-rc.8",
+  "version": "0.2.3-rc.9",
   "description": "Vault-native agents for Claude Code — a #agent/definition note + an inbound message becomes a sandboxed claude turn; the reply is written back as a note. Messaging gateway on :1941.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/src/daemon-step-up.test.ts
+++ b/src/daemon-step-up.test.ts
@@ -531,3 +531,53 @@ describe("B — filesystem:full spawn gating (sandboxed spawn NOT gated)", () =>
     }
   });
 });
+
+// ===========================================================================
+// C. Deliberate NON-gates (#154) — these admin POSTs are intentionally NOT
+// step-up-gated. Pin the exclusions so a future reader doesn't "fix" a non-gap:
+//   - POST /api/agent-vaults — mints a VAULT-scoped token (lower blast radius).
+//   - POST /api/agent-defs   — authoring a #agent/definition note already requires
+//     a scope-gated vault:write; the filesystem:full SPAWN path is gated, not this.
+// A PIN is configured (so a gate, if wrongly present, would 403 reason:"token"
+// rather than "setup"); no step-up token is sent. The handlers may fail downstream
+// for other reasons (e.g. no def-vaults), but MUST NOT 403 step_up_required.
+// ===========================================================================
+describe("C — deliberate non-gates (#154)", () => {
+  test("POST /api/agent-vaults is NOT step-up-gated (vault-scoped token, lower blast radius)", async () => {
+    const { srv, base } = buildServer();
+    try {
+      await setupAndExchange(base); // a PIN exists, but we deliberately send no step-up token
+      const res = await fetch(`${base}/api/agent-vaults`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ vault: "default" }),
+      });
+      expect(res.status).not.toBe(403);
+      if (res.status === 403) {
+        expect((await res.json()).error).not.toBe("step_up_required");
+      }
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("POST /api/agent-defs is NOT step-up-gated (authoring already requires vault:write)", async () => {
+    const { srv, base } = buildServer();
+    try {
+      await setupAndExchange(base); // a PIN exists, but we deliberately send no step-up token
+      const res = await fetch(`${base}/api/agent-defs`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...adminAuth },
+        body: JSON.stringify({ vault: "default", name: "x", backend: "programmatic", systemPrompt: "" }),
+      });
+      // With no def-vaults configured the handler 400s — what matters is it never
+      // 403s step_up_required (the authoring path is intentionally not gated).
+      expect(res.status).not.toBe(403);
+      if (res.status === 403) {
+        expect((await res.json()).error).not.toBe("step_up_required");
+      }
+    } finally {
+      srv.stop(true);
+    }
+  });
+});

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -2353,6 +2353,14 @@ export function createFetchHandler(
     // ---------------------------------------------------------------------
     if (url.pathname === "/api/agent-defs" && (req.method === "GET" || req.method === "POST")) {
       // GET is READ-scoped (a listing, no secrets); POST is admin (it mints/writes).
+      //
+      // NOTE (step-up, agent#80/#154): POST is intentionally NOT step-up-gated, even
+      // though a `#agent/definition` note can carry `filesystem: "full"`. Authoring a
+      // def already requires the scope-gated `vault:write` (the daemon writes the note
+      // with a vault token), so a step-up challenge here would gate a capability the
+      // caller already had to hold a write credential to reach — mirrors the carve-out
+      // comment on the vault-native parse path in agent-defs.ts. The `filesystem:full`
+      // SPAWN path (`POST /api/agents`) IS step-up-gated; this AUTHORING path is not.
       const scope = req.method === "GET" ? SCOPE_READ : SCOPE_ADMIN;
       const denied = await requireScope(req, url, scope);
       if (denied) return denied;
@@ -2506,6 +2514,12 @@ export function createFetchHandler(
       // GET is READ-scoped to mirror GET /api/agent-defs — the listing is non-sensitive
       // ({vault,url,tokenPresent}); `tokenPresent` is a boolean, NEVER the token value.
       // POST is admin (it mints a token + writes config).
+      //
+      // NOTE (step-up, agent#80/#154): POST is intentionally NOT step-up-gated. It mints
+      // a VAULT-SCOPED token (`vault:<name>:write`) — a lower blast radius than the
+      // Claude OAuth credential / terminal / full-fs spawn the step-up PIN guards (those
+      // can exfiltrate every token or open a raw host shell). A def-vault token only
+      // reaches the named vault's notes, so `agent:admin` alone is the right bar here.
       const scope = req.method === "GET" ? SCOPE_READ : SCOPE_ADMIN;
       const denied = await requireScope(req, url, scope);
       if (denied) return denied;

--- a/web/ui/src/StepUpModal.test.tsx
+++ b/web/ui/src/StepUpModal.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * StepUpModal tests (agent#80, #154).
+ *
+ * Focus: the modal's `friendly()` error mapping — specifically the 429 (rate-limit
+ * lockout) path. The daemon 429s a PIN exchange after 5 wrong attempts in 5 min
+ * (`stepUpLimiter`); the modal must surface a friendly lockout message, NOT the raw
+ * "PIN exchange failed: 429" string. We drive the real provider → prompt → submit
+ * flow with `exchangePin` mocked to throw `HttpError(429)`.
+ */
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as stepUp from "./lib/step-up.ts";
+import { HttpError } from "./lib/api.ts";
+
+// Keep the REAL registration bridge (registerStepUpPrompt / requestStepUpToken) so the
+// provider wires up its prompt handler; override only the network calls.
+vi.mock("./lib/step-up.ts", async (orig) => {
+  const actual = (await orig()) as typeof stepUp;
+  return {
+    ...actual,
+    exchangePin: vi.fn(),
+    setPin: vi.fn(),
+    getStepUpStatus: vi.fn(async () => ({ configured: true })),
+  };
+});
+
+import { StepUpProvider } from "./StepUpModal.tsx";
+import { requestStepUpToken, registerStepUpPrompt } from "./lib/step-up.ts";
+
+const exchangePin = vi.mocked(stepUp.exchangePin);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  stepUp._resetStepUpForTest();
+});
+
+afterEach(() => {
+  registerStepUpPrompt(null);
+});
+
+describe("StepUpModal — friendly() error mapping", () => {
+  it("shows the lockout message on a 429 (rate-limit) from the PIN exchange (#154)", async () => {
+    exchangePin.mockRejectedValue(new HttpError(429, "rate_limited"));
+    render(
+      <StepUpProvider>
+        <div />
+      </StepUpProvider>,
+    );
+
+    // The provider registers a prompt handler on mount; driving a "token" reason
+    // opens the PIN-prompt modal (the same path api.ts:authedFetch takes on a
+    // 403 step_up_required).
+    let pending: Promise<string | null>;
+    act(() => {
+      pending = requestStepUpToken("token");
+    });
+
+    // Enter a PIN and submit; the mocked exchange rejects 429.
+    const input = await screen.findByLabelText("PIN");
+    await userEvent.type(input, "0000");
+    await userEvent.click(screen.getByRole("button", { name: "Confirm" }));
+
+    // friendly(HttpError(429)) → the lockout message, NOT the raw error.
+    expect(
+      await screen.findByText("Too many attempts — wait a minute and try again."),
+    ).toBeInTheDocument();
+    expect(exchangePin).toHaveBeenCalledWith("0000");
+    // The modal stays open (the action did not resolve with a token).
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    // A 401 maps to the "Incorrect PIN." message (regression guard alongside 429).
+    exchangePin.mockRejectedValueOnce(new HttpError(401, "invalid_pin"));
+    await userEvent.click(screen.getByRole("button", { name: "Confirm" }));
+    expect(await screen.findByText("Incorrect PIN.")).toBeInTheDocument();
+
+    // Cancel resolves the pending request with null (no leaked promise).
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await waitFor(() => expect(pending).resolves.toBeNull());
+  });
+});

--- a/web/ui/src/lib/api.test.ts
+++ b/web/ui/src/lib/api.test.ts
@@ -26,6 +26,7 @@ import {
   listChannels,
   listMessages,
   messageStreamUrl,
+  normalizeBackend,
   removeAgentSecret,
   removeAgentVault,
   sendMessage,
@@ -58,6 +59,18 @@ function fetchFn(impl: (input: string, init?: RequestInit) => Promise<Response>)
   return vi.fn<(input: string, init?: RequestInit) => Promise<Response>>(impl);
 }
 
+describe("normalizeBackend (#150 — daemon wire value → SPA display)", () => {
+  it("maps the daemon's `attached` to the display `channel`", () => {
+    expect(normalizeBackend("attached")).toBe("channel");
+  });
+  it("passes `channel` through (older daemon / def endpoints)", () => {
+    expect(normalizeBackend("channel")).toBe("channel");
+  });
+  it("maps `programmatic` to `programmatic`", () => {
+    expect(normalizeBackend("programmatic")).toBe("programmatic");
+  });
+});
+
 describe("apiBase", () => {
   it("falls back to /agent/api when the mount isn't an /app sub-path (dev origin root)", () => {
     // In vitest BASE_URL is "/", so the /app match fails → canonical fallback.
@@ -78,6 +91,28 @@ describe("listAgents / listAgentDefs / listAgentVaults", () => {
     const headers = new Headers(init?.headers);
     expect(headers.get("authorization")).toBe("Bearer jwt-tok");
     expect(headers.get("accept")).toBe("application/json");
+  });
+
+  it("normalizes the daemon's `attached` backend → the SPA's `channel` display (#150)", async () => {
+    // The daemon emits `backend: "attached"` for a channel agent (listAttachedAgents
+    // in src/daemon.ts). The SPA must normalize it to `"channel"` at ingestion so the
+    // amber `.pill.backend-channel` styling + the "channel" label both apply — without
+    // it the row fell through to the bare unstyled `.pill` and read "attached".
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse(200, {
+          agents: [
+            { name: "eng", session: "eng-agent", workspace: "/w", hasWorkspace: true, backend: "attached", channel: "eng" },
+            { name: "auto", session: "auto-agent", workspace: "/w", hasWorkspace: true, backend: "programmatic" },
+          ],
+        }),
+      ),
+    );
+    const res = await listAgents();
+    expect(res.agents[0]!.backend).toBe("channel");
+    // The programmatic row is untouched.
+    expect(res.agents[1]!.backend).toBe("programmatic");
   });
 
   it("listAgentDefs hits /agent/api/agent-defs and parses defs", async () => {

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -205,12 +205,34 @@ function deleteJsonWithBody<T>(suffix: string, body: unknown): Promise<T> {
 // ---------------------------------------------------------------------------
 
 /**
- * The backend that drives an agent. The primary axis of the v2 view. The
- * `interactive` (tmux) backend was retired (#114) and can never be returned by
- * the daemon, so it's gone from the display type too (#115). `"channel"` is the
- * SPA's label for the daemon's `attached` backend.
+ * The backend that drives an agent — the SPA's DISPLAY vocabulary. The primary
+ * axis of the v2 view. The `interactive` (tmux) backend was retired (#114) and can
+ * never be returned by the daemon, so it's gone from the display type too (#115).
+ * `"channel"` is the SPA's label for the daemon's `attached` backend.
  */
 export type AgentBackend = "programmatic" | "channel";
+
+/**
+ * The backend value the DAEMON puts on the wire. The daemon's canonical name for
+ * the channel-backend agent is `"attached"` (`AgentBackendKind` in
+ * `src/sandbox/types.ts`); the SPA displays it as `"channel"`. This wire type is
+ * the input to the one normalization point (`normalizeBackend`) — the rest of the
+ * SPA only ever sees the display `AgentBackend`. (#150)
+ */
+export type WireAgentBackend = "programmatic" | "channel" | "attached";
+
+/**
+ * Map the daemon's wire backend to the SPA's display vocabulary, in ONE place
+ * (the cross-repo derived value's canonical INPUT is the daemon's `backend`; the
+ * SPA derives its display from it here — #150). The daemon emits `"attached"` for
+ * a channel-backend agent; we display it as `"channel"` so the pill class
+ * (`backendPillClass` branches on `"channel"`) AND the pill text both line up
+ * with the create flow's "Channel" label. `"channel"` is tolerated too (an older
+ * daemon / the def endpoints already emit it).
+ */
+export function normalizeBackend(backend: WireAgentBackend | string): AgentBackend {
+  return backend === "attached" || backend === "channel" ? "channel" : "programmatic";
+}
 
 /** Execution-lifecycle mode — the top-level branch. Rides in `metadata.mode`. */
 export type AgentMode = "single-threaded" | "multi-threaded";
@@ -310,9 +332,21 @@ export interface AgentVaultsResponse {
   vaults: AgentVaultRow[];
 }
 
-/** List every agent across all backends. */
-export function listAgents(): Promise<AgentsResponse> {
-  return getJson<AgentsResponse>("/agents");
+/**
+ * List every agent across all backends. The daemon emits the canonical wire
+ * backend (`"attached"` for a channel agent — `listAttachedAgents` in
+ * `src/daemon.ts`); we NORMALIZE it to the SPA's display vocabulary here, the
+ * single ingestion point, so the pill class + label are consistent everywhere
+ * downstream (#150). Without this an `attached` row rendered with the bare,
+ * unstyled `.pill` fallback and the text "attached" instead of "channel".
+ */
+export async function listAgents(): Promise<AgentsResponse> {
+  const res = await getJson<{ agents: (Omit<AgentRow, "backend"> & { backend: string })[] }>(
+    "/agents",
+  );
+  return {
+    agents: res.agents.map((a) => ({ ...a, backend: normalizeBackend(a.backend) })),
+  };
 }
 
 /** List the vault-native agent definitions. */


### PR DESCRIPTION
Bundles two clean follow-up issues. `0.2.3-rc.8` → `0.2.3-rc.9`.

## #150 — normalize the daemon's `attached` backend label in the SPA

The daemon emits `backend: "attached"` for a channel-backend agent (`listAttachedAgents`, `src/daemon.ts`), but the SPA's `AgentBackend` display type only knew `"programmatic" | "channel"` and `backendPillClass` only branched on `"channel"`. So a real live channel agent rendered with the bare unstyled `.pill` fallback and the pill text read **"attached"** instead of **"channel"** (the create flow's label).

**Fix:** normalize at the single ingestion point. `listAgents()` now maps the daemon's wire backend → the SPA's display vocabulary via a new `normalizeBackend` (`"attached"`/`"channel"` → `"channel"`; `"programmatic"` untouched). The canonical INPUT is the daemon's `backend`; the SPA derives its display from it in **one place**, fixing BOTH the pill class and the text label consistently. `interactive` is not reintroduced (removed in #115).

- `web/ui/src/lib/api.ts` — `normalizeBackend` + `WireAgentBackend`; `listAgents()` normalizes on parse.
- `web/ui/src/lib/api.test.ts` — an `attached`-backend row resolves to the `channel` display (+ direct `normalizeBackend` unit cases).

## #154 — step-up follow-ups (docs + tests)

From the #80 (PR #153) review:

1. **Document the deliberate non-gates in `daemon.ts`** (mirroring the `agent-defs.ts` carve-out comment): `POST /api/agent-vaults` (mints a vault-scoped token — lower blast radius) and `POST /api/agent-defs` (a `#agent/definition` note can carry `filesystem:full`, but authoring already requires a scope-gated `vault:write`) are intentionally NOT step-up-gated. Two `daemon-step-up.test.ts` cases (new section C) pin the exclusions — neither POST ever returns `403 step_up_required`.
2. **StepUpModal 429 test** — `web/ui/src/StepUpModal.test.tsx` drives the real provider → prompt → submit flow with `exchangePin` throwing `HttpError(429)`; asserts `friendly()` surfaces the lockout message ("Too many attempts…"), plus a `401`→"Incorrect PIN." guard.
3. **Upgrade note** — CLAUDE.md (Auth section): upgrading to the step-up build makes credential/terminal/full-fs-spawn actions require a PIN; operators hit `403 step_up_required (setup)` until they set one via the admin UI. Also documents the 4–12 digit PIN bound.

## Gates
- `bun run typecheck` — clean (`tsc --noEmit`).
- `bun test ./src` — **1202 pass / 0 fail** (incl. the 2 new daemon-step-up non-gate tests).
- `web/ui` `bunx vitest run` — **160 pass / 0 fail** (incl. the new api `attached`-normalize + StepUpModal 429 tests).
- `web/ui` `bun run build` — ok (tsc -b + vite build + verify-base).
- `bunx biome check .` — clean on touched files (2 pre-existing `noExplicitAny` warnings in `src/transports/vault.test.ts`, untouched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)