### PR TITLE
Agent runtime context + thread legibility (#162, #163)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/agent",
-  "version": "0.2.3-rc.10",
+  "version": "0.2.3-rc.11",
   "description": "Vault-native agents for Claude Code — a #agent/definition note + an inbound message becomes a sandboxed claude turn; the reply is written back as a note. Messaging gateway on :1941.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/src/backends/programmatic.test.ts
+++ b/src/backends/programmatic.test.ts
@@ -26,6 +26,7 @@ import { tmpdir } from "node:os";
 import {
   ProgrammaticBackend,
   buildProgrammaticClaudeArgs,
+  renderRunContext,
   PROGRAMMATIC_BACKEND_KIND,
   isTransientTurnError,
   isSessionNotFoundError,
@@ -37,7 +38,7 @@ import {
   type ProgrammaticBackendDeps,
   type ProgrammaticSpawnFn,
 } from "./programmatic.ts";
-import type { TurnSession } from "./types.ts";
+import type { RunContext, TurnSession } from "./types.ts";
 import type { InboundAttachment } from "../transport.ts";
 import type { SandboxEngine } from "../sandbox/index.ts";
 import type { SandboxRuntimeConfig } from "@anthropic-ai/sandbox-runtime";
@@ -388,7 +389,71 @@ describe("buildProgrammaticClaudeArgs", () => {
 
 // ---- single-turn runner tests ----------------------------------------------
 
+describe("renderRunContext — daemon-injected runtime preamble (agent#162)", () => {
+  const NOW = "2026-06-28T17:05:42.000Z";
+
+  test("absent runContext → the message is UNCHANGED (additive)", () => {
+    expect(renderRunContext("the real message", undefined)).toBe("the real message");
+  });
+
+  test("prepends a labeled preamble carrying the REAL wall-clock + session, then the message", () => {
+    const out = renderRunContext("write the digest", { now: NOW, session: "resumed" });
+    // The preamble is clearly labeled as daemon-injected runtime context (not the system prompt).
+    expect(out).toContain("Run context");
+    expect(out).toContain("injected by the agent daemon");
+    // It carries the REAL clock (the whole point — the agent stops fabricating timestamps).
+    expect(out).toContain(`now=${NOW}`);
+    expect(out).toContain("session=resumed");
+    // The real message survives, AFTER the preamble (a blank line between).
+    expect(out.endsWith("write the digest")).toBe(true);
+    expect(out.indexOf("now=")).toBeLessThan(out.indexOf("write the digest"));
+  });
+
+  test("includes fired-by + the 1-based turn number when known", () => {
+    const out = renderRunContext("go", {
+      now: NOW,
+      session: "resumed",
+      firedBy: "scheduled-job:morning-weave",
+      priorTurnCount: 24, // 24 completed → this is turn 25.
+    });
+    expect(out).toContain("fired-by=scheduled-job:morning-weave");
+    expect(out).toContain("turn=25");
+  });
+
+  test("omits the optional fields when not provided (only now + session)", () => {
+    const out = renderRunContext("go", { now: NOW, session: "new" });
+    expect(out).toContain("now=" + NOW);
+    expect(out).toContain("session=new");
+    expect(out).not.toContain("fired-by=");
+    expect(out).not.toContain("turn=");
+  });
+});
+
 describe("ProgrammaticBackend.deliver — CREATE turn (--session-id)", () => {
+  test("the assembled turn message carries the injected run-context timestamp (agent#162)", async () => {
+    mkDirs("runctx");
+    const { fn, calls } = recordingSpawn({ stdout: successTurn("sess-RC", "ok") });
+    const engine = fakeEngine();
+    const backend = new ProgrammaticBackend(baseDeps(fn, { sandboxEngine: engine }));
+
+    const handle = await backend.start(specWithVault("eng"));
+    const now = "2026-06-28T17:05:42.000Z";
+    const runContext: RunContext = { now, session: "resumed", firedBy: "scheduled-job:weave" };
+    const result = await backend.deliver(handle, "report your status", createSession("sess-RC"), undefined, undefined, runContext);
+
+    expect(result.ok).toBe(true);
+    // The actual `claude -p` invocation (the wrapped command in argv[2]) carries the
+    // daemon-injected run context — the real clock the headless turn otherwise lacks — AND
+    // the original message. This is the issue's core assertion: the turn input carries the
+    // injected timestamp instead of the agent fabricating one.
+    const cmd = calls[0]!.argv[2]!;
+    expect(cmd).toContain(now);
+    expect(cmd).toContain("Run context");
+    expect(cmd).toContain("session=resumed");
+    expect(cmd).toContain("fired-by=scheduled-job:weave");
+    expect(cmd).toContain("report your status");
+  });
+
   test("a create session → argv has --session-id <id> (NOT --resume); reply + sessionId returned", async () => {
     mkDirs("first");
     const { fn, calls } = recordingSpawn({ stdout: successTurn("sess-FIRST", "the reply text") });

--- a/src/backends/programmatic.ts
+++ b/src/backends/programmatic.ts
@@ -85,6 +85,7 @@ import type {
   DeliverResult,
   DeliverUsage,
   InterimSink,
+  RunContext,
   TurnSession,
 } from "./types.ts";
 
@@ -327,6 +328,32 @@ export function buildProgrammaticClaudeArgs(opts: {
   return argv;
 }
 
+/**
+ * Render the {@link RunContext} as a concise, clearly-LABELED preamble to PREPEND to a turn's
+ * message (agent#162). A headless `claude -p` turn has no clock + no notion of which run it is,
+ * so the daemon hands it these facts (the real wall-clock, new-vs-resumed, why it fired, the
+ * prior turn count) — the agent then stamps ACCURATE times instead of fabricating them.
+ *
+ * It is a single fenced block clearly marked as daemon-injected runtime context (NOT the
+ * agent's own system prompt — that's untouched), then a blank line, then the real message. The
+ * `now` is always present; the rest are appended only when known. Returns the message UNCHANGED
+ * when `rc` is absent (additive — no behavior change for a caller that doesn't pass one).
+ */
+export function renderRunContext(message: string, rc: RunContext | undefined): string {
+  if (!rc) return message;
+  const parts: string[] = [`now=${rc.now}`, `session=${rc.session}`];
+  if (typeof rc.priorTurnCount === "number" && rc.priorTurnCount >= 0) {
+    // The NUMBER of this turn (1-based) = completed turns + 1 — what an agent stamps as "turn N".
+    parts.push(`turn=${rc.priorTurnCount + 1}`);
+  }
+  if (rc.firedBy) parts.push(`fired-by=${rc.firedBy}`);
+  const preamble =
+    `[Run context — injected by the agent daemon (this is the real runtime state, NOT your ` +
+    `system prompt). Use these for any timestamp/clock or "which run is this" reasoning instead ` +
+    `of guessing: ${parts.join(", ")}]`;
+  return `${preamble}\n\n${message}`;
+}
+
 /** Read the full text of a (possibly null) byte stream; null/error → "". */
 async function drainStream(stream: ReadableStream<Uint8Array> | null): Promise<string> {
   if (!stream) return "";
@@ -414,6 +441,7 @@ export class ProgrammaticBackend implements AgentBackend {
     session: TurnSession,
     onInterim?: InterimSink,
     attachments?: InboundAttachment[],
+    runContext?: RunContext,
   ): Promise<DeliverResult> {
     const spec = handle.spec;
     if (!spec) {
@@ -537,13 +565,18 @@ export class ProgrammaticBackend implements AgentBackend {
     // per-agent even when the working dir is shared. Best-effort + isolated: a single
     // attachment's fetch/stage failure logs + is SKIPPED (the turn still runs with the rest
     // + the text). Absent/empty → no staging, no prompt change (today's behavior exactly).
-    let turnMessage = message;
+    // RUN CONTEXT (agent#162): prepend the daemon-injected runtime preamble (the real
+    // wall-clock + new/resumed + why-it-fired) so the headless turn reads ACCURATE facts
+    // instead of fabricating a clock. Done FIRST so the preamble sits at the very top of the
+    // prompt; attachments append after the (already-prefixed) message. Absent runContext →
+    // the message is unchanged (additive).
+    let turnMessage = renderRunContext(message, runContext);
     if (attachments && attachments.length > 0) {
       const staged = await this.stageAttachments(workspace, attachments, vaultArg);
       if (staged.length > 0) {
         const lines = staged.map((s) => `- ${s.absPath} (${s.mimeType})`);
         turnMessage =
-          `${message}\n\n[Attached files — read them as needed:\n${lines.join("\n")}\n]`;
+          `${turnMessage}\n\n[Attached files — read them as needed:\n${lines.join("\n")}\n]`;
       }
     }
 

--- a/src/backends/registry.test.ts
+++ b/src/backends/registry.test.ts
@@ -16,6 +16,7 @@ import {
   PENDING_INBOUND_CAP,
   MAX_DELEGATION_DEPTH,
   isTransientOutboundError,
+  outboundThreadId,
   type WriteOutbound,
   type WriteThread,
   type WriteCallback,
@@ -119,6 +120,24 @@ function recorder(): { calls: { channel: string; reply: string; inReplyTo?: stri
   const calls: { channel: string; reply: string; inReplyTo?: string }[] = [];
   const fn: WriteOutbound = async (channel, reply, inReplyTo) => {
     calls.push({ channel, reply, ...(inReplyTo ? { inReplyTo } : {}) });
+  };
+  return { calls, fn };
+}
+
+/**
+ * A recorder WriteOutbound that ALSO captures the stamped `threadId` (the outbound note's
+ * `metadata.thread`, agent#163) — kept separate from {@link recorder} so the existing
+ * exact-`toEqual` reply assertions stay unaffected. Used to pin that a single-threaded
+ * outbound carries the DETERMINISTIC thread-NOTE id and a multi-threaded one carries the
+ * per-fire id.
+ */
+function recorderWithThreadId(): {
+  calls: { channel: string; reply: string; inReplyTo?: string; threadId?: string }[];
+  fn: WriteOutbound;
+} {
+  const calls: { channel: string; reply: string; inReplyTo?: string; threadId?: string }[] = [];
+  const fn: WriteOutbound = async (channel, reply, inReplyTo, threadId) => {
+    calls.push({ channel, reply, ...(inReplyTo ? { inReplyTo } : {}), ...(threadId ? { threadId } : {}) });
   };
   return { calls, fn };
 }
@@ -1723,5 +1742,128 @@ describe("ProgrammaticAgentRegistry — agent-to-agent callbacks (reply_to)", ()
     const { meta } = cb.calls[0]!;
     // A bare per-turn UUID fallback — present (never undefined), just not a thread-note path.
     expect(meta.source_thread).toMatch(/^[0-9a-f-]{36}$/);
+  });
+});
+
+describe("outboundThreadId — mode-correct, resolvable thread id (agent#163)", () => {
+  test("single-threaded → the resolvable thread-NOTE id; multi-threaded → the per-fire id", () => {
+    // single-threaded: prefer the resolvable note id (the deterministic thread-NOTE path).
+    expect(outboundThreadId(false, "turn-uuid", "Threads/eng/eng")).toBe("Threads/eng/eng");
+    // multi-threaded: ALWAYS the per-fire turn id (which IS that fire's note leaf).
+    expect(outboundThreadId(true, "turn-uuid", "Threads/eng/turn-uuid")).toBe("turn-uuid");
+  });
+
+  test("falls back to the per-turn id when no resolvable note id surfaced (never undefined)", () => {
+    // single-threaded with no durable store / failed thread write → the per-turn id, never undefined.
+    expect(outboundThreadId(false, "turn-uuid", undefined)).toBe("turn-uuid");
+    expect(outboundThreadId(true, "turn-uuid", undefined)).toBe("turn-uuid");
+  });
+});
+
+describe("ProgrammaticAgentRegistry — outbound metadata.thread is the resolvable thread id (agent#163)", () => {
+  test("a SINGLE-THREADED outbound carries the DETERMINISTIC thread-NOTE id (NOT a per-turn UUID)", async () => {
+    const backend = new FakeBackend();
+    const rec = recorderWithThreadId();
+    const threads = threadRecorderWithIds();
+    const reg = new ProgrammaticAgentRegistry({
+      backend,
+      writeOutbound: rec.fn,
+      writeThread: threads.fn,
+    });
+    // specFor → no mode → single-threaded (the default).
+    await reg.register(specFor("uni-weaver"));
+
+    reg.enqueue("uni-weaver", { content: "hello" });
+    await until(() => rec.calls.length === 1);
+
+    // The stamped `metadata.thread` is the agent's ONE deterministic thread-note id — the
+    // SAME `query-notes { id }` resolves it across every turn (the stable resumed session),
+    // NOT the per-turn correlation UUID that misled an observer into "a fresh session each run".
+    const expected = `Threads/uni-weaver/uni-weaver`;
+    expect(rec.calls[0]!.threadId).toBe(expected);
+    expect(rec.calls[0]!.threadId).not.toMatch(/^[0-9a-f-]{36}$/); // it's a path, not a UUID.
+    // It matches the actual written thread-note's id (faithful to VaultTransport's path-as-id).
+    expect(rec.calls[0]!.threadId).toBe(threads.idFor(threads.ends()[0]!));
+  });
+
+  test("a single-threaded outbound carries the SAME thread id across turns (stable, not per-turn)", async () => {
+    const backend = new FakeBackend();
+    const rec = recorderWithThreadId();
+    const threads = threadRecorderWithIds();
+    const reg = new ProgrammaticAgentRegistry({
+      backend,
+      writeOutbound: rec.fn,
+      writeThread: threads.fn,
+    });
+    await reg.register(specFor("uni-weaver"));
+
+    reg.enqueue("uni-weaver", { content: "turn 1" });
+    reg.enqueue("uni-weaver", { content: "turn 2" });
+    await until(() => rec.calls.length === 2);
+
+    // The whole point of #163: the stamped thread id is STABLE across turns (the resumed
+    // single-threaded session), unlike the per-turn UUID that changed every run.
+    expect(rec.calls[0]!.threadId).toBe(`Threads/uni-weaver/uni-weaver`);
+    expect(rec.calls[1]!.threadId).toBe(rec.calls[0]!.threadId);
+  });
+
+  test("a MULTI-THREADED outbound carries the PER-FIRE id (distinct per fire — correct there)", async () => {
+    const backend = new FakeBackend();
+    const rec = recorderWithThreadId();
+    const threads = threadRecorderWithIds();
+    const reg = new ProgrammaticAgentRegistry({
+      backend,
+      writeOutbound: rec.fn,
+      writeThread: threads.fn,
+    });
+    await reg.register(specMultiThreaded("digest", "digest", "Agents/digest"));
+
+    reg.enqueue("digest", { content: "fire 1" });
+    reg.enqueue("digest", { content: "fire 2" });
+    await until(() => rec.calls.length === 2);
+
+    // Multi-threaded: each fire is its own thread, so the per-fire id (the note leaf) is the
+    // right link — and the two fires carry DIFFERENT ids (not collapsed to one).
+    expect(rec.calls[0]!.threadId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(rec.calls[1]!.threadId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(rec.calls[0]!.threadId).not.toBe(rec.calls[1]!.threadId);
+    // The stamped per-fire id is the leaf of that fire's written thread note.
+    const end0 = threads.ends().find((t) => t.input === "fire 1")!;
+    expect(threads.idFor(end0)).toBe(`Threads/digest/${rec.calls[0]!.threadId}`);
+  });
+
+  test("a single-threaded FAILURE note also carries the deterministic thread-note id (agent#163)", async () => {
+    const backend = new FakeBackend();
+    backend.resultFor = () => ({ ok: false, error: "mint refused" }); // a failed turn → failure note.
+    const rec = recorderWithThreadId();
+    const threads = threadRecorderWithIds();
+    const reg = new ProgrammaticAgentRegistry({
+      backend,
+      writeOutbound: rec.fn,
+      writeThread: threads.fn,
+    });
+    await reg.register(specFor("uni-weaver"));
+
+    reg.enqueue("uni-weaver", { content: "do it" });
+    await until(() => rec.calls.length === 1);
+
+    // The user-facing failure note (the only outbound on a failed turn) carries the SAME
+    // resolvable, deterministic thread-note id — not a per-turn UUID.
+    expect(rec.calls[0]!.reply).toContain("mint refused");
+    expect(rec.calls[0]!.threadId).toBe(`Threads/uni-weaver/uni-weaver`);
+    expect(rec.calls[0]!.threadId).not.toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  test("with NO durable thread store wired, a single-threaded outbound falls back to a per-turn id (never undefined)", async () => {
+    const backend = new FakeBackend();
+    const rec = recorderWithThreadId();
+    // No writeThread → no resolvable note id → fall back to the per-turn UUID (still stamped).
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    await reg.register(specFor("eng"));
+
+    reg.enqueue("eng", { content: "hi" });
+    await until(() => rec.calls.length === 1);
+
+    expect(rec.calls[0]!.threadId).toMatch(/^[0-9a-f-]{36}$/); // present, the fallback.
   });
 });

--- a/src/backends/registry.test.ts
+++ b/src/backends/registry.test.ts
@@ -17,6 +17,7 @@ import {
   MAX_DELEGATION_DEPTH,
   isTransientOutboundError,
   outboundThreadId,
+  runFiredBy,
   type WriteOutbound,
   type WriteThread,
   type WriteCallback,
@@ -30,7 +31,9 @@ import type {
   AgentHandle,
   AgentStatus,
   DeliverResult,
+  InboundAttachment,
   InterimSink,
+  RunContext,
   TurnSession,
 } from "./types.ts";
 import type { AgentSpec } from "../sandbox/types.ts";
@@ -52,7 +55,12 @@ function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
 class FakeBackend implements AgentBackend {
   readonly kind = "programmatic";
   /** Per-call records, in arrival order — including the caller-resolved {@link TurnSession}. */
-  readonly calls: { channel: string; message: string; session: TurnSession }[] = [];
+  readonly calls: {
+    channel: string;
+    message: string;
+    session: TurnSession;
+    runContext?: RunContext;
+  }[] = [];
   /** Max concurrent in-flight turns observed (must stay ≤ 1 for serial). */
   maxConcurrent = 0;
   private inFlight = 0;
@@ -86,8 +94,10 @@ class FakeBackend implements AgentBackend {
     message: string,
     session: TurnSession,
     onInterim?: InterimSink,
+    _attachments?: InboundAttachment[],
+    runContext?: RunContext,
   ): Promise<DeliverResult> {
-    this.calls.push({ channel: handle.channel, message, session });
+    this.calls.push({ channel: handle.channel, message, session, ...(runContext ? { runContext } : {}) });
     this.inFlight++;
     this.maxConcurrent = Math.max(this.maxConcurrent, this.inFlight);
     try {
@@ -1742,6 +1752,72 @@ describe("ProgrammaticAgentRegistry — agent-to-agent callbacks (reply_to)", ()
     const { meta } = cb.calls[0]!;
     // A bare per-turn UUID fallback — present (never undefined), just not a thread-note path.
     expect(meta.source_thread).toMatch(/^[0-9a-f-]{36}$/);
+  });
+});
+
+describe("ProgrammaticAgentRegistry — run context injection (agent#162)", () => {
+  test("a turn carries run context: a REAL now (ISO), session=new for a fresh turn", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    await reg.register(specFor("eng"));
+
+    reg.enqueue("eng", { content: "hi" });
+    await until(() => backend.calls.length === 1);
+
+    const rc = backend.calls[0]!.runContext;
+    expect(rc).toBeDefined();
+    // A REAL wall-clock timestamp the headless turn would otherwise lack (parseable ISO).
+    expect(typeof rc!.now).toBe("string");
+    expect(Number.isFinite(Date.parse(rc!.now))).toBe(true);
+    // No prior session (no readSession wired) → a fresh create → session=new.
+    expect(rc!.session).toBe("new");
+  });
+
+  test("session=resumed when the single-threaded turn resumes a prior session", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const readSession = async () => "sess-PRIOR"; // a persisted single-threaded session.
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn, readSession });
+    await reg.register(specFor("uni-weaver"));
+
+    reg.enqueue("uni-weaver", { content: "next turn" });
+    await until(() => backend.calls.length === 1);
+
+    expect(backend.calls[0]!.session.resume).toBe(true);
+    expect(backend.calls[0]!.runContext!.session).toBe("resumed");
+  });
+
+  test("fired-by = scheduled-job:<id> for a runner fire; interactive otherwise; absent when no sender", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    await reg.register(specFor("eng"));
+
+    // A SCHEDULED job fire (the runner stamps sender = runner:<jobId>).
+    reg.enqueue("eng", { content: "cron tick", sender: "runner:morning-weave" });
+    await until(() => backend.calls.length === 1);
+    expect(backend.calls[0]!.runContext!.firedBy).toBe("scheduled-job:morning-weave");
+
+    // An interactive / human message (a non-runner sender) → interactive.
+    reg.enqueue("eng", { content: "hello", sender: "aaron" });
+    await until(() => backend.calls.length === 2);
+    expect(backend.calls[1]!.runContext!.firedBy).toBe("interactive");
+
+    // No sender → fired-by OMITTED (the run context still carries now + session).
+    reg.enqueue("eng", { content: "no sender" });
+    await until(() => backend.calls.length === 3);
+    expect(backend.calls[2]!.runContext!.firedBy).toBeUndefined();
+  });
+});
+
+describe("runFiredBy — run-context provenance (agent#162)", () => {
+  test("maps runner:<id> → scheduled-job:<id>, other senders → interactive, absent → undefined", () => {
+    expect(runFiredBy("runner:morning-weave")).toBe("scheduled-job:morning-weave");
+    expect(runFiredBy("aaron")).toBe("interactive");
+    expect(runFiredBy("session")).toBe("interactive");
+    expect(runFiredBy(undefined)).toBeUndefined();
+    expect(runFiredBy("")).toBeUndefined();
   });
 });
 

--- a/src/backends/registry.ts
+++ b/src/backends/registry.ts
@@ -44,7 +44,7 @@
 
 import type { AgentSpec, AgentMode } from "../sandbox/types.ts";
 import { normalizeChannel } from "../sandbox/types.ts";
-import type { AgentBackend, AgentHandle, InterimTurnEvent, TurnSession } from "./types.ts";
+import type { AgentBackend, AgentHandle, InterimTurnEvent, RunContext, TurnSession } from "./types.ts";
 import type { InboundAttachment } from "../transport.ts";
 
 /**
@@ -331,6 +331,20 @@ export function outboundThreadId(
   return threadNoteId ?? turnThreadId;
 }
 
+/**
+ * Derive the run-context `fired-by` provenance (agent#162) from an inbound message's
+ * `sender` (the note's `metadata.sender`). A SCHEDULED job fire stamps `runner:<jobId>`
+ * (the runner's sender provenance) → reported as the job id so the agent knows it's a cron
+ * fire; anything else (a human / a delegated agent message) → `interactive`. Absent sender →
+ * undefined (the run context omits `fired-by`).
+ */
+export function runFiredBy(sender: string | undefined): string | undefined {
+  if (!sender) return undefined;
+  const m = /^runner:(.+)$/.exec(sender);
+  if (m) return `scheduled-job:${m[1]}`;
+  return "interactive";
+}
+
 /** A queued inbound message awaiting its serial turn. */
 export interface QueuedMessage {
   /** The inbound text handed to the `claude -p` turn as the prompt. */
@@ -372,6 +386,13 @@ export interface QueuedMessage {
    * `Read` it. Absent/empty → no attachments (today's behavior unchanged).
    */
   attachments?: InboundAttachment[];
+  /**
+   * WHO/WHAT sent this inbound (the note's `metadata.sender`) — used ONLY to derive the
+   * run-context `fired-by` provenance the daemon injects into the turn (agent#162): a
+   * SCHEDULED job fire stamps `runner:<jobId>`, an interactive/delegated message stamps
+   * something else. Absent → the run context omits `fired-by`. Carries no routing meaning.
+   */
+  sender?: string;
 }
 
 /** A registered programmatic agent's live status (surfaced in /health + the list). */
@@ -855,6 +876,21 @@ export class ProgrammaticAgentRegistry {
       // every path (early failure, ok, outbound-failure) stamps the same resolvable link.
       const outThreadId = outboundThreadId(multiThreaded, turnThreadId, startThreadNoteId);
 
+      // RUN CONTEXT (agent#162): assemble the runtime facts a headless `claude -p` turn can't
+      // know — the REAL wall-clock (`startedAt`), whether this run CONTINUES a prior session
+      // (`turnSession.resume`) or starts fresh, and WHY it fired (a scheduled job vs an
+      // interactive/delegated message, from the inbound sender). The backend prepends these as
+      // a labeled preamble so the agent stamps ACCURATE times instead of fabricating them.
+      // (DEFERRED: `priorTurnCount` — the rolling turn_count lives in the transport's thread
+      // note and isn't surfaced back to the drain; wiring it is a follow-up. Until then the
+      // preamble omits the `turn=N` line — the `now`/session/fired-by trio is the floor.)
+      const firedBy = runFiredBy(msg.sender);
+      const runContext: RunContext = {
+        now: startedAt,
+        session: turnSession.resume ? "resumed" : "new",
+        ...(firedBy ? { firedBy } : {}),
+      };
+
       let result;
       try {
         // Forward each interim event to the streaming-view sink (keyed by channel)
@@ -868,6 +904,8 @@ export class ProgrammaticAgentRegistry {
           // Phase 1: inbound attachments → the programmatic backend stages them into the
           // agent's private workspace so the turn can Read them. Absent/empty → no staging.
           msg.attachments,
+          // agent#162: the daemon-known runtime context (real clock, new/resumed, fired-by).
+          runContext,
         );
       } catch (err) {
         // The backend contract is failure-as-VALUE, never a throw — but defend so a

--- a/src/backends/registry.ts
+++ b/src/backends/registry.ts
@@ -90,12 +90,15 @@ export type WriteOutbound = (
   reply: string,
   inReplyTo?: string,
   /**
-   * The per-turn thread id this reply belongs to — the explicit definition→thread→message
-   * link the outbound note carries (stamped into `metadata.thread`). For multi-threaded it
-   * IS the per-fire thread note's leaf (an exact link); for single-threaded it's a per-turn
-   * correlation id (the note's stable deterministic leaf is the def name — single-threaded
-   * outbound→note linkage by the stable path is a follow-up). INBOUND-note stamping is
-   * deferred (those notes are externally written; see the PR notes).
+   * The RESOLVABLE, MODE-CORRECT thread id this reply belongs to — the explicit
+   * definition→thread→message link the outbound note carries (stamped into `metadata.thread`),
+   * mirroring the callback `source_thread` fix (agent#124/#163). For multi-threaded it IS the
+   * per-fire thread note's leaf (`Threads/<channel>/<id>`); for single-threaded it is the
+   * DETERMINISTIC thread-NOTE id (`Threads/<channel>/<name>`), STABLE across turns — so an
+   * observer reading the outbound note's `metadata.thread` resolves the agent's ONE thread
+   * with `query-notes { id }`, instead of the per-turn correlation UUID that changed every
+   * run (the pre-#163 bug that looked like a fresh session each time). INBOUND-note stamping
+   * is deferred (those notes are externally written; see the PR notes).
    */
   threadId?: string,
 ) => Promise<{ id?: string } | void>;
@@ -300,6 +303,32 @@ export function isTransientOutboundError(err: unknown): boolean {
 /** Sleep helper for the outbound retry backoff (injectable-free; small + bounded). */
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * The thread id to stamp into an OUTBOUND note's `metadata.thread` (agent#163) — the
+ * MODE-CORRECT, RESOLVABLE definition→thread→message link, mirroring the callback
+ * `source_thread` fix (agent#124):
+ *
+ *  - SINGLE-THREADED — the resolvable thread-NOTE id (the deterministic
+ *    `Threads/<safeChannel>/<safeName>` note), so an observer reading the outbound note's
+ *    `metadata.thread` resolves the agent's ONE stable thread with `query-notes { id }`.
+ *    The pre-#163 bug stamped the per-turn correlation UUID here, which changed every turn
+ *    and resolved to nothing — misleading an observer into "a fresh session each run" when
+ *    the single-threaded session is actually stable + resumed across turns.
+ *  - MULTI-THREADED — the per-fire id (`turnThreadId`), which IS that fire's thread-note leaf
+ *    (`Threads/<safeChannel>/<turnThreadId>`) — correct as-is: each fire is its own thread.
+ *
+ * Falls back to `turnThreadId` when no resolvable note id surfaced (no durable thread store
+ * wired, or the thread-note write failed) — never undefined, so the link is always stamped.
+ */
+export function outboundThreadId(
+  multiThreaded: boolean,
+  turnThreadId: string,
+  threadNoteId: string | undefined,
+): string {
+  if (multiThreaded) return turnThreadId;
+  return threadNoteId ?? turnThreadId;
 }
 
 /** A queued inbound message awaiting its serial turn. */
@@ -806,7 +835,11 @@ export class ProgrammaticAgentRegistry {
       // start+end never double-count. Best-effort: a start-ensure write failure is logged
       // (inside recordThread) and the turn STILL runs — a missing/stale working note must
       // never strand the queue or skip the turn.
-      await this.recordThread(handle, msg, "working", "", startedAt, undefined, {
+      // Capture the start-ensure's WRITTEN thread-note id. For single-threaded this is the
+      // DETERMINISTIC `Threads/<safeChannel>/<safeName>` note (the same every turn) — so a
+      // resolvable thread id is available BEFORE the turn runs, for the failure-note +
+      // outbound `metadata.thread` stamping (agent#163), even on a turn that fails early.
+      const startThreadNoteId = await this.recordThread(handle, msg, "working", "", startedAt, undefined, {
         threadId: turnThreadId,
         phase: "start",
         // NO session on the start-ensure: it runs BEFORE claude, so claude may never
@@ -816,6 +849,11 @@ export class ProgrammaticAgentRegistry {
         // the `end` record, and ONLY the id claude actually echoed (FIX 2). For a
         // single-threaded resume turn the prior session is preserved by writeThread anyway.
       });
+      // The MODE-CORRECT, RESOLVABLE thread id stamped into outbound + failure notes
+      // (agent#163): single-threaded → the deterministic thread-NOTE id (stable across turns);
+      // multi-threaded → the per-fire `turnThreadId`. Computed once from the start-ensure id so
+      // every path (early failure, ok, outbound-failure) stamps the same resolvable link.
+      const outThreadId = outboundThreadId(multiThreaded, turnThreadId, startThreadNoteId);
 
       let result;
       try {
@@ -854,8 +892,8 @@ export class ProgrammaticAgentRegistry {
         });
         this.emitTurnEvent(channel, { kind: "error", error: reason });
         // Post a user-facing failure note so the channel shows SOMETHING (not a silent
-        // no-reply) — best-effort.
-        await this.postFailureNote(channel, msg.inReplyTo, turnThreadId, reason);
+        // no-reply) — best-effort. Stamp the MODE-CORRECT resolvable thread id (agent#163).
+        await this.postFailureNote(channel, msg.inReplyTo, outThreadId, reason);
         // CALLBACK on the failure too — an orchestrator MUST learn its sub-task failed, not
         // hang waiting forever. No outbound note was produced, so no `source_message`; the
         // RESOLVABLE thread-note id (written above) is `source_thread` so the orchestrator can
@@ -886,8 +924,8 @@ export class ProgrammaticAgentRegistry {
         });
         this.emitTurnEvent(channel, { kind: "error", error: result.error });
         // Post a user-facing failure note so the channel shows SOMETHING (not a silent
-        // no-reply) — best-effort.
-        await this.postFailureNote(channel, msg.inReplyTo, turnThreadId, result.error);
+        // no-reply) — best-effort. Stamp the MODE-CORRECT resolvable thread id (agent#163).
+        await this.postFailureNote(channel, msg.inReplyTo, outThreadId, result.error);
         // CALLBACK on the failure-as-value too (status:error) — the orchestrator learns the
         // sub-task failed and can react. No delivered reply, so no `source_message`; the
         // RESOLVABLE thread-note id (written above) is `source_thread` (agent#124).
@@ -931,7 +969,12 @@ export class ProgrammaticAgentRegistry {
           channel,
           result.reply,
           msg.inReplyTo,
-          turnThreadId,
+          // agent#163: stamp the MODE-CORRECT, RESOLVABLE thread id into the outbound note's
+          // `metadata.thread` — single-threaded → the deterministic thread-NOTE id (stable
+          // across turns; an observer resolves the ONE thread), multi-threaded → the per-fire
+          // id. NOT the per-turn correlation UUID (the pre-#163 bug that looked like a fresh
+          // session every run).
+          outThreadId,
         );
         if (delivered.ok) sourceMessage = delivered.noteId;
         if (!delivered.ok) {

--- a/src/backends/types.ts
+++ b/src/backends/types.ts
@@ -85,6 +85,43 @@ export interface TurnSession {
 }
 
 /**
+ * RUN CONTEXT for one turn (agent#162) — the runtime facts a programmatic `claude -p` turn
+ * otherwise has NO way to know, so an agent stops FABRICATING them. A headless `-p` turn has
+ * no clock and no notion of "which run this is": uni-weaver was openly inventing report
+ * timestamps (a fixed `10:05` slot, the date "derived from context") because it couldn't read
+ * a real clock mid-run. The daemon KNOWS these facts at dispatch time, so it injects them into
+ * the turn (a concise, clearly-labeled preamble the agent reads) rather than letting the agent
+ * guess. Cheap, and it removes a whole class of fabricated-time confusion.
+ *
+ * The backend renders this as a SHORT preamble prepended to the turn message — it never
+ * mangles the agent's own system-prompt semantics. ADDITIVE: a caller that omits it leaves the
+ * turn message exactly as before.
+ */
+export interface RunContext {
+  /** The REAL wall-clock at dispatch (ISO 8601) — the authoritative clock the turn lacks. */
+  now: string;
+  /**
+   * Whether this turn CONTINUES a prior conversation (`resumed`, single-threaded turn 2+) or
+   * STARTS a fresh one (`new`, the first turn / every multi-threaded fire) — the cheap "which
+   * run is this" signal the daemon already resolved (`TurnSession.resume`).
+   */
+  session: "new" | "resumed";
+  /**
+   * WHY this turn is running (provenance): a SCHEDULED job fire stamps `runner:<jobId>` (the
+   * runner's sender provenance) → reported as the job id; anything else is an interactive /
+   * delegated message → `interactive`. Lets a scheduled agent know it's a cron fire vs a live
+   * reply. Absent when the inbound carried no sender.
+   */
+  firedBy?: string;
+  /**
+   * The thread's COMPLETED turn count BEFORE this turn (single-threaded's rolling counter;
+   * 0 on the first turn). Best-effort — omitted when the daemon can't cheaply resolve it
+   * (no durable thread store). So the agent can stamp "turn N" accurately.
+   */
+  priorTurnCount?: number;
+}
+
+/**
  * An opaque handle to a started agent, returned by {@link AgentBackend.start} and
  * passed back to `deliver`/`stop`/`status`. The only field the seam itself depends
  * on is `channel` (the wake channel a turn/push targets) + the backend's own
@@ -201,6 +238,12 @@ export interface AgentBackend {
    * a safe basename) before the turn and appends a workspace-relative pointer to the
    * prompt, so the `claude -p` turn can `Read` them. ADDITIVE — absent/empty → no
    * staging, the turn behaves exactly as before.
+   *
+   * `runContext` (optional, agent#162) is the runtime context the daemon knows but a headless
+   * `-p` turn can't (the real wall-clock, whether this run is new vs resumed, why it fired).
+   * The programmatic backend prepends it as a concise, clearly-labeled preamble to the turn
+   * message so the agent stamps ACCURATE times instead of fabricating them. ADDITIVE — omitted
+   * → the turn message is exactly as before.
    */
   deliver(
     handle: AgentHandle,
@@ -208,6 +251,7 @@ export interface AgentBackend {
     session: TurnSession,
     onInterim?: InterimSink,
     attachments?: InboundAttachment[],
+    runContext?: RunContext,
   ): Promise<DeliverResult>;
 
   /**

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -342,6 +342,9 @@ export function contextFor(
           // Phase 1: carry inbound file attachments through to the turn (the programmatic
           // backend stages them into the agent's private workspace so the turn can Read them).
           ...(msg.attachments && msg.attachments.length > 0 ? { attachments: msg.attachments } : {}),
+          // agent#162: carry the inbound sender so the drain can derive the run-context
+          // `fired-by` (a scheduled `runner:<jobId>` fire vs an interactive/delegated message).
+          ...(msg.meta?.sender ? { sender: msg.meta.sender } : {}),
         });
         return;
       }
@@ -366,6 +369,9 @@ export function contextFor(
           // Phase 1: carry inbound attachments through the pending buffer too, so a turn
           // that runs on register() still stages them.
           ...(msg.attachments && msg.attachments.length > 0 ? { attachments: msg.attachments } : {}),
+          // agent#162: carry the sender through the pending buffer too, so a turn that runs on
+          // register() still derives the right run-context `fired-by`.
+          ...(msg.meta?.sender ? { sender: msg.meta.sender } : {}),
         });
         if (outcome === "queued") return;
         // outcome === "unknown" — not an expected programmatic channel. It may still be a

--- a/src/transports/vault.ts
+++ b/src/transports/vault.ts
@@ -761,11 +761,14 @@ export class VaultTransport implements Transport {
     // Thread the reply to the inbound note id when the bridge passes it through.
     const inReplyTo = args.meta?.in_reply_to;
     if (inReplyTo) metadata.in_reply_to = inReplyTo;
-    // The explicit definition→thread→message link: stamp the outbound note with its thread
-    // id (the programmatic worker passes the per-turn thread id through `meta.thread`). For a
-    // multi-threaded turn this IS the per-fire `#agent/thread` note's leaf; for a
-    // single-threaded turn it's a per-turn correlation id. INBOUND-note stamping is deferred
-    // (those notes are written externally, before the turn knows its thread).
+    // The explicit definition→thread→message link: stamp the outbound note with its
+    // RESOLVABLE, mode-correct thread id (the programmatic worker passes it through
+    // `meta.thread`, agent#163). For a multi-threaded turn this IS the per-fire `#agent/thread`
+    // note's leaf; for a single-threaded turn it's the DETERMINISTIC thread-NOTE id
+    // (`Threads/<channel>/<name>`), STABLE across turns — so an observer resolves the agent's
+    // ONE thread from `metadata.thread`, not a per-turn UUID that changed every run.
+    // INBOUND-note stamping is deferred (those notes are written externally, before the turn
+    // knows its thread).
     const threadId = args.meta?.thread;
     if (threadId) metadata.thread = threadId;
 


### PR DESCRIPTION
Two daemon-side fixes for vault-native **programmatic** agents, surfaced by auditing the live agents (uni-weaver / uni-evolve, 2026-06-28). Both close a "the agent can't see / an observer is misled about" gap. `0.2.3-rc.10 → rc.11`.

---

## #162 — inject run-context (real wall-clock + run id) into each turn

A headless `claude -p` turn has **no clock** and no notion of *which run it is*, so agents **fabricate** timestamps — uni-weaver openly invented its report time (a fixed `10:05` slot, the date "derived from context"). The daemon *knows* these facts at dispatch, so it now injects them.

- The registry assembles a `RunContext` per turn: the **real wall-clock** (`now`, ISO), whether this run is **`new` vs `resumed`** (from `TurnSession.resume`), and **why it fired** (`scheduled-job:<id>` for a runner fire vs `interactive`, derived from the inbound `metadata.sender`). Passed to `deliver()` as a new optional param.
- The programmatic backend renders it as a concise, clearly-labeled preamble (`renderRunContext`) **prepended to the `claude -p` message** — it never touches the agent's own system prompt.

**Injection point:** `src/backends/programmatic.ts` `deliver()` — `turnMessage = renderRunContext(message, runContext)` (before the attachment-pointer append), so the preamble sits at the top of the `-p` prompt. The inbound `sender` is threaded transport → daemon → `QueuedMessage.sender` on **both** the live-enqueue and the pending-buffer paths (`src/daemon.ts`). Additive: omit `runContext` → the turn message is exactly as before.

*Deferred (noted inline):* `priorTurnCount` (a `turn=N` line) — the rolling `turn_count` lives on the transport's thread note and isn't surfaced back to the drain yet; the `now`/session/fired-by trio is the floor.

**Tests:** `renderRunContext` unit tests (labeled preamble carries the real clock; message survives; optional fields gated); a `deliver()` test that the assembled `claude -p` argv carries the injected timestamp; registry tests that the assembled RunContext has a real ISO `now`, correct `session`, and correct `fired-by`; `runFiredBy` unit tests.

## #163 — single-threaded outbound `metadata.thread` → the resolvable thread-note id

A single-threaded agent has **ONE stable, resumed** Claude session across turns (uni-weaver's thread note carries one `session` across 25 turns). But each **outbound** message stamped a **different per-turn correlation UUID** in `metadata.thread` — which misled an observer (uni-evolve) into "a fresh session each run, fictional rolling memory" when resume actually works.

Fix mirrors the #124 callback `source_thread` fix — stamp the **mode-correct, resolvable** thread id:
- **single-threaded** → the **deterministic thread-NOTE id** (`Threads/<channel>/<name>`), **stable across turns** — an observer resolves the agent's ONE thread with `query-notes { id }`.
- **multi-threaded** → the per-fire id (that fire's note leaf) — correct as-is; each fire is its own thread.

**Resolution point:** new exported `outboundThreadId(multiThreaded, turnThreadId, threadNoteId)` in `src/backends/registry.ts`, computed once in the drain from the **start-ensure's written thread-note id** (`startThreadNoteId`), then passed to the outbound write **and both `postFailureNote` paths**. The per-turn `turnThreadId` is still used for thread-note correlation / `sameTurn` / callbacks (unchanged). Falls back to the per-turn id when no resolvable note id surfaced (no durable store / failed thread write) — never undefined.

**Tests:** a single-threaded outbound carries the deterministic thread-note id and the **same** id across turns; a multi-threaded outbound carries the distinct per-fire id; a failure note carries the deterministic id too; the no-durable-store fallback; plus `outboundThreadId` unit tests.

---

## Gates
- `bun run typecheck` — clean
- `bun test ./src` — **1224 pass, 0 fail**
- `bunx biome check .` — exit 0 (2 pre-existing warnings in `vault.test.ts`, untouched)

Independent reviewer pass: LGTM, no critical issues; the three reviewer nits (a double `runFiredBy` call, a deferred-`priorTurnCount` marker, a stray blank line) + a failure-note test-coverage gap were folded inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)