### PR TITLE
feat(agent): roles×threads NEXT slice — subject routing + per-thread continuity + per-thread workspace (F+G, #120)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/agent",
-  "version": "0.2.3-rc.12",
+  "version": "0.2.3-rc.13",
   "description": "Vault-native agents for Claude Code — a #agent/definition note + an inbound message becomes a sandboxed claude turn; the reply is written back as a note. Messaging gateway on :1941.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/src/backends/programmatic.ts
+++ b/src/backends/programmatic.ts
@@ -443,13 +443,19 @@ export class ProgrammaticBackend implements AgentBackend {
     attachments?: InboundAttachment[],
     runContext?: RunContext,
     subjectDossier?: string,
+    subject?: string,
   ): Promise<DeliverResult> {
     const spec = handle.spec;
     if (!spec) {
       return { ok: false, error: `ProgrammaticBackend.deliver: handle for "${handle.name}" carries no spec` };
     }
     const channel = handle.channel;
-    const workspace = sessionWorkspace(this.deps.sessionsDir, spec.name);
+    // roles×threads NEXT slice (#120, G): the PER-THREAD private workspace. A subject keys
+    // a distinct `sessions/<name>--<slug(subject)>/` dir (its own `.mcp.json` /
+    // `system-prompt.txt` / HOME / attachment staging — see stageAttachments below, which
+    // takes THIS workspace), so concurrent subjects of one multi-threaded agent never clobber
+    // each other's per-turn files. NO subject → `sessions/<name>/` (HEAD, byte-identical).
+    const workspace = sessionWorkspace(this.deps.sessionsDir, spec.name, subject);
 
     // Resolve the Claude OAuth credential keyed on the wake channel. A missing
     // credential throws (CredentialNotConfigured) BEFORE any mint/spawn side effect.

--- a/src/backends/registry.test.ts
+++ b/src/backends/registry.test.ts
@@ -60,14 +60,31 @@ class FakeBackend implements AgentBackend {
     message: string;
     session: TurnSession;
     runContext?: RunContext;
+    /** roles×threads NEXT slice (#120, G): the thread subject the drain threaded in. */
+    subject?: string;
   }[] = [];
-  /** Max concurrent in-flight turns observed (must stay ≤ 1 for serial). */
+  /** Max concurrent in-flight turns observed (must stay ≤ 1 for serial — PER drain key). */
   maxConcurrent = 0;
+  /**
+   * Max concurrent in-flight turns observed PER (channel, subject) thread key — the
+   * per-THREAD serial guarantee (roles×threads NEXT slice #120): two DIFFERENT subjects of
+   * one agent MAY interleave (so the channel-wide max can exceed 1), but each (name, subject)
+   * thread must stay ≤ 1. Keyed by `${channel}::${subject ?? ""}`.
+   */
+  readonly maxConcurrentByThread = new Map<string, number>();
+  private readonly inFlightByThread = new Map<string, number>();
   private inFlight = 0;
   /** Whether `stop` was called, per channel. */
   readonly stopped = new Set<string>();
   /** A gate the next turn waits on (release to let it finish). Reset per use. */
   gate: { promise: Promise<void>; resolve: () => void } | null = null;
+  /**
+   * Per-SUBJECT gates (roles×threads NEXT slice #120) — a turn for subject S blocks on
+   * `gateBySubject.get(S)` if present (else the shared `gate`, else not at all). Lets a test
+   * hold subject A's turn while subject B's turn runs to completion, proving two subjects of
+   * one agent INTERLEAVE while each subject stays serial. Keyed by the raw subject string.
+   */
+  readonly gateBySubject = new Map<string, { promise: Promise<void>; resolve: () => void }>();
   /**
    * The result function — given the message + the turn's session id, returns the
    * DeliverResult to resolve. The DEFAULT ECHOES `sessionId` (mirroring real claude, which
@@ -96,15 +113,36 @@ class FakeBackend implements AgentBackend {
     onInterim?: InterimSink,
     _attachments?: InboundAttachment[],
     runContext?: RunContext,
+    _subjectDossier?: string,
+    subject?: string,
   ): Promise<DeliverResult> {
-    this.calls.push({ channel: handle.channel, message, session, ...(runContext ? { runContext } : {}) });
+    this.calls.push({
+      channel: handle.channel,
+      message,
+      session,
+      ...(runContext ? { runContext } : {}),
+      ...(subject ? { subject } : {}),
+    });
     this.inFlight++;
     this.maxConcurrent = Math.max(this.maxConcurrent, this.inFlight);
+    // Per-THREAD concurrency: key by (channel, subject) so two subjects of one agent are
+    // distinct threads (may interleave) but the SAME (name, subject) must stay serial.
+    const threadKey = `${handle.channel}::${subject ?? ""}`;
+    const cur = (this.inFlightByThread.get(threadKey) ?? 0) + 1;
+    this.inFlightByThread.set(threadKey, cur);
+    this.maxConcurrentByThread.set(
+      threadKey,
+      Math.max(this.maxConcurrentByThread.get(threadKey) ?? 0, cur),
+    );
     try {
       // Emit any configured interim events (mirrors the real backend streaming text +
       // tool_use as the turn runs) so the registry's forwarding can be asserted.
       if (onInterim) for (const e of this.interimToEmit) onInterim(e);
-      if (this.gate) await this.gate.promise;
+      // A per-subject gate (if set for THIS turn's subject) takes precedence over the shared
+      // gate — so a test can release subject B while subject A is still held.
+      const subjectGate = subject !== undefined ? this.gateBySubject.get(subject) : undefined;
+      if (subjectGate) await subjectGate.promise;
+      else if (this.gate) await this.gate.promise;
       if (this.throwOnce) {
         const e = this.throwOnce;
         this.throwOnce = null;
@@ -113,6 +151,7 @@ class FakeBackend implements AgentBackend {
       return this.resultFor(message, session.id);
     } finally {
       this.inFlight--;
+      this.inFlightByThread.set(threadKey, (this.inFlightByThread.get(threadKey) ?? 1) - 1);
     }
   }
 
@@ -978,6 +1017,254 @@ describe("ProgrammaticAgentRegistry — serial queue (the hard invariant)", () =
     gate.resolve();
     await until(() => rec.calls.length === 2);
     expect(reg.statusOf("eng")).toEqual({ state: "idle", queued: 0 });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────────────────
+// roles×threads NEXT slice (#120) — F. subject routing + the PER-THREAD serial guarantee.
+//
+// The load-bearing invariant (registry.ts:13-20, generalized): a given (name, subject) thread
+// is NEVER processed by two concurrent `claude -p` turns, BUT two DIFFERENT subjects of one
+// multi-threaded agent MAY run concurrently. A single-threaded / no-subject agent maps to
+// exactly ONE queue (the bare channel), byte-identical to HEAD.
+// ─────────────────────────────────────────────────────────────────────────────────────────
+describe("ProgrammaticAgentRegistry — F. per-thread serial guarantee (#120)", () => {
+  test("two messages with the SAME (name, subject) are processed ONE AT A TIME, FIFO, never concurrent", async () => {
+    const backend = new FakeBackend();
+    // Hold subject "alpha" so the second alpha message must wait behind the first.
+    const alphaGate = deferred<void>();
+    backend.gateBySubject.set("alpha", { promise: alphaGate.promise, resolve: alphaGate.resolve });
+    const rec = recorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    await reg.register(specMultiThreaded("digest", "digest"));
+
+    reg.enqueue("digest", { content: "a1", subject: "alpha" });
+    await until(() => backend.calls.length === 1);
+    // A SECOND alpha message arrives while the first is held — it must QUEUE behind it.
+    reg.enqueue("digest", { content: "a2", subject: "alpha" });
+    // Still exactly one alpha turn STARTED (the gate holds the first; the second waits serially).
+    expect(backend.calls).toHaveLength(1);
+
+    alphaGate.resolve();
+    await until(() => rec.calls.length === 2);
+    // FIFO + strictly serial: a1 then a2, NEVER concurrent for the (digest, alpha) thread.
+    expect(backend.calls.map((c) => c.message)).toEqual(["a1", "a2"]);
+    expect(backend.maxConcurrentByThread.get("digest::alpha")).toBe(1);
+  });
+
+  test("two DIFFERENT subjects of one agent can run CONCURRENTLY (interleave), each serial", async () => {
+    const backend = new FakeBackend();
+    // Hold subject "alpha" indefinitely; leave "beta" ungated so it runs to completion while
+    // alpha is still in flight — proving the two subject threads interleave.
+    const alphaGate = deferred<void>();
+    backend.gateBySubject.set("alpha", { promise: alphaGate.promise, resolve: alphaGate.resolve });
+    const rec = recorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    await reg.register(specMultiThreaded("digest", "digest"));
+
+    // Start alpha (held), then beta (free). If subjects shared one queue, beta would block
+    // behind the held alpha and NEVER complete; concurrency lets beta finish first.
+    reg.enqueue("digest", { content: "a1", subject: "alpha" });
+    await until(() => backend.calls.length === 1);
+    reg.enqueue("digest", { content: "b1", subject: "beta" });
+    // beta completes WHILE alpha is still held — only possible if the two run concurrently.
+    await until(() => rec.calls.some((c) => c.reply === "reply:b1"));
+    expect(rec.calls.map((c) => c.reply)).toContain("reply:b1");
+    // alpha hasn't been delivered as an outbound yet (its turn is still gated).
+    expect(rec.calls.some((c) => c.reply === "reply:a1")).toBe(false);
+
+    // Release alpha; it now completes too.
+    alphaGate.resolve();
+    await until(() => rec.calls.some((c) => c.reply === "reply:a1"));
+    // Each subject thread stayed serial (≤1 concurrent within a thread) even though the two
+    // threads ran concurrently across the channel.
+    expect(backend.maxConcurrentByThread.get("digest::alpha")).toBe(1);
+    expect(backend.maxConcurrentByThread.get("digest::beta")).toBe(1);
+    // The drain threaded the subject through to the backend (the per-thread workspace key, G).
+    const alphaCall = backend.calls.find((c) => c.message === "a1");
+    const betaCall = backend.calls.find((c) => c.message === "b1");
+    expect(alphaCall?.subject).toBe("alpha");
+    expect(betaCall?.subject).toBe("beta");
+  });
+
+  test("a SINGLE-threaded agent maps every message to ONE queue (the channel), subject ignored for routing", async () => {
+    const backend = new FakeBackend();
+    const gate = deferred<void>();
+    backend.gate = { promise: gate.promise, resolve: gate.resolve };
+    const rec = recorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    await reg.register(specFor("eng")); // single-threaded (default).
+
+    // Even if messages carry DIFFERENT subjects, a single-threaded agent serializes them ALL
+    // on the one channel queue (the subject is NOT a routing axis for single-threaded).
+    reg.enqueue("eng", { content: "m1", subject: "alpha" });
+    await until(() => backend.calls.length === 1);
+    reg.enqueue("eng", { content: "m2", subject: "beta" });
+    // The second is QUEUED behind the first (one queue) — not started concurrently.
+    expect(backend.calls).toHaveLength(1);
+    expect(reg.statusOf("eng")).toEqual({ state: "queued", queued: 1 });
+
+    gate.resolve();
+    await until(() => rec.calls.length === 2);
+    expect(backend.calls.map((c) => c.message)).toEqual(["m1", "m2"]);
+    // Never two concurrent turns for the single-threaded channel — the HEAD serial guarantee.
+    expect(backend.maxConcurrent).toBe(1);
+  });
+
+  test("a multi-threaded agent with NO subject maps to ONE queue (the channel) — HEAD behavior", async () => {
+    const backend = new FakeBackend();
+    const gate = deferred<void>();
+    backend.gate = { promise: gate.promise, resolve: gate.resolve };
+    const rec = recorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    await reg.register(specMultiThreaded("digest", "digest"));
+
+    // No subject on either fire → both route to the bare channel queue (HEAD), strictly serial.
+    reg.enqueue("digest", { content: "f1" });
+    await until(() => backend.calls.length === 1);
+    reg.enqueue("digest", { content: "f2" });
+    expect(backend.calls).toHaveLength(1);
+
+    gate.resolve();
+    await until(() => rec.calls.length === 2);
+    expect(backend.calls.map((c) => c.message)).toEqual(["f1", "f2"]);
+    expect(backend.maxConcurrent).toBe(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────────────────
+// roles×threads NEXT slice (#120) — F. per-thread session CONTINUITY.
+//
+// A multi-threaded SUBJECT thread reads/writes its session at the SUBJECT-scoped thread note
+// and `--resume`s it (turning "fresh thread per fire" into "resume the named thread"); a
+// multi-threaded agent with NO subject still never resumes (HEAD), and a single-threaded agent
+// resumes its def-named note (HEAD).
+// ─────────────────────────────────────────────────────────────────────────────────────────
+describe("ProgrammaticAgentRegistry — F. per-thread session continuity (#120)", () => {
+  function subjectSessionReader(priorBySubject: Record<string, string | undefined> = {}): {
+    calls: { channel: string; name: string; subject?: string }[];
+    fn: (channel: string, name: string, subject?: string) => Promise<string | undefined>;
+  } {
+    const calls: { channel: string; name: string; subject?: string }[] = [];
+    const fn = async (channel: string, name: string, subject?: string) => {
+      calls.push({ channel, name, ...(subject ? { subject } : {}) });
+      return priorBySubject[subject ?? ""];
+    };
+    return { calls, fn };
+  }
+
+  test("a multi-threaded SUBJECT thread RESUMES the session persisted on its subject-scoped note", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const threads = threadRecorder();
+    // A PRIOR session exists for subject "alpha" only.
+    const reader = subjectSessionReader({ alpha: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" });
+    const reg = new ProgrammaticAgentRegistry({
+      backend,
+      writeOutbound: rec.fn,
+      writeThread: threads.fn,
+      readSession: reader.fn,
+    });
+    await reg.register(specMultiThreaded("digest", "digest"));
+
+    reg.enqueue("digest", { content: "second fire", subject: "alpha" });
+    await until(() => backend.calls.length === 1);
+
+    // readSession was consulted with the channel, the DEF NAME, and the SUBJECT (subject-scoped).
+    expect(reader.calls).toEqual([{ channel: "digest", name: "digest", subject: "alpha" }]);
+    // A prior session for this subject → RESUME it (NOT a fresh uuid) — per-thread continuity.
+    expect(backend.calls[0]!.session).toEqual({
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      resume: true,
+    });
+    // The thread note carries the SUBJECT so the transport upserts the subject-scoped note.
+    await until(() => threads.ends().length === 1);
+    expect(threads.ends()[0]!.subject).toBe("alpha");
+    expect(threads.ends()[0]!.session).toBe("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa");
+  });
+
+  test("a multi-threaded subject with NO prior session CREATES a fresh one (first fire of the named thread)", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const threads = threadRecorder();
+    const reader = subjectSessionReader({}); // no prior for any subject.
+    const reg = new ProgrammaticAgentRegistry({
+      backend,
+      writeOutbound: rec.fn,
+      writeThread: threads.fn,
+      readSession: reader.fn,
+    });
+    await reg.register(specMultiThreaded("digest", "digest"));
+
+    reg.enqueue("digest", { content: "first fire", subject: "alpha" });
+    await until(() => backend.calls.length === 1);
+
+    expect(reader.calls).toEqual([{ channel: "digest", name: "digest", subject: "alpha" }]);
+    // No prior → CREATE (resume:false) with a fresh uuid, persisted onto the subject note.
+    expect(backend.calls[0]!.session.resume).toBe(false);
+    expect(backend.calls[0]!.session.id).toMatch(/^[0-9a-f-]{36}$/);
+    await until(() => threads.ends().length === 1);
+    expect(threads.ends()[0]!.subject).toBe("alpha");
+    expect(threads.ends()[0]!.session).toBe(backend.calls[0]!.session.id);
+  });
+
+  test("a multi-threaded agent with NO subject NEVER consults readSession (fresh per fire — HEAD)", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const threads = threadRecorder();
+    const reader = subjectSessionReader({ "": "should-never-be-used" });
+    const reg = new ProgrammaticAgentRegistry({
+      backend,
+      writeOutbound: rec.fn,
+      writeThread: threads.fn,
+      readSession: reader.fn,
+    });
+    await reg.register(specMultiThreaded("digest", "digest"));
+
+    reg.enqueue("digest", { content: "no-subject fire" });
+    await until(() => backend.calls.length === 1);
+
+    // No subject on a multi-threaded agent → readSession is NEVER consulted (HEAD: each fire
+    // is a fresh thread), and the session is created fresh.
+    expect(reader.calls).toHaveLength(0);
+    expect(backend.calls[0]!.session.resume).toBe(false);
+    await until(() => threads.ends().length === 1);
+    expect(threads.ends()[0]!.subject).toBeUndefined();
+  });
+
+  test("NULL-SUBJECT INVARIANT — a single-threaded agent's path is byte-identical to HEAD (the steward weave)", async () => {
+    // The live steward weave is single-threaded + carries NO subject. This pins that nothing
+    // in F changes its drain: readSession is keyed on (channel, def-name, undefined), the
+    // session resumes the def-named note, the thread note carries NO subject, and the backend
+    // sees NO subject. A regression here breaks the 4am weave.
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const threads = threadRecorder();
+    const reader = subjectSessionReader({ "": "55555555-5555-4555-8555-555555555555" });
+    const reg = new ProgrammaticAgentRegistry({
+      backend,
+      writeOutbound: rec.fn,
+      writeThread: threads.fn,
+      readSession: reader.fn,
+    });
+    await reg.register(specFor("steward")); // single-threaded, no subject.
+
+    reg.enqueue("steward", { content: "weave digest" }); // no subject — the runner fire.
+    await until(() => backend.calls.length === 1);
+
+    // readSession consulted with the def name and NO subject (the deterministic def-named note).
+    expect(reader.calls).toEqual([{ channel: "steward", name: "steward" }]);
+    // Resumes the def-named note's session (HEAD single-threaded behavior).
+    expect(backend.calls[0]!.session).toEqual({
+      id: "55555555-5555-4555-8555-555555555555",
+      resume: true,
+    });
+    // The backend sees NO subject (no per-thread workspace re-key — sessions/<name>/ unchanged).
+    expect(backend.calls[0]!.subject).toBeUndefined();
+    // The thread note carries NO subject (the deterministic def-named upsert, unchanged).
+    await until(() => threads.ends().length === 1);
+    expect(threads.ends()[0]!.subject).toBeUndefined();
+    expect(threads.ends()[0]!.name).toBe("steward");
   });
 });
 

--- a/src/backends/registry.ts
+++ b/src/backends/registry.ts
@@ -672,6 +672,10 @@ export class ProgrammaticAgentRegistry {
    * /health + the agents list to render `programmatic · idle|working|queued:N`.
    */
   statusOf(channel: string): { state: ProgrammaticAgentState; queued: number } {
+    // NOTE (roles×threads NEXT slice): this reads only the BARE-channel drain key, so a
+    // multi-threaded agent whose active work is on subject keys (`name--subject`) reports
+    // `idle` here. Acceptable while multi-threaded agents aren't in production; tracked for
+    // a /health upgrade before they are (the drain key, not the channel, is the unit of work).
     const queued = this.queues.get(channel)?.length ?? 0;
     if (this.draining.has(channel)) {
       // A worker is in flight. If there are messages waiting BEHIND the in-flight
@@ -705,15 +709,13 @@ export class ProgrammaticAgentRegistry {
       // channel's EXPECTED mark + any stranded pending buffer — nothing routes there now,
       // so a residual mark/buffer would leak (reviewer nit; defense-in-depth — the normal
       // flow only ever expects the NEW channel before this register).
-      this.byChannel.delete(priorChannel);
       // Clear EVERY per-thread queue/drain for the old channel (bare + subject keys), not
       // just the bare-channel key — a multi-threaded agent's subject queues would otherwise
-      // leak (roles×threads NEXT slice). clearChannelQueues reads the handle for the name
-      // prefix; do it BEFORE byChannel.delete so the prefix resolves — but byChannel was
-      // already deleted above for priorChannel, so it falls back to the channel-as-name
-      // prefix (correct for name===channel; a residual subject key self-clears on its next
-      // loop regardless, since the drain re-reads byChannel).
+      // leak (roles×threads NEXT slice). clearChannelQueues reads the handle for the subject-key
+      // name prefix, so run it BEFORE byChannel.delete while the handle is still present — that
+      // resolves the REAL agent name even if name !== channel in a future split (reviewer nit).
       this.clearChannelQueues(priorChannel);
+      this.byChannel.delete(priorChannel);
       this.expectedChannels.delete(priorChannel);
       this.pending.delete(priorChannel);
     }

--- a/src/backends/registry.ts
+++ b/src/backends/registry.ts
@@ -43,7 +43,7 @@
  */
 
 import type { AgentSpec, AgentMode } from "../sandbox/types.ts";
-import { normalizeChannel } from "../sandbox/types.ts";
+import { normalizeChannel, threadKey } from "../sandbox/types.ts";
 import type { AgentBackend, AgentHandle, InterimTurnEvent, RunContext, TurnSession } from "./types.ts";
 import type { InboundAttachment } from "../transport.ts";
 
@@ -118,6 +118,14 @@ export interface ThreadNote {
    * transport sanitizes it into the deterministic upsert path). Falls back to the channel.
    */
   name?: string;
+  /**
+   * The thread SUBJECT (roles×threads NEXT slice, #120) — when present, a MULTI-threaded
+   * thread becomes a DETERMINISTIC, upserting note at `threadKey(name, subject)`
+   * (`Threads/<ch>/<name>--<subject>`) carrying a session across fires (per-thread
+   * continuity), instead of a per-fire uuid note. Absent/empty → today's identity
+   * (single-threaded deterministic note / multi-threaded per-fire note), byte-identical to HEAD.
+   */
+  subject?: string;
   /** The `#agent/definition` note id (provenance; plain id string). */
   definition?: string;
   /** The mode the turn ran under — governs thread identity + whether the note upserts. */
@@ -308,26 +316,26 @@ function delay(ms: number): Promise<void> {
 /**
  * The thread id to stamp into an OUTBOUND note's `metadata.thread` (agent#163) — the
  * MODE-CORRECT, RESOLVABLE definition→thread→message link, mirroring the callback
- * `source_thread` fix (agent#124):
+ * `source_thread` fix (agent#124). Keyed on `perFire`:
  *
- *  - SINGLE-THREADED — the resolvable thread-NOTE id (the deterministic
- *    `Threads/<safeChannel>/<safeName>` note), so an observer reading the outbound note's
- *    `metadata.thread` resolves the agent's ONE stable thread with `query-notes { id }`.
- *    The pre-#163 bug stamped the per-turn correlation UUID here, which changed every turn
- *    and resolved to nothing — misleading an observer into "a fresh session each run" when
- *    the single-threaded session is actually stable + resumed across turns.
- *  - MULTI-THREADED — the per-fire id (`turnThreadId`), which IS that fire's thread-note leaf
- *    (`Threads/<safeChannel>/<turnThreadId>`) — correct as-is: each fire is its own thread.
+ *  - DETERMINISTIC thread (`perFire: false`) — single-threaded, OR a multi-threaded SUBJECT
+ *    thread (roles×threads NEXT slice, #120). The note is the resolvable, deterministic
+ *    `Threads/<safeChannel>/<name[--subject]>` note, so an observer reading the outbound's
+ *    `metadata.thread` resolves the agent's stable thread with `query-notes { id }`. Stamp
+ *    the resolvable `threadNoteId`. The pre-#163 bug stamped the per-turn correlation UUID
+ *    here, which changed every turn and resolved to nothing.
+ *  - PER-FIRE thread (`perFire: true`) — a multi-threaded thread with NO subject: each fire is
+ *    its own note at `Threads/<safeChannel>/<turnThreadId>`, so the per-fire id IS the leaf.
  *
  * Falls back to `turnThreadId` when no resolvable note id surfaced (no durable thread store
  * wired, or the thread-note write failed) — never undefined, so the link is always stamped.
  */
 export function outboundThreadId(
-  multiThreaded: boolean,
+  perFire: boolean,
   turnThreadId: string,
   threadNoteId: string | undefined,
 ): string {
-  if (multiThreaded) return turnThreadId;
+  if (perFire) return turnThreadId;
   return threadNoteId ?? turnThreadId;
 }
 
@@ -437,9 +445,25 @@ export class ProgrammaticAgentRegistry {
   private readonly byChannel = new Map<string, ProgrammaticAgentHandle>();
   /** name → channel (the lifecycle index; an agent has exactly one wake channel). */
   private readonly nameToChannel = new Map<string, string>();
-  /** channel → FIFO queue of pending messages. */
+  /**
+   * DRAIN-KEY → FIFO queue of pending messages — the PER-THREAD serial queue
+   * (roles×threads NEXT slice, #120). The drain key is {@link drainKeyFor}:
+   *  - a single-threaded agent, OR a message with NO subject → the bare CHANNEL
+   *    (byte-identical to HEAD — every current agent incl. the weave routes here).
+   *  - a multi-threaded agent WITH a subject → `threadKey(spec.name, subject)`
+   *    (`<name>--<subject>`), so distinct subjects of one agent get distinct queues.
+   * Keying queues + {@link draining} by the SAME drain key is what makes two messages
+   * of the SAME (name, subject) strictly serial while letting two DIFFERENT subjects
+   * of one agent run concurrently — the per-thread serial guarantee (class doc lines 13-20).
+   */
   private readonly queues = new Map<string, QueuedMessage[]>();
-  /** channel → the in-flight drain promise (its presence == a worker is running). */
+  /**
+   * DRAIN-KEY → the in-flight drain promise (its presence == a worker is running for that
+   * thread). One promise per drain key is the structural lock: a second message for the
+   * SAME drain key never starts a second worker (it appends + the running worker picks it
+   * up), so a given (name, subject) thread is NEVER processed by two concurrent `claude -p`.
+   * A DIFFERENT subject is a DIFFERENT key → its own promise → may run concurrently.
+   */
   private readonly draining = new Map<string, Promise<void>>();
   /**
    * channel → FIFO queue of PENDING-INBOUND messages that arrived BEFORE a live
@@ -480,14 +504,18 @@ export class ProgrammaticAgentRegistry {
    * 2+ `--resume`s its prior conversation. Unwired (or no prior) → every turn creates a
    * fresh session. Multi-threaded NEVER consults it (each fire is a fresh thread).
    */
-  private readonly readSession?: (channel: string, name: string) => Promise<string | undefined>;
+  private readonly readSession?: (
+    channel: string,
+    name: string,
+    subject?: string,
+  ) => Promise<string | undefined>;
   /**
    * Optional session CLEAR — wipe a single-threaded agent's persisted thread-note session
    * so its next turn starts a FRESH claude conversation (the per-agent restart). The daemon
    * wires this to the channel transport's `clearThreadSession`. Called by {@link resetSession}.
    * Unwired → reset is a clean no-op beyond returning that the agent exists.
    */
-  private readonly clearSession?: (channel: string, name: string) => Promise<void>;
+  private readonly clearSession?: (channel: string, name: string, subject?: string) => Promise<void>;
   /**
    * Optional pre-turn SUBJECT-DOSSIER read (roles×threads NOW slice) — per-thread
    * context for the current subject, folded into the composed system prompt (the
@@ -507,10 +535,17 @@ export class ProgrammaticAgentRegistry {
     writeThread?: WriteThread;
     writeCallback?: WriteCallback;
     onTurnEvent?: TurnEventSink;
-    /** Read the persisted thread-note session UUID (single-threaded resume). */
-    readSession?: (channel: string, name: string) => Promise<string | undefined>;
-    /** Clear the persisted thread-note session (the per-agent restart / reset). */
-    clearSession?: (channel: string, name: string) => Promise<void>;
+    /**
+     * Read the persisted thread-note session UUID. `subject` (roles×threads NEXT slice, #120)
+     * resolves the SUBJECT-scoped thread note for a multi-threaded subject thread; omitted →
+     * the deterministic def-named note (single-threaded resume, HEAD).
+     */
+    readSession?: (channel: string, name: string, subject?: string) => Promise<string | undefined>;
+    /**
+     * Clear the persisted thread-note session (the per-agent restart / reset). `subject`
+     * resolves the subject-scoped thread note; omitted → the def-named note (HEAD).
+     */
+    clearSession?: (channel: string, name: string, subject?: string) => Promise<void>;
     /**
      * Read the per-thread subject dossier (roles×threads NOW slice). Optional + UNWIRED
      * by default — the composed prompt is the role body verbatim until a dossier source exists.
@@ -550,6 +585,59 @@ export class ProgrammaticAgentRegistry {
       throw new Error(`programmatic registry: spec "${spec.name}" declares no channels`);
     }
     return normalizeChannel(spec.channels[0]!).name;
+  }
+
+  /**
+   * The PER-THREAD serial DRAIN KEY for an inbound message (roles×threads NEXT slice, #120)
+   * — what {@link queues} + {@link draining} are keyed by:
+   *  - SINGLE-threaded agent, OR a message with NO subject → the bare CHANNEL. This is the
+   *    back-compat path: every agent today (incl. the weave) carries no subject, so the key
+   *    is exactly the channel and the queue/drain behavior is byte-identical to HEAD.
+   *  - MULTI-threaded agent WITH a subject → `threadKey(spec.name, subject)` (`<name>--<sub>`),
+   *    so two subjects of one agent get DISTINCT queues + DISTINCT drain promises (concurrent),
+   *    while two messages of the SAME subject share one queue + one promise (strictly serial).
+   *
+   * NOTE: a message can only carry a subject route when a LIVE handle exists for the channel
+   * (enqueue requires byChannel), so we read the mode off that handle. A missing handle (the
+   * caller already returns false) defaults to the channel key.
+   */
+  private drainKeyFor(channel: string, msg: QueuedMessage): string {
+    const handle = this.byChannel.get(channel);
+    if (!handle) return channel;
+    const multiThreaded = (handle.spec.mode ?? "single-threaded") === "multi-threaded";
+    if (!multiThreaded) return channel;
+    // threadKey returns the bare name for no/empty subject — but the channel (not the name)
+    // is the back-compat single-thread key, so only re-key when a subject actually narrows it.
+    const subject = msg.subject?.trim();
+    if (!subject) return channel;
+    return threadKey(handle.spec.name, subject);
+  }
+
+  /**
+   * Drop EVERY per-thread queue + drain promise belonging to a channel — used on
+   * teardown/re-key (deregister, a name moving channels). Because {@link queues} +
+   * {@link draining} are now keyed by the per-thread DRAIN KEY (`<channel>` or
+   * `<channel-name>--<subject>`), deleting only the bare-channel key would orphan a
+   * multi-threaded agent's subject queues. We clear the channel key AND every
+   * `<channel-name>--*` subject key whose threadKey is prefixed by the channel's agent name.
+   * An in-flight subject drain self-terminates on its next loop (it re-reads byChannel,
+   * now empty for that channel); dropping the `draining` entry just stops the map leaking.
+   */
+  private clearChannelQueues(channel: string): void {
+    // The bare-channel key (single-threaded / no-subject path).
+    this.queues.delete(channel);
+    this.draining.delete(channel);
+    // Subject keys are `${spec.name}--${slug(subject)}`. Resolve the agent name for this
+    // channel if a handle is still present; else fall back to the channel as the name prefix
+    // (covers the common case name===channel). Match any key with that `--`-prefixed form.
+    const handle = this.byChannel.get(channel);
+    const namePrefix = `${handle?.spec.name ?? channel}--`;
+    for (const key of [...this.queues.keys()]) {
+      if (key.startsWith(namePrefix)) this.queues.delete(key);
+    }
+    for (const key of [...this.draining.keys()]) {
+      if (key.startsWith(namePrefix)) this.draining.delete(key);
+    }
   }
 
   /** Is a programmatic agent registered for this channel? (the inbound-routing check) */
@@ -618,8 +706,14 @@ export class ProgrammaticAgentRegistry {
       // so a residual mark/buffer would leak (reviewer nit; defense-in-depth — the normal
       // flow only ever expects the NEW channel before this register).
       this.byChannel.delete(priorChannel);
-      this.queues.delete(priorChannel);
-      this.draining.delete(priorChannel);
+      // Clear EVERY per-thread queue/drain for the old channel (bare + subject keys), not
+      // just the bare-channel key — a multi-threaded agent's subject queues would otherwise
+      // leak (roles×threads NEXT slice). clearChannelQueues reads the handle for the name
+      // prefix; do it BEFORE byChannel.delete so the prefix resolves — but byChannel was
+      // already deleted above for priorChannel, so it falls back to the channel-as-name
+      // prefix (correct for name===channel; a residual subject key self-clears on its next
+      // loop regardless, since the drain re-reads byChannel).
+      this.clearChannelQueues(priorChannel);
       this.expectedChannels.delete(priorChannel);
       this.pending.delete(priorChannel);
     }
@@ -740,9 +834,13 @@ export class ProgrammaticAgentRegistry {
     const channel = this.nameToChannel.get(name);
     if (channel === undefined) return false;
     const handle = this.byChannel.get(channel);
+    // Clear every per-thread queue/drain for this channel (bare + subject keys) BEFORE
+    // dropping byChannel, so the handle is still present to resolve the agent-name prefix
+    // for the subject keys (roles×threads NEXT slice). An in-flight subject drain
+    // self-terminates on its next loop (it re-reads byChannel, now empty for the channel).
+    this.clearChannelQueues(channel);
     this.byChannel.delete(channel);
     this.nameToChannel.delete(name);
-    this.queues.delete(channel);
     // Clear the EXPECTED mark + any buffered pending inbound for this channel too —
     // the agent is gone, so a pending message has nothing to drain into and would
     // strand forever (and the next register would replay stale messages). The daemon's
@@ -804,17 +902,26 @@ export class ProgrammaticAgentRegistry {
    */
   enqueue(channel: string, msg: QueuedMessage): boolean {
     if (!this.byChannel.has(channel)) return false;
-    const queue = this.queues.get(channel) ?? [];
+    // PER-THREAD ROUTING (roles×threads NEXT slice, #120): resolve the drain key. A
+    // single-threaded / no-subject message keys by the bare CHANNEL (byte-identical to
+    // HEAD); a multi-threaded agent WITH a subject keys by `threadKey(name, subject)`, so
+    // distinct subjects get distinct queues + distinct drain promises (concurrent), while
+    // the SAME subject shares one queue + one promise (strictly serial). The serial
+    // guarantee is per DRAIN KEY, not per channel.
+    const drainKey = this.drainKeyFor(channel, msg);
+    const queue = this.queues.get(drainKey) ?? [];
     queue.push(msg);
-    this.queues.set(channel, queue);
-    // Start the worker if it isn't already running. The drain promise's PRESENCE in
-    // `draining` is the "a worker is running" flag — set it synchronously before any
-    // await so a second enqueue in the same tick can't start a second worker.
-    if (!this.draining.has(channel)) {
-      const p = this.drain(channel).finally(() => {
-        this.draining.delete(channel);
+    this.queues.set(drainKey, queue);
+    // Start the worker if it isn't already running FOR THIS DRAIN KEY. The drain promise's
+    // PRESENCE in `draining` (keyed by drain key) is the "a worker is running for this
+    // thread" flag — set it synchronously before any await so a second enqueue for the same
+    // drain key in the same tick can't start a second worker (the per-thread serial lock).
+    // A DIFFERENT drain key has its own entry → its own worker → may run concurrently.
+    if (!this.draining.has(drainKey)) {
+      const p = this.drain(drainKey, channel).finally(() => {
+        this.draining.delete(drainKey);
       });
-      this.draining.set(channel, p);
+      this.draining.set(drainKey, p);
     }
     return true;
   }
@@ -833,9 +940,13 @@ export class ProgrammaticAgentRegistry {
    * failure is logged; the turn still counts as drained (the reply is durable-or-not
    * at the transport's discretion; we don't re-run the turn, which would fork).
    */
-  private async drain(channel: string): Promise<void> {
+  private async drain(drainKey: string, channel: string): Promise<void> {
     for (;;) {
-      const queue = this.queues.get(channel);
+      // The FIFO for THIS thread — keyed by the per-thread drain key, NOT the channel. A
+      // single-threaded / no-subject thread's drain key IS the channel (back-compat); a
+      // subject thread's is `threadKey(name, subject)`. Reading the queue by drain key is
+      // what keeps two subjects of one agent independently serial.
+      const queue = this.queues.get(drainKey);
       if (!queue || queue.length === 0) return;
       const handle = this.byChannel.get(channel);
       if (!handle) return; // deregistered mid-drain — stop.
@@ -860,9 +971,23 @@ export class ProgrammaticAgentRegistry {
       // CREATE a fresh session with a new uuid (`--session-id`). The backend just runs the
       // turn with this {@link TurnSession}; it reads no session store.
       const multiThreaded = (handle.spec.mode ?? "single-threaded") === "multi-threaded";
+      // The thread SUBJECT (roles×threads NEXT slice, #120) — trimmed; empty → none.
+      const turnSubject = msg.subject?.trim() ? msg.subject : undefined;
+      // A multi-threaded agent WITH a subject is a NAMED thread: a deterministic note at
+      // `Threads/<ch>/<name>--<subject>` that upserts + carries a session across fires
+      // (turning "fresh thread per fire" into "resume the named thread"). A multi-threaded
+      // agent with NO subject stays fresh-per-fire (HEAD); a single-threaded agent is the
+      // HEAD deterministic def-named note.
+      const hasSubjectThread = multiThreaded && !!turnSubject;
+      // RESUME the persisted session when one exists for this thread note:
+      //  - single-threaded → its deterministic def-named note (HEAD behavior, unchanged).
+      //  - multi-threaded WITH a subject → the subject-scoped note (NEW: per-thread continuity).
+      //  - multi-threaded with NO subject → NEVER resume (each fire is a fresh thread; HEAD).
+      // The leaf is resolved transport-side via `singleThreadedPath(channel, name, subject)`,
+      // so write + read + clear all agree on the path (no leaf math duplicated here).
       let resumeId: string | undefined;
-      if (!multiThreaded && this.readSession) {
-        resumeId = await this.readSession(handle.channel, handle.spec.name);
+      if (this.readSession && (!multiThreaded || hasSubjectThread)) {
+        resumeId = await this.readSession(handle.channel, handle.spec.name, turnSubject);
       }
       const turnSession: TurnSession = resumeId
         ? { id: resumeId, resume: true }
@@ -897,10 +1022,13 @@ export class ProgrammaticAgentRegistry {
         // single-threaded resume turn the prior session is preserved by writeThread anyway.
       });
       // The MODE-CORRECT, RESOLVABLE thread id stamped into outbound + failure notes
-      // (agent#163): single-threaded → the deterministic thread-NOTE id (stable across turns);
-      // multi-threaded → the per-fire `turnThreadId`. Computed once from the start-ensure id so
-      // every path (early failure, ok, outbound-failure) stamps the same resolvable link.
-      const outThreadId = outboundThreadId(multiThreaded, turnThreadId, startThreadNoteId);
+      // (agent#163): a DETERMINISTIC thread (single-threaded OR a multi-threaded subject
+      // thread) → the deterministic thread-NOTE id (stable across turns); a PER-FIRE thread
+      // (multi-threaded, NO subject) → the per-fire `turnThreadId`. `perFire` is multi-threaded
+      // AND no subject. Computed once from the start-ensure id so every path (early failure, ok,
+      // outbound-failure) stamps the same resolvable link.
+      const perFire = multiThreaded && !hasSubjectThread;
+      const outThreadId = outboundThreadId(perFire, turnThreadId, startThreadNoteId);
 
       // RUN CONTEXT (agent#162): assemble the runtime facts a headless `claude -p` turn can't
       // know — the REAL wall-clock (`startedAt`), whether this run CONTINUES a prior session
@@ -953,6 +1081,11 @@ export class ProgrammaticAgentRegistry {
           // roles×threads NOW slice: the per-thread subject dossier, folded into the composed
           // system prompt. Undefined (no subject / unwired source) → role body verbatim.
           subjectDossier,
+          // roles×threads NEXT slice (#120, G): the thread SUBJECT — the backend keys the
+          // PER-THREAD private workspace off it (`sessions/<name>--<subject>/`), so concurrent
+          // subjects of one agent never clobber each other's per-turn `.mcp.json` /
+          // `system-prompt.txt` / HOME. Undefined → `sessions/<name>/` (HEAD, unchanged).
+          turnSubject,
         );
       } catch (err) {
         // The backend contract is failure-as-VALUE, never a throw — but defend so a
@@ -1245,6 +1378,12 @@ export class ProgrammaticAgentRegistry {
     const thread: ThreadNote = {
       channel: handle.channel,
       name: handle.spec.name,
+      // roles×threads NEXT slice (#120): carry the thread SUBJECT so the transport can
+      // resolve a subject-scoped deterministic thread note (`Threads/<ch>/<name>--<subject>`)
+      // that UPSERTS + carries a session across fires (per-thread continuity) instead of a
+      // per-fire uuid note. Absent/empty → no subject → today's identity (single-threaded
+      // deterministic note, or multi-threaded per-fire note) is byte-identical to HEAD.
+      ...(msg.subject?.trim() ? { subject: msg.subject } : {}),
       ...(handle.spec.definition ? { definition: handle.spec.definition } : {}),
       mode: handle.spec.mode ?? "single-threaded",
       status,

--- a/src/backends/types.ts
+++ b/src/backends/types.ts
@@ -252,6 +252,14 @@ export interface AgentBackend {
    * subject-specific context layers on top. The run-context preamble is unaffected (it stays on
    * the MESSAGE). ADDITIVE — omitted/empty → the system prompt is the role body verbatim
    * (byte-identical to HEAD; the null-subject invariant).
+   *
+   * `subject` (optional, roles×threads NEXT slice #120) is the thread SUBJECT — the programmatic
+   * backend keys the agent's PER-THREAD private session workspace off it
+   * (`sessions/<name>--<slug(subject)>/`), so concurrent subjects of one multi-threaded agent get
+   * ISOLATED per-turn files (`.mcp.json`, `system-prompt.txt`, HOME, attachment staging) and never
+   * clobber each other. ADDITIVE — omitted/empty → `sessions/<name>/` (byte-identical to HEAD;
+   * the null-subject invariant). Distinct from `subjectDossier` (which is prompt CONTENT); this is
+   * the workspace IDENTITY.
    */
   deliver(
     handle: AgentHandle,
@@ -261,6 +269,7 @@ export interface AgentBackend {
     attachments?: InboundAttachment[],
     runContext?: RunContext,
     subjectDossier?: string,
+    subject?: string,
   ): Promise<DeliverResult>;
 
   /**

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -838,11 +838,14 @@ export function buildWriteCallback(channels: Map<string, Channel>): WriteCallbac
  */
 export function buildReadSession(
   channels: Map<string, Channel>,
-): (channel: string, name: string) => Promise<string | undefined> {
-  return async (channel, name) => {
+): (channel: string, name: string, subject?: string) => Promise<string | undefined> {
+  return async (channel, name, subject) => {
     const ch = channels.get(channel);
     if (!ch?.transport.readThreadSession) return undefined;
-    return ch.transport.readThreadSession(channel, name);
+    // roles×threads NEXT slice (#120): pass the subject so a multi-threaded SUBJECT thread
+    // resumes its own subject-scoped note (`Threads/<ch>/<name>--<subject>`). Omitted → the
+    // deterministic def-named note (single-threaded resume, HEAD).
+    return ch.transport.readThreadSession(channel, name, subject);
   };
 }
 
@@ -856,11 +859,12 @@ export function buildReadSession(
  */
 export function buildClearSession(
   channels: Map<string, Channel>,
-): (channel: string, name: string) => Promise<void> {
-  return async (channel, name) => {
+): (channel: string, name: string, subject?: string) => Promise<void> {
+  return async (channel, name, subject) => {
     const ch = channels.get(channel);
     if (!ch?.transport.clearThreadSession) return;
-    await ch.transport.clearThreadSession(channel, name);
+    // roles×threads NEXT slice (#120): a subject clears its own subject-scoped note.
+    await ch.transport.clearThreadSession(channel, name, subject);
   };
 }
 
@@ -1076,6 +1080,15 @@ export async function reregisterProgrammaticAgents(
   }
   let count = 0;
   for (const name of entries) {
+    // PER-THREAD WORKSPACE GUARD (roles×threads NEXT slice #120, G). A subject thread's
+    // workspace dir is `<name>--<slug(subject)>` (the `--` separator). Those are PER-TURN
+    // scratch dirs for a multi-threaded agent's subject threads, NOT agent specs — they hold
+    // no authoritative spec.json (the spec is per-AGENT, persisted only at the name-only
+    // `<name>/` dir). Re-registering one would resurrect a phantom agent keyed on a
+    // subject-leaf name. So a dir name containing `--` is INERT on boot: skip it. The
+    // canonical per-agent spec dir (no `--`) is re-registered as before — byte-identical to
+    // HEAD for every current agent (no current agent's name contains `--`).
+    if (name.includes("--")) continue;
     const workspace = sessionWorkspace(sessionsDirPath, name);
     const spec = readPersistedSpec(workspace);
     // Re-register ONLY specs that explicitly persisted `backend: "programmatic"`.

--- a/src/programmatic-wiring.test.ts
+++ b/src/programmatic-wiring.test.ts
@@ -549,6 +549,36 @@ describe("boot re-register", () => {
     );
     expect(count).toBe(0);
   });
+
+  test("roles×threads (#120, G): a per-thread `<name>--<subject>` workspace dir is NOT re-registered on boot", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "prog-boot-subject-"));
+    try {
+      const sessionsDir = join(dir, "sessions");
+      // The per-AGENT spec dir (no `--`) carries the authoritative spec → re-registered.
+      persistSpec(sessionWorkspace(sessionsDir, "pm"), { name: "pm", channels: ["pm"], backend: "programmatic" });
+      // A per-THREAD subject workspace dir `pm--eco-civ` is a per-turn scratch dir. Even if it
+      // somehow holds a programmatic spec.json (it normally never does — the spec is per-agent),
+      // the `--` guard makes it INERT on boot: it must NOT resurrect a phantom agent.
+      // Build the subject dir by passing the subject so the leaf is exactly `pm--eco-civ`.
+      persistSpec(sessionWorkspace(sessionsDir, "pm", "eco-civ"), {
+        name: "pm--eco-civ",
+        channels: ["pm"],
+        backend: "programmatic",
+      });
+
+      const backend = new FakeBackend();
+      const rec = recorder();
+      const programmatic = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+
+      const count = await reregisterProgrammaticAgents(programmatic, liveChannels(["pm"]), sessionsDir);
+      // Exactly the per-AGENT spec was re-registered; the `--` subject dir was skipped.
+      expect(count).toBe(1);
+      expect(programmatic.hasName("pm")).toBe(true);
+      expect(programmatic.hasName("pm--eco-civ")).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("/health + GET /api/agents include programmatic agents", () => {

--- a/src/spawn-agent.test.ts
+++ b/src/spawn-agent.test.ts
@@ -835,6 +835,46 @@ describe("spawnAgent — full wiring with stubs (no real token)", () => {
 // (.mcp.json / system-prompt.txt / spec.json / seeded CLAUDE_CONFIG_DIR) STAYS in
 // the per-agent sessions/<name> dir, never written into the shared workspace.
 
+// roles×threads NEXT slice (#120) — G. per-thread private workspace.
+// `sessionWorkspace(dir, name, subject?)` → `join(dir, threadKey(name, subject))`. A subject
+// keys an ISOLATED `sessions/<name>--<slug(subject)>/` dir; NO subject is byte-identical to HEAD.
+describe("sessionWorkspace — per-thread private workspace (#120, G)", () => {
+  test("NO subject → sessions/<name>/ — byte-identical to HEAD", () => {
+    expect(sessionWorkspace("/s", "steward")).toBe(join("/s", "steward"));
+  });
+
+  test("empty / whitespace-only subject → falls back to sessions/<name>/ (no subject narrows it)", () => {
+    expect(sessionWorkspace("/s", "steward", "")).toBe(join("/s", "steward"));
+    expect(sessionWorkspace("/s", "steward", "   ")).toBe(join("/s", "steward"));
+  });
+
+  test("a subject → an ISOLATED sessions/<name>--<slug(subject)>/ dir", () => {
+    expect(sessionWorkspace("/s", "pm", "eco-civ")).toBe(join("/s", "pm--eco-civ"));
+  });
+
+  test("DISTINCT subjects of one agent → DISTINCT dirs (per-thread isolation)", () => {
+    const a = sessionWorkspace("/s", "pm", "alpha");
+    const b = sessionWorkspace("/s", "pm", "beta");
+    expect(a).toBe(join("/s", "pm--alpha"));
+    expect(b).toBe(join("/s", "pm--beta"));
+    expect(a).not.toBe(b);
+    // And neither collides with the name-only (per-AGENT spec) dir.
+    expect(a).not.toBe(sessionWorkspace("/s", "pm"));
+  });
+
+  test("an untrusted subject is SLUGGED into the leaf — no path traversal / escape", () => {
+    // `../`, slashes, spaces, NUL all collapse to `-` (the shared slug), so the leaf can never
+    // climb out of the sessions dir.
+    expect(sessionWorkspace("/s", "pm", "../../etc/passwd")).toBe(join("/s", "pm--------etc-passwd"));
+    expect(sessionWorkspace("/s", "pm", "a b/c")).toBe(join("/s", "pm--a-b-c"));
+    expect(sessionWorkspace("/s", "pm", "x y")).toBe(join("/s", "pm--x-y"));
+    // The leaf stays a single path segment under the sessions dir (no extra separators).
+    const ws = sessionWorkspace("/s", "pm", "../escape");
+    expect(ws.startsWith(join("/s") + "/")).toBe(true);
+    expect(ws.slice(join("/s").length + 1).includes("/")).toBe(false);
+  });
+});
+
 describe("resolveAgentCwd — cwd is the workspace when set, else the private dir", () => {
   test("workspace set → that path; the private dir is untouched as the cwd", () => {
     expect(resolveAgentCwd({ name: "a", channels: ["c"], workspace: "/ws/repo" }, "/private/a")).toBe("/ws/repo");

--- a/src/spawn-agent.ts
+++ b/src/spawn-agent.ts
@@ -27,6 +27,7 @@ import { writeFileSync, mkdirSync, chmodSync, existsSync, readFileSync } from "n
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { AgentSpec, BaseBinds } from "./sandbox/types.ts";
+import { threadKey } from "./sandbox/types.ts";
 import { Sandbox, type SandboxEngine, type WrappedCommand } from "./sandbox/index.ts";
 import type { EgressBaseInput } from "./sandbox/egress.ts";
 import { DENYLISTED_ENV } from "./credentials.ts";
@@ -181,9 +182,18 @@ export interface SpawnAgentBaseDeps {
   ripgrep?: { command: string; args?: string[] };
 }
 
-/** Per-session workspace dir under the sessions base. */
-export function sessionWorkspace(sessionsDir: string, specName: string): string {
-  return join(sessionsDir, specName);
+/**
+ * Per-session workspace dir under the sessions base. The leaf is {@link threadKey}`(specName,
+ * subject)` (roles×threads NEXT slice, #120):
+ *  - NO subject → `<sessionsDir>/<specName>` — byte-identical to HEAD (every current agent,
+ *    incl. the weave, and the per-AGENT spec.json / persist callsites which never pass a subject).
+ *  - A subject → `<sessionsDir>/<specName>--<slug(subject)>` — a PER-THREAD private workspace
+ *    (its own `.mcp.json` / `system-prompt.txt` / HOME / staging), so concurrent subjects of one
+ *    multi-threaded agent never clobber each other's per-turn files. `slug` (inside threadKey)
+ *    strips the untrusted subject to a path-safe leaf — no traversal.
+ */
+export function sessionWorkspace(sessionsDir: string, specName: string, subject?: string): string {
+  return join(sessionsDir, threadKey(specName, subject));
 }
 
 /**

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -80,6 +80,15 @@ export interface ThreadRecord {
    * Omitted falls back to the channel (the 1:1 default, where channel == name).
    */
   name?: string;
+  /**
+   * The thread SUBJECT (roles×threads NEXT slice, #120). When present on a MULTI-threaded
+   * thread, the note becomes a DETERMINISTIC, upserting record at `threadKey(name, subject)`
+   * (`Threads/<safeChannel>/<safeName>--<safeSubject>`) — rolling turn_count + cumulative
+   * usage + a preserved session across fires (per-thread continuity), exactly like the
+   * single-threaded deterministic path but at the subject-scoped leaf. Absent/empty → the
+   * HEAD identity (single-threaded deterministic note / multi-threaded per-fire uuid note).
+   */
+  subject?: string;
   /** The `#agent/definition` note id this thread came from (provenance; plain id string). */
   definition?: string;
   /** The mode the turn ran under — governs thread identity + whether the note upserts. */
@@ -235,20 +244,23 @@ export interface Transport {
    */
   writeThread?(thread: ThreadRecord): Promise<{ sent: string[] }>;
   /**
-   * Optional: read the persisted Claude session UUID for a single-threaded agent's
-   * deterministic `#agent/thread` note (the thread≡session record), or undefined when
-   * none yet (the first turn). The daemon reads this BEFORE a turn so it can `--resume`
-   * the prior conversation. Only a durable transport (the VaultTransport) implements it;
-   * transports without a durable thread store (telegram) omit it.
+   * Optional: read the persisted Claude session UUID for a thread's deterministic
+   * `#agent/thread` note (the thread≡session record), or undefined when none yet (the
+   * first turn). The daemon reads this BEFORE a turn so it can `--resume` the prior
+   * conversation. `subject` (roles×threads NEXT slice, #120) resolves the SUBJECT-scoped
+   * note (`Threads/<ch>/<name>--<subject>`) for a multi-threaded subject thread; omitted →
+   * the def-named note (single-threaded resume, HEAD). Only a durable transport (the
+   * VaultTransport) implements it; transports without a durable thread store (telegram) omit it.
    */
-  readThreadSession?(channel: string, name: string): Promise<string | undefined>;
+  readThreadSession?(channel: string, name: string, subject?: string): Promise<string | undefined>;
   /**
-   * Optional: CLEAR the persisted session on a single-threaded agent's `#agent/thread`
-   * note so its next turn starts a fresh Claude conversation (the per-agent restart /
-   * reset). Only a durable transport (the VaultTransport) implements it; transports
-   * without a durable thread store (telegram) omit it.
+   * Optional: CLEAR the persisted session on a thread's `#agent/thread` note so its next
+   * turn starts a fresh Claude conversation (the per-agent restart / reset). `subject`
+   * resolves the subject-scoped note; omitted → the def-named note (HEAD). Only a durable
+   * transport (the VaultTransport) implements it; transports without a durable thread store
+   * (telegram) omit it.
    */
-  clearThreadSession?(channel: string, name: string): Promise<void>;
+  clearThreadSession?(channel: string, name: string, subject?: string): Promise<void>;
   /**
    * Optional: write an agent-to-agent CALLBACK as an INBOUND note on THIS channel (the
    * "reply_to" substrate). A recipient agent's drain, on turn completion, calls this on the

--- a/src/transports/vault.test.ts
+++ b/src/transports/vault.test.ts
@@ -946,6 +946,127 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
     expect(stored!.metadata.session).toBe("sess-ESTABLISHED"); // preserved, not dropped.
   });
 
+  // ── roles×threads NEXT slice (#120) — a MULTI-THREADED SUBJECT thread is a DETERMINISTIC,
+  //    upserting note at `Threads/<ch>/<name>--<subject>` (rolling turn_count + preserved
+  //    session across fires), NOT a per-fire uuid note. ─────────────────────────────────────
+  test("MULTI-THREADED SUBJECT: writeThread() upserts a DETERMINISTIC `<name>--<subject>` note (rolls turn_count, reads back)", async () => {
+    // Per (channel, leaf) store — keyed by the path so distinct subjects are distinct notes.
+    const store = new Map<string, { metadata: Record<string, string>; content: string }>();
+    const patched: string[] = [];
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const u = decodeURIComponent(String(url));
+      const method = init?.method ?? "GET";
+      if (u.includes("/api/notes/") && method === "GET") {
+        const path = u.split("/api/notes/")[1]!;
+        const hit = store.get(path);
+        return hit ? new Response(JSON.stringify(hit), { status: 200 }) : new Response("nf", { status: 404 });
+      }
+      if (u.includes("/api/notes/") && method === "PATCH") {
+        const body = JSON.parse(String(init?.body)) as { path: string; metadata: Record<string, string>; content: string };
+        store.set(body.path, { metadata: body.metadata, content: body.content });
+        patched.push(body.path);
+        return new Response(JSON.stringify({ id: body.path }), { status: 200 });
+      }
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("pm"));
+
+    // Fire 1 of subject "eco-civ" — creates the deterministic subject note, turn_count 1.
+    const r1 = await t.writeThread({
+      channel: "pm", name: "pm", subject: "eco-civ", mode: "multi-threaded", status: "ok",
+      input: "kickoff", output: "ok1", started_at: "2026-06-18T07:00:00.000Z",
+      ended_at: "2026-06-18T07:00:05.000Z", session: "sess-ECO", phase: "end",
+    });
+    // Fire 2 of the SAME subject — UPSERTS the same note (turn_count 2), proving continuity.
+    const r2 = await t.writeThread({
+      channel: "pm", name: "pm", subject: "eco-civ", mode: "multi-threaded", status: "ok",
+      input: "next", output: "ok2", started_at: "2026-06-18T08:00:00.000Z",
+      ended_at: "2026-06-18T08:00:09.000Z", session: "sess-ECO", phase: "end",
+    });
+
+    // BOTH fires hit the SAME deterministic subject-scoped path (NOT a per-fire uuid).
+    expect(r1.sent[0]).toBe("Threads/pm/pm--eco-civ");
+    expect(r2.sent[0]).toBe("Threads/pm/pm--eco-civ");
+    expect(patched.every((p) => p === "Threads/pm/pm--eco-civ")).toBe(true);
+    const note = store.get("Threads/pm/pm--eco-civ")!;
+    expect(note.metadata.turn_count).toBe("2"); // rolled across fires — per-thread continuity.
+    expect(note.metadata.started_at).toBe("2026-06-18T07:00:00.000Z"); // first fire's, preserved.
+    expect(note.metadata.session).toBe("sess-ECO"); // session carried across fires.
+    expect(note.metadata.mode).toBe("multi-threaded");
+
+    // A DIFFERENT subject of the same agent is a DISTINCT note (distinct leaf).
+    const r3 = await t.writeThread({
+      channel: "pm", name: "pm", subject: "ai-livelihood", mode: "multi-threaded", status: "ok",
+      input: "other", output: "ok3", started_at: "2026-06-18T09:00:00.000Z",
+      ended_at: "2026-06-18T09:00:03.000Z", phase: "end",
+    });
+    expect(r3.sent[0]).toBe("Threads/pm/pm--ai-livelihood");
+    expect(store.get("Threads/pm/pm--ai-livelihood")!.metadata.turn_count).toBe("1"); // its own count.
+    // The eco-civ note is untouched by the ai-livelihood fire (no cross-subject clobber).
+    expect(store.get("Threads/pm/pm--eco-civ")!.metadata.turn_count).toBe("2");
+  });
+
+  test("MULTI-THREADED with NO subject stays a PER-FIRE uuid note (HEAD) — no read-back, turn_count 1", async () => {
+    const patches: string[] = [];
+    let gets = 0;
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const u = decodeURIComponent(String(url));
+      const method = init?.method ?? "GET";
+      if (u.includes("/api/notes/") && method === "GET") { gets++; return new Response("nf", { status: 404 }); }
+      if (u.includes("/api/notes/") && method === "PATCH") {
+        patches.push(u.split("/api/notes/")[1]!);
+        return new Response(JSON.stringify({ id: "x" }), { status: 200 });
+      }
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("pm"));
+    await t.writeThread({
+      channel: "pm", name: "pm", mode: "multi-threaded", status: "ok", input: "q", output: "a",
+      started_at: "2026-06-18T07:00:00.000Z", ended_at: "2026-06-18T07:00:01.000Z", threadId: "fire-xyz",
+    });
+    // Per-fire uuid leaf, NO read-back (HEAD multi-threaded behavior — byte-identical).
+    expect(gets).toBe(0);
+    expect(patches[0]).toBe("Threads/pm/fire-xyz");
+  });
+
+  test("SUBJECT continuity round-trip: readThreadSession(subject) reads the session written at the subject-scoped note", async () => {
+    const store = new Map<string, { metadata: Record<string, string>; content: string }>();
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const u = decodeURIComponent(String(url));
+      const method = init?.method ?? "GET";
+      if (u.includes("/api/notes/") && method === "GET") {
+        const path = u.split("/api/notes/")[1]!;
+        const hit = store.get(path);
+        return hit ? new Response(JSON.stringify(hit), { status: 200 }) : new Response("nf", { status: 404 });
+      }
+      if (u.includes("/api/notes/") && method === "PATCH") {
+        const body = JSON.parse(String(init?.body)) as { path: string; metadata: Record<string, string>; content: string };
+        store.set(body.path, { metadata: body.metadata, content: body.content });
+        return new Response(JSON.stringify({ id: body.path }), { status: 200 });
+      }
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("pm"));
+
+    // No subject note yet → undefined.
+    expect(await t.readThreadSession("pm", "pm", "eco-civ")).toBeUndefined();
+    // Write a subject thread carrying a session…
+    await t.writeThread({
+      channel: "pm", name: "pm", subject: "eco-civ", mode: "multi-threaded", status: "ok",
+      input: "q", output: "a", started_at: "2026-06-18T07:00:00.000Z",
+      ended_at: "2026-06-18T07:00:05.000Z", session: "sess-SUBJECT", phase: "end",
+    });
+    // …readThreadSession(subject) reads it back off the SUBJECT-scoped path.
+    expect(await t.readThreadSession("pm", "pm", "eco-civ")).toBe("sess-SUBJECT");
+    // A different subject (no note) is independent → undefined (no cross-subject leak).
+    expect(await t.readThreadSession("pm", "pm", "other")).toBeUndefined();
+    // The NO-subject read targets the def-named note (different leaf) → undefined here.
+    expect(await t.readThreadSession("pm", "pm")).toBeUndefined();
+  });
+
   test("readThreadSession() round-trips the stored session (the pre-turn resume read)", async () => {
     let stored: { metadata: Record<string, string>; content: string } | undefined;
     const gets: string[] = [];

--- a/src/transports/vault.ts
+++ b/src/transports/vault.ts
@@ -66,6 +66,10 @@ import type {
   CallbackMetadata,
   InboundAttachment,
 } from "../transport.ts";
+// roles×threads NEXT slice (#120): the shared thread-key sanitizer — REUSED here for the
+// subject-scoped deterministic thread-note leaf (`<name>--<slug(subject)>`) so the path
+// math matches the registry's drain key exactly (no drift).
+import { threadKey } from "../sandbox/types.ts";
 
 /** The safe basename of a (possibly path-ful, possibly untrusted) string — the LAST
  *  path segment, with traversal markers stripped. Used to derive a display `filename`
@@ -820,20 +824,33 @@ export class VaultTransport implements Transport {
   }
 
   /**
-   * The DETERMINISTIC path of a single-threaded agent's ONE thread note —
-   * `Threads/<safeChannel>/<safeName>` (named after the def). The single shared
-   * source of truth for that path so {@link writeThread} (the upsert) and
-   * {@link readThreadSession} (the pre-turn session read) can never disagree on
-   * where the note lives. Sanitizes both segments to a flat, predictable slug.
+   * The DETERMINISTIC path of a thread note that UPSERTS in place —
+   * `Threads/<safeChannel>/<leaf>`. The single shared source of truth for that path so
+   * {@link writeThread} (the upsert), {@link readThreadSession} (the pre-turn session read),
+   * and {@link clearThreadSession} (the reset) can never disagree on where the note lives.
+   * Sanitizes the channel segment to a flat, predictable slug.
    *
-   * COLLISION NOTE: two single-threaded agents whose names collapse to the SAME safeName
-   * on the same channel would share this note. Acceptable because the registry enforces
-   * ONE agent per channel (byChannel index), so the collision can't arise in practice.
+   * The LEAF is {@link threadKey}`(name, subject)` (roles×threads NEXT slice, #120):
+   *  - NO subject → the bare def name (`<safeName>`) — the HEAD single-threaded path,
+   *    byte-identical. `threadKey` returns the bare name AND `slug`s it the same way the
+   *    prior inline `replace(/[^a-zA-Z0-9_-]/g, "-")` did, so the path is unchanged.
+   *  - A subject → `<safeName>--<safeSubject>` (the subject thread's deterministic note),
+   *    so a multi-threaded SUBJECT upserts + carries a session across fires.
+   *
+   * COLLISION NOTE: two agents whose (name, subject) collapse to the SAME leaf on the same
+   * channel would share this note. Acceptable: the registry enforces ONE agent per channel
+   * (byChannel index), and distinct subjects produce distinct leaves.
    */
-  private singleThreadedPath(channel: string, name: string): string {
+  private singleThreadedPath(channel: string, name: string, subject?: string): string {
     const safeChannel = channel.replace(/[^a-zA-Z0-9_-]/g, "-");
+    // Slug the NAME segment exactly as HEAD did (the prior inline `replace`), then let
+    // threadKey append `--<slug(subject)>` when a subject narrows the thread. With no
+    // subject threadKey returns the (already-slugged) name verbatim → the leaf is
+    // byte-identical to the HEAD single-threaded path. With a subject the leaf becomes
+    // `<safeName>--<safeSubject>` (both slugged → path-safe, no traversal).
     const safeName = (name ?? channel).replace(/[^a-zA-Z0-9_-]/g, "-");
-    return `${THREAD_PATH_PREFIX}/${safeChannel}/${safeName}`;
+    const leaf = threadKey(safeName, subject);
+    return `${THREAD_PATH_PREFIX}/${safeChannel}/${leaf}`;
   }
 
   /**
@@ -865,32 +882,36 @@ export class VaultTransport implements Transport {
   async writeThread(thread: ThreadRecord): Promise<{ sent: string[] }> {
     const safeChannel = thread.channel.replace(/[^a-zA-Z0-9_-]/g, "-");
     const singleThreaded = thread.mode === "single-threaded";
+    // roles×threads NEXT slice (#120): a thread is DETERMINISTIC (a named, upserting note
+    // that rolls turn_count/usage + carries a session across fires) when it's single-threaded
+    // (HEAD) OR it's a multi-threaded thread that carries a SUBJECT. A subject-scoped
+    // multi-threaded thread turns "fresh note per fire" into "resume the named thread" — its
+    // leaf is `<name>--<subject>`. A multi-threaded thread with NO subject stays a per-fire
+    // uuid note (HEAD), byte-identical for the weave + every current agent.
+    const subject = thread.subject?.trim();
+    const deterministic = singleThreaded || (!singleThreaded && !!subject);
 
-    // IDENTITY by mode (HARD CONSTRAINT 3 — the path leaf IS the thread's identity; no
-    // ambiguous `thread_id` metadata field). single-threaded: a DETERMINISTIC leaf named
-    // after the def (the agent/spec name, sanitized) so the SAME note upserts across turns.
-    // multi-threaded: a fresh uuid per fire (one fire = one thread = one note today).
-    // COLLISION NOTE: two single-threaded agents whose names collapse to the SAME safeName
-    // on the same channel would upsert each other's thread note. Acceptable because the
-    // registry enforces ONE agent per channel (byChannel index), so the collision can't
-    // arise in practice.
-    // Multi-threaded leaf: a per-FIRE id. Reuse the caller's `threadId` when given (a
-    // re-record of the same turn — e.g. the outbound-failure status flip — targets the
-    // SAME per-fire note instead of minting a duplicate); else mint a fresh one. Single-
-    // threaded uses the DETERMINISTIC path (named after the def) so the one-per-channel
-    // note upserts — computed via {@link singleThreadedPath} so writeThread and
-    // readThreadSession agree on exactly where the note lives.
-    const path = singleThreaded
-      ? this.singleThreadedPath(thread.channel, thread.name ?? thread.channel)
+    // IDENTITY (HARD CONSTRAINT 3 — the path leaf IS the thread's identity; no ambiguous
+    // `thread_id` metadata field). A DETERMINISTIC thread upserts at a stable leaf named after
+    // the def (+ subject when present), via {@link singleThreadedPath} so writeThread,
+    // readThreadSession + clearThreadSession all agree on exactly where the note lives. A
+    // non-deterministic (multi-threaded, no-subject) thread is a per-FIRE uuid note — reuse
+    // the caller's `threadId` when given (a re-record of the same turn — the outbound-failure
+    // status flip — targets the SAME per-fire note instead of minting a duplicate); else mint.
+    // COLLISION NOTE: two threads whose (name[, subject]) collapse to the SAME leaf on the
+    // same channel would upsert each other's note. Acceptable: the registry enforces ONE agent
+    // per channel (byChannel index), and distinct subjects produce distinct leaves.
+    const path = deterministic
+      ? this.singleThreadedPath(thread.channel, thread.name ?? thread.channel, subject)
       : `${THREAD_PATH_PREFIX}/${safeChannel}/${thread.threadId ?? crypto.randomUUID()}`;
 
-    // For single-threaded UPSERT, read the existing thread note (by its deterministic
-    // path) to roll up the aggregates. SAFE because the drain is serial per channel and
-    // single-threaded is one-thread-per-channel today (see the method doc) — there's no
-    // concurrent writer to lose an update against.
-    //   WHEN CONTINUATION brings concurrent threads per channel, switch to re-deriving
-    //   aggregates from the #agent/message children or a vault atomic-merge, to avoid
-    //   lost-update.
+    // For a DETERMINISTIC UPSERT (single-threaded OR a multi-threaded subject thread), read
+    // the existing thread note (by its deterministic path) to roll up the aggregates. SAFE
+    // because the drain is serial PER THREAD KEY (registry per-thread serial guarantee) — a
+    // given (name, subject) thread has no concurrent writer to lose an update against.
+    //   WHEN per-channel concurrency across DIFFERENT subjects lands they each have their OWN
+    //   deterministic note (distinct leaf), so no cross-subject lost-update; only same-subject
+    //   would race, and that's serialized by the per-thread drain.
     let priorTurnCount = 0;
     let priorInputTokens = 0;
     let priorOutputTokens = 0;
@@ -898,7 +919,7 @@ export class VaultTransport implements Transport {
     let priorStartedAt: string | undefined;
     let priorLastTurnAt: string | undefined;
     let priorSession: string | undefined;
-    if (singleThreaded) {
+    if (deterministic) {
       const prior = await this.readThreadNote(path);
       if (prior) {
         priorTurnCount = numFromMeta(prior.metadata?.turn_count);
@@ -932,8 +953,8 @@ export class VaultTransport implements Transport {
     const isStart = thread.phase === "start";
     let turnCount: number;
     if (isStart) {
-      turnCount = singleThreaded ? priorTurnCount : 0;
-    } else if (singleThreaded) {
+      turnCount = deterministic ? priorTurnCount : 0;
+    } else if (deterministic) {
       turnCount = thread.sameTurn ? priorTurnCount : priorTurnCount + 1;
     } else {
       turnCount = 1;
@@ -944,13 +965,13 @@ export class VaultTransport implements Transport {
     const startedAt = priorStartedAt ?? thread.started_at;
     const lastTurnAt = isStart ? (priorLastTurnAt ?? "") : thread.ended_at;
 
-    // Cumulative usage: single-threaded SUMS this turn into the prior totals; multi-threaded
-    // carries just this turn's (one fire = one thread).
+    // Cumulative usage: a DETERMINISTIC thread SUMS this turn into the prior totals; a
+    // per-fire (multi-threaded, no-subject) note carries just this turn's (one fire = one thread).
     const inputTokens =
-      (singleThreaded ? priorInputTokens : 0) + (thread.usage?.inputTokens ?? 0);
+      (deterministic ? priorInputTokens : 0) + (thread.usage?.inputTokens ?? 0);
     const outputTokens =
-      (singleThreaded ? priorOutputTokens : 0) + (thread.usage?.outputTokens ?? 0);
-    const costUsd = (singleThreaded ? priorCostUsd : 0) + (thread.usage?.totalCostUsd ?? 0);
+      (deterministic ? priorOutputTokens : 0) + (thread.usage?.outputTokens ?? 0);
+    const costUsd = (deterministic ? priorCostUsd : 0) + (thread.usage?.totalCostUsd ?? 0);
 
     // Indexed string fields (queryable) + the thread-state observability fields. The
     // vault stores metadata as strings; numbers are stringified.
@@ -969,14 +990,14 @@ export class VaultTransport implements Transport {
     if (thread.definition) metadata.definition = thread.definition;
     // The thread≡session record: persist the Claude session UUID onto the note so the
     // NEXT turn can `--resume` it. Prefer the session this write carries; else (a write
-    // with no session, e.g. a start-phase working-ensure) PRESERVE the prior single-
-    // threaded note's session so an upsert never drops continuity. Multi-threaded carries
-    // its own per-fire session each write (no preserve — each fire is a fresh thread).
-    const session = thread.session ?? (singleThreaded ? priorSession : undefined);
+    // with no session, e.g. a start-phase working-ensure) PRESERVE the prior DETERMINISTIC
+    // note's session so an upsert never drops continuity. A per-fire (no-subject multi)
+    // note carries its own per-fire session each write (no preserve — each fire is fresh).
+    const session = thread.session ?? (deterministic ? priorSession : undefined);
     if (session) metadata.session = session;
     // Usage is always present once a turn carried it OR we accumulated any — emit the
     // running totals so a query sees cumulative cost for the thread.
-    if (singleThreaded || thread.usage) {
+    if (deterministic || thread.usage) {
       if (inputTokens) metadata.input_tokens = String(inputTokens);
       if (outputTokens) metadata.output_tokens = String(outputTokens);
       // Round the accumulated cost to 9 decimals before serializing — summing floats
@@ -1088,19 +1109,22 @@ export class VaultTransport implements Transport {
     }
   }
 
-  /** The persisted Claude session UUID for a single-threaded agent's deterministic
-   *  thread note, or undefined if none yet (first turn). Read before a turn so the
-   *  daemon can --resume it. */
-  async readThreadSession(channel: string, name: string): Promise<string | undefined> {
-    const prior = await this.readThreadNote(this.singleThreadedPath(channel, name));
+  /** The persisted Claude session UUID for a thread's deterministic note, or undefined if
+   *  none yet (first turn). Read before a turn so the daemon can --resume it. `subject`
+   *  (roles×threads NEXT slice, #120) resolves the subject-scoped note
+   *  (`Threads/<ch>/<name>--<subject>`) for a multi-threaded subject thread; omitted → the
+   *  def-named note (HEAD). Uses {@link singleThreadedPath} so the path math matches writeThread. */
+  async readThreadSession(channel: string, name: string, subject?: string): Promise<string | undefined> {
+    const prior = await this.readThreadNote(this.singleThreadedPath(channel, name, subject));
     const s = prior?.metadata?.session;
     return typeof s === "string" && s ? s : undefined;
   }
 
-  /** Clear a single-threaded agent's persisted session so its next turn starts a
-   *  fresh Claude conversation (the per-agent restart). No-op if no thread note yet. */
-  async clearThreadSession(channel: string, name: string): Promise<void> {
-    const path = this.singleThreadedPath(channel, name);
+  /** Clear a thread's persisted session so its next turn starts a fresh Claude conversation
+   *  (the per-agent restart). `subject` resolves the subject-scoped note; omitted → the
+   *  def-named note (HEAD). No-op if no thread note yet. */
+  async clearThreadSession(channel: string, name: string, subject?: string): Promise<void> {
+    const path = this.singleThreadedPath(channel, name, subject);
     const url = `${this.vaultUrl}/vault/${this.vault}/api/notes/${encodeURIComponent(path)}`;
     const res = await fetch(url, {
       method: "PATCH",


### PR DESCRIPTION
Builds on the merged NOW slice (#165, `0.2.3-rc.12`). This is the **NEXT slice (F+G)** of roles×threads — it activates the thread axis. **Slice H (hub thread-axis grant key) is deliberately SKIPPED** — grants stay role-scoped by default (a documented future opt-in); the hub + grant keying are untouched here.

## F. #120 subject routing + per-thread session continuity

A multi-threaded agent **with a subject** now routes to a per-thread serial queue and resumes a named, subject-scoped thread.

- **Routing** (`registry.ts`): the per-channel `queues`/`draining` maps are re-keyed by a per-thread **drain key** — `threadKey(spec.name, subject)` for a multi-threaded agent with a subject, the **bare channel** otherwise.
- **Continuity** (`vault.ts` + `daemon.ts` seams): a multi-threaded subject thread reads/writes its session at the deterministic subject-scoped note `Threads/<ch>/<name>--<subject>` and `--resume`s it — turning "fresh thread per fire" into "resume the named thread." `singleThreadedPath` / `writeThread` / `readThreadSession` / `clearThreadSession` generalize their leaf to `threadKey(name, subject)`; a subject-bearing multi-threaded thread becomes a DETERMINISTIC, upserting note (rolling `turn_count` + cumulative usage + preserved session), not a per-fire uuid note. `outboundThreadId` keys on `perFire` (multi-threaded AND no subject) so a subject thread's outbound `metadata.thread` points at the resolvable deterministic note.
- Subject is **untrusted** → run through `slug` (via `threadKey`) before any path leaf — no traversal.

### The per-thread serial-guarantee design + the test proving it

The serial guarantee is enforced **per drain key** by the existing structural lock — **one in-flight drain promise per drain key**. `enqueue` computes the drain key and starts at most one drain promise for it; a second message for the same key only appends (the running worker picks it up). So the SAME `(name, subject)` thread is never two concurrent `claude -p`; a DIFFERENT subject is a different key → its own promise → may run concurrently.

Proven by `registry.test.ts`:
- **SAME (name, subject) serializes** — a gated first turn holds the second behind it (FIFO); `maxConcurrentByThread["digest::alpha"] === 1`.
- **DIFFERENT subjects interleave** — subject `alpha` is held while subject `beta` runs to completion (only possible if they run concurrently); each thread still ≤1 concurrent.
- **single-threaded / no-subject-multi map to ONE queue** (the bare channel), `maxConcurrent === 1`.
- **continuity** — a multi-threaded subject's 2nd fire `--resume`s the SAME session id persisted on its subject-scoped note (not a fresh uuid); the deterministic subject note upserts (`turn_count` 1→2, session carried) while a different subject is a distinct note.

## G. Per-thread workspace

`sessionWorkspace(dir, name, subject?)` → `join(dir, threadKey(name, subject))` (REUSES the exported `slug`/`threadKey`). A subject keys an isolated `sessions/<name>--<slug(subject)>/` dir (its own `.mcp.json` / `system-prompt.txt` / HOME / staging). The live per-turn `deliver` callsite (programmatic.ts) passes the subject; the per-AGENT callsites (spec.json persist, list/health, agents.ts) stay name-only. **Boot re-register guard** (daemon.ts): a session dir whose name contains `--` is skipped, so subject workspaces are inert on boot.

## Back-compat — the null-subject invariant (top risk: the live steward weave)

With **no subject** (every current agent, incl. the 4am steward weave), every path/key/workspace/queue is **byte-identical to HEAD**: `threadKey(name)` returns the bare name; `sessionWorkspace(dir, name)` is `dir/name`; the single-threaded thread note stays `Threads/<ch>/<name>`; the drain key is the bare channel; `readSession` is keyed `(channel, def-name, undefined)`; no current agent name contains `--`.

- Test: `NULL-SUBJECT INVARIANT — a single-threaded agent's path is byte-identical to HEAD (the steward weave)` pins the full single-threaded drain (readSession key, resume of the def-named note, no subject on the thread note, no subject to the backend).
- Integration: all **1250 pre-existing tests** pass unchanged.

## Gate counts (exact)

- `bun run typecheck` — **clean** (`tsc --noEmit`, 0 errors).
- `bun test ./src/` — **1267 pass, 0 fail**, 3784 expect() calls, 57 files. (Baseline was 1250 → +17 new tests: registry +8, spawn-agent +5, programmatic-wiring +1, vault +3.)
- The `web/ui` vitest suite fails at baseline and is **not** part of `bun test ./src/` (the repo's `test` script is `typecheck && bun test ./src/`).

Version: `0.2.3-rc.12` → **`0.2.3-rc.13`**.

Files changed: `src/backends/registry.ts`, `src/backends/registry.test.ts`, `src/backends/programmatic.ts`, `src/backends/types.ts`, `src/transports/vault.ts`, `src/transports/vault.test.ts`, `src/transport.ts`, `src/daemon.ts`, `src/spawn-agent.ts`, `src/spawn-agent.test.ts`, `src/programmatic-wiring.test.ts`, `package.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)