### PR TITLE
feat(agent): threads-only Phase B — thread registry + resolve-or-create routing + #169 (rc.15)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/agent",
-  "version": "0.2.3-rc.14",
+  "version": "0.2.3-rc.15",
   "description": "Vault-native agents for Claude Code — a #agent/definition note + an inbound message becomes a sandboxed claude turn; the reply is written back as a note. Messaging gateway on :1941.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/src/agent-defs.test.ts
+++ b/src/agent-defs.test.ts
@@ -62,6 +62,32 @@ describe("parseAgentDef", () => {
     expect(resolveDefStatus(def)).toEqual({ status: "enabled" });
   });
 
+  test("#169: note.path → spec.definitionPath; spec.definition stays the (timestamp-slug) id", () => {
+    // In a live vault the note ID is a timestamp-slug, while the PATH is the legible address.
+    const def = parseAgentDef(
+      {
+        id: "2026-06-20-07-30-56-487050", // the note ID (timestamp-slug)
+        path: "Agents/steward", // the legible PATH — the self-entry header source (#169)
+        content: "You are the steward.",
+        metadata: { name: "steward" },
+      },
+      { vault: "default" },
+    );
+    // The ID provenance is unchanged (still the timestamp-slug).
+    expect(def.spec.definition).toBe("2026-06-20-07-30-56-487050");
+    // NEW: the PATH rides onto the spec for the composed-prompt self-entry header.
+    expect(def.spec.definitionPath).toBe("Agents/steward");
+  });
+
+  test("#169: absent note.path → spec.definitionPath undefined (header falls back to name)", () => {
+    const def = parseAgentDef(
+      { id: "2026-06-20-07-30-56-487050", content: "role", metadata: { name: "steward" } },
+      { vault: "default" },
+    );
+    expect(def.spec.definition).toBe("2026-06-20-07-30-56-487050");
+    expect(def.spec.definitionPath).toBeUndefined();
+  });
+
   test("parses the full config knobs (backend, mode, workspace, filesystem, network, egress)", () => {
     const def = parseAgentDef(
       {

--- a/src/agent-defs.ts
+++ b/src/agent-defs.ts
@@ -238,6 +238,13 @@ function nameOfDefNote(note: { metadata?: Record<string, unknown> }): string | u
  */
 export function parseAgentDef(note: {
   id?: string;
+  /**
+   * The note's PATH (e.g. `Agents/steward`) — carried onto `spec.definitionPath` for the
+   * composed-prompt self-entry header (#169). Distinct from the note ID (a timestamp-slug).
+   * Optional: a reader that doesn't surface a path leaves it unset and the header falls back
+   * to the id then the name.
+   */
+  path?: string;
   content?: string;
   metadata?: Record<string, unknown>;
 }, binding: { vault: string }): ParsedAgentDef {
@@ -246,6 +253,7 @@ export function parseAgentDef(note: {
     throw new AgentDefParseError("#agent/definition note has no id");
   }
   const meta = note.metadata ?? {};
+  const notePath = typeof note.path === "string" && note.path ? note.path : undefined;
 
   const name = metaStr(meta.name);
   if (!name) {
@@ -339,6 +347,10 @@ export function parseAgentDef(note: {
     // The def note id — provenance carried into the `#agent/thread` note (BOTH modes;
     // interim plain id string; typed link fields are a future vault feature).
     definition: noteId,
+    // The def note PATH (when the reader surfaced one) — the human-legible loadout path
+    // used for the composed-prompt self-entry header (#169). The note ID above is a
+    // timestamp-slug; the PATH (`Agents/steward`) is what the header should read.
+    ...(notePath ? { definitionPath: notePath } : {}),
     // Own-vault binding (4a): the def-vault, write-scoped. NOT sourced from the note
     // — it's the vault the note LIVES in (passed in by the caller).
     vault: { name: binding.vault, access: "write" },
@@ -538,7 +550,7 @@ export class DefVaultClient {
    * silently-empty agent set.
    */
   async listDefNotes(opts?: { limit?: number }): Promise<
-    Array<{ id: string; content?: string; metadata?: Record<string, unknown> }>
+    Array<{ id: string; path?: string; content?: string; metadata?: Record<string, unknown> }>
   > {
     const limit = opts?.limit ?? DEF_LIST_LIMIT;
     const params = new URLSearchParams();
@@ -557,14 +569,21 @@ export class DefVaultClient {
     } catch (err) {
       throw new Error(`def-vault "${this.vault}": list defs — bad JSON: ${(err as Error).message}`);
     }
-    type RawNote = { id?: string; content?: string; metadata?: Record<string, unknown> };
+    type RawNote = { id?: string; path?: string; content?: string; metadata?: Record<string, unknown> };
     const notes: RawNote[] = Array.isArray(parsed)
       ? (parsed as RawNote[])
       : ((parsed as { notes?: RawNote[] })?.notes ?? []);
-    const out: Array<{ id: string; content?: string; metadata?: Record<string, unknown> }> = [];
+    const out: Array<{ id: string; path?: string; content?: string; metadata?: Record<string, unknown> }> = [];
     for (const n of notes) {
       if (typeof n.id === "string" && n.id) {
-        out.push({ id: n.id, content: n.content, metadata: n.metadata });
+        // Carry the note PATH (when the vault surfaces one) so parseAgentDef can label the
+        // composed-prompt self entry with the human-legible path, not the timestamp-id (#169).
+        out.push({
+          id: n.id,
+          ...(typeof n.path === "string" && n.path ? { path: n.path } : {}),
+          content: n.content,
+          metadata: n.metadata,
+        });
       }
     }
     return out;
@@ -573,7 +592,7 @@ export class DefVaultClient {
   /** Fetch ONE note by id (for a created/updated reload). Null on 404/miss. */
   async getNote(
     id: string,
-  ): Promise<{ id: string; content?: string; metadata?: Record<string, unknown> } | null> {
+  ): Promise<{ id: string; path?: string; content?: string; metadata?: Record<string, unknown> } | null> {
     const url = `${this.vaultUrl}/vault/${this.vault}/api/notes/${encodeURIComponent(id)}?include_content=true`;
     const res = await this.fetchFn(url, { headers: { authorization: `Bearer ${this.token}` } });
     if (res.status === 404) return null;
@@ -587,10 +606,16 @@ export class DefVaultClient {
     } catch (err) {
       throw new Error(`def-vault "${this.vault}": get note ${id} — bad JSON: ${(err as Error).message}`);
     }
-    const n = (parsed ?? {}) as { id?: string; note?: { id?: string; content?: string; metadata?: Record<string, unknown> }; content?: string; metadata?: Record<string, unknown> };
+    const n = (parsed ?? {}) as { id?: string; path?: string; note?: { id?: string; path?: string; content?: string; metadata?: Record<string, unknown> }; content?: string; metadata?: Record<string, unknown> };
     const note = n.note ?? n;
     if (typeof note.id !== "string" || !note.id) return null;
-    return { id: note.id, content: note.content, metadata: note.metadata };
+    return {
+      id: note.id,
+      // Carry the note PATH for the self-entry header (#169).
+      ...(typeof note.path === "string" && note.path ? { path: note.path } : {}),
+      content: note.content,
+      metadata: note.metadata,
+    };
   }
 
   /**
@@ -1492,7 +1517,7 @@ export class AgentDefRegistry {
    */
   private async instantiate(
     vault: string,
-    note: { id: string; content?: string; metadata?: Record<string, unknown> },
+    note: { id: string; path?: string; content?: string; metadata?: Record<string, unknown> },
   ): Promise<boolean> {
     const binding = this.bindings.get(vault);
     const client = this.clients.get(vault);

--- a/src/backends/programmatic.test.ts
+++ b/src/backends/programmatic.test.ts
@@ -566,16 +566,27 @@ describe("ProgrammaticBackend.deliver — the backend is a pure function of the 
 describe("ProgrammaticBackend.deliver — composed system prompt (threads-only Phase A: arity-N loadout)", () => {
   const ROLE = "You are the eng agent. Be terse.";
 
-  /** A spec whose def-note PATH (spec.definition) is set — the self-entry header source. */
-  function specWithDef(prompt: string, definition: string, name = "eng"): AgentSpec {
-    return { ...specWithSystemPrompt(prompt, undefined, name), definition };
+  /**
+   * A spec whose def-note PATH (`spec.definitionPath`) is the self-entry header source (#169).
+   * It ALSO carries a realistic `spec.definition` = the note ID (a timestamp-slug, NOT a path),
+   * so these tests prove the header derives from the PATH and IGNORES the id — the exact #169
+   * fix (before it, the header wrongly read `# <spec.definition>` = the timestamp-id).
+   */
+  const DEF_NOTE_ID = "2026-06-20-07-30-56-487050"; // a realistic timestamp-slug note id
+  function specWithDef(prompt: string, definitionPath: string, name = "eng"): AgentSpec {
+    return {
+      ...specWithSystemPrompt(prompt, undefined, name),
+      definition: DEF_NOTE_ID, // the note ID (timestamp-slug) — must NOT be the header
+      definitionPath, // the legible PATH — the header source
+    };
   }
 
   test("NO-LOADOUT INVARIANT: system-prompt.txt = `# <path>\\n\\n<body>`, body byte-identical (the steward weave path)", async () => {
     mkDirs("compose-none");
     const { fn } = recordingSpawn({ stdout: successTurn("sess-CP1", "ok") });
     const backend = new ProgrammaticBackend(baseDeps(fn));
-    // def note PATH set → the self entry is labeled with it (resolved from spec.definition).
+    // def note PATH set → the self entry is labeled with it (resolved from spec.definitionPath,
+    // NOT spec.definition = the timestamp-id) — the #169 fix.
     const handle = await backend.start(specWithDef(ROLE, "Agents/steward", "eng"));
 
     // deliver WITHOUT a loadout — exactly the weave call shape (no 7th param).
@@ -587,21 +598,30 @@ describe("ProgrammaticBackend.deliver — composed system prompt (threads-only P
     // EXACTLY the self entry: `# <path>\n\n<body>`. The header line is the ONLY change to a
     // no-loadout prompt; the body after `# <path>\n\n` is BYTE-IDENTICAL to spec.systemPrompt.
     expect(written).toBe(`# Agents/steward\n\n${ROLE}`);
+    // #169 — the header is the PATH, NOT the timestamp-id (`spec.definition`): the id never appears.
+    expect(written).not.toContain(DEF_NOTE_ID);
+    expect(written.startsWith(`# Agents/steward\n\n`)).toBe(true);
     // And asserted from the other direction: strip the header → the body is the role verbatim.
     expect(written.slice(`# Agents/steward\n\n`.length)).toBe(ROLE);
   });
 
-  test("self-entry PATH falls back to spec.name when spec.definition is absent", async () => {
+  test("self-entry PATH falls back to spec.name when spec.definitionPath is absent (the note-id is NEVER the header)", async () => {
     mkDirs("compose-fallback");
     const { fn } = recordingSpawn({ stdout: successTurn("sess-CP1b", "ok") });
     const backend = new ProgrammaticBackend(baseDeps(fn));
-    // No definition set → the self entry header is the spec name.
-    const handle = await backend.start(specWithSystemPrompt(ROLE, undefined, "eng"));
+    // No definitionPath set, but a `definition` (note ID) IS present → the header is the spec
+    // NAME, NOT the timestamp-id (#169 — the id never becomes the header even as the fallback).
+    const handle = await backend.start({
+      ...specWithSystemPrompt(ROLE, undefined, "eng"),
+      definition: DEF_NOTE_ID,
+    });
 
     await backend.deliver(handle, "go", createSession("sess-CP1b"));
 
     const promptPath = join(sessionWorkspace(sessionsDir, "eng"), "system-prompt.txt");
-    expect(readFileSync(promptPath, "utf8")).toBe(`# eng\n\n${ROLE}`);
+    const written = readFileSync(promptPath, "utf8");
+    expect(written).toBe(`# eng\n\n${ROLE}`);
+    expect(written).not.toContain(DEF_NOTE_ID); // the note-id is never the header label.
   });
 
   test("empty/whitespace loadout → still just the self entry (treated as no loadout)", async () => {

--- a/src/backends/programmatic.ts
+++ b/src/backends/programmatic.ts
@@ -600,12 +600,18 @@ export class ProgrammaticBackend implements AgentBackend {
     // COMPOSED PROMPT (threads-only Phase A — DESIGN-2026-06-29-threads-only.md §1/§9):
     // the system prompt is an ORDERED LIST of loaded notes — a direct arity-N generalization
     // of the rc.13 arity-2 `roleBody [+ dossier]` seam. Entry 0 is the thread's SELF entry:
-    // the spec's `systemPrompt` (the def body), labeled with the def note's PATH
-    // (`spec.definition`, the `#agent/definition` note id which IS its vault path; fallback
-    // `spec.name`). Entries 1..N are the resolved `loadout` notes (read CONTENT-only, never
-    // metadata). composeSystemPrompt dedupes by path, skips blank entries, renders each as
+    // the spec's `systemPrompt` (the def body), labeled with the def note's human-legible
+    // PATH (`spec.definitionPath`, e.g. `Agents/steward`; fallback `spec.name`). Entries
+    // 1..N are the resolved `loadout` notes (read CONTENT-only, never metadata).
+    // composeSystemPrompt dedupes by path, skips blank entries, renders each as
     // `# <path>\n\n<content>`, joins with `\n\n---\n\n`, and enforces the byte budget
     // (truncate loadout-notes-first, NEVER the self entry).
+    //
+    // #169 — the self-entry header uses the def note's PATH, NOT its id. The note ID is a
+    // timestamp-slug (`2026-06-20-07-30-56-487050`); the legible loadout path is
+    // `Agents/steward`. `spec.definitionPath` carries the path (set by parseAgentDef from
+    // `note.path`); when absent (a spec not sourced from a def note, or a reader that didn't
+    // surface a path) the header falls back to `spec.name`.
     //
     // NO-LOADOUT INVARIANT (the live 4am steward weave path): a thread with NO loadout
     // composes to EXACTLY `# <path>\n\n<def body>` — `<def body>` byte-identical to
@@ -613,12 +619,12 @@ export class ProgrammaticBackend implements AgentBackend {
     // prompt (design decision #4, accepted). The run-context preamble stays on the MESSAGE.
     let systemPromptFile: string | undefined;
     if (typeof spec.systemPrompt === "string" && spec.systemPrompt.length > 0) {
-      // Self entry: the def body, labeled by the def note's PATH (resolve from the def note
-      // id when available — in a Parachute vault the note id IS the path, e.g.
-      // `Agents/uni-weaver`; acceptable fallback label is the spec name).
+      // Self entry: the def body, labeled by the def note's PATH (`spec.definitionPath`);
+      // fallback the spec name. The note ID (`spec.definition`) is deliberately NOT used —
+      // it's a timestamp-slug, not the legible path the header should read (#169).
       const selfPath =
-        typeof spec.definition === "string" && spec.definition.length > 0
-          ? spec.definition
+        typeof spec.definitionPath === "string" && spec.definitionPath.length > 0
+          ? spec.definitionPath
           : spec.name;
       const entries: LoadoutEntry[] = [
         { path: selfPath, content: spec.systemPrompt },

--- a/src/backends/registry.test.ts
+++ b/src/backends/registry.test.ts
@@ -1137,6 +1137,179 @@ describe("ProgrammaticAgentRegistry — F. per-thread serial guarantee (#120)", 
 });
 
 // ─────────────────────────────────────────────────────────────────────────────────────────
+// threads-only Phase B — thread registry (byThread) + drain-key-is-the-thread-id +
+// resolve-or-create + status-driven teardown. DESIGN-2026-06-29-threads-only.md §5/§9.
+// ─────────────────────────────────────────────────────────────────────────────────────────
+describe("ProgrammaticAgentRegistry — Phase B: byThread index + thread-id routing", () => {
+  test("register indexes by thread-id; hasThread/channelForThread resolve it (thread-id ≡ name for the live cast)", async () => {
+    const backend = new FakeBackend();
+    const { fn } = recorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: fn });
+
+    expect(reg.hasThread("steward")).toBe(false);
+    await reg.register(specFor("steward"));
+    // thread-id ≡ name ≡ channel for the live cast: a metadata.thread:steward inbound resolves
+    // the same live agent a metadata.agent:steward inbound does.
+    expect(reg.hasThread("steward")).toBe(true);
+    expect(reg.channelForThread("steward")).toBe("steward");
+
+    // deregister drops the byThread entry too — a thread-addressed inbound stops resolving.
+    await reg.deregister("steward");
+    expect(reg.hasThread("steward")).toBe(false);
+    expect(reg.channelForThread("steward")).toBeUndefined();
+  });
+
+  test("drain key = the thread-id directly: same thread → strictly serial (FIFO, never concurrent)", async () => {
+    const backend = new FakeBackend();
+    const gate = deferred<void>(); // hold ALL turns so we can observe what started.
+    backend.gate = { promise: gate.promise, resolve: gate.resolve };
+    const rec = recorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    await reg.register(specFor("eng"));
+
+    // Two messages for the SAME thread-id on the channel → ONE drain key → strictly serial.
+    reg.enqueue("eng", { content: "t1-a", thread: "t1" });
+    await until(() => backend.calls.length === 1);
+    reg.enqueue("eng", { content: "t1-b", thread: "t1" });
+    // The second waits behind the first (one queue for thread t1) — only one started.
+    expect(backend.calls).toHaveLength(1);
+
+    gate.resolve();
+    await until(() => rec.calls.length === 2);
+    expect(backend.calls.map((c) => c.message)).toEqual(["t1-a", "t1-b"]);
+    expect(backend.maxConcurrent).toBe(1); // never two concurrent for the same thread.
+  });
+
+  test("different thread-ids on ONE channel run CONCURRENTLY (distinct drain keys)", async () => {
+    const backend = new FakeBackend();
+    const gate = deferred<void>(); // hold both turns; if they shared a queue only 1 would start.
+    backend.gate = { promise: gate.promise, resolve: gate.resolve };
+    const rec = recorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    await reg.register(specFor("eng"));
+
+    // Two DIFFERENT thread-ids → two distinct drain keys → two distinct drain promises → BOTH
+    // start while the gate holds them (concurrent). A shared queue would start only one.
+    reg.enqueue("eng", { content: "t1", thread: "t1" });
+    reg.enqueue("eng", { content: "t2", thread: "t2" });
+    await until(() => backend.calls.length === 2);
+    expect(backend.calls).toHaveLength(2); // both in flight concurrently.
+    expect(backend.maxConcurrent).toBe(2);
+
+    gate.resolve();
+    await until(() => rec.calls.length === 2);
+    expect(backend.calls.map((c) => c.message).sort()).toEqual(["t1", "t2"]);
+  });
+
+  test("a def-agent inbound with NO thread + NO subject still maps to ONE queue (the bare channel = HEAD)", async () => {
+    const backend = new FakeBackend();
+    const gate = deferred<void>();
+    backend.gate = { promise: gate.promise, resolve: gate.resolve };
+    const rec = recorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    await reg.register(specFor("steward")); // single-threaded def (the weave shape).
+
+    // The live weave path: no thread, no subject → the bare-channel drain key, strictly serial.
+    reg.enqueue("steward", { content: "weave-1" });
+    await until(() => backend.calls.length === 1);
+    reg.enqueue("steward", { content: "weave-2" });
+    expect(backend.calls).toHaveLength(1);
+    expect(reg.statusOf("steward")).toEqual({ state: "queued", queued: 1 });
+
+    gate.resolve();
+    await until(() => rec.calls.length === 2);
+    expect(backend.calls.map((c) => c.message)).toEqual(["weave-1", "weave-2"]);
+    expect(backend.maxConcurrent).toBe(1);
+  });
+});
+
+describe("ProgrammaticAgentRegistry — Phase B: resolve-or-create (own, don't 401-drop)", () => {
+  test("a LIVE thread → 'live'; the caller routes to its channel", async () => {
+    const backend = new FakeBackend();
+    const { fn } = recorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: fn });
+    await reg.register(specFor("steward"));
+    expect(reg.resolveOrCreateThread("steward", true)).toBe("live");
+  });
+
+  test("a NOT-YET-LIVE but RESOLVABLE thread → 'owned': marked expected so queuePending BUFFERS (then replays on register)", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+
+    // No agent live for "proj-thread" yet, but a thread note exists (resolvable=true).
+    expect(reg.resolveOrCreateThread("proj-thread", true)).toBe("owned");
+    expect(reg.isExpected("proj-thread")).toBe(true);
+
+    // queuePending now OWNS the inbound (it's expected) instead of returning "unknown"/dropping.
+    expect(reg.queuePending("proj-thread", { content: "hello", thread: "proj-thread" })).toBe("queued");
+    expect(reg.pendingCount("proj-thread")).toBe(1);
+
+    // When the thread agent finally registers, the buffered inbound REPLAYS (not lost).
+    await reg.register(specFor("proj-thread"));
+    await until(() => rec.calls.length === 1);
+    expect(rec.calls[0]!.reply).toBe("reply:hello");
+    expect(reg.pendingCount("proj-thread")).toBe(0);
+  });
+
+  test("a genuinely UNKNOWN thread (not live, not resolvable) → 'unknown' (today's 401 path; NOT marked expected)", () => {
+    const backend = new FakeBackend();
+    const { fn } = recorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: fn });
+    expect(reg.resolveOrCreateThread("ghost", false)).toBe("unknown");
+    // NOT expected → queuePending would return "unknown" (the caller 401s, as today).
+    expect(reg.isExpected("ghost")).toBe(false);
+    expect(reg.queuePending("ghost", { content: "x" })).toBe("unknown");
+  });
+});
+
+describe("ProgrammaticAgentRegistry — Phase B: status-driven teardown (archiveThread)", () => {
+  test("archiveThread clears a thread's queues + indexes (the def-set-diff teardown replacement)", async () => {
+    const backend = new FakeBackend();
+    const gate = deferred<void>(); // hold the turn so a second message sits in the queue.
+    backend.gate = { promise: gate.promise, resolve: gate.resolve };
+    const { fn } = recorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: fn });
+    await reg.register(specFor("eng"));
+
+    // Build up queue state for thread "t1": one in flight (held), one queued behind it.
+    reg.enqueue("eng", { content: "t1-a", thread: "t1" });
+    await until(() => backend.calls.length === 1);
+    reg.enqueue("eng", { content: "t1-b", thread: "t1" });
+    expect(reg.statusOf("t1")).toEqual({ state: "queued", queued: 1 });
+    expect(reg.hasThread("eng")).toBe(true); // the registered agent's thread-id (eng) resolves.
+
+    // Status transition → archive: tear the thread down. The QUEUED message is dropped, the
+    // byThread entry for the registered agent is cleared.
+    expect(reg.archiveThread("t1")).toBe(true); // had queue state.
+    expect(reg.statusOf("t1")).toEqual({ state: "idle", queued: 0 }); // queue cleared.
+
+    // Tearing down the registered agent's own thread-id stops thread-routing to it.
+    expect(reg.archiveThread("eng")).toBe(true);
+    expect(reg.hasThread("eng")).toBe(false);
+
+    gate.resolve(); // release the in-flight turn (it self-completes; nothing left queued).
+    // A second archive of an unknown thread is a clean no-op false.
+    expect(reg.archiveThread("never-existed")).toBe(false);
+  });
+
+  test("archiveThread drops an EXPECTED-but-not-live thread's pending buffer (owned message can't strand)", () => {
+    const backend = new FakeBackend();
+    const { fn } = recorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: fn });
+
+    reg.resolveOrCreateThread("proj-thread", true); // expected.
+    reg.queuePending("proj-thread", { content: "buffered", thread: "proj-thread" });
+    expect(reg.pendingCount("proj-thread")).toBe(1);
+    expect(reg.isExpected("proj-thread")).toBe(true);
+
+    expect(reg.archiveThread("proj-thread")).toBe(true);
+    expect(reg.pendingCount("proj-thread")).toBe(0);
+    expect(reg.isExpected("proj-thread")).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────────────────
 // roles×threads NEXT slice (#120) — F. per-thread session CONTINUITY.
 //
 // A multi-threaded SUBJECT thread reads/writes its session at the SUBJECT-scoped thread note

--- a/src/backends/registry.ts
+++ b/src/backends/registry.ts
@@ -411,6 +411,15 @@ export interface QueuedMessage {
    * the weave path is untouched). Carries no routing meaning in NOW.
    */
   subject?: string;
+  /**
+   * The THREAD-ID (threads-only Phase B — DESIGN-2026-06-29-threads-only.md §5/§9) — rides
+   * from the inbound note's `metadata.thread` (read FIRST by {@link noteAgentKey}). When
+   * present it IS the {@link drainKeyFor} drain key directly, so a thread-addressed inbound
+   * serializes per-thread regardless of subject/mode. ADDITIVE + dormant: nothing writes
+   * `metadata.thread` yet (Phase C flips the writer), and the 4 live def agents carry only
+   * `metadata.agent` → no `thread` → the bare-channel drain key (byte-identical to HEAD).
+   */
+  thread?: string;
 }
 
 /** A registered programmatic agent's live status (surfaced in /health + the list). */
@@ -445,6 +454,18 @@ export class ProgrammaticAgentRegistry {
   private readonly byChannel = new Map<string, ProgrammaticAgentHandle>();
   /** name → channel (the lifecycle index; an agent has exactly one wake channel). */
   private readonly nameToChannel = new Map<string, string>();
+  /**
+   * thread-id → channel (the THREAD-ADDRESS index — threads-only Phase B,
+   * DESIGN-2026-06-29-threads-only.md §3/§5). An ADDITIVE parallel index to
+   * {@link nameToChannel}: an inbound carrying `metadata.thread` routes through here.
+   * Populated on {@link register} from {@link threadIdOf} (the spec's thread identity).
+   * For the 4 live def agents the thread-id ≡ name ≡ channel, so this maps `steward → steward`
+   * exactly like `nameToChannel` — the def path is unchanged; this index is just the
+   * additional lookup a `metadata.thread`-addressed inbound consults (a `metadata.agent`
+   * inbound never reads it). It's a CACHE of the live set, rebuildable by listing
+   * `#agent/thread`; the durable record is the thread note.
+   */
+  private readonly byThread = new Map<string, string>();
   /**
    * DRAIN-KEY → FIFO queue of pending messages — the PER-THREAD serial queue
    * (roles×threads NEXT slice, #120). The drain key is {@link drainKeyFor}:
@@ -596,28 +617,53 @@ export class ProgrammaticAgentRegistry {
   }
 
   /**
-   * The PER-THREAD serial DRAIN KEY for an inbound message (roles×threads NEXT slice, #120)
-   * — what {@link queues} + {@link draining} are keyed by:
-   *  - SINGLE-threaded agent, OR a message with NO subject → the bare CHANNEL. This is the
-   *    back-compat path: every agent today (incl. the weave) carries no subject, so the key
-   *    is exactly the channel and the queue/drain behavior is byte-identical to HEAD.
-   *  - MULTI-threaded agent WITH a subject → `threadKey(spec.name, subject)` (`<name>--<sub>`),
-   *    so two subjects of one agent get DISTINCT queues + DISTINCT drain promises (concurrent),
-   *    while two messages of the SAME subject share one queue + one promise (strictly serial).
+   * The THREAD-ID a spec registers under (threads-only Phase B) — the address a
+   * `metadata.thread`-routed inbound resolves through {@link byThread}. For the live cast
+   * the thread-id ≡ the spec name ≡ the channel (the design's "thread-id ≡ agent-name ≡
+   * channel, by construction" — §9), so this is `spec.name`. A future explicit thread record
+   * (Phase C) would override this; today it's the name, which keeps the def path unchanged.
+   */
+  private static threadIdOf(spec: AgentSpec): string {
+    return spec.name;
+  }
+
+  /**
+   * The PER-THREAD serial DRAIN KEY for an inbound message — what {@link queues} +
+   * {@link draining} are keyed by. The per-drain-key serial guarantee (class doc lines
+   * 13-20) holds for ANY of these: same key → strictly serial; different keys → concurrent.
    *
-   * NOTE: a message can only carry a subject route when a LIVE handle exists for the channel
-   * (enqueue requires byChannel), so we read the mode off that handle. A missing handle (the
-   * caller already returns false) defaults to the channel key.
+   * Precedence (threads-only Phase B — DESIGN-2026-06-29-threads-only.md §5):
+   *  1. A thread-addressed message (`msg.thread`, from `metadata.thread`) → that thread-id IS
+   *     the drain key DIRECTLY. This is the Phase-B simplification: the `multiThreaded && subject`
+   *     gate is bypassed — a thread-addressed inbound serializes per-thread independent of
+   *     subject/mode (same thread-id → strictly serial; different thread-ids → concurrent, even
+   *     across one channel's worker, since each thread-id is its own queue + drain promise).
+   *  2. Else a MULTI-threaded agent WITH a subject → `threadKey(spec.name, subject)`
+   *     (`<name>--<subject>`), so two subjects of one agent get DISTINCT queues (concurrent),
+   *     while two messages of the SAME subject share one queue (strictly serial). This is the
+   *     #120 subject-routing path, UNCHANGED (a single-threaded agent's subject is NOT a routing
+   *     axis — it coalesces to the bare channel, as before).
+   *  3. Else (no thread; OR single-threaded; OR no subject) → the bare CHANNEL. The BACK-COMPAT
+   *     path: every live def agent (incl. the steward weave) carries no thread + no subject, so
+   *     the key is exactly the channel and the queue/drain behavior is BYTE-IDENTICAL to HEAD.
+   *
+   * NOTE: a message can only enqueue here when a LIVE handle exists for the channel (enqueue
+   * requires byChannel), so the handle resolves the agent name + mode for the subject key. A
+   * missing handle (the caller already returns false) defaults to the channel key. The thread-id
+   * path (1) does NOT need the handle — the explicit address keys directly.
    */
   private drainKeyFor(channel: string, msg: QueuedMessage): string {
+    // 1. Explicit thread-id address → the drain key directly (per-thread serial), gate-free.
+    const thread = msg.thread?.trim();
+    if (thread) return thread;
     const handle = this.byChannel.get(channel);
     if (!handle) return channel;
+    // 2. The #120 subject path — multi-threaded only (a single-threaded agent's subject is
+    //    not a routing axis; it coalesces to the bare channel, back-compat).
     const multiThreaded = (handle.spec.mode ?? "single-threaded") === "multi-threaded";
     if (!multiThreaded) return channel;
-    // threadKey returns the bare name for no/empty subject — but the channel (not the name)
-    // is the back-compat single-thread key, so only re-key when a subject actually narrows it.
     const subject = msg.subject?.trim();
-    if (!subject) return channel;
+    if (!subject) return channel; // 3. No subject → the bare channel.
     return threadKey(handle.spec.name, subject);
   }
 
@@ -656,6 +702,102 @@ export class ProgrammaticAgentRegistry {
   /** Is a programmatic agent registered under this name? (the mutual-exclusion check) */
   hasName(name: string): boolean {
     return this.nameToChannel.has(name);
+  }
+
+  /**
+   * Is a LIVE programmatic agent registered for this THREAD-ID? (threads-only Phase B —
+   * the thread-address routing check). True when the thread-id resolves to a live channel
+   * via {@link byThread}. For the live cast thread-id ≡ channel, so a `metadata.thread:
+   * steward` inbound finds the same live agent a `metadata.agent: steward` inbound does.
+   */
+  hasThread(threadId: string): boolean {
+    const channel = this.byThread.get(threadId);
+    return channel !== undefined && this.byChannel.has(channel);
+  }
+
+  /** The live channel a thread-id resolves to, or undefined (threads-only Phase B). */
+  channelForThread(threadId: string): string | undefined {
+    const channel = this.byThread.get(threadId);
+    return channel !== undefined && this.byChannel.has(channel) ? channel : undefined;
+  }
+
+  /**
+   * RESOLVE-OR-CREATE a thread for a `metadata.thread`-addressed inbound (threads-only
+   * Phase B — DESIGN-2026-06-29-threads-only.md §5/§9). This GENERALIZES the inbound
+   * handler's old `channels.get → 401-if-absent` lookup into a path that OWNS a message for
+   * a not-yet-instantiated thread instead of dropping it. Returns:
+   *
+   *  - `"live"`    — a live agent already serves this thread (via {@link byThread} →
+   *                  {@link byChannel}); the caller routes/enqueues normally to its channel.
+   *  - `"owned"`   — no live agent YET, but the thread is RESOLVABLE (`resolvable` true — a
+   *                  thread note / def exists for it). We mark the thread-id EXPECTED (so a
+   *                  subsequent {@link queuePending} BUFFERS the inbound, owned + replayed on
+   *                  {@link register}) and return `"owned"`. The caller queues-pending under
+   *                  the thread-id, never 401/drops. This REUSES the agent#121 buffer pattern,
+   *                  generalized from "channel not yet live" to "thread not yet instantiated".
+   *  - `"unknown"` — nothing maps to this thread-id (not live, not resolvable). The caller
+   *                  behaves EXACTLY as today (the inbound handler's existing 401 / no-route
+   *                  semantics — no silent-drop change).
+   *
+   * BACK-COMPAT: a `metadata.agent`-addressed inbound never reaches here (the handler resolves
+   * a live channel for it directly), so the 4 live def agents are untouched.
+   *
+   * PHASE-C INVARIANT (do not break when wiring the writer): the "owned" path marks the
+   * thread-id EXPECTED via {@link expectChannel} (a CHANNEL-keyed set) and the caller buffers
+   * via {@link queuePending}`(threadId, …)`; the replay on {@link register} runs
+   * `drainPending(channel)`. This relies on `threadId ≡ channel` (true today —
+   * {@link threadIdOf} = `spec.name` = the channel). If Phase C introduces a thread-id that
+   * DIFFERS from the channel, the buffered inbound must be replayed under the THREAD-ID key on
+   * register (generalize `drainPending`), or a thread-addressed pending message would silently
+   * never drain. Keep thread-id ≡ channel, or fix the replay key together.
+   */
+  resolveOrCreateThread(threadId: string, resolvable: boolean): "live" | "owned" | "unknown" {
+    if (this.hasThread(threadId)) return "live";
+    if (!resolvable) return "unknown";
+    // Not yet live, but a thread note / def exists → OWN the message: mark the thread-id
+    // expected so queuePending buffers it (replayed when the thread agent registers).
+    this.expectChannel(threadId);
+    return "owned";
+  }
+
+  /**
+   * Tear down a thread on a thread-note `status` transition to ARCHIVE (threads-only Phase B
+   * — DESIGN-2026-06-29-threads-only.md §5/§9). This is the status-driven replacement for the
+   * auto-teardown the def-set diff (`agent-defs.ts`) gave defs for free — which is GONE for
+   * NON-def threads (nothing diffs a set of thread notes). When a thread note's `status` goes
+   * to archived/done, the surface (or a vault trigger) calls this to converge the daemon:
+   *
+   *  - DROP every per-thread queue + drain promise for the thread (reusing the thread-key-aware
+   *    {@link clearChannelQueues} — the drain key for a thread-addressed thread IS the thread-id,
+   *    so the bare-key delete clears exactly this thread's queue. NOTE: a thread-addressed message
+   *    uses the thread-id drain key DIRECTLY (drainKeyFor path 1, bypassing the subject axis), so
+   *    in Phase B there are no `<threadId>--<subject>` sub-keys to orphan; clearChannelQueues'
+   *    prefix-scan is harmless belt-and-suspenders here);
+   *  - DROP the thread-id's EXPECTED mark + any buffered pending inbound (so an archived thread
+   *    can't strand a buffered message or replay stale ones on a future register);
+   *  - DROP the {@link byThread} address entry so a later `metadata.thread` inbound resolves
+   *    as `unknown` (not a torn-down thread).
+   *
+   * Lightweight: a NON-def thread may only be EXPECTED/buffered (never fully registered), so
+   * this does NOT require a backend handle. If a live agent IS registered for the thread, its
+   * deregister (the def path / explicit removal) tears down the backend handle; archiveThread
+   * is the queue/index convergence the status transition drives. Returns whether anything was
+   * cleared (false = the thread-id had no live/expected/buffered state).
+   */
+  archiveThread(threadId: string): boolean {
+    const had =
+      this.queues.has(threadId) ||
+      this.draining.has(threadId) ||
+      this.expectedChannels.has(threadId) ||
+      this.pending.has(threadId) ||
+      this.byThread.has(threadId);
+    // clearChannelQueues clears the bare key (= the thread-id drain key for a thread-addressed
+    // thread) AND any `<threadId>--*` subject sub-keys.
+    this.clearChannelQueues(threadId);
+    this.expectedChannels.delete(threadId);
+    this.pending.delete(threadId);
+    this.byThread.delete(threadId);
+    return had;
   }
 
   /** The registered handle for a channel, or undefined. */
@@ -736,6 +878,11 @@ export class ProgrammaticAgentRegistry {
     };
     this.byChannel.set(channel, handle);
     this.nameToChannel.set(spec.name, channel);
+    // THREAD-ADDRESS index (threads-only Phase B) — map the spec's thread-id → channel so a
+    // `metadata.thread`-routed inbound resolves here. For the live cast thread-id ≡ name ≡
+    // channel (so this is `steward → steward`, mirroring nameToChannel) — additive, the def
+    // path is unchanged.
+    this.byThread.set(ProgrammaticAgentRegistry.threadIdOf(spec), channel);
     // The channel now has a live agent — it's no longer merely "expected" (the gate that
     // let pre-registration inbound queue pending); the live byChannel index is the truth now.
     this.expectedChannels.delete(channel);
@@ -851,6 +998,11 @@ export class ProgrammaticAgentRegistry {
     this.clearChannelQueues(channel);
     this.byChannel.delete(channel);
     this.nameToChannel.delete(name);
+    // Drop the THREAD-ADDRESS index entry (threads-only Phase B). Resolve the thread-id from
+    // the handle's spec when present (it may differ from `name` under a future explicit thread
+    // record); fall back to `name` (today thread-id ≡ name). A `metadata.thread`-routed inbound
+    // must stop resolving to a torn-down agent.
+    this.byThread.delete(handle ? ProgrammaticAgentRegistry.threadIdOf(handle.spec) : name);
     // Clear the EXPECTED mark + any buffered pending inbound for this channel too —
     // the agent is gone, so a pending message has nothing to drain into and would
     // strand forever (and the next register would replay stale messages). The daemon's

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -3159,11 +3159,12 @@ export function createFetchHandler(
         return json({ error: "invalid JSON body" }, 400);
       }
       const meta = body.note?.metadata ?? {};
-      // The thread-id: the note's `metadata.thread` (the thread address), else its
-      // `metadata.agent` (a def-thread whose id ≡ name), else the note id/path leaf.
-      const threadId =
-        (typeof meta.thread === "string" && meta.thread ? meta.thread : undefined) ??
-        (typeof meta.agent === "string" && meta.agent ? meta.agent : undefined);
+      // The thread-id is the note's EXPLICIT `metadata.thread` address only. We deliberately do
+      // NOT fall back to `metadata.agent`: a def-backed agent (uni/steward/…) is torn down only
+      // via the def-set diff, never this endpoint — so a stray or abusive thread-status POST
+      // naming `agent: steward` can't clear the live heartbeat's queue (reviewer nit). Non-def
+      // threads (the only thing this endpoint archives) always carry `metadata.thread`.
+      const threadId = typeof meta.thread === "string" && meta.thread ? meta.thread : undefined;
       const status = typeof meta.status === "string" ? meta.status.trim().toLowerCase() : "";
       // ARCHIVE terminals — a transition into any of these tears the thread down. Any other
       // status (running/working/etc.) is a benign no-op ack (the trigger may fire on every

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -350,6 +350,11 @@ export function contextFor(
           // composed prompt's loadout can use it (and the NEXT slice can route by
           // it). No routing meaning yet. Absent → unchanged (the weave path is untouched).
           ...(msg.meta?.subject ? { subject: msg.meta.subject } : {}),
+          // threads-only Phase B: carry the THREAD-ID (the note's `metadata.thread`, read
+          // FIRST by noteAgentKey) so the drain keys per-thread directly. ADDITIVE + dormant —
+          // nothing writes `metadata.thread` yet, and the 4 live def agents carry only
+          // `metadata.agent` → no thread → the bare-channel drain key (byte-identical to HEAD).
+          ...(msg.meta?.thread ? { thread: msg.meta.thread } : {}),
         });
         return;
       }
@@ -381,6 +386,9 @@ export function contextFor(
           // so a turn that runs on register() still composes its loadout. No routing
           // meaning yet. Absent → unchanged.
           ...(msg.meta?.subject ? { subject: msg.meta.subject } : {}),
+          // threads-only Phase B: carry the THREAD-ID through the pending buffer too, so a
+          // turn that replays on register() keys per-thread. Absent → unchanged (the weave).
+          ...(msg.meta?.thread ? { thread: msg.meta.thread } : {}),
         });
         if (outcome === "queued") return;
         // outcome === "unknown" — not an expected programmatic channel. It may still be a
@@ -1360,6 +1368,18 @@ export function createFetchHandler(
      */
     agentDefs?: AgentDefRegistry;
     /**
+     * Is a `metadata.thread`-addressed inbound for a NOT-YET-LIVE thread RESOLVABLE? —
+     * the resolve-or-create gate (threads-only Phase B, DESIGN-2026-06-29-threads-only.md
+     * §5). The inbound handler consults this ONLY when a thread-addressed inbound finds no
+     * live channel: `true` → OWN the message (buffer via queuePending, replay on register)
+     * instead of 401-dropping; `false`/unwired → behave EXACTLY as today (the genuinely-unknown
+     * 401, no silent-drop change). "Resolvable" means a `#agent/thread` note (or a def) exists
+     * for the thread-id. Injected so tests drive the resolve-or-create path deterministically;
+     * `main` leaves it unset until the Phase-C writer + a thread-note probe land — so Phase B is
+     * DORMANT (nothing writes `metadata.thread` yet, so this is never consulted in production).
+     */
+    threadResolvable?: (threadId: string) => boolean | Promise<boolean>;
+    /**
      * Add a def-vault to the live registry — the `POST /api/agent-vaults` body of work
      * (mint the vault's write token, persist `agent-vaults.json`, `addVault` + `loadAll`
      * for it). Injected so tests exercise the route WITHOUT a live hub mint or a real
@@ -1420,6 +1440,12 @@ export function createFetchHandler(
   // reload webhook is a no-op ack (a daemon with no def-vaults). `main` passes the
   // boot instance so the route reloads the same set the boot instantiated.
   const agentDefs: AgentDefRegistry | undefined = opts?.agentDefs;
+
+  // The resolve-or-create gate for a `metadata.thread`-addressed inbound to a not-yet-live
+  // thread (threads-only Phase B). Unwired → undefined → the inbound handler treats every
+  // not-yet-live thread-addressed inbound as today's UNKNOWN (401, no silent-drop change), so
+  // Phase B is dormant in production until the Phase-C writer + a thread-note probe wire it.
+  const threadResolvable = opts?.threadResolvable;
 
   // Add-a-def-vault (the `POST /api/agent-vaults` body of work). Defaulted to the real
   // mint + persist path so a plain createFetchHandler serves the route; tests inject a
@@ -2933,6 +2959,14 @@ export function createFetchHandler(
       }
       const ch = channels.get(channelName);
       const vt = ch?.transport instanceof VaultTransport ? ch.transport : undefined;
+      // The EXPLICIT thread-id address (threads-only Phase B) — present only when the note
+      // carried `metadata.thread` (`noteAgentKey` reads it FIRST, so `channelName` already
+      // equals it). The 4 live def agents carry `metadata.agent` only → no thread-id → this
+      // is undefined and the path below is byte-identical to HEAD.
+      const threadId =
+        typeof note.metadata?.thread === "string" && note.metadata.thread
+          ? note.metadata.thread
+          : undefined;
 
       // Branch on Authorization-header PRESENCE, not token truthiness. A
       // whitespace-only `Authorization: Bearer   ` (which extractBearer trims to
@@ -2951,7 +2985,45 @@ export function createFetchHandler(
         // vs 403 — fine for the operator-facing config API, but this endpoint
         // stays opaque.)
         const denied = await requireScope(req, url, SCOPE_SEND);
-        if (denied || !vt) {
+        if (denied) {
+          return json({ error: "unauthorized" }, 401);
+        }
+        if (!vt) {
+          // RESOLVE-OR-CREATE (threads-only Phase B, DESIGN-2026-06-29-threads-only.md §5).
+          // No live vault channel for this routing key. The OLD behavior was a flat 401. For a
+          // `metadata.thread`-addressed inbound to a NOT-YET-LIVE thread, OWN the message
+          // (buffer it, replayed when the thread agent registers) instead of dropping it — the
+          // vault trigger acks success on our 200 and never retries, so a 401 would PERMANENTLY
+          // lose the message. Only the modern JWT path serves this (the `?secret=` path is
+          // per-channel and can't authenticate a not-yet-live thread). A genuinely-unknown
+          // target (no thread-id, or no thread note / def for it) still 401s — no silent-drop
+          // change. The token is already validated (denied handled above), so owning the
+          // message is authorized.
+          if (threadId && threadResolvable) {
+            const resolvable = await threadResolvable(threadId);
+            const outcome = programmatic.resolveOrCreateThread(threadId, resolvable);
+            if (outcome !== "unknown") {
+              // "owned" (not yet live) → buffer pending; "live" (a registration raced in) →
+              // enqueue to the live channel. Either way the message is OWNED, not dropped.
+              if (markSeen(note.id)) {
+                const queued: QueuedMessage = {
+                  content: note.content ?? "",
+                  thread: threadId,
+                  ...(note.id ? { inReplyTo: note.id } : {}),
+                  ...(typeof note.metadata?.sender === "string" && note.metadata.sender
+                    ? { sender: note.metadata.sender }
+                    : {}),
+                  ...(typeof note.metadata?.subject === "string" && note.metadata.subject.trim()
+                    ? { subject: note.metadata.subject }
+                    : {}),
+                };
+                const liveChannel = programmatic.channelForThread(threadId);
+                if (liveChannel) programmatic.enqueue(liveChannel, queued);
+                else programmatic.queuePending(threadId, queued);
+              }
+              return json({ ok: true });
+            }
+          }
           return json({ error: "unauthorized" }, 401);
         }
       } else {
@@ -3054,6 +3126,54 @@ export function createFetchHandler(
           : undefined;
       const result = await agentDefs.reload(vault, noteId, event);
       return json({ ok: true, reloaded: result });
+    }
+
+    // ---------------------------------------------------------------------
+    // Thread-status TEARDOWN webhook — POST /api/vault/thread-status
+    // (threads-only Phase B, DESIGN-2026-06-29-threads-only.md §5/§9). A vault
+    // trigger on an `#agent/thread` note whose `status` transitions to an ARCHIVE
+    // terminal (`archived`/`done`/`dropped`/`closed`) POSTs here; we converge the
+    // daemon by clearing that thread's queues + indexes (`archiveThread`). This is
+    // the status-driven replacement for the auto-teardown the def-set diff gave
+    // defs for free — which is GONE for non-def threads. DEFS keep their existing
+    // teardown path (the def-set diff + the reload-delete webhook); this is purely
+    // additive, for thread-addressed threads. Mirrors /api/vault/agent-def's auth
+    // (hub JWT, scope agent:send) + uniform-401. Body: { event?, note: { id/path,
+    // metadata: { thread?, status? } } }. A non-archive status (or no thread-id) is
+    // a clean no-op ack. Externally `<hub>/agent/api/vault/thread-status`.
+    //
+    // The trigger's `when.tags: ["#agent/thread"]` predicate is the PRIMARY guard that this
+    // only fires for thread notes; the daemon's threadId+archive-status checks below are
+    // defense-in-depth (a benign no-op ack for anything that doesn't name an archived thread).
+    // ---------------------------------------------------------------------
+    if (req.method === "POST" && url.pathname === "/api/vault/thread-status") {
+      const denied = await requireScope(req, url, SCOPE_SEND);
+      if (denied) return json({ error: "unauthorized" }, 401);
+      let body: {
+        event?: string;
+        note?: { id?: string; path?: string; metadata?: Record<string, unknown> };
+      };
+      try {
+        body = (await req.json()) as typeof body;
+      } catch {
+        return json({ error: "invalid JSON body" }, 400);
+      }
+      const meta = body.note?.metadata ?? {};
+      // The thread-id: the note's `metadata.thread` (the thread address), else its
+      // `metadata.agent` (a def-thread whose id ≡ name), else the note id/path leaf.
+      const threadId =
+        (typeof meta.thread === "string" && meta.thread ? meta.thread : undefined) ??
+        (typeof meta.agent === "string" && meta.agent ? meta.agent : undefined);
+      const status = typeof meta.status === "string" ? meta.status.trim().toLowerCase() : "";
+      // ARCHIVE terminals — a transition into any of these tears the thread down. Any other
+      // status (running/working/etc.) is a benign no-op ack (the trigger may fire on every
+      // status write; only the archive transition converges).
+      const ARCHIVE_STATES = new Set(["archived", "archive", "done", "dropped", "closed"]);
+      if (!threadId || !ARCHIVE_STATES.has(status)) {
+        return json({ ok: true, torn_down: false });
+      }
+      const torn = programmatic.archiveThread(threadId);
+      return json({ ok: true, torn_down: torn });
     }
 
     // One-time SSE ticket mint — POST /api/ui/sse-ticket (agent#25). The chat

--- a/src/programmatic-wiring.test.ts
+++ b/src/programmatic-wiring.test.ts
@@ -204,6 +204,8 @@ function buildServer(opts: {
   channels: Map<string, Channel>;
   programmatic: ProgrammaticAgentRegistry;
   deliveryState?: DeliveryState;
+  /** threads-only Phase B: the resolve-or-create gate (a not-yet-live thread is RESOLVABLE). */
+  threadResolvable?: (threadId: string) => boolean | Promise<boolean>;
 }) {
   const registry = new ClientRegistry();
   const srv = Bun.serve({
@@ -213,6 +215,7 @@ function buildServer(opts: {
     fetch: createFetchHandler(opts.channels, registry, {
       programmatic: opts.programmatic,
       ...(opts.deliveryState ? { deliveryState: opts.deliveryState } : {}),
+      ...(opts.threadResolvable ? { threadResolvable: opts.threadResolvable } : {}),
     }),
   });
   return { srv, base: `http://127.0.0.1:${srv.port}` };
@@ -355,6 +358,216 @@ describe("inbound for a programmatic channel → deliver → outbound note", () 
       // A failed turn now posts a single user-facing failure note (carrying the reason).
       expect(rec.calls).toHaveLength(1);
       expect(rec.calls[0]!.reply).toContain("mint refused");
+    } finally {
+      srv.stop(true);
+    }
+  });
+});
+
+describe("threads-only Phase B — inbound routing (metadata.thread dual-read + resolve-or-create)", () => {
+  /** POST an inbound carrying an arbitrary routing-key metadata shape (agent and/or thread). */
+  async function inboundWith(
+    base: string,
+    metadata: Record<string, unknown>,
+    noteId: string,
+    content: string,
+  ) {
+    return fetch(`${base}/api/vault/inbound`, {
+      method: "POST",
+      headers: { ...adminAuth, "content-type": "application/json" },
+      body: JSON.stringify({
+        note: {
+          id: noteId,
+          content,
+          tags: ["agent/message", "agent/message/inbound"],
+          metadata: { direction: "inbound", sender: "aaron", ts: "2026-06-29T00:00:01Z", ...metadata },
+        },
+      }),
+    });
+  }
+
+  // ── BACK-COMPAT (load-bearing): the 4 live def agents (uni, STEWARD [4am weave], uni-evolve,
+  // eco-civilization) carry `metadata.agent` and NO `metadata.thread`, so they route EXACTLY as
+  // before Phase B — to the def channel, one on-demand turn. This proves the live steward weave
+  // route is unchanged.
+  test("BACK-COMPAT: a `metadata.agent`-ONLY inbound (the steward weave) routes to the def channel exactly as today", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const programmatic = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    await programmatic.register({ name: "steward", channels: ["steward"], backend: "programmatic" });
+
+    const registry = new ClientRegistry();
+    const deliveryState = new DeliveryState();
+    const channels = new Map<string, Channel>([
+      ["steward", vaultChannel("steward", registry, deliveryState, programmatic)],
+    ]);
+    // threadResolvable wired but it must NEVER be consulted for a `metadata.agent` inbound.
+    let resolvableCalls = 0;
+    const { srv, base } = buildServer({
+      channels,
+      programmatic,
+      deliveryState,
+      threadResolvable: () => {
+        resolvableCalls++;
+        return true;
+      },
+    });
+    try {
+      // The weave fires `metadata.agent: steward`, NO `metadata.thread`.
+      const res = await inboundWith(base, { agent: "steward" }, "weave-note-1", "run the weave");
+      expect(res.status).toBe(200);
+      await until(() => rec.calls.length === 1);
+      // Routed to the steward def channel + ran one turn (byte-identical to HEAD).
+      expect(backend.calls).toEqual([{ channel: "steward", message: "run the weave", loadout: [] }]);
+      expect(rec.calls).toEqual([{ channel: "steward", reply: "reply:run the weave", inReplyTo: "weave-note-1" }]);
+      // resolve-or-create was NOT consulted — the def path is untouched.
+      expect(resolvableCalls).toBe(0);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("a `metadata.thread` inbound for a LIVE thread routes to it (thread-id ≡ the live channel)", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const programmatic = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    // The thread agent is LIVE under thread-id "eng" (≡ channel for the live cast).
+    await programmatic.register({ name: "eng", channels: ["eng"], backend: "programmatic" });
+
+    const registry = new ClientRegistry();
+    const deliveryState = new DeliveryState();
+    const channels = new Map<string, Channel>([
+      ["eng", vaultChannel("eng", registry, deliveryState, programmatic)],
+    ]);
+    const { srv, base } = buildServer({ channels, programmatic, deliveryState });
+    try {
+      // `metadata.thread` (read FIRST by noteAgentKey) addresses the live thread.
+      const res = await inboundWith(base, { thread: "eng" }, "t-note-1", "thread hello");
+      expect(res.status).toBe(200);
+      await until(() => rec.calls.length === 1);
+      expect(backend.calls).toEqual([{ channel: "eng", message: "thread hello", loadout: [] }]);
+      expect(rec.calls).toEqual([{ channel: "eng", reply: "reply:thread hello", inReplyTo: "t-note-1" }]);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("RESOLVE-OR-CREATE: a `metadata.thread` inbound for a NOT-YET-LIVE but resolvable thread is OWNED (buffered, 200) then REPLAYED on register — NOT 401/dropped", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const programmatic = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    // NO agent live for thread "proj-thread" yet — the old code would 401 (→ permanent loss).
+    const registry = new ClientRegistry();
+    const deliveryState = new DeliveryState();
+    const channels = new Map<string, Channel>(); // no channels yet.
+    const { srv, base } = buildServer({
+      channels,
+      programmatic,
+      deliveryState,
+      threadResolvable: (threadId) => threadId === "proj-thread", // a thread note exists for it.
+    });
+    try {
+      const res = await inboundWith(base, { thread: "proj-thread" }, "p-note-1", "queued work");
+      // OWNED, not dropped: 200 (not 401), and buffered pending under the thread-id.
+      expect(res.status).toBe(200);
+      expect(programmatic.isExpected("proj-thread")).toBe(true);
+      expect(programmatic.pendingCount("proj-thread")).toBe(1);
+      expect(backend.calls).toHaveLength(0); // nothing ran yet (no live agent).
+
+      // The thread agent finally registers → the buffered inbound REPLAYS (not lost).
+      await programmatic.register({ name: "proj-thread", channels: ["proj-thread"], backend: "programmatic" });
+      await until(() => rec.calls.length === 1);
+      expect(backend.calls).toEqual([{ channel: "proj-thread", message: "queued work", loadout: [] }]);
+      expect(programmatic.pendingCount("proj-thread")).toBe(0);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("a genuinely UNKNOWN thread (no thread note, no def) still 401s — no silent-drop change", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const programmatic = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    const channels = new Map<string, Channel>(); // nothing live.
+    const { srv, base } = buildServer({
+      channels,
+      programmatic,
+      threadResolvable: () => false, // NOT resolvable — no thread note, no def.
+    });
+    try {
+      const res = await inboundWith(base, { thread: "ghost" }, "g-note-1", "into the void");
+      expect(res.status).toBe(401); // today's behavior — not owned, not buffered.
+      expect(programmatic.isExpected("ghost")).toBe(false);
+      expect(programmatic.pendingCount("ghost")).toBe(0);
+    } finally {
+      srv.stop(true);
+    }
+  });
+});
+
+describe("threads-only Phase B — thread-status teardown webhook (POST /api/vault/thread-status)", () => {
+  async function threadStatus(base: string, metadata: Record<string, unknown>) {
+    return fetch(`${base}/api/vault/thread-status`, {
+      method: "POST",
+      headers: { ...adminAuth, "content-type": "application/json" },
+      body: JSON.stringify({ event: "updated", note: { id: "Threads/x/y", metadata } }),
+    });
+  }
+
+  test("a status transition to ARCHIVE tears the thread's queues + indexes down", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const programmatic = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    // A not-yet-live thread that has been OWNED (expected + a buffered message).
+    programmatic.resolveOrCreateThread("proj-thread", true);
+    programmatic.queuePending("proj-thread", { content: "buffered", thread: "proj-thread" });
+    expect(programmatic.pendingCount("proj-thread")).toBe(1);
+
+    const { srv, base } = buildServer({ channels: new Map(), programmatic });
+    try {
+      const res = await threadStatus(base, { thread: "proj-thread", status: "archived" });
+      expect(res.status).toBe(200);
+      expect((await res.json()) as { ok: boolean; torn_down: boolean }).toEqual({ ok: true, torn_down: true });
+      // The thread's buffered message + expected mark are gone (the def-set-diff teardown replacement).
+      expect(programmatic.pendingCount("proj-thread")).toBe(0);
+      expect(programmatic.isExpected("proj-thread")).toBe(false);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("a NON-archive status (e.g. running) is a clean no-op ack (does not tear down)", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const programmatic = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    programmatic.resolveOrCreateThread("proj-thread", true);
+    programmatic.queuePending("proj-thread", { content: "buffered", thread: "proj-thread" });
+
+    const { srv, base } = buildServer({ channels: new Map(), programmatic });
+    try {
+      const res = await threadStatus(base, { thread: "proj-thread", status: "running" });
+      expect(res.status).toBe(200);
+      expect((await res.json()) as { ok: boolean; torn_down: boolean }).toEqual({ ok: true, torn_down: false });
+      // Still buffered — a running thread is NOT torn down.
+      expect(programmatic.pendingCount("proj-thread")).toBe(1);
+      expect(programmatic.isExpected("proj-thread")).toBe(true);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  test("the teardown webhook requires agent:send (401 without a valid token)", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const programmatic = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    const { srv, base } = buildServer({ channels: new Map(), programmatic });
+    try {
+      const res = await fetch(`${base}/api/vault/thread-status`, {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: "Bearer bogus" },
+        body: JSON.stringify({ note: { metadata: { thread: "x", status: "archived" } } }),
+      });
+      expect(res.status).toBe(401);
     } finally {
       srv.stop(true);
     }

--- a/src/sandbox/types.ts
+++ b/src/sandbox/types.ts
@@ -350,6 +350,17 @@ export interface AgentSpec {
    * definition link).
    */
   definition?: string;
+  /**
+   * The def note's PATH (e.g. `Agents/steward`) — distinct from {@link definition},
+   * the note ID (a timestamp-slug like `2026-06-20-07-30-56-487050`). Used for the
+   * composed system prompt's SELF-ENTRY HEADER (`# Agents/steward`), so the header
+   * reads as the human-legible loadout PATH the design specifies (#169) rather than an
+   * opaque id. Set by {@link parseAgentDef} from `note.path`; unset for a spec not
+   * sourced from a def note OR a def note whose read didn't carry a path — the self
+   * entry then falls back to {@link name} (the note ID {@link definition} is NOT used for
+   * the header — it's an opaque timestamp-slug, not the legible path).
+   */
+  definitionPath?: string;
 }
 
 /**

--- a/src/transports/vault.test.ts
+++ b/src/transports/vault.test.ts
@@ -63,7 +63,7 @@ function baseConfig() {
   };
 }
 
-describe("noteAgentKey — the expand-phase dual-read routing key", () => {
+describe("noteAgentKey — the three-level dual-read routing key (thread ?? agent ?? channel)", () => {
   test("returns `agent` when present", () => {
     expect(noteAgentKey({ agent: "eng" })).toBe("eng");
   });
@@ -72,6 +72,21 @@ describe("noteAgentKey — the expand-phase dual-read routing key", () => {
   });
   test("prefers `agent` over `channel` when BOTH are present", () => {
     expect(noteAgentKey({ agent: "eng", channel: "legacy" })).toBe("eng");
+  });
+  // threads-only Phase B — the NEW `thread` read, FIRST in precedence.
+  test("returns `thread` when present (the thread-id address)", () => {
+    expect(noteAgentKey({ thread: "proj-thread" })).toBe("proj-thread");
+  });
+  test("prefers `thread` over `agent` and `channel` (the three-level precedence)", () => {
+    expect(noteAgentKey({ thread: "t1", agent: "eng", channel: "legacy" })).toBe("t1");
+  });
+  test("BACK-COMPAT: a `metadata.agent`-only note (the 4 live def agents) still routes by agent — no `thread` → unchanged", () => {
+    // The steward weave carries `agent: steward`, no `thread` → routes to the def, as today.
+    expect(noteAgentKey({ agent: "steward" })).toBe("steward");
+  });
+  test("an empty/non-string `thread` falls through to `agent` (blank thread can't hijack routing)", () => {
+    expect(noteAgentKey({ thread: "", agent: "eng" })).toBe("eng");
+    expect(noteAgentKey({ thread: 123 as unknown as string, agent: "eng" })).toBe("eng");
   });
   test("returns undefined when neither is present", () => {
     expect(noteAgentKey({})).toBeUndefined();

--- a/src/transports/vault.ts
+++ b/src/transports/vault.ts
@@ -299,11 +299,21 @@ const STATUS_META_KEY = "status";
 /** Metadata key carrying the ISO timestamp an inbound was claimed (for the TTL sweep). */
 const CLAIMED_AT_META_KEY = "claimedAt";
 
-/** The agent (routing) key carried on a vault note's metadata. Reads the canonical
- *  `agent` field, falling back to the legacy `channel` field as a read-only TOLERANCE
- *  for any in-flight note written by an older build during the live cutover. New writes
- *  carry `agent` only (the channel→agent CONTRACT dropped the `channel` dual-write). */
+/** The agent (routing) key carried on a vault note's metadata — a THREE-LEVEL dual-read
+ *  (threads-only Phase B — DESIGN-2026-06-29-threads-only.md §5/§9): the NEW `thread`
+ *  field (the thread-id address) FIRST, then the canonical `agent` field, then the legacy
+ *  `channel` field as a read-only TOLERANCE for any in-flight note written by an older
+ *  build during the live cutover.
+ *
+ *  BACK-COMPAT (load-bearing): the 4 live def agents (uni, steward, uni-evolve,
+ *  eco-civilization) — and the 4am steward weave job — carry `metadata.agent` and NO
+ *  `metadata.thread`, so they route EXACTLY as before this change. The `thread` read is an
+ *  ADDITIVE parallel path: nothing WRITES `metadata.thread` yet (Phase C flips the writer),
+ *  so it is dormant until a thread-addressed inbound appears. New writes carry `agent` only
+ *  (the channel→agent CONTRACT dropped the `channel` dual-write). */
 export function noteAgentKey(meta: Record<string, unknown> | undefined | null): string | undefined {
+  const t = meta?.thread;
+  if (typeof t === "string" && t) return t;
   const a = meta?.agent;
   if (typeof a === "string" && a) return a;
   const c = meta?.channel;


### PR DESCRIPTION
## Threads-only Phase B (routing + registry + lifecycle + the #169 header fix)

Phase B of the threads-only agent model (`DESIGN-2026-06-29-threads-only.md` §5 + §9). **Additive + dormant**: nothing writes `metadata.thread` yet, so the thread registry is a parallel path that only activates for a `metadata.thread`-addressed inbound. Scope is routing + registry + lifecycle + the header fix only — **grants / `wants:` are explicitly out of scope (that's Phase B′, next).**

### What's in

1. **Thread-id dual-read routing** — `noteAgentKey` (`src/transports/vault.ts`) → `thread ?? agent ?? channel`. The new `thread` read is FIRST in precedence but dormant (no writer).
2. **Thread registry + resolve-or-create** — a `byThread` index alongside `byChannel`/`nameToChannel` (`src/backends/registry.ts`). The inbound handler's `channels.get → 401-if-absent` (`src/daemon.ts`) generalizes to **resolve-or-create**: a `metadata.thread` inbound for a not-yet-live but RESOLVABLE thread is **owned** (`expectChannel` + `queuePending` → replayed on `register`) instead of 401-dropped. A genuinely-unknown target still 401s (no silent-drop change). Gated by an injectable `threadResolvable` dep (unwired in prod → dormant).
3. **drainKeyFor simplification** — a thread-addressed message keys by the thread-id directly (gate-free); the #120 multi-threaded-subject path is unchanged; a def agent with no thread/subject still keys the bare channel. The per-thread serial guarantee holds (same thread serial; different threads concurrent).
4. **Status-driven teardown** — `archiveThread` (reuses the thread-key-aware `clearChannelQueues`) + a `POST /api/vault/thread-status` webhook — the replacement for the def-set-diff auto-teardown that's gone for non-def threads. Defs keep their existing teardown path.
5. **#169** — the composed-prompt self-entry header uses the def note's **PATH** (`spec.definitionPath`, carried from `note.path` at `parseAgentDef`) not its note ID (a timestamp-slug like `2026-06-20-…`). Fixed the Phase-A tests that passed a path-like value as `definition` to use a realistic id + assert the path-derived header.

### Back-compat invariant (LOAD-BEARING) + its test

The 4 live def agents (uni, **steward** [4am weave], uni-evolve, eco-civilization) carry `metadata.agent` and **no** `metadata.thread`, so they route to the def channel and instantiate via the def path **EXACTLY as today**. The live weave fires `metadata.agent: steward` → still routes + resumes `Threads/steward/steward` unchanged.

Proven by `programmatic-wiring.test.ts` → **"BACK-COMPAT: a `metadata.agent`-ONLY inbound (the steward weave) routes to the def channel exactly as today"** — asserts the def channel + the turn AND that resolve-or-create (`threadResolvable`) is **never consulted** (`resolvableCalls === 0`).

### How resolve-or-create avoids the 401-drop

Old: a routing key with no live `VaultTransport` channel → flat 401. Since the vault trigger acks on our 200 and never retries, a 401 is a **permanent** message loss. New: under the validated JWT path, a `metadata.thread` inbound to a not-yet-live thread calls `resolveOrCreateThread(threadId, resolvable)`; `"owned"` → buffer via the existing agent#121 `queuePending`/`expectedChannels` pattern (replayed on `register`), return 200. `"unknown"` (no thread note / def) → still 401. The deprecated `?secret=` path is per-channel and cannot reach resolve-or-create.

### Gates (exact)

- `bun test ./src/` — **1312 pass / 0 fail** (3906 expect() calls, 58 files)
- `bun run typecheck` — **clean**
- (web/ui vitest is a separate `test:spa`, excluded + failing at baseline — untouched.)

Independent reviewer: **APPROVE-WITH-NITS** (no must-fix; nits were forward-looking Phase-C doc notes, all addressed inline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
