### PR TITLE
fix(agent): callback source_thread → a resolvable thread-note id for both modes (#124)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 *.log
+.claude/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/agent",
-  "version": "0.2.3-rc.9",
+  "version": "0.2.3-rc.10",
   "description": "Vault-native agents for Claude Code — a #agent/definition note + an inbound message becomes a sandboxed claude turn; the reply is written back as a note. Messaging gateway on :1941.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/src/backends/registry.test.ts
+++ b/src/backends/registry.test.ts
@@ -152,6 +152,50 @@ function threadRecorder(): {
   };
 }
 
+/**
+ * A recorder WriteThread that RETURNS the written note id — FAITHFUL to the
+ * VaultTransport's path-as-id logic (agent#124), so a test can assert the callback's
+ * `source_thread` equals what `query-notes { id }` would resolve:
+ *  - single-threaded → the DETERMINISTIC id `Threads/<safeChannel>/<safeName>` (NOT the
+ *    per-turn correlation id — the pre-#124 bug).
+ *  - multi-threaded → the per-fire id `Threads/<safeChannel>/<threadId>`.
+ * The sanitization mirrors {@link VaultTransport.singleThreadedPath}. Captures every write
+ * in order; `idFor(thread)` exposes the same derivation so a test can compute the expected id.
+ */
+function threadRecorderWithIds(): {
+  threads: ThreadNote[];
+  ends: () => ThreadNote[];
+  idFor: (thread: ThreadNote) => string;
+  fn: WriteThread;
+} {
+  const slug = (s: string) => s.replace(/[^a-zA-Z0-9_-]/g, "-");
+  const idFor = (thread: ThreadNote): string => {
+    const safeChannel = slug(thread.channel);
+    if (thread.mode === "single-threaded") {
+      return `Threads/${safeChannel}/${slug(thread.name ?? thread.channel)}`;
+    }
+    return `Threads/${safeChannel}/${thread.threadId ?? "no-id"}`;
+  };
+  const threads: ThreadNote[] = [];
+  const fn: WriteThread = async (thread) => {
+    threads.push(thread);
+    return { id: idFor(thread) };
+  };
+  return {
+    threads,
+    ends: () => threads.filter((t) => t.phase !== "start"),
+    idFor,
+    fn,
+  };
+}
+
+/** A single-threaded spec (the DEFAULT mode — one upserting thread note per channel). */
+const specSingleThreaded = (name: string, channel = name): AgentSpec => ({
+  name,
+  channels: [channel],
+  mode: "single-threaded",
+});
+
 /** A multi-threaded spec (materializes one `#agent/thread` note per fire). */
 const specMultiThreaded = (name: string, channel = name, definition?: string): AgentSpec => ({
   name,
@@ -1490,5 +1534,150 @@ describe("ProgrammaticAgentRegistry — agent-to-agent callbacks (reply_to)", ()
     expect(out.calls.map((c) => c.reply)).toEqual(
       Array.from({ length: N }, (_, i) => `ack:callback-${i}`),
     );
+  });
+
+  // ── source_thread is a RESOLVABLE thread-note id for BOTH modes (agent#124) ──────────────
+  // The callback's `source_thread` must be the actual written thread-note id (what
+  // `query-notes { id }` resolves), not the per-turn correlation UUID. The faithful
+  // `threadRecorderWithIds` returns the SAME id the VaultTransport would (single-threaded:
+  // the deterministic name path; multi-threaded: the per-fire uuid path), so these tests pin
+  // the end-to-end contract: the id the seam wrote is the id the orchestrator gets back.
+
+  test("source_thread = the WRITTEN single-threaded thread-note id (deterministic path, NOT the per-turn id)", async () => {
+    const backend = new FakeBackend();
+    backend.resultFor = (m) => ({ ok: true, reply: "done:" + m });
+    const out = recorderWithId("reply-note-1");
+    const threads = threadRecorderWithIds();
+    const cb = callbackRecorder();
+    const reg = new ProgrammaticAgentRegistry({
+      backend,
+      writeOutbound: out.fn,
+      writeThread: threads.fn,
+      writeCallback: cb.fn,
+    });
+    // DEFAULT mode is single-threaded; be explicit here.
+    await reg.register(specSingleThreaded("worker"));
+
+    reg.enqueue("worker", { content: "sub-task", replyTo: "orchestrator" });
+    await until(() => cb.calls.length === 1);
+
+    const endRecord = threads.ends().at(-1)!;
+    const expectedId = threads.idFor(endRecord); // "Threads/worker/worker" (det. name path).
+    const { meta } = cb.calls[0]!;
+    expect(meta.source_thread).toBe(expectedId); // RESOLVABLE — the written note id.
+    expect(meta.source_thread).toBe("Threads/worker/worker"); // the deterministic leaf,
+    // …and CRUCIALLY not a bare per-turn correlation UUID (the pre-#124 bug).
+    expect(meta.source_thread).not.toMatch(/^[0-9a-f-]{36}$/);
+    // The single-threaded + reply common case still also carries source_message.
+    expect(meta.source_message).toBe("reply-note-1");
+  });
+
+  test("source_thread = the WRITTEN multi-threaded per-fire thread-note id", async () => {
+    const backend = new FakeBackend();
+    backend.resultFor = (m) => ({ ok: true, reply: "done:" + m });
+    const out = recorderWithId("reply-note-2");
+    const threads = threadRecorderWithIds();
+    const cb = callbackRecorder();
+    const reg = new ProgrammaticAgentRegistry({
+      backend,
+      writeOutbound: out.fn,
+      writeThread: threads.fn,
+      writeCallback: cb.fn,
+    });
+    await reg.register(specMultiThreaded("worker"));
+
+    reg.enqueue("worker", { content: "sub-task", replyTo: "orchestrator" });
+    await until(() => cb.calls.length === 1);
+
+    const endRecord = threads.ends().at(-1)!;
+    const expectedId = threads.idFor(endRecord); // "Threads/worker/<per-fire uuid>".
+    const { meta } = cb.calls[0]!;
+    expect(meta.source_thread).toBe(expectedId); // RESOLVABLE — the per-fire note id.
+    expect(meta.source_thread).toMatch(/^Threads\/worker\/[0-9a-f-]{36}$/);
+    expect(meta.source_message).toBe("reply-note-2");
+  });
+
+  test("single-threaded ERROR turn: source_thread is STILL the resolvable thread-note id (no source_message)", async () => {
+    // The narrow edge the issue targets: a single-threaded recipient whose turn produced NO
+    // reply (an error). `source_message` is absent — pre-#124 the orchestrator had only an
+    // unresolvable per-turn UUID. Now `source_thread` is the written (error) thread note id.
+    const backend = new FakeBackend();
+    backend.resultFor = () => ({ ok: false, error: "mint refused" });
+    const out = recorderWithId();
+    const threads = threadRecorderWithIds();
+    const cb = callbackRecorder();
+    const reg = new ProgrammaticAgentRegistry({
+      backend,
+      writeOutbound: out.fn,
+      writeThread: threads.fn,
+      writeCallback: cb.fn,
+    });
+    await reg.register(specSingleThreaded("worker"));
+
+    reg.enqueue("worker", { content: "do it", replyTo: "orchestrator" });
+    await until(() => cb.calls.length === 1);
+
+    const endRecord = threads.ends().at(-1)!;
+    expect(endRecord.status).toBe("error"); // the recorded turn failed,
+    const { meta } = cb.calls[0]!;
+    expect(meta.status).toBe("error");
+    expect(meta.source_message).toBeUndefined(); // no delivered reply note on an error turn,
+    // …yet source_thread is the RESOLVABLE written thread-note id (the agent#124 fix).
+    expect(meta.source_thread).toBe(threads.idFor(endRecord));
+    expect(meta.source_thread).toBe("Threads/worker/worker");
+    expect(meta.source_thread).not.toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  test("single-threaded EMPTY/tool-only turn (no reply): source_thread is the resolvable thread-note id, no source_message", async () => {
+    // A success turn that produced NO text (tool-only work) → no outbound note → no
+    // source_message. The callback still fires (status:ok) and carries the resolvable
+    // source_thread so the orchestrator can pull the recipient's thread.
+    const backend = new FakeBackend();
+    backend.resultFor = () => ({ ok: true, reply: "" }); // empty reply → no outbound note.
+    const out = recorderWithId();
+    const threads = threadRecorderWithIds();
+    const cb = callbackRecorder();
+    const reg = new ProgrammaticAgentRegistry({
+      backend,
+      writeOutbound: out.fn,
+      writeThread: threads.fn,
+      writeCallback: cb.fn,
+    });
+    await reg.register(specSingleThreaded("worker"));
+
+    reg.enqueue("worker", { content: "tool-only", replyTo: "orchestrator" });
+    await until(() => cb.calls.length === 1);
+
+    expect(out.calls).toHaveLength(0); // no reply text → no outbound note written.
+    const endRecord = threads.ends().at(-1)!;
+    const { meta } = cb.calls[0]!;
+    expect(meta.status).toBe("ok");
+    expect(meta.source_message).toBeUndefined(); // no reply note to point at,
+    expect(meta.source_thread).toBe(threads.idFor(endRecord)); // but the thread is resolvable.
+    expect(meta.source_thread).toBe("Threads/worker/worker");
+  });
+
+  test("falls back to the per-turn id when the WriteThread seam surfaces no id (e.g. no durable store)", async () => {
+    // Defensive: a transport with no durable store (telegram) returns void from the seam.
+    // The callback still fires with a source_thread — the per-turn id (a stable provenance
+    // token, just not a pullable note). Never undefined.
+    const backend = new FakeBackend();
+    backend.resultFor = (m) => ({ ok: true, reply: "done:" + m });
+    const out = recorderWithId();
+    const voidThread: WriteThread = async () => {}; // returns void — no id.
+    const cb = callbackRecorder();
+    const reg = new ProgrammaticAgentRegistry({
+      backend,
+      writeOutbound: out.fn,
+      writeThread: voidThread,
+      writeCallback: cb.fn,
+    });
+    await reg.register(specSingleThreaded("worker"));
+
+    reg.enqueue("worker", { content: "x", replyTo: "orchestrator" });
+    await until(() => cb.calls.length === 1);
+    const { meta } = cb.calls[0]!;
+    // A bare per-turn UUID fallback — present (never undefined), just not a thread-note path.
+    expect(meta.source_thread).toMatch(/^[0-9a-f-]{36}$/);
   });
 });

--- a/src/backends/registry.test.ts
+++ b/src/backends/registry.test.ts
@@ -131,6 +131,11 @@ function recorder(): { calls: { channel: string; reply: string; inReplyTo?: stri
  * holds ALL writes in order; `ends()` / `starts()` filter by phase so a test can assert
  * the FINAL records (the pre-thread-as-container assertions) without counting the
  * working-ensure, or assert the working-ensure specifically.
+ *
+ * This recorder returns VOID (no id) — so any callback test using it exercises the
+ * per-turn-id FALLBACK for `source_thread`. The id-pinning tests (agent#124) use
+ * {@link threadRecorderWithIds} instead. (Pre-existing callback tests don't assert on
+ * `source_thread`, so the void return doesn't affect them.)
  */
 function threadRecorder(): {
   threads: ThreadNote[];
@@ -1594,6 +1599,9 @@ describe("ProgrammaticAgentRegistry — agent-to-agent callbacks (reply_to)", ()
     const { meta } = cb.calls[0]!;
     expect(meta.source_thread).toBe(expectedId); // RESOLVABLE — the per-fire note id.
     expect(meta.source_thread).toMatch(/^Threads\/worker\/[0-9a-f-]{36}$/);
+    // Concrete cross-check (not just the regex): the per-fire leaf IS the recorded threadId,
+    // so a formula bug in idFor's multi-threaded branch can't be masked.
+    expect(meta.source_thread).toBe(`Threads/worker/${endRecord.threadId}`);
     expect(meta.source_message).toBe("reply-note-2");
   });
 
@@ -1654,6 +1662,42 @@ describe("ProgrammaticAgentRegistry — agent-to-agent callbacks (reply_to)", ()
     expect(meta.status).toBe("ok");
     expect(meta.source_message).toBeUndefined(); // no reply note to point at,
     expect(meta.source_thread).toBe(threads.idFor(endRecord)); // but the thread is resolvable.
+    expect(meta.source_thread).toBe("Threads/worker/worker");
+  });
+
+  test("single-threaded OUTBOUND-FAILURE re-record: source_thread is the re-recorded (sameTurn) thread-note id", async () => {
+    // The reply was produced but the outbound write failed after retries → the drain
+    // re-records the SAME turn as status:error (sameTurn upsert) and calls back error. The
+    // callback's source_thread must be the (resolvable) re-recorded thread-note id — pinning
+    // the `?? threadNoteId` precedence leg on the outbound-failure terminal path.
+    const backend = new FakeBackend();
+    backend.resultFor = (m) => ({ ok: true, reply: "done:" + m });
+    const threads = threadRecorderWithIds();
+    // Always-fail outbound (a permanent 4xx → no retry); the reply was produced but lost.
+    const alwaysFail: WriteOutbound = async () => {
+      throw new Error("vault transport: write reply failed (400) bad request");
+    };
+    const cb = callbackRecorder();
+    const reg = new ProgrammaticAgentRegistry({
+      backend,
+      writeOutbound: alwaysFail,
+      writeThread: threads.fn,
+      writeCallback: cb.fn,
+      outboundRetryBaseMs: 1,
+    });
+    await reg.register(specSingleThreaded("worker"));
+
+    reg.enqueue("worker", { content: "x", replyTo: "orchestrator" });
+    await until(() => cb.calls.length === 1);
+
+    const endRecord = threads.ends().at(-1)!; // the sameTurn error re-record.
+    expect(endRecord.status).toBe("error");
+    expect(endRecord.sameTurn).toBe(true);
+    const { meta } = cb.calls[0]!;
+    expect(meta.status).toBe("error");
+    expect(meta.source_message).toBeUndefined(); // the outbound note never landed,
+    // …but source_thread is the resolvable re-recorded thread-note id (agent#124).
+    expect(meta.source_thread).toBe(threads.idFor(endRecord));
     expect(meta.source_thread).toBe("Threads/worker/worker");
   });
 

--- a/src/backends/registry.ts
+++ b/src/backends/registry.ts
@@ -174,8 +174,16 @@ export interface ThreadNote {
  * per channel, multi-threaded writes one per fire. A write failure is the implementation's
  * to surface (the registry logs whatever it throws); it never re-runs the turn. Optional on
  * the registry — when unwired (no vault-backed channel), a turn still runs, just no note.
+ *
+ * RETURNS the WRITTEN thread-note's id (`{ id }`) so the drain can use it as a RESOLVABLE
+ * `source_thread` on the agent-to-agent callback (agent#124) — for BOTH modes, this is the
+ * actual note an orchestrator can pull with `query-notes { id }` (single-threaded: the
+ * deterministic `Threads/<safeChannel>/<safeName>` note; multi-threaded: the per-fire
+ * `Threads/<safeChannel>/<uuid>` note). `void` is in the union (back-compat) — a transport
+ * with no durable store, or one that can't surface an id, returns it and the drain falls
+ * back to the per-turn id.
  */
-export type WriteThread = (thread: ThreadNote) => Promise<void>;
+export type WriteThread = (thread: ThreadNote) => Promise<{ id?: string } | void>;
 
 /**
  * A callback delivered back to a SENDER's channel when a turn it requested finishes —
@@ -216,15 +224,16 @@ export interface CallbackMeta {
   /** The channel/def whose turn just finished (the recipient) — provenance for the sender. */
   source_channel: string;
   /**
-   * The per-turn thread id the drain minted. RESOLVABILITY DIFFERS BY MODE:
-   *  - multi-threaded: this IS the per-fire note's leaf — the orchestrator can pull the
-   *    thread note at `Threads/<channel>/<source_thread>`.
-   *  - single-threaded: this is a per-turn CORRELATION id, NOT the note leaf (the
-   *    single-threaded note lives at the deterministic `Threads/<channel>/<name>`), so it
-   *    is NOT directly resolvable. Use `source_message` as the reliable pull-link for a
-   *    single-threaded recipient. Making this a resolvable thread id for both modes
-   *    (widen the writeThread seam to return the written note id) is tracked as a
-   *    follow-up (parachute-agent#124).
+   * The WRITTEN thread-note id — RESOLVABLE for BOTH modes (agent#124): an orchestrator can
+   * always pull the recipient's full thread record with `query-notes { id: source_thread }`,
+   * even on an error/empty/tool-only turn (the thread note is written BEFORE the outbound
+   * reply, so its id exists when there's no `source_message`).
+   *  - multi-threaded: the per-fire note id (`Threads/<safeChannel>/<uuid>`).
+   *  - single-threaded: the deterministic note id (`Threads/<safeChannel>/<safeName>`) — NOT
+   *    the per-turn correlation id (the pre-#124 bug: that correlation id wasn't the note leaf
+   *    for single-threaded, so it couldn't be resolved).
+   * The drain sources this from {@link WriteThread}'s returned id; if the seam can't surface
+   * one (no durable store) it falls back to the per-turn id (still a stable provenance token).
    */
   source_thread: string;
   /**
@@ -835,7 +844,7 @@ export class ProgrammaticAgentRegistry {
         // thread note captures the turn outcome, so a failed turn is still a queryable
         // `status:error` (single-threaded upserts the rolling thread; multi-threaded writes
         // a per-fire note).
-        await this.recordThread(handle, msg, "error", reason, startedAt, undefined, {
+        const threadNoteId = await this.recordThread(handle, msg, "error", reason, startedAt, undefined, {
           threadId: turnThreadId,
           phase: "end",
           // No `result` (the backend threw) → NO session to persist. We never write a
@@ -848,8 +857,10 @@ export class ProgrammaticAgentRegistry {
         // no-reply) — best-effort.
         await this.postFailureNote(channel, msg.inReplyTo, turnThreadId, reason);
         // CALLBACK on the failure too — an orchestrator MUST learn its sub-task failed, not
-        // hang waiting forever. No outbound note was produced, so no `source_message`.
-        await this.maybeDeliverCallback(handle, msg, turnThreadId, "error");
+        // hang waiting forever. No outbound note was produced, so no `source_message`; the
+        // RESOLVABLE thread-note id (written above) is `source_thread` so the orchestrator can
+        // still pull the recipient's thread on a no-reply turn (agent#124).
+        await this.maybeDeliverCallback(handle, msg, turnThreadId, "error", undefined, threadNoteId);
         continue;
       }
 
@@ -863,7 +874,7 @@ export class ProgrammaticAgentRegistry {
         // BOTH modes record the failed turn (status:error) on the thread note so a failure
         // always leaves a queryable trace (single-threaded upserts the rolling thread,
         // marking it errored; multi-threaded writes a per-fire status:error note).
-        await this.recordThread(handle, msg, "error", result.error, startedAt, undefined, {
+        const threadNoteId = await this.recordThread(handle, msg, "error", result.error, startedAt, undefined, {
           threadId: turnThreadId,
           phase: "end",
           // Persist ONLY the session claude ECHOED (FIX 2). A turn can fail AFTER
@@ -878,8 +889,9 @@ export class ProgrammaticAgentRegistry {
         // no-reply) — best-effort.
         await this.postFailureNote(channel, msg.inReplyTo, turnThreadId, result.error);
         // CALLBACK on the failure-as-value too (status:error) — the orchestrator learns the
-        // sub-task failed and can react. No delivered reply, so no `source_message`.
-        await this.maybeDeliverCallback(handle, msg, turnThreadId, "error");
+        // sub-task failed and can react. No delivered reply, so no `source_message`; the
+        // RESOLVABLE thread-note id (written above) is `source_thread` (agent#124).
+        await this.maybeDeliverCallback(handle, msg, turnThreadId, "error", undefined, threadNoteId);
         continue;
       }
 
@@ -891,7 +903,11 @@ export class ProgrammaticAgentRegistry {
       // multi-threaded writes the per-fire note. Best-effort: a thread-note failure is
       // logged + the turn still resolves (we never re-run a `claude -p` turn — that would
       // burn quota for a duplicate).
-      await this.recordThread(handle, msg, "ok", result.reply ?? "", startedAt, result.usage, {
+      // Capture the WRITTEN thread-note id — the RESOLVABLE `source_thread` for the callback
+      // (agent#124). The same note id is reused for the outbound-failure re-record below
+      // (sameTurn → same note), so a callback on either terminal path points at a pullable
+      // thread record.
+      let threadNoteId = await this.recordThread(handle, msg, "ok", result.reply ?? "", startedAt, result.usage, {
         threadId: turnThreadId,
         phase: "end",
         // Persist the session claude ECHOED (FIX 2) so the next turn `--resume`s this
@@ -938,7 +954,9 @@ export class ProgrammaticAgentRegistry {
           // `sameTurn` so this updates the note the `ok` record above just wrote (one
           // note, no turn_count double-count) rather than minting a duplicate / advancing
           // the count (the FIX-1 re-record bug the reviewer caught).
-          await this.recordThread(
+          // Re-record returns the SAME note's id (sameTurn upsert / same per-fire note) — use
+          // it as the callback `source_thread` (agent#124), falling back to the ok-record id.
+          threadNoteId = (await this.recordThread(
             handle,
             msg,
             "error",
@@ -955,7 +973,7 @@ export class ProgrammaticAgentRegistry {
               // write failed. Only claude's echoed id (FIX 2), never the passed uuid.
               ...(result.sessionId ? { session: result.sessionId } : {}),
             },
-          );
+          )) ?? threadNoteId;
           this.emitTurnEvent(channel, {
             kind: "error",
             error: `reply produced but not saved: ${delivered.error}`,
@@ -963,8 +981,8 @@ export class ProgrammaticAgentRegistry {
           // CALLBACK as status:error — the reply was produced but NOT delivered, so the
           // turn did not truly succeed; the orchestrator must learn that. No `source_message`
           // (the outbound note never landed); the undelivered text lives in the error thread
-          // note for an operator to recover.
-          await this.maybeDeliverCallback(handle, msg, turnThreadId, "error");
+          // note for an operator to recover — pull it via the RESOLVABLE `source_thread`.
+          await this.maybeDeliverCallback(handle, msg, turnThreadId, "error", undefined, threadNoteId);
           continue;
         }
       }
@@ -976,8 +994,10 @@ export class ProgrammaticAgentRegistry {
       // (empty/tool-only turn → clean resolve, no note expected).
       this.emitTurnEvent(channel, { kind: "done", reply: result.reply ?? "" });
       // CALLBACK on success — the turn finished cleanly (status:ok). `sourceMessage` is the
-      // delivered reply note (when there was one) the orchestrator pulls the full result from.
-      await this.maybeDeliverCallback(handle, msg, turnThreadId, "ok", sourceMessage);
+      // delivered reply note (when there was one) the orchestrator pulls the full result from;
+      // `source_thread` (the WRITTEN thread-note id, agent#124) is the RESOLVABLE pull-link in
+      // both modes, including an empty/tool-only turn where there's no `sourceMessage`.
+      await this.maybeDeliverCallback(handle, msg, turnThreadId, "ok", sourceMessage, threadNoteId);
     }
   }
 
@@ -1013,6 +1033,7 @@ export class ProgrammaticAgentRegistry {
     turnThreadId: string,
     status: "ok" | "error",
     sourceMessage?: string,
+    sourceThreadId?: string,
   ): Promise<void> {
     // Guard 1 + 2: no sink, or this wasn't a delegated request → nothing to call back.
     if (!this.writeCallback) return;
@@ -1041,11 +1062,17 @@ export class ProgrammaticAgentRegistry {
     // source_message are echoed/included only when present. The daemon's WriteCallback
     // wiring writes this as a `#agent/message/inbound` note to `msg.replyTo` and — CRUCIALLY
     // — does NOT stamp a `reply_to` on it (the terminal-callback loop guard).
+    //
+    // `source_thread` is the WRITTEN thread-note id (agent#124) — RESOLVABLE for BOTH modes
+    // (`query-notes { id: source_thread }`), available even on an error/empty/tool-only turn
+    // (the thread note is written before the outbound). Fall back to the per-turn id only when
+    // the thread seam surfaced none (no durable store / a write failure) — still a stable
+    // provenance token, just not a pullable note.
     const meta: CallbackMeta = {
       callback: "true",
       status,
       source_channel: handle.channel,
-      source_thread: turnThreadId,
+      source_thread: sourceThreadId ?? turnThreadId,
       ...(sourceMessage ? { source_message: sourceMessage } : {}),
       ...(msg.correlationId ? { correlation_id: msg.correlationId } : {}),
       delegation_depth: String(incomingDepth + 1),
@@ -1071,6 +1098,11 @@ export class ProgrammaticAgentRegistry {
    * agent name (single-threaded's thread is "named after the definition"). Best-effort: a
    * write failure is LOGGED, never thrown out — a missing thread note must not strand the
    * queue, and the turn is never re-run (it would burn quota for a duplicate `claude -p`).
+   *
+   * RETURNS the WRITTEN thread-note id so the drain can use it as a RESOLVABLE
+   * `source_thread` on the agent-to-agent callback (agent#124), for BOTH modes. `undefined`
+   * when no sink is wired, the write failed, or the seam surfaced no id — the drain then
+   * falls back to the per-turn id.
    */
   private async recordThread(
     handle: ProgrammaticAgentHandle,
@@ -1080,8 +1112,8 @@ export class ProgrammaticAgentRegistry {
     startedAt: string,
     usage: ThreadNote["usage"],
     opts: { threadId?: string; sameTurn?: boolean; phase?: "start" | "end"; session?: string } = {},
-  ): Promise<void> {
-    if (!this.writeThread) return;
+  ): Promise<string | undefined> {
+    if (!this.writeThread) return undefined;
     const thread: ThreadNote = {
       channel: handle.channel,
       name: handle.spec.name,
@@ -1107,12 +1139,18 @@ export class ProgrammaticAgentRegistry {
       ...(opts.phase ? { phase: opts.phase } : {}),
     };
     try {
-      await this.writeThread(thread);
+      // The seam returns the WRITTEN note id (`{ id }`) for a durable transport; `void` for
+      // one with no store. Surface it so the drain can set a RESOLVABLE callback
+      // `source_thread` (agent#124). A missing id → undefined → the drain falls back to the
+      // per-turn id.
+      const written = await this.writeThread(thread);
+      return written?.id;
     } catch (err) {
       console.error(
         `parachute-agent: writing #agent/thread note for channel "${handle.channel}" failed ` +
           `(continuing): ${(err as Error).message}`,
       );
+      return undefined;
     }
   }
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -735,7 +735,7 @@ export function buildWriteThread(channels: Map<string, Channel>): WriteThread {
     }
     // Only a transport with a durable store implements writeThread (the VaultTransport).
     if (!ch.transport.writeThread) return;
-    await ch.transport.writeThread({
+    const written = await ch.transport.writeThread({
       channel: thread.channel,
       ...(thread.name ? { name: thread.name } : {}),
       ...(thread.definition ? { definition: thread.definition } : {}),
@@ -759,6 +759,13 @@ export function buildWriteThread(channels: Map<string, Channel>): WriteThread {
       ...(thread.sameTurn ? { sameTurn: true } : {}),
       ...(thread.phase ? { phase: thread.phase } : {}),
     });
+    // Surface the WRITTEN note id so the drain can set a RESOLVABLE callback `source_thread`
+    // (agent#124). `writeThread` returns `{ sent: [id] }` — the id is the actual note an
+    // orchestrator can pull with `query-notes { id }` for BOTH modes (single-threaded: the
+    // deterministic `Threads/<safeChannel>/<safeName>` note; multi-threaded: the per-fire
+    // `Threads/<safeChannel>/<uuid>` note). Empty/absent → undefined (the drain falls back).
+    const id = written?.sent?.[0];
+    return id ? { id } : undefined;
   };
 }
 


### PR DESCRIPTION
Closes #124.

## The bug
The agent-to-agent callback (PR #123) puts `source_thread` on the callback metadata so an orchestrator can pull the recipient's full thread record. For **multi-threaded** recipients it worked (`source_thread` = the per-fire note leaf, resolvable at `Threads/<channel>/<source_thread>`). For **single-threaded** recipients (the DEFAULT), `source_thread` was a per-turn **CORRELATION id**, NOT the note leaf — the single-threaded note lives at the deterministic `Threads/<safeChannel>/<safeName>`, so the orchestrator couldn't resolve the thread from `source_thread`.

The reliable single-threaded pull-link was `source_message` (the outbound reply note id) — but that's **ABSENT** on an error/empty/tool-only turn, leaving the orchestrator with an unresolvable `source_thread` and no link at all.

## The fix
Make `source_thread` the **actual written thread-note id** for BOTH modes, so it's always resolvable via `query-notes { id: source_thread }`:

- **`WriteThread` seam widened** (`src/backends/registry.ts`) to return the written note id — `Promise<{ id?: string } | void>` (back-compat union, mirrors `WriteOutbound`).
- **`buildWriteThread`** (`src/daemon.ts`) surfaces the transport's existing `{ sent: [id] }` return as `{ id }` (the `VaultTransport.writeThread` already returned it; it was being discarded).
- **`recordThread`** returns the written id; the drain captures it at **every terminal point** (success, failure-as-value, defensive-catch throw, outbound-delivery failure) and passes it to `maybeDeliverCallback` as `source_thread` — instead of the per-turn correlation UUID.
- **Resolvable on no-reply turns:** the thread note is written BEFORE the outbound reply, so its id is available even on an error/empty/tool-only turn (where there's no `source_message`) — the narrow edge the issue targets.
- **Fallback:** when the seam surfaces no id (a transport with no durable store, or a write failure), `source_thread` falls back to the per-turn id — a stable provenance token, never `undefined`.

`source_message` is preserved as-is (still the per-reply pull-link when present).

By mode, `source_thread` is now:
- single-threaded → the deterministic note id `Threads/<safeChannel>/<safeName>` (NOT the per-turn correlation id).
- multi-threaded → the per-fire note id `Threads/<safeChannel>/<uuid>` (unchanged behavior, now sourced from the seam's return).

## Tests (both modes + no-reply edges)
Added to `src/backends/registry.test.ts` a faithful `WriteThread` recorder that returns the SAME id the `VaultTransport` would (mirroring its path-as-id logic), then pins:
- single-threaded ok turn → `source_thread` = `Threads/worker/worker` (the deterministic id; explicitly **not** a bare per-turn UUID).
- multi-threaded ok turn → `source_thread` = `Threads/worker/<per-fire uuid>`.
- single-threaded **error** turn → `source_thread` is the resolvable (error) thread-note id, `source_message` absent.
- single-threaded **empty/tool-only** turn → no outbound note (no `source_message`), `source_thread` still resolvable.
- no-durable-store fallback → `source_thread` is the per-turn id (present, never undefined).

The `VaultTransport.writeThread` suite already asserts `result.sent` carries the real vault note id / deterministic path, backing the seam's faithfulness.

## Also
- `.claude/` added to root `.gitignore` (recurring reviewer nit — stray `.claude/worktrees/` local artifact).

## Versioning + gates
- `0.2.3-rc.9` → `0.2.3-rc.10`.
- `bun run typecheck` clean.
- `bun test ./src` → 1207 pass / 0 fail (5 new).
- `bunx biome check .` → exit 0 (the 2 warnings are pre-existing `noExplicitAny` in `src/transports/vault.test.ts`, untouched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)