### PR TITLE
feat(agent): threads-only Phase A — arity-N loadout composer (rc.14)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/agent",
-  "version": "0.2.3-rc.13",
+  "version": "0.2.3-rc.14",
   "description": "Vault-native agents for Claude Code — a #agent/definition note + an inbound message becomes a sandboxed claude turn; the reply is written back as a note. Messaging gateway on :1941.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/src/backends/compose.test.ts
+++ b/src/backends/compose.test.ts
@@ -1,0 +1,120 @@
+/**
+ * composeSystemPrompt tests (threads-only Phase A — DESIGN-2026-06-29-threads-only.md §1/§9).
+ *
+ * The compose seam generalizes from "one role body" to an ORDERED LIST of loaded notes (a
+ * LOADOUT). Covered here at the PURE-function level (the backend integration — the
+ * `system-prompt.txt` write — is exercised in programmatic.test.ts):
+ *
+ *  - the NO-LOADOUT invariant: one (self) entry → `# <path>\n\n<body>`, body byte-identical;
+ *  - arity-N: [self, ...notes] in order, each path-headered, joined by `\n\n---\n\n`;
+ *  - dedupe by path (first wins); skip blank/whitespace content;
+ *  - the BYTE BUDGET: over-budget truncates loadout-notes-first, NEVER the self entry; warns.
+ */
+import { describe, test, expect } from "bun:test";
+import { composeSystemPrompt, LOADOUT_BUDGET_BYTES, type LoadoutEntry } from "./types.ts";
+
+describe("composeSystemPrompt — the no-loadout invariant (the steward weave path)", () => {
+  test("ONE self entry → `# <path>\\n\\n<body>`, body BYTE-IDENTICAL after the header", () => {
+    const body = "You are the steward.\nTend the vault.\n\n  trailing spaces preserved  ";
+    const out = composeSystemPrompt([{ path: "Agents/steward", content: body }]);
+    expect(out).toBe(`# Agents/steward\n\n${body}`);
+    // From the other direction: strip the header → the body is byte-identical.
+    expect(out.slice("# Agents/steward\n\n".length)).toBe(body);
+  });
+
+  test("the header is the ONLY addition — no separator, no trailing newline", () => {
+    const out = composeSystemPrompt([{ path: "x", content: "just this" }]);
+    expect(out).toBe("# x\n\njust this");
+    expect(out.endsWith("just this")).toBe(true);
+  });
+});
+
+describe("composeSystemPrompt — arity-N loadout", () => {
+  test("[self, ...notes] in ORDER, each path-headered, joined by `---`", () => {
+    const entries: LoadoutEntry[] = [
+      { path: "Agents/steward", content: "self body" },
+      { path: "Projects/Surface", content: "project body" },
+      { path: "Packs/GitHub", content: "pack body" },
+    ];
+    expect(composeSystemPrompt(entries)).toBe(
+      "# Agents/steward\n\nself body" +
+        "\n\n---\n\n# Projects/Surface\n\nproject body" +
+        "\n\n---\n\n# Packs/GitHub\n\npack body",
+    );
+  });
+
+  test("DEDUPE by path — first occurrence wins, later duplicates dropped", () => {
+    const entries: LoadoutEntry[] = [
+      { path: "a", content: "A1" },
+      { path: "b", content: "B" },
+      { path: "a", content: "A2-DROPPED" },
+    ];
+    expect(composeSystemPrompt(entries)).toBe("# a\n\nA1\n\n---\n\n# b\n\nB");
+  });
+
+  test("SKIP blank/whitespace-only content entries", () => {
+    const entries: LoadoutEntry[] = [
+      { path: "self", content: "S" },
+      { path: "blank", content: "   \n\t  " },
+      { path: "empty", content: "" },
+      { path: "keep", content: "K" },
+    ];
+    expect(composeSystemPrompt(entries)).toBe("# self\n\nS\n\n---\n\n# keep\n\nK");
+  });
+
+  test("empty entries → empty string", () => {
+    expect(composeSystemPrompt([])).toBe("");
+  });
+});
+
+describe("composeSystemPrompt — byte budget", () => {
+  test("under budget → no truncation, no warn", () => {
+    let warned = 0;
+    const out = composeSystemPrompt(
+      [
+        { path: "self", content: "self" },
+        { path: "n1", content: "small" },
+      ],
+      { budgetBytes: 10_000, onWarn: () => (warned += 1) },
+    );
+    expect(out).toContain("# n1");
+    expect(warned).toBe(0);
+  });
+
+  test("OVER budget → truncates LOADOUT notes (tail-first), NEVER the self entry; warns", () => {
+    const self = { path: "Agents/steward", content: "SELF-" + "s".repeat(500) };
+    const big = (p: string) => ({ path: p, content: p + "-" + "x".repeat(400) });
+    const warnings: string[] = [];
+    // Budget fits the self entry + one loadout note, but not all three.
+    const budget = 700;
+    const out = composeSystemPrompt([self, big("n1"), big("n2"), big("n3")], {
+      budgetBytes: budget,
+      onWarn: (m) => warnings.push(m),
+    });
+    // The SELF entry is ALWAYS present, byte-for-byte.
+    expect(out.startsWith(`# ${self.path}\n\n${self.content}`)).toBe(true);
+    // The composed output fits the budget.
+    expect(Buffer.byteLength(out, "utf8")).toBeLessThanOrEqual(budget);
+    // A loud warn fired, naming dropped notes.
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("over budget");
+    expect(warnings[0]).toContain("n3");
+  });
+
+  test("self entry ALONE exceeds budget → still kept whole (never truncated), loadout all dropped", () => {
+    const self = { path: "self", content: "S".repeat(2000) };
+    const warnings: string[] = [];
+    const out = composeSystemPrompt([self, { path: "n1", content: "x".repeat(50) }], {
+      budgetBytes: 100, // smaller than even the self entry
+      onWarn: (m) => warnings.push(m),
+    });
+    // The self entry is preserved in full — the no-truncate-self guarantee outweighs the budget.
+    expect(out).toBe(`# ${self.path}\n\n${self.content}`);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("n1");
+  });
+
+  test("the default budget is the documented LOADOUT_BUDGET_BYTES", () => {
+    expect(LOADOUT_BUDGET_BYTES).toBe(600_000);
+  });
+});

--- a/src/backends/programmatic.test.ts
+++ b/src/backends/programmatic.test.ts
@@ -563,66 +563,110 @@ describe("ProgrammaticBackend.deliver — the backend is a pure function of the 
   });
 });
 
-describe("ProgrammaticBackend.deliver — composed system prompt (roles×threads NOW slice)", () => {
+describe("ProgrammaticBackend.deliver — composed system prompt (threads-only Phase A: arity-N loadout)", () => {
   const ROLE = "You are the eng agent. Be terse.";
 
-  test("NO subjectDossier → system-prompt.txt is the role body VERBATIM (null-subject invariant)", async () => {
+  /** A spec whose def-note PATH (spec.definition) is set — the self-entry header source. */
+  function specWithDef(prompt: string, definition: string, name = "eng"): AgentSpec {
+    return { ...specWithSystemPrompt(prompt, undefined, name), definition };
+  }
+
+  test("NO-LOADOUT INVARIANT: system-prompt.txt = `# <path>\\n\\n<body>`, body byte-identical (the steward weave path)", async () => {
     mkDirs("compose-none");
     const { fn } = recordingSpawn({ stdout: successTurn("sess-CP1", "ok") });
     const backend = new ProgrammaticBackend(baseDeps(fn));
-    const handle = await backend.start(specWithSystemPrompt(ROLE, undefined, "eng"));
+    // def note PATH set → the self entry is labeled with it (resolved from spec.definition).
+    const handle = await backend.start(specWithDef(ROLE, "Agents/steward", "eng"));
 
-    // deliver WITHOUT the 7th param — exactly today's call shape (the weave path).
+    // deliver WITHOUT a loadout — exactly the weave call shape (no 7th param).
     const result = await backend.deliver(handle, "do the thing", createSession("sess-CP1"));
     expect(result.ok).toBe(true);
 
     const promptPath = join(sessionWorkspace(sessionsDir, "eng"), "system-prompt.txt");
-    // BYTE-IDENTICAL to the role body — no separator, no dossier, no trailing additions.
-    expect(readFileSync(promptPath, "utf8")).toBe(ROLE);
+    const written = readFileSync(promptPath, "utf8");
+    // EXACTLY the self entry: `# <path>\n\n<body>`. The header line is the ONLY change to a
+    // no-loadout prompt; the body after `# <path>\n\n` is BYTE-IDENTICAL to spec.systemPrompt.
+    expect(written).toBe(`# Agents/steward\n\n${ROLE}`);
+    // And asserted from the other direction: strip the header → the body is the role verbatim.
+    expect(written.slice(`# Agents/steward\n\n`.length)).toBe(ROLE);
   });
 
-  test("empty/whitespace subjectDossier → still the role body VERBATIM (treated as absent)", async () => {
+  test("self-entry PATH falls back to spec.name when spec.definition is absent", async () => {
+    mkDirs("compose-fallback");
+    const { fn } = recordingSpawn({ stdout: successTurn("sess-CP1b", "ok") });
+    const backend = new ProgrammaticBackend(baseDeps(fn));
+    // No definition set → the self entry header is the spec name.
+    const handle = await backend.start(specWithSystemPrompt(ROLE, undefined, "eng"));
+
+    await backend.deliver(handle, "go", createSession("sess-CP1b"));
+
+    const promptPath = join(sessionWorkspace(sessionsDir, "eng"), "system-prompt.txt");
+    expect(readFileSync(promptPath, "utf8")).toBe(`# eng\n\n${ROLE}`);
+  });
+
+  test("empty/whitespace loadout → still just the self entry (treated as no loadout)", async () => {
     mkDirs("compose-empty");
     const { fn } = recordingSpawn({ stdout: successTurn("sess-CP2", "ok") });
     const backend = new ProgrammaticBackend(baseDeps(fn));
-    const handle = await backend.start(specWithSystemPrompt(ROLE, undefined, "eng"));
+    const handle = await backend.start(specWithDef(ROLE, "Agents/steward", "eng"));
 
-    await backend.deliver(handle, "go", createSession("sess-CP2"), undefined, undefined, undefined, "");
+    await backend.deliver(handle, "go", createSession("sess-CP2"), undefined, undefined, undefined, []);
 
     const promptPath = join(sessionWorkspace(sessionsDir, "eng"), "system-prompt.txt");
-    expect(readFileSync(promptPath, "utf8")).toBe(ROLE);
+    expect(readFileSync(promptPath, "utf8")).toBe(`# Agents/steward\n\n${ROLE}`);
   });
 
-  test("a subjectDossier → system-prompt.txt is `role + \"\\n\\n---\\n\\n\" + dossier`", async () => {
-    mkDirs("compose-dossier");
+  test("MULTI-NOTE loadout → [self, ...notes] in order, each path-headered, joined by `---`", async () => {
+    mkDirs("compose-multi");
     const { fn } = recordingSpawn({ stdout: successTurn("sess-CP3", "ok") });
     const backend = new ProgrammaticBackend(baseDeps(fn));
-    const handle = await backend.start(specWithSystemPrompt(ROLE, undefined, "eng"));
+    const handle = await backend.start(specWithDef(ROLE, "Agents/steward", "eng"));
 
-    const dossier = "## Subject: launch-blockers\nFocus only on items tagged P0.";
-    await backend.deliver(
-      handle,
-      "go",
-      createSession("sess-CP3"),
-      undefined,
-      undefined,
-      undefined,
-      dossier,
-    );
+    await backend.deliver(handle, "go", createSession("sess-CP3"), undefined, undefined, undefined, [
+      { path: "Projects/Surface", content: "Project body A." },
+      { path: "Packs/GitHub", content: "Pack body B." },
+    ]);
 
     const promptPath = join(sessionWorkspace(sessionsDir, "eng"), "system-prompt.txt");
-    expect(readFileSync(promptPath, "utf8")).toBe(`${ROLE}\n\n---\n\n${dossier}`);
+    expect(readFileSync(promptPath, "utf8")).toBe(
+      `# Agents/steward\n\n${ROLE}` +
+        `\n\n---\n\n# Projects/Surface\n\nProject body A.` +
+        `\n\n---\n\n# Packs/GitHub\n\nPack body B.`,
+    );
   });
 
-  test("no spec.systemPrompt + a dossier → NO system-prompt file (the role-less case is unchanged)", async () => {
+  test("loadout DEDUPES by path (first wins) and SKIPS blank-bodied entries", async () => {
+    mkDirs("compose-dedupe");
+    const { fn } = recordingSpawn({ stdout: successTurn("sess-CP5", "ok") });
+    const backend = new ProgrammaticBackend(baseDeps(fn));
+    const handle = await backend.start(specWithDef(ROLE, "Agents/steward", "eng"));
+
+    await backend.deliver(handle, "go", createSession("sess-CP5"), undefined, undefined, undefined, [
+      { path: "Projects/Surface", content: "First wins." },
+      { path: "Projects/Surface", content: "Duplicate — dropped." },
+      { path: "Packs/Blank", content: "   \n  " }, // whitespace-only → skipped
+      { path: "Packs/GitHub", content: "Kept." },
+    ]);
+
+    const promptPath = join(sessionWorkspace(sessionsDir, "eng"), "system-prompt.txt");
+    expect(readFileSync(promptPath, "utf8")).toBe(
+      `# Agents/steward\n\n${ROLE}` +
+        `\n\n---\n\n# Projects/Surface\n\nFirst wins.` +
+        `\n\n---\n\n# Packs/GitHub\n\nKept.`,
+    );
+  });
+
+  test("no spec.systemPrompt + a loadout → NO system-prompt file (the role-less case is unchanged)", async () => {
     mkDirs("compose-noprompt");
     const { fn } = recordingSpawn({ stdout: successTurn("sess-CP4", "ok") });
     const backend = new ProgrammaticBackend(baseDeps(fn));
-    // specWithVault carries NO systemPrompt — a dossier alone must NOT synthesize a prompt file
-    // (composing onto an empty role is out of scope for NOW; the role gate is unchanged).
+    // specWithVault carries NO systemPrompt — a loadout alone must NOT synthesize a prompt file
+    // (composing onto an empty self entry is out of scope; the role gate is unchanged).
     const handle = await backend.start(specWithVault("eng"));
 
-    await backend.deliver(handle, "go", createSession("sess-CP4"), undefined, undefined, undefined, "a dossier");
+    await backend.deliver(handle, "go", createSession("sess-CP4"), undefined, undefined, undefined, [
+      { path: "Packs/GitHub", content: "a note" },
+    ]);
 
     const promptPath = join(sessionWorkspace(sessionsDir, "eng"), "system-prompt.txt");
     expect(existsSync(promptPath)).toBe(false);
@@ -792,9 +836,10 @@ describe("ProgrammaticBackend.deliver — system prompt (file-backed, per-turn)"
     await backend.deliver(handle, "hello", freshSession());
 
     const promptPath = join(sessionsDir, "eng", "system-prompt.txt");
-    // The file exists, is 0600, and carries the EXACT prompt text.
+    // The file exists, is 0600, and carries the composed prompt: the self entry headered by the
+    // def path (here the spec name `eng`, no spec.definition set) + the role body verbatim.
     expect(statSync(promptPath).mode & 0o777).toBe(0o600);
-    expect(readFileSync(promptPath, "utf8")).toBe("You are the eng release bot.");
+    expect(readFileSync(promptPath, "utf8")).toBe("# eng\n\nYou are the eng release bot.");
     // The wrapped claude command (engine echoes it in argv[2]) carries the -file flag.
     const cmd = calls[0]!.argv[2]!;
     expect(cmd).toContain("--append-system-prompt-file");
@@ -813,7 +858,7 @@ describe("ProgrammaticBackend.deliver — system prompt (file-backed, per-turn)"
     await backend.deliver(handle, "hello", freshSession());
 
     const promptPath = join(sessionsDir, "eng", "system-prompt.txt");
-    expect(readFileSync(promptPath, "utf8")).toBe("Full custom persona.");
+    expect(readFileSync(promptPath, "utf8")).toBe("# eng\n\nFull custom persona.");
     const cmd = calls[0]!.argv[2]!;
     expect(cmd).toContain("--system-prompt-file");
     expect(cmd).not.toContain("--append-system-prompt-file");
@@ -845,8 +890,9 @@ describe("ProgrammaticBackend.deliver — system prompt (file-backed, per-turn)"
     await backend.deliver(handle, "turn two", resumeSession("sess-SP"));
 
     const promptPath = join(sessionsDir, "eng", "system-prompt.txt");
-    // The file is present after the resume turn too (re-written each deliver).
-    expect(readFileSync(promptPath, "utf8")).toBe("Per-turn role.");
+    // The file is present after the resume turn too (re-written each deliver), composed with
+    // the self-entry path header (the spec name `eng`, no spec.definition set).
+    expect(readFileSync(promptPath, "utf8")).toBe("# eng\n\nPer-turn role.");
     // Turn 1: -file flag + --session-id. Turn 2 (resume): -file flag AND --resume.
     const cmd1 = calls[0]!.argv[2]!;
     const cmd2 = calls[1]!.argv[2]!;

--- a/src/backends/programmatic.ts
+++ b/src/backends/programmatic.ts
@@ -78,6 +78,7 @@ import { buildAgentMcpConfigJson, vaultEntryKey } from "../agent-mcp-config.ts";
 import { resolveClaudeCredential, resolveChannelEnv } from "../credentials.ts";
 import { resolveInjectedGrants, type GrantsClient } from "../grants.ts";
 import { parseStreamJsonStream } from "./stream-json.ts";
+import { composeSystemPrompt } from "./types.ts";
 import type {
   AgentBackend,
   AgentHandle,
@@ -85,6 +86,7 @@ import type {
   DeliverResult,
   DeliverUsage,
   InterimSink,
+  LoadoutEntry,
   RunContext,
   TurnSession,
 } from "./types.ts";
@@ -442,7 +444,7 @@ export class ProgrammaticBackend implements AgentBackend {
     onInterim?: InterimSink,
     attachments?: InboundAttachment[],
     runContext?: RunContext,
-    subjectDossier?: string,
+    loadout?: LoadoutEntry[],
     subject?: string,
   ): Promise<DeliverResult> {
     const spec = handle.spec;
@@ -595,19 +597,34 @@ export class ProgrammaticBackend implements AgentBackend {
     // robust to long/multiline prompts and keeps the prompt visible-on-disk. Its
     // lifecycle is tied to the workspace (like .mcp.json) — it disappears with it.
     //
-    // COMPOSED PROMPT (roles×threads NOW slice): when a `subjectDossier` is handed in,
-    // the agent's stable ROLE (the spec's systemPrompt) is composed with the per-thread
-    // subject context as `roleBody + "\n\n---\n\n" + dossier`. The role stays constant
-    // across a role's threads; the subject-specific dossier layers on top. Absent/empty
-    // dossier → the role body is written VERBATIM (byte-identical to HEAD — the
-    // null-subject invariant; the run-context preamble stays on the MESSAGE, not here).
+    // COMPOSED PROMPT (threads-only Phase A — DESIGN-2026-06-29-threads-only.md §1/§9):
+    // the system prompt is an ORDERED LIST of loaded notes — a direct arity-N generalization
+    // of the rc.13 arity-2 `roleBody [+ dossier]` seam. Entry 0 is the thread's SELF entry:
+    // the spec's `systemPrompt` (the def body), labeled with the def note's PATH
+    // (`spec.definition`, the `#agent/definition` note id which IS its vault path; fallback
+    // `spec.name`). Entries 1..N are the resolved `loadout` notes (read CONTENT-only, never
+    // metadata). composeSystemPrompt dedupes by path, skips blank entries, renders each as
+    // `# <path>\n\n<content>`, joins with `\n\n---\n\n`, and enforces the byte budget
+    // (truncate loadout-notes-first, NEVER the self entry).
+    //
+    // NO-LOADOUT INVARIANT (the live 4am steward weave path): a thread with NO loadout
+    // composes to EXACTLY `# <path>\n\n<def body>` — `<def body>` byte-identical to
+    // `spec.systemPrompt`. The single `# <path>` header is the ONLY change to a no-loadout
+    // prompt (design decision #4, accepted). The run-context preamble stays on the MESSAGE.
     let systemPromptFile: string | undefined;
     if (typeof spec.systemPrompt === "string" && spec.systemPrompt.length > 0) {
-      const roleBody = spec.systemPrompt;
-      const composed =
-        typeof subjectDossier === "string" && subjectDossier.length > 0
-          ? `${roleBody}\n\n---\n\n${subjectDossier}`
-          : roleBody;
+      // Self entry: the def body, labeled by the def note's PATH (resolve from the def note
+      // id when available — in a Parachute vault the note id IS the path, e.g.
+      // `Agents/uni-weaver`; acceptable fallback label is the spec name).
+      const selfPath =
+        typeof spec.definition === "string" && spec.definition.length > 0
+          ? spec.definition
+          : spec.name;
+      const entries: LoadoutEntry[] = [
+        { path: selfPath, content: spec.systemPrompt },
+        ...(loadout ?? []),
+      ];
+      const composed = composeSystemPrompt(entries);
       systemPromptFile = join(workspace, "system-prompt.txt");
       writeFileSync(systemPromptFile, composed, { mode: 0o600 });
     }

--- a/src/backends/registry.test.ts
+++ b/src/backends/registry.test.ts
@@ -33,6 +33,7 @@ import type {
   DeliverResult,
   InboundAttachment,
   InterimSink,
+  LoadoutEntry,
   RunContext,
   TurnSession,
 } from "./types.ts";
@@ -62,6 +63,8 @@ class FakeBackend implements AgentBackend {
     runContext?: RunContext;
     /** roles×threads NEXT slice (#120, G): the thread subject the drain threaded in. */
     subject?: string;
+    /** threads-only Phase A: the resolved LOADOUT entries the drain threaded in. */
+    loadout?: LoadoutEntry[];
   }[] = [];
   /** Max concurrent in-flight turns observed (must stay ≤ 1 for serial — PER drain key). */
   maxConcurrent = 0;
@@ -113,7 +116,7 @@ class FakeBackend implements AgentBackend {
     onInterim?: InterimSink,
     _attachments?: InboundAttachment[],
     runContext?: RunContext,
-    _subjectDossier?: string,
+    loadout?: LoadoutEntry[],
     subject?: string,
   ): Promise<DeliverResult> {
     this.calls.push({
@@ -122,6 +125,7 @@ class FakeBackend implements AgentBackend {
       session,
       ...(runContext ? { runContext } : {}),
       ...(subject ? { subject } : {}),
+      ...(loadout ? { loadout } : {}),
     });
     this.inFlight++;
     this.maxConcurrent = Math.max(this.maxConcurrent, this.inFlight);

--- a/src/backends/registry.ts
+++ b/src/backends/registry.ts
@@ -44,7 +44,7 @@
 
 import type { AgentSpec, AgentMode } from "../sandbox/types.ts";
 import { normalizeChannel, threadKey } from "../sandbox/types.ts";
-import type { AgentBackend, AgentHandle, InterimTurnEvent, RunContext, TurnSession } from "./types.ts";
+import type { AgentBackend, AgentHandle, InterimTurnEvent, LoadoutEntry, RunContext, TurnSession } from "./types.ts";
 import type { InboundAttachment } from "../transport.ts";
 
 /**
@@ -517,15 +517,22 @@ export class ProgrammaticAgentRegistry {
    */
   private readonly clearSession?: (channel: string, name: string, subject?: string) => Promise<void>;
   /**
-   * Optional pre-turn SUBJECT-DOSSIER read (roles×threads NOW slice) — per-thread
-   * context for the current subject, folded into the composed system prompt (the
-   * programmatic backend's `roleBody + "\n\n---\n\n" + dossier`). Read in {@link drain}
-   * keyed on the inbound message's subject. UNWIRED in the NOW slice (the default registry
-   * does NOT set it — there's no dossier-note convention yet), so every turn composes the
-   * role body verbatim and the null-subject path is byte-identical to HEAD. The seam is
-   * here so a future dossier source threads in without re-plumbing `deliver`.
+   * Optional pre-turn LOADOUT read (threads-only Phase A — DESIGN-2026-06-29-threads-only.md
+   * §9). Resolves the thread's `metadata.loadout` (an array of note PATHS) off its
+   * `#agent/thread` note and returns each as a {@link LoadoutEntry} (`{path, content}` —
+   * CONTENT only, never metadata). Read in {@link drain} and passed to the backend's `deliver`,
+   * which prepends the SELF entry (the def body) and composes the arity-N system prompt. This
+   * SUPERSEDES the rc.13 `readSubjectDossier` (arity-2) seam. UNWIRED → empty loadout, so every
+   * turn composes `# <path>\n\n<def body>` (the no-loadout invariant — byte-identical to HEAD
+   * apart from the path header). Best-effort: a read failure logs + the turn runs with the empty
+   * loadout (self entry only), never strands the queue. Missing paths are skipped-and-warned by
+   * the resolver itself (never throws on a missing note).
    */
-  private readonly readSubjectDossier?: (channel: string, subject: string) => Promise<string | undefined>;
+  private readonly readLoadout?: (
+    channel: string,
+    name: string,
+    subject?: string,
+  ) => Promise<LoadoutEntry[]>;
   /** Base backoff (ms) between outbound retries (FIX 1). Injectable so tests run fast. */
   private readonly outboundRetryBaseMs: number;
 
@@ -547,10 +554,11 @@ export class ProgrammaticAgentRegistry {
      */
     clearSession?: (channel: string, name: string, subject?: string) => Promise<void>;
     /**
-     * Read the per-thread subject dossier (roles×threads NOW slice). Optional + UNWIRED
-     * by default — the composed prompt is the role body verbatim until a dossier source exists.
+     * Read the thread's LOADOUT (threads-only Phase A) — the `metadata.loadout` note paths
+     * resolved to `{path, content}` entries. Optional — UNWIRED → empty loadout (the def body
+     * alone, the no-loadout invariant). `subject` resolves the subject-scoped thread note.
      */
-    readSubjectDossier?: (channel: string, subject: string) => Promise<string | undefined>;
+    readLoadout?: (channel: string, name: string, subject?: string) => Promise<LoadoutEntry[]>;
     /** Override the outbound-retry backoff base (ms). Default {@link OUTBOUND_RETRY_BASE_MS}. */
     outboundRetryBaseMs?: number;
   }) {
@@ -561,7 +569,7 @@ export class ProgrammaticAgentRegistry {
     if (deps.onTurnEvent) this.onTurnEvent = deps.onTurnEvent;
     if (deps.readSession) this.readSession = deps.readSession;
     if (deps.clearSession) this.clearSession = deps.clearSession;
-    if (deps.readSubjectDossier) this.readSubjectDossier = deps.readSubjectDossier;
+    if (deps.readLoadout) this.readLoadout = deps.readLoadout;
     this.outboundRetryBaseMs = deps.outboundRetryBaseMs ?? OUTBOUND_RETRY_BASE_MS;
   }
 
@@ -1047,20 +1055,25 @@ export class ProgrammaticAgentRegistry {
         ...(firedBy ? { firedBy } : {}),
       };
 
-      // SUBJECT DOSSIER (roles×threads NOW slice): when the inbound carries a subject AND a
-      // dossier source is wired, resolve the per-thread context the backend folds into the
-      // composed system prompt. UNWIRED by default (no dossier-note convention yet) and
-      // no-subject always → `undefined`, so the system prompt is the role body verbatim and
-      // the null-subject path is byte-identical to HEAD. Best-effort: a dossier read failure
-      // logs + the turn still runs (role-only), never strands the queue.
-      let subjectDossier: string | undefined;
-      if (msg.subject && this.readSubjectDossier) {
+      // LOADOUT (threads-only Phase A — DESIGN-2026-06-29-threads-only.md §9): resolve the
+      // thread's `metadata.loadout` note paths off its `#agent/thread` note (CONTENT-only,
+      // each → a {path, content} entry). The backend prepends the SELF entry (the def body)
+      // and composes the arity-N system prompt. Read for EVERY thread (single- and
+      // multi-threaded) at its mode-correct note (subject-scoped when a subject narrows the
+      // thread; the def-named note otherwise). UNWIRED → empty loadout, so the system prompt
+      // is the def body alone (the no-loadout invariant — byte-identical to HEAD apart from
+      // the `# <path>` header). Best-effort: a read failure logs + the turn runs with the
+      // empty loadout (self entry only), never strands the queue. Missing paths are
+      // skipped-and-warned inside the resolver (never throws).
+      let loadout: LoadoutEntry[] = [];
+      if (this.readLoadout) {
         try {
-          subjectDossier = await this.readSubjectDossier(handle.channel, msg.subject);
+          loadout = await this.readLoadout(handle.channel, handle.spec.name, turnSubject);
         } catch (err) {
           console.error(
-            `parachute-agent: subject-dossier read for channel "${channel}" ` +
-              `subject "${msg.subject}" failed (turn runs role-only): ${(err as Error).message}`,
+            `parachute-agent: loadout read for channel "${channel}"` +
+              (turnSubject ? ` subject "${turnSubject}"` : "") +
+              ` failed (turn runs with the def body alone): ${(err as Error).message}`,
           );
         }
       }
@@ -1080,9 +1093,10 @@ export class ProgrammaticAgentRegistry {
           msg.attachments,
           // agent#162: the daemon-known runtime context (real clock, new/resumed, fired-by).
           runContext,
-          // roles×threads NOW slice: the per-thread subject dossier, folded into the composed
-          // system prompt. Undefined (no subject / unwired source) → role body verbatim.
-          subjectDossier,
+          // threads-only Phase A: the thread's resolved LOADOUT notes (entries 1..N). The
+          // backend prepends the SELF entry (the def body) and composes the arity-N system
+          // prompt. Empty (unwired / no loadout) → the def body alone (the no-loadout invariant).
+          loadout,
           // roles×threads NEXT slice (#120, G): the thread SUBJECT — the backend keys the
           // PER-THREAD private workspace off it (`sessions/<name>--<subject>/`), so concurrent
           // subjects of one agent never clobber each other's per-turn `.mcp.json` /

--- a/src/backends/types.ts
+++ b/src/backends/types.ts
@@ -122,6 +122,106 @@ export interface RunContext {
 }
 
 /**
+ * One entry in a thread's LOADOUT (threads-only Phase A — DESIGN-2026-06-29-threads-only.md
+ * §1/§9). The composed system prompt is an ORDERED LIST of these — entry 0 is the thread's
+ * "self" entry (the def body, labeled by the def note's PATH), entries 1..N are the notes the
+ * thread loads from its `metadata.loadout` (an array of note PATHS). The composer reads the
+ * note's CONTENT only — NEVER its metadata — and renders each as `# <path>\n\n<content>`.
+ *
+ * This is the arity-N generalization of the rc.13 arity-2 `roleBody [+ subjectDossier]` seam:
+ * a thread that loads no notes (every current agent, incl. the 4am steward weave) composes to
+ * EXACTLY its def body, prefixed by a single `# <path>` header — the only change to a
+ * no-loadout prompt (the no-loadout invariant; design decision #4, accepted).
+ */
+export interface LoadoutEntry {
+  /** The note PATH — rendered as the entry's `# <path>` header AND the dedupe key. */
+  path: string;
+  /** The note CONTENT (body only — NEVER metadata). Blank/whitespace entries are skipped. */
+  content: string;
+}
+
+/**
+ * The total composed-system-prompt BUDGET (bytes, UTF-8). When the composed loadout exceeds
+ * this, the composer truncates the LOADOUT notes (entries 1..N) FIRST — NEVER the self entry
+ * (entry 0, the def body) — with a loud warn (threads-only Phase A, §9.5 / R5).
+ *
+ * Chosen sane cap: 600_000 bytes (~150k tokens at ~4 bytes/token). Claude's context window is
+ * ~200k tokens; this leaves headroom for the turn message, attachments, and tool I/O while
+ * bounding an accreting loadout so it can't silently blow the context (or degrade the steward
+ * mid-tend). The cap is on the composed PROMPT FILE (bytes), not a token count — a sane,
+ * cheap-to-enforce ceiling, documented here as the single source of truth.
+ */
+export const LOADOUT_BUDGET_BYTES = 600_000;
+
+/**
+ * Compose a thread's system prompt from an ORDERED LIST of loaded notes (threads-only Phase A).
+ * The MECHANICAL shape (DESIGN §1):
+ *
+ *   composed = entries
+ *     .filter(dedupe by path)          // first occurrence wins
+ *     .filter(content.trim().length>0) // skip blank/whitespace entries
+ *     .map(`# ${path}\n\n${content}`)  // CONTENT only, path as header
+ *     .join("\n\n---\n\n")
+ *
+ * Then enforce {@link LOADOUT_BUDGET_BYTES}: if the composed byte length exceeds the cap,
+ * drop trailing LOADOUT entries (index ≥ 1) until it fits — the self entry (index 0) is
+ * NEVER truncated. A loud warn fires on truncation (via `onWarn`, defaulting to console.warn).
+ *
+ * The NO-LOADOUT INVARIANT: with exactly one (self) entry whose content is the def body, the
+ * result is `# <path>\n\n<body>` where `<body>` is byte-identical to the def body — the single
+ * header line is the ONLY change to a no-loadout (e.g. the steward weave) prompt.
+ *
+ * PURE (apart from the injectable `onWarn`). The caller resolves the entries (self + loadout
+ * notes) and supplies them in order; this function only dedupes, skips, renders, and budgets.
+ */
+export function composeSystemPrompt(
+  entries: LoadoutEntry[],
+  opts?: { budgetBytes?: number; onWarn?: (msg: string) => void },
+): string {
+  const budget = opts?.budgetBytes ?? LOADOUT_BUDGET_BYTES;
+  const warn = opts?.onWarn ?? ((m: string) => console.warn(m));
+  const byteLen = (s: string): number => Buffer.byteLength(s, "utf8");
+
+  // Dedupe by path (first occurrence wins) + skip blank/whitespace content. The self entry
+  // (index 0) is processed exactly like the rest — but it is index 0, so the budget step
+  // below can never drop it (the steward's def body survives any over-budget loadout).
+  const seen = new Set<string>();
+  const kept: LoadoutEntry[] = [];
+  for (const e of entries) {
+    if (seen.has(e.path)) continue;
+    seen.add(e.path);
+    if (e.content.trim().length === 0) continue;
+    kept.push(e);
+  }
+
+  const render = (es: LoadoutEntry[]): string =>
+    es.map((e) => `# ${e.path}\n\n${e.content}`).join("\n\n---\n\n");
+
+  let composed = render(kept);
+  if (byteLen(composed) <= budget) return composed;
+
+  // OVER BUDGET — truncate LOADOUT entries (index ≥ 1) from the TAIL inward; never the self
+  // entry. Keep entry 0 always; add later entries only while they still fit.
+  const dropped: string[] = [];
+  const fit: LoadoutEntry[] = kept.length > 0 ? [kept[0]!] : [];
+  for (let i = 1; i < kept.length; i++) {
+    const candidate = render([...fit, kept[i]!]);
+    if (byteLen(candidate) <= budget) {
+      fit.push(kept[i]!);
+    } else {
+      dropped.push(kept[i]!.path);
+    }
+  }
+  composed = render(fit);
+  warn(
+    `parachute-agent: LOADOUT over budget (${byteLen(render(kept))} > ${budget} bytes) — ` +
+      `truncated ${dropped.length} loadout note(s), NEVER the self entry. ` +
+      `Dropped: ${dropped.join(", ")}`,
+  );
+  return composed;
+}
+
+/**
  * An opaque handle to a started agent, returned by {@link AgentBackend.start} and
  * passed back to `deliver`/`stop`/`status`. The only field the seam itself depends
  * on is `channel` (the wake channel a turn/push targets) + the backend's own
@@ -245,20 +345,23 @@ export interface AgentBackend {
    * message so the agent stamps ACCURATE times instead of fabricating them. ADDITIVE — omitted
    * → the turn message is exactly as before.
    *
-   * `subjectDossier` (optional, roles×threads NOW slice) is per-THREAD context for the
-   * agent's CURRENT subject — folded into the SYSTEM prompt (NOT the message): the programmatic
-   * backend writes `roleBody + "\n\n---\n\n" + dossier` to the per-turn `system-prompt.txt` when
-   * present, so the agent's ROLE (the spec's systemPrompt) stays stable across threads while the
-   * subject-specific context layers on top. The run-context preamble is unaffected (it stays on
-   * the MESSAGE). ADDITIVE — omitted/empty → the system prompt is the role body verbatim
-   * (byte-identical to HEAD; the null-subject invariant).
+   * `loadout` (optional, threads-only Phase A — DESIGN-2026-06-29-threads-only.md §9) is the
+   * thread's ORDERED LIST of loaded notes (entries 1..N — the SELF entry is prepended by the
+   * backend from `spec.systemPrompt` + the def note path). The programmatic backend folds them
+   * into the SYSTEM prompt via {@link composeSystemPrompt}: `[self, ...loadout]` deduped by path,
+   * blank-skipped, each rendered `# <path>\n\n<content>`, joined by `\n\n---\n\n`, then budgeted
+   * ({@link LOADOUT_BUDGET_BYTES}, truncating loadout-notes-first, NEVER the self entry). This
+   * SUPERSEDES the rc.13 arity-2 `subjectDossier` string with an arity-N note list. ADDITIVE —
+   * omitted/empty → the system prompt is `# <path>\n\n<def body>`, byte-identical to HEAD APART
+   * FROM the single `# <path>` header (the no-loadout invariant; design decision #4, accepted).
+   * The run-context preamble is unaffected (it stays on the MESSAGE).
    *
    * `subject` (optional, roles×threads NEXT slice #120) is the thread SUBJECT — the programmatic
    * backend keys the agent's PER-THREAD private session workspace off it
    * (`sessions/<name>--<slug(subject)>/`), so concurrent subjects of one multi-threaded agent get
    * ISOLATED per-turn files (`.mcp.json`, `system-prompt.txt`, HOME, attachment staging) and never
    * clobber each other. ADDITIVE — omitted/empty → `sessions/<name>/` (byte-identical to HEAD;
-   * the null-subject invariant). Distinct from `subjectDossier` (which is prompt CONTENT); this is
+   * the null-subject invariant). Distinct from `loadout` (which is prompt CONTENT); this is
    * the workspace IDENTITY.
    */
   deliver(
@@ -268,7 +371,7 @@ export interface AgentBackend {
     onInterim?: InterimSink,
     attachments?: InboundAttachment[],
     runContext?: RunContext,
-    subjectDossier?: string,
+    loadout?: LoadoutEntry[],
     subject?: string,
   ): Promise<DeliverResult>;
 

--- a/src/backends/types.ts
+++ b/src/backends/types.ts
@@ -200,18 +200,16 @@ export function composeSystemPrompt(
   let composed = render(kept);
   if (byteLen(composed) <= budget) return composed;
 
-  // OVER BUDGET — truncate LOADOUT entries (index ≥ 1) from the TAIL inward; never the self
-  // entry. Keep entry 0 always; add later entries only while they still fit.
-  const dropped: string[] = [];
+  // OVER BUDGET — keep the self entry (index 0) ALWAYS, then keep loadout entries from the
+  // front while they fit and STOP at the first that doesn't (tail-drop: the loadout's order
+  // IS its priority — earlier notes win, the tail is shed first). The self entry survives even
+  // if it alone exceeds the budget.
   const fit: LoadoutEntry[] = kept.length > 0 ? [kept[0]!] : [];
   for (let i = 1; i < kept.length; i++) {
-    const candidate = render([...fit, kept[i]!]);
-    if (byteLen(candidate) <= budget) {
-      fit.push(kept[i]!);
-    } else {
-      dropped.push(kept[i]!.path);
-    }
+    if (byteLen(render([...fit, kept[i]!])) <= budget) fit.push(kept[i]!);
+    else break;
   }
+  const dropped = kept.slice(fit.length).map((e) => e.path);
   composed = render(fit);
   warn(
     `parachute-agent: LOADOUT over budget (${byteLen(render(kept))} > ${budget} bytes) — ` +

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -137,6 +137,7 @@ import {
   type QueuedMessage,
   type TurnEventSink,
 } from "./backends/registry.ts";
+import type { LoadoutEntry } from "./backends/types.ts";
 import {
   AttachedQueueRegistry,
   type AttachedQueueStore,
@@ -869,6 +870,26 @@ export function buildClearSession(
 }
 
 /**
+ * Build the {@link ProgrammaticAgentRegistry}'s pre-turn LOADOUT read (threads-only Phase A —
+ * DESIGN-2026-06-29-threads-only.md §9). Resolve the channel's transport and read the thread's
+ * `metadata.loadout` note paths off its `#agent/thread` note, each as a {@link LoadoutEntry}
+ * (`{ path, content }` — CONTENT only). Only the VaultTransport implements `readThreadLoadout`;
+ * other transports omit it → an empty loadout (the def body alone, the no-loadout invariant).
+ * The registry calls this BEFORE a turn so the backend composes the arity-N system prompt.
+ * Mirrors {@link buildReadSession}. (The transport's `{path,content}[]` is structurally
+ * identical to `LoadoutEntry[]` — the transport layer doesn't import the backend layer.)
+ */
+export function buildReadLoadout(
+  channels: Map<string, Channel>,
+): (channel: string, name: string, subject?: string) => Promise<LoadoutEntry[]> {
+  return async (channel, name, subject) => {
+    const ch = channels.get(channel);
+    if (!ch?.transport.readThreadLoadout) return [];
+    return ch.transport.readThreadLoadout(channel, name, subject);
+  };
+}
+
+/**
  * Build the REAL programmatic-agent registry — the {@link ProgrammaticBackend}
  * wired to the env-resolved spawn deps, plus the outbound-write + thread-note +
  * session-read seams over the live `channels`. The session UUID lives on the durable
@@ -927,6 +948,10 @@ export function createDefaultProgrammaticRegistry(
     writeCallback: buildWriteCallback(channels),
     readSession: buildReadSession(channels),
     clearSession: buildClearSession(channels),
+    // threads-only Phase A: resolve the thread's loadout notes (metadata.loadout → content)
+    // so the backend composes the arity-N system prompt. SUPERSEDES the never-wired
+    // subjectDossier seam. Empty loadout (no metadata.loadout) → the def body alone.
+    readLoadout: buildReadLoadout(channels),
     ...(onTurnEvent ? { onTurnEvent } : {}),
   });
 }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -347,7 +347,7 @@ export function contextFor(
           // `fired-by` (a scheduled `runner:<jobId>` fire vs an interactive/delegated message).
           ...(msg.meta?.sender ? { sender: msg.meta.sender } : {}),
           // roles×threads NOW slice: carry the thread subject through to the drain so the
-          // composed prompt can fold in a subject dossier (and the NEXT slice can route by
+          // composed prompt's loadout can use it (and the NEXT slice can route by
           // it). No routing meaning yet. Absent → unchanged (the weave path is untouched).
           ...(msg.meta?.subject ? { subject: msg.meta.subject } : {}),
         });
@@ -378,7 +378,7 @@ export function contextFor(
           // register() still derives the right run-context `fired-by`.
           ...(msg.meta?.sender ? { sender: msg.meta.sender } : {}),
           // roles×threads NOW slice: carry the thread subject through the pending buffer too,
-          // so a turn that runs on register() still folds in its subject dossier. No routing
+          // so a turn that runs on register() still composes its loadout. No routing
           // meaning yet. Absent → unchanged.
           ...(msg.meta?.subject ? { subject: msg.meta.subject } : {}),
         });
@@ -3433,7 +3433,7 @@ function main(): void {
         throw new Error(`channel "${job.channel}" is not a live vault channel`);
       }
       // roles×threads NOW slice: thread the job's subject onto the inbound note so the
-      // turn's composed prompt can fold in its dossier. Absent → no subject (the weave
+      // turn's composed prompt/loadout can use it. Absent → no subject (the weave
       // job carries none → byte-identical to HEAD).
       await transport.injectInbound({
         content: job.message,

--- a/src/programmatic-wiring.test.ts
+++ b/src/programmatic-wiring.test.ts
@@ -59,7 +59,7 @@ import {
   type WriteCallback,
   type CallbackMeta,
 } from "./backends/registry.ts";
-import type { AgentBackend, AgentHandle, AgentStatus, DeliverResult } from "./backends/types.ts";
+import type { AgentBackend, AgentHandle, AgentStatus, DeliverResult, LoadoutEntry } from "./backends/types.ts";
 import type { AgentSpec } from "./sandbox/types.ts";
 import type { InboundAttachment } from "./transport.ts";
 import { VaultTransport } from "./transports/vault.ts";
@@ -149,7 +149,7 @@ class FakeBackend implements AgentBackend {
     channel: string;
     message: string;
     attachments?: InboundAttachment[];
-    subjectDossier?: string;
+    loadout?: LoadoutEntry[];
   }[] = [];
   resultFor: (message: string) => DeliverResult = (m) => ({ ok: true, reply: "reply:" + m });
   async start(spec: AgentSpec): Promise<AgentHandle> {
@@ -162,14 +162,14 @@ class FakeBackend implements AgentBackend {
     _onInterim?: unknown,
     attachments?: InboundAttachment[],
     _runContext?: unknown,
-    subjectDossier?: string,
+    loadout?: LoadoutEntry[],
   ): Promise<DeliverResult> {
     this.calls.push({
       channel: handle.channel,
       message,
       ...(attachments ? { attachments } : {}),
-      // Record whether a dossier reached deliver (undefined for the null-subject path).
-      subjectDossier,
+      // Record the LOADOUT that reached deliver (empty [] for the no-loadout / weave path).
+      loadout,
     });
     return this.resultFor(message);
   }
@@ -300,8 +300,9 @@ describe("inbound for a programmatic channel → deliver → outbound note", () 
       const res = await inbound(base, "eng", "note-1", "hello there");
       expect(res.status).toBe(200);
       await until(() => rec.calls.length === 1);
-      // deliver invoked with the inbound content.
-      expect(backend.calls).toEqual([{ channel: "eng", message: "hello there" }]);
+      // deliver invoked with the inbound content + an empty loadout (no readLoadout wired —
+      // the no-loadout / weave path; the backend composes the def body alone).
+      expect(backend.calls).toEqual([{ channel: "eng", message: "hello there", loadout: [] }]);
       // reply written as an outbound note, threaded to the inbound note id.
       expect(rec.calls).toEqual([{ channel: "eng", reply: "reply:hello there", inReplyTo: "note-1" }]);
     } finally {
@@ -405,7 +406,7 @@ describe("inbound for an EXPECTED-but-not-yet-registered channel → queued pend
       // The agent registers (instantiation completes) → the pending buffer replays.
       await programmatic.register({ name: "eng", channels: ["eng"], backend: "programmatic" });
       await until(() => rec.calls.length === 1);
-      expect(backend.calls).toEqual([{ channel: "eng", message: "early message" }]);
+      expect(backend.calls).toEqual([{ channel: "eng", message: "early message", loadout: [] }]);
       expect(rec.calls).toEqual([{ channel: "eng", reply: "reply:early message", inReplyTo: "note-1" }]);
       expect(programmatic.pendingCount("eng")).toBe(0);
     } finally {
@@ -843,74 +844,67 @@ describe("contextFor.emit threads reply_to → a callback end-to-end through the
   });
 });
 
-// ── roles×threads NOW slice: subject threads emit → QueuedMessage → drain → deliver dossier ──
-describe("contextFor.emit threads the subject → composed-prompt dossier end-to-end", () => {
-  test("NULL-SUBJECT INVARIANT: an emit with NO subject → deliver receives subjectDossier=undefined (the weave path)", async () => {
+// ── threads-only Phase A: the drain resolves the thread LOADOUT → deliver end-to-end ──
+describe("the drain reads the thread loadout → deliver receives it (threads-only Phase A)", () => {
+  test("NO-LOADOUT / UNWIRED (the weave path): no readLoadout → deliver receives an empty loadout", async () => {
     const backend = new FakeBackend();
     const out = recorder();
-    // A dossier source IS wired — but with no subject it must NEVER be consulted.
-    let dossierReads = 0;
-    const programmatic = new ProgrammaticAgentRegistry({
-      backend,
-      writeOutbound: out.fn,
-      readSubjectDossier: async () => {
-        dossierReads += 1;
-        return "SHOULD NOT BE READ";
-      },
-    });
+    // No readLoadout wired — the back-compat default. deliver gets [] (the def body alone).
+    const programmatic = new ProgrammaticAgentRegistry({ backend, writeOutbound: out.fn });
     await programmatic.register({ name: "worker", channels: ["worker"], backend: "programmatic" });
     const ctx = contextFor(new ClientRegistry(), "worker", new DeliveryState(), programmatic);
 
     ctx.emit({ channel: "worker", content: "plain", meta: { note_id: "n1", source: "vault" }, source: "vault" });
     await until(() => backend.calls.length === 1);
-    expect(backend.calls[0]!.subjectDossier).toBeUndefined();
-    // No subject → the dossier source is never even called (the weave path is untouched).
-    expect(dossierReads).toBe(0);
+    expect(backend.calls[0]!.loadout).toEqual([]);
   });
 
-  test("a subject + a wired dossier source → the dossier reaches deliver (keyed by channel + subject)", async () => {
+  test("a wired readLoadout → the resolved loadout reaches deliver (keyed by channel + name)", async () => {
     const backend = new FakeBackend();
     const out = recorder();
-    const seen: { channel: string; subject: string }[] = [];
+    const seen: { channel: string; name: string; subject?: string }[] = [];
     const programmatic = new ProgrammaticAgentRegistry({
       backend,
       writeOutbound: out.fn,
-      readSubjectDossier: async (channel, subject) => {
-        seen.push({ channel, subject });
-        return `dossier-for:${subject}`;
+      readLoadout: async (channel, name, subject) => {
+        seen.push({ channel, name, ...(subject ? { subject } : {}) });
+        return [
+          { path: "Projects/Surface", content: "project body" },
+          { path: "Packs/GitHub", content: "pack body" },
+        ];
       },
     });
     await programmatic.register({ name: "worker", channels: ["worker"], backend: "programmatic" });
     const ctx = contextFor(new ClientRegistry(), "worker", new DeliveryState(), programmatic);
 
-    ctx.emit({
-      channel: "worker",
-      content: "status please",
-      meta: { note_id: "n1", source: "vault", subject: "launch-blockers" },
-      source: "vault",
-    });
+    ctx.emit({ channel: "worker", content: "go", meta: { note_id: "n1", source: "vault" }, source: "vault" });
     await until(() => backend.calls.length === 1);
-    expect(backend.calls[0]!.subjectDossier).toBe("dossier-for:launch-blockers");
-    expect(seen).toEqual([{ channel: "worker", subject: "launch-blockers" }]);
+    expect(backend.calls[0]!.loadout).toEqual([
+      { path: "Projects/Surface", content: "project body" },
+      { path: "Packs/GitHub", content: "pack body" },
+    ]);
+    // The loader is consulted for EVERY thread (no subject → resolves the def-named note).
+    expect(seen).toEqual([{ channel: "worker", name: "worker" }]);
   });
 
-  test("a subject but NO wired dossier source (the NOW default) → deliver still gets undefined", async () => {
+  test("a readLoadout that THROWS → the turn still runs (deliver gets [] — never strands the queue)", async () => {
     const backend = new FakeBackend();
     const out = recorder();
-    // No readSubjectDossier wired — the NOW default. A subject rides through, but with no
-    // source the composed prompt is role-only (dossier undefined).
-    const programmatic = new ProgrammaticAgentRegistry({ backend, writeOutbound: out.fn });
+    const programmatic = new ProgrammaticAgentRegistry({
+      backend,
+      writeOutbound: out.fn,
+      readLoadout: async () => {
+        throw new Error("vault blip");
+      },
+    });
     await programmatic.register({ name: "worker", channels: ["worker"], backend: "programmatic" });
     const ctx = contextFor(new ClientRegistry(), "worker", new DeliveryState(), programmatic);
 
-    ctx.emit({
-      channel: "worker",
-      content: "go",
-      meta: { note_id: "n1", source: "vault", subject: "some-subject" },
-      source: "vault",
-    });
+    ctx.emit({ channel: "worker", content: "go", meta: { note_id: "n1", source: "vault" }, source: "vault" });
     await until(() => backend.calls.length === 1);
-    expect(backend.calls[0]!.subjectDossier).toBeUndefined();
+    expect(backend.calls[0]!.loadout).toEqual([]);
+    // And the turn completed (the outbound reply was written) — the read failure didn't strand it.
+    await until(() => out.calls.length === 1);
   });
 });
 

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -262,6 +262,21 @@ export interface Transport {
    */
   clearThreadSession?(channel: string, name: string, subject?: string): Promise<void>;
   /**
+   * Optional: read the thread's LOADOUT (threads-only Phase A —
+   * DESIGN-2026-06-29-threads-only.md §9) — the `metadata.loadout` array of note PATHS on the
+   * thread's `#agent/thread` note, resolved to `{ path, content }` entries (note CONTENT only,
+   * NEVER metadata), preserving the declared ORDER. `subject` resolves the subject-scoped note;
+   * omitted → the def-named note (HEAD). Absent `metadata.loadout` → an empty array. A missing
+   * note path is SKIPPED-and-WARNED (never throws — mirrors the def-load skip discipline); a
+   * blank-bodied note is returned and the composer skips it. Only a durable transport (the
+   * VaultTransport) implements it; transports without a durable thread store omit it.
+   */
+  readThreadLoadout?(
+    channel: string,
+    name: string,
+    subject?: string,
+  ): Promise<{ path: string; content: string }[]>;
+  /**
    * Optional: write an agent-to-agent CALLBACK as an INBOUND note on THIS channel (the
    * "reply_to" substrate). A recipient agent's drain, on turn completion, calls this on the
    * SENDER's channel transport to wake the sender with a completion notification. The note

--- a/src/transports/vault.test.ts
+++ b/src/transports/vault.test.ts
@@ -25,7 +25,7 @@
  */
 
 import { describe, test, expect, afterEach } from "bun:test";
-import { VaultTransport, AGENT_VAULT_TAG_SCHEMA, AGENT_THREAD_TAG, AGENT_JOB_TAG, InboundClaimConflictError, noteAgentKey } from "./vault.ts";
+import { VaultTransport, AGENT_VAULT_TAG_SCHEMA, AGENT_THREAD_TAG, AGENT_JOB_TAG, InboundClaimConflictError, noteAgentKey, parseLoadoutPaths } from "./vault.ts";
 import type { TransportContext, InboundMessage } from "../transport.ts";
 import { instantiateTransport } from "../registry.ts";
 
@@ -2270,5 +2270,136 @@ describe("VaultTransport — setInboundStatus (FIX 3 compare-and-swap claim)", (
     const err = await t.setInboundStatus("n1", "in-flight", "now", "u1").catch((e) => e);
     expect(err).toBeInstanceOf(Error);
     expect(err).not.toBeInstanceOf(InboundClaimConflictError);
+  });
+});
+
+// ── threads-only Phase A: parseLoadoutPaths + readThreadLoadout (DESIGN-2026-06-29-threads-only) ──
+
+describe("parseLoadoutPaths — the metadata.loadout parser", () => {
+  test("a real string[] → kept (trimmed, blanks dropped)", () => {
+    expect(parseLoadoutPaths(["Projects/Surface", "  Packs/GitHub  ", "", "   "])).toEqual([
+      "Projects/Surface",
+      "Packs/GitHub",
+    ]);
+  });
+
+  test("a JSON-encoded array STRING → that array (the vault stores metadata as strings)", () => {
+    expect(parseLoadoutPaths('["a/b","c/d"]')).toEqual(["a/b", "c/d"]);
+  });
+
+  test("a single non-JSON path string → a one-element list", () => {
+    expect(parseLoadoutPaths("Projects/Surface")).toEqual(["Projects/Surface"]);
+  });
+
+  test("absent / empty / non-string → empty", () => {
+    expect(parseLoadoutPaths(undefined)).toEqual([]);
+    expect(parseLoadoutPaths(null)).toEqual([]);
+    expect(parseLoadoutPaths("")).toEqual([]);
+    expect(parseLoadoutPaths("   ")).toEqual([]);
+    expect(parseLoadoutPaths(42)).toEqual([]);
+  });
+
+  test("a malformed array-looking string falls back to one path (never throws)", () => {
+    expect(parseLoadoutPaths("[not json")).toEqual(["[not json"]);
+  });
+
+  test("non-string array members are dropped", () => {
+    expect(parseLoadoutPaths(["ok", 5, null, "ok2"])).toEqual(["ok", "ok2"]);
+  });
+});
+
+describe("VaultTransport — readThreadLoadout (the Phase A loader)", () => {
+  test("reads metadata.loadout off the thread note + resolves each path's CONTENT, in order", async () => {
+    // The thread note carries metadata.loadout = [two paths]; each path resolves to its body.
+    const noteByPath: Record<string, { metadata?: Record<string, unknown>; content?: string }> = {
+      "Threads/eng/eng": { metadata: { loadout: ["Projects/Surface", "Packs/GitHub"] }, content: "thread summary" },
+      "Projects/Surface": { metadata: { status: "active" }, content: "project body" },
+      "Packs/GitHub": { metadata: {}, content: "pack body" },
+    };
+    const reads: string[] = [];
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      const u = String(url);
+      const m = /\/api\/notes\/([^?]+)/.exec(u);
+      const path = m ? decodeURIComponent(m[1]!) : "";
+      reads.push(path);
+      const note = noteByPath[path];
+      if (!note) return new Response("not found", { status: 404 });
+      return new Response(JSON.stringify(note), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+    const loadout = await t.readThreadLoadout("eng", "eng");
+
+    // CONTENT only — never the metadata — in the declared order.
+    expect(loadout).toEqual([
+      { path: "Projects/Surface", content: "project body" },
+      { path: "Packs/GitHub", content: "pack body" },
+    ]);
+    // The thread note is read first, then each loadout path.
+    expect(reads[0]).toBe("Threads/eng/eng");
+    expect(reads).toContain("Projects/Surface");
+    expect(reads).toContain("Packs/GitHub");
+  });
+
+  test("a MISSING loadout path (404) is SKIPPED (never throws); the rest resolve", async () => {
+    const noteByPath: Record<string, { metadata?: Record<string, unknown>; content?: string }> = {
+      "Threads/eng/eng": { metadata: { loadout: ["Gone/Stale", "Packs/GitHub"] }, content: "x" },
+      "Packs/GitHub": { metadata: {}, content: "pack body" },
+      // "Gone/Stale" intentionally absent → 404 → skipped.
+    };
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      const u = String(url);
+      const m = /\/api\/notes\/([^?]+)/.exec(u);
+      const path = m ? decodeURIComponent(m[1]!) : "";
+      const note = noteByPath[path];
+      if (!note) return new Response("not found", { status: 404 });
+      return new Response(JSON.stringify(note), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+    const loadout = await t.readThreadLoadout("eng", "eng");
+    expect(loadout).toEqual([{ path: "Packs/GitHub", content: "pack body" }]);
+  });
+
+  test("no thread note yet (first turn) → empty loadout", async () => {
+    globalThis.fetch = (async () => new Response("not found", { status: 404 })) as unknown as typeof fetch;
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+    expect(await t.readThreadLoadout("eng", "eng")).toEqual([]);
+  });
+
+  test("thread note exists but NO metadata.loadout → empty loadout (the no-loadout invariant)", async () => {
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      const u = String(url);
+      if (u.includes("Threads/eng/eng")) {
+        return new Response(JSON.stringify({ metadata: { session: "s1" }, content: "x" }), { status: 200 });
+      }
+      return new Response("not found", { status: 404 });
+    }) as unknown as typeof fetch;
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+    expect(await t.readThreadLoadout("eng", "eng")).toEqual([]);
+  });
+
+  test("a SUBJECT resolves the subject-scoped thread note (Threads/eng/eng--subj)", async () => {
+    const reads: string[] = [];
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      const u = String(url);
+      const m = /\/api\/notes\/([^?]+)/.exec(u);
+      const path = m ? decodeURIComponent(m[1]!) : "";
+      reads.push(path);
+      if (path === "Threads/eng/eng--launch-blockers") {
+        return new Response(JSON.stringify({ metadata: { loadout: ["Note/A"] }, content: "x" }), { status: 200 });
+      }
+      if (path === "Note/A") return new Response(JSON.stringify({ content: "A body" }), { status: 200 });
+      return new Response("not found", { status: 404 });
+    }) as unknown as typeof fetch;
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+    const loadout = await t.readThreadLoadout("eng", "eng", "launch blockers");
+    expect(loadout).toEqual([{ path: "Note/A", content: "A body" }]);
+    expect(reads[0]).toBe("Threads/eng/eng--launch-blockers");
   });
 });

--- a/src/transports/vault.ts
+++ b/src/transports/vault.ts
@@ -333,6 +333,39 @@ function numFromMeta(v: unknown): number {
 }
 
 /**
+ * Parse a thread note's `metadata.loadout` into an ordered list of note PATHS
+ * (threads-only Phase A — DESIGN-2026-06-29-threads-only.md §9). The model home is an
+ * ARRAY of path strings, but the vault stores metadata flexibly (a real JSON array, a
+ * JSON-encoded array STRING, or — defensively — a single path string), so accept all three:
+ *
+ *  - a real `string[]` → kept (string entries only);
+ *  - a `string` that JSON-parses to an array of strings → that array;
+ *  - any other non-empty `string` → a single-element list (one path);
+ *  - absent / empty / unparseable → `[]` (no loadout — the no-loadout invariant).
+ *
+ * Each entry is trimmed; blank entries are dropped. PURE — no I/O. Exported for unit tests.
+ */
+export function parseLoadoutPaths(v: unknown): string[] {
+  const clean = (arr: unknown[]): string[] =>
+    arr.filter((x): x is string => typeof x === "string").map((s) => s.trim()).filter((s) => s.length > 0);
+  if (Array.isArray(v)) return clean(v);
+  if (typeof v === "string") {
+    const trimmed = v.trim();
+    if (trimmed.length === 0) return [];
+    if (trimmed.startsWith("[")) {
+      try {
+        const parsed = JSON.parse(trimmed) as unknown;
+        if (Array.isArray(parsed)) return clean(parsed);
+      } catch {
+        // Not valid JSON — fall through to treat the whole string as one path.
+      }
+    }
+    return [trimmed];
+  }
+  return [];
+}
+
+/**
  * Build the `#agent/thread` note BODY — the rolling SUMMARY of the thread (design
  * 2026-06-18: "hold a summary of this thread in the content; maybe another agent
  * facilitates that"). The MODULE writes a useful default, STRUCTURED (`## Summary` /
@@ -1136,6 +1169,55 @@ export class VaultTransport implements Transport {
       const detail = await res.text().catch(() => "");
       throw new Error(`vault transport: clear thread session failed (${res.status}) ${detail}`.trim());
     }
+  }
+
+  /**
+   * Read the thread's LOADOUT (threads-only Phase A — DESIGN-2026-06-29-threads-only.md §9):
+   * the `metadata.loadout` array of note PATHS on the thread's `#agent/thread` note, each
+   * resolved to `{ path, content }` (the note's CONTENT only — NEVER its metadata), preserving
+   * the declared ORDER. `subject` resolves the subject-scoped thread note; omitted → the
+   * def-named note (HEAD). The thread note's path math reuses {@link singleThreadedPath}, so
+   * it agrees with writeThread / readThreadSession.
+   *
+   * SKIP-AND-WARN (mirrors the def-load skip discipline `agent-defs.ts` / `registry.ts`): a
+   * loadout path that resolves to no note (404) is SKIPPED with a warn — NEVER thrown — so one
+   * stale path can't brick a turn. A blank-bodied note is RETURNED (the composer skips blank
+   * entries by content). No thread note yet / absent `metadata.loadout` → an empty array.
+   *
+   * Best-effort per path: an UNEXPECTED read error on one path is logged + skipped (the turn
+   * runs with the rest); the thread-note read itself, if it fails non-404, propagates to the
+   * registry's try/catch (which runs the turn with the def body alone).
+   */
+  async readThreadLoadout(
+    channel: string,
+    name: string,
+    subject?: string,
+  ): Promise<{ path: string; content: string }[]> {
+    const thread = await this.readThreadNote(this.singleThreadedPath(channel, name, subject));
+    if (!thread) return []; // no thread note yet (first turn) → empty loadout.
+    const paths = parseLoadoutPaths(thread.metadata?.loadout);
+    if (paths.length === 0) return [];
+    const out: { path: string; content: string }[] = [];
+    for (const path of paths) {
+      let note: { metadata?: Record<string, unknown>; content?: string } | undefined;
+      try {
+        note = await this.readThreadNote(path);
+      } catch (err) {
+        // An unexpected (non-404) read error on ONE loadout note — skip it, run with the rest.
+        console.warn(
+          `parachute-agent: loadout note "${path}" read failed (skipping): ${(err as Error).message}`,
+        );
+        continue;
+      }
+      if (!note) {
+        // 404 — a stale/renamed loadout path. Skip-and-warn (never throw); the def-load discipline.
+        console.warn(`parachute-agent: loadout note "${path}" not found (skipping)`);
+        continue;
+      }
+      // CONTENT only — never the note's metadata. A blank body is returned; the composer skips it.
+      out.push({ path, content: typeof note.content === "string" ? note.content : "" });
+    }
+    return out;
   }
 
   // react / edit / download: vault has no reactions; v1 is reply-only. Omitted.


### PR DESCRIPTION
**Phase A of threads-only** (DESIGN-2026-06-29-threads-only.md §1/§9). Generalizes the rc.13 arity-2 composed-prompt seam (`roleBody [+ subjectDossier]`) into an **ordered list of loaded notes (a LOADOUT)**. This touches the prompt path the **LIVE 4am steward weave** uses — back-compat is load-bearing and asserted exactly.

Scope: **Phase A ONLY.** No grants, routing/registry-keying, or scheduling changes (those are later phases).

### The arity-N generalization
`src/backends/types.ts` adds `composeSystemPrompt(entries)` — a pure composer:
- **entry 0 = the self entry**: `spec.systemPrompt` (the def body), labeled with the def note's **PATH** (`spec.definition` — the `#agent/definition` note id, which IS its vault path, e.g. `Agents/steward`; **fallback** = `spec.name`).
- **entries 1..N = the loadout notes** resolved from the thread's `metadata.loadout` (an array of note PATHS).
- Render each as `# <path>\n\n<content>` (note **CONTENT only — never metadata**), join with `\n\n---\n\n`. **Dedupe by path** (first wins), **skip blank/whitespace** entries, **skip missing notes with a warn** (mirrors the def-load skip discipline) — never throws.

The drain's `deliver(... subjectDossier?: string ...)` param is **superseded** by `loadout?: LoadoutEntry[]` across `AgentBackend`, `ProgrammaticBackend`, the registry, and the fakes.

### The no-loadout invariant (the live heartbeat)
A thread with **no `loadout`** (every current agent, incl. steward) composes to **EXACTLY** `# <path>\n\n<body>` where `<body>` is **byte-identical** to `spec.systemPrompt`. The single `# <path>` header is the **only** change to a live prompt (design decision #4, accepted). Asserted exactly in a test (the steward weave path), from both directions (full-string equality + strip-the-header → body verbatim).

### The loader (wires the dead seam)
`readSubjectDossier` (arity-2, never wired in `createDefaultProgrammaticRegistry`) → **`readLoadout(channel, name, subject)`**, wired via `buildReadLoadout` → `VaultTransport.readThreadLoadout`, which reads `metadata.loadout` off the `#agent/thread` note and resolves each path's content. Absent `metadata.loadout` → empty loadout. A read failure logs + the turn runs with the def body alone (never strands the queue). `parseLoadoutPaths` tolerates a real `string[]`, a JSON-encoded array string (the vault stores metadata as strings), or a single path string.

### Budget (new — none existed)
`LOADOUT_BUDGET_BYTES = 600_000` bytes (~150k tokens at ~4 bytes/token; ~200k context window with headroom for the message/tools). Over budget → truncate the **LOADOUT notes tail-first, NEVER the self entry**, with a loud warn naming dropped notes. Even a self entry larger than the budget is kept whole.

### Gates (exact)
- `bun test ./src/` → **1290 pass / 0 fail** (the web/ui vitest suite fails at baseline and is NOT part of `bun test ./src/`).
- `bun run typecheck` → **clean (exit 0)**.

New tests: `src/backends/compose.test.ts` (compose + budget), loadout cases in `programmatic.test.ts` (no-loadout invariant, fallback label, multi-note order, dedupe, blank-skip, role-less), `parseLoadoutPaths` + `readThreadLoadout` in `vault.test.ts` (reads `metadata.loadout`, resolves contents, missing-skip, subject-scoped), drain wiring + throw-tolerance in `programmatic-wiring.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)