### PR TITLE
feat(agent): threads-only Phase B′ — pack-only grant model (rc.16)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/agent",
-  "version": "0.2.3-rc.15",
+  "version": "0.2.3-rc.16",
   "description": "Vault-native agents for Claude Code — a #agent/definition note + an inbound message becomes a sandboxed claude turn; the reply is written back as a note. Messaging gateway on :1941.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/src/agent-defs.test.ts
+++ b/src/agent-defs.test.ts
@@ -22,7 +22,7 @@ import {
   type DefVaultBinding,
   type InstantiateDeps,
 } from "./agent-defs.ts";
-import { GrantsClient, connectionKey, type ConnectionSpec } from "./grants.ts";
+import { GrantsClient, connectionKey, packPathKey, type ConnectionSpec } from "./grants.ts";
 import type { AgentSpec } from "./sandbox/types.ts";
 
 const realFetch = globalThis.fetch;
@@ -1526,5 +1526,169 @@ describe("AgentDefRegistry — deleteDef ordering + grant-GC surfacing (FIX 4/5,
     await reg.loadAll();
     const removed = await reg.deleteDef("Agents/uni");
     expect(removed.grantsReconciled).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AgentDefRegistry.reconcilePack — per-pack grant reconcile (threads-only Phase B′)
+// ---------------------------------------------------------------------------
+
+describe("AgentDefRegistry — reconcilePack (per-pack grant reconcile, Phase B′)", () => {
+  test("a clean #pack with wants → registers each under the pack PATH key + reconciles that set", async () => {
+    const { deps } = recorderDeps();
+    const registered: Array<{ agent: string; connection: ConnectionSpec }> = [];
+    const reconciled: Array<{ agent: string; liveConnections: ConnectionSpec[] }> = [];
+    const grants = fakeGrantsClient({ registered, reconciled });
+    // The vault serves the pack note by id (getNote), with the #pack tag + wants.
+    const fetchFn = vaultFetch({
+      byId: {
+        "Packs/github": {
+          id: "Packs/github",
+          // tags carried through (cast: vaultFetch's byId type omits tags but serializes the object).
+          ...( { tags: ["pack"] } as Record<string, unknown> ),
+          content: "pack body",
+          metadata: { wants: "vault:research:read, env:github" },
+        } as never,
+      },
+    });
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn, grants });
+    const result = await reg.reconcilePack("default", "Packs/github", "created");
+    expect(result).toBe("reconciled");
+
+    const expectedKey = packPathKey("Packs/github");
+    // Each want registered UNDER THE PACK PATH KEY (not the thread, not any def name).
+    expect(registered.every((r) => r.agent === expectedKey)).toBe(true);
+    expect(registered.map((r) => r.connection.target).sort()).toEqual(["github", "research"]);
+    // Reconcile sent the live SPECS under the SAME pack key (its OWN partition).
+    expect(reconciled).toHaveLength(1);
+    expect(reconciled[0]!.agent).toBe(expectedKey);
+    expect(reconciled[0]!.liveConnections.map((c) => c.target).sort()).toEqual(["github", "research"]);
+  });
+
+  test("SECURITY GATE: a loaded note WITHOUT the #pack tag → prune-to-[] (its wants are inert)", async () => {
+    const { deps } = recorderDeps();
+    const registered: Array<{ agent: string; connection: ConnectionSpec }> = [];
+    const reconciled: Array<{ agent: string; liveConnections: ConnectionSpec[] }> = [];
+    const grants = fakeGrantsClient({ registered, reconciled });
+    const fetchFn = vaultFetch({
+      byId: {
+        "Refs/leaky": {
+          id: "Refs/leaky",
+          ...( { tags: ["reference"] } as Record<string, unknown> ), // NOT a pack
+          content: "body",
+          metadata: { wants: "vault:secrets:read" }, // declared but inert
+        } as never,
+      },
+    });
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn, grants });
+    const result = await reg.reconcilePack("default", "Refs/leaky", "updated");
+    expect(result).toBe("pruned");
+    // NOTHING registered (the gate) — and its partition pruned to [].
+    expect(registered).toHaveLength(0);
+    expect(reconciled).toEqual([{ agent: packPathKey("Refs/leaky"), liveConnections: [] }]);
+  });
+
+  test("a #pack that DROPPED wants → prune-to-[] for ITS OWN partition only", async () => {
+    const { deps } = recorderDeps();
+    const reconciled: Array<{ agent: string; liveConnections: ConnectionSpec[] }> = [];
+    const grants = fakeGrantsClient({ reconciled });
+    const fetchFn = vaultFetch({
+      byId: {
+        "Packs/github": {
+          id: "Packs/github",
+          ...( { tags: ["pack"] } as Record<string, unknown> ),
+          content: "body",
+          metadata: {}, // wants removed
+        } as never,
+      },
+    });
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn, grants });
+    expect(await reg.reconcilePack("default", "Packs/github", "updated")).toBe("pruned");
+    expect(reconciled).toEqual([{ agent: packPathKey("Packs/github"), liveConnections: [] }]);
+  });
+
+  test("a deleted pack → prune-to-[] without a fetch (CONFIRMED removal), its partition only", async () => {
+    const { deps } = recorderDeps();
+    const reconciled: Array<{ agent: string; liveConnections: ConnectionSpec[] }> = [];
+    const grants = fakeGrantsClient({ reconciled });
+    // byId is irrelevant — a delete event prunes without fetching.
+    const fetchFn = vaultFetch({ byId: {} });
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn, grants });
+    expect(await reg.reconcilePack("default", "Packs/github", "deleted")).toBe("pruned");
+    expect(reconciled).toEqual([{ agent: packPathKey("Packs/github"), liveConnections: [] }]);
+  });
+
+  test("a 404 on the pack note (gone) → prune-to-[] (confirmed removal)", async () => {
+    const { deps } = recorderDeps();
+    const reconciled: Array<{ agent: string; liveConnections: ConnectionSpec[] }> = [];
+    const grants = fakeGrantsClient({ reconciled });
+    const fetchFn = vaultFetch({ byId: { "Packs/github": null } }); // 404
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn, grants });
+    expect(await reg.reconcilePack("default", "Packs/github", "updated")).toBe("pruned");
+    expect(reconciled).toEqual([{ agent: packPathKey("Packs/github"), liveConnections: [] }]);
+  });
+
+  test("a MALFORMED wants → status:error stamped, NEVER reconciled (no nuke of approved grants)", async () => {
+    const { deps } = recorderDeps();
+    const reconciled: Array<{ agent: string; liveConnections: ConnectionSpec[] }> = [];
+    const grants = fakeGrantsClient({ reconciled });
+    const patches: Array<{ id: string; status?: string; pending?: string }> = [];
+    const fetchFn = vaultFetch({
+      patches,
+      byId: {
+        "Packs/bad": {
+          id: "Packs/bad",
+          ...( { tags: ["pack"] } as Record<string, unknown> ),
+          content: "body",
+          metadata: { wants: "garbage-no-colon" },
+        } as never,
+      },
+    });
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn, grants });
+    expect(await reg.reconcilePack("default", "Packs/bad", "updated")).toBe("error");
+    // The note is stamped error; NO reconcile happened (a malformed pack must not present a
+    // stale/empty live set that would prune its approved grants — the safety rule).
+    expect(patches.find((p) => p.id === "Packs/bad")!.status).toBe("error");
+    expect(reconciled).toHaveLength(0);
+  });
+
+  test("no grants client wired → no-op (skipped)", async () => {
+    const { deps } = recorderDeps();
+    const fetchFn = vaultFetch({ byId: {} });
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn }); // no grants
+    expect(await reg.reconcilePack("default", "Packs/github", "created")).toBe("skipped");
+  });
+
+  test("an unknown vault → skipped (never throws)", async () => {
+    const { deps } = recorderDeps();
+    const grants = fakeGrantsClient({});
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn: vaultFetch({}), grants });
+    expect(await reg.reconcilePack("ghost-vault", "Packs/github", "created")).toBe("skipped");
+  });
+
+  test("PARTITION ISOLATION: a pack reconcile never touches a def's grant key", async () => {
+    const { deps } = recorderDeps();
+    const registered: Array<{ agent: string; connection: ConnectionSpec }> = [];
+    const reconciled: Array<{ agent: string; liveConnections: ConnectionSpec[] }> = [];
+    const grants = fakeGrantsClient({ registered, reconciled });
+    const fetchFn = vaultFetch({
+      byId: {
+        "Packs/github": {
+          id: "Packs/github",
+          ...( { tags: ["pack"] } as Record<string, unknown> ),
+          content: "body",
+          metadata: { wants: "env:github" },
+        } as never,
+      },
+    });
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn, grants });
+    await reg.reconcilePack("default", "Packs/github", "created");
+    // Every register + reconcile addressed the PACK key — never `steward` or any bare def name.
+    const packKey = packPathKey("Packs/github");
+    expect(registered.every((r) => r.agent === packKey)).toBe(true);
+    expect(reconciled.every((r) => r.agent === packKey)).toBe(true);
+    // Specifically: no def-name partition was touched.
+    expect(registered.some((r) => r.agent === "steward")).toBe(false);
+    expect(reconciled.some((r) => r.agent === "steward")).toBe(false);
   });
 });

--- a/src/agent-defs.ts
+++ b/src/agent-defs.ts
@@ -53,6 +53,8 @@ import {
   resolveConnectionStatus,
   WantsParseError,
   GrantsClient,
+  isPackNote,
+  packPathKey,
   type ConnectionSpec,
 } from "./grants.ts";
 
@@ -589,10 +591,11 @@ export class DefVaultClient {
     return out;
   }
 
-  /** Fetch ONE note by id (for a created/updated reload). Null on 404/miss. */
+  /** Fetch ONE note by id (for a created/updated reload). Null on 404/miss. `tags` is carried
+   *  through (threads-only Phase B′ — reconcilePack needs it for the `#pack` security gate). */
   async getNote(
     id: string,
-  ): Promise<{ id: string; path?: string; content?: string; metadata?: Record<string, unknown> } | null> {
+  ): Promise<{ id: string; path?: string; content?: string; metadata?: Record<string, unknown>; tags?: unknown } | null> {
     const url = `${this.vaultUrl}/vault/${this.vault}/api/notes/${encodeURIComponent(id)}?include_content=true`;
     const res = await this.fetchFn(url, { headers: { authorization: `Bearer ${this.token}` } });
     if (res.status === 404) return null;
@@ -606,7 +609,7 @@ export class DefVaultClient {
     } catch (err) {
       throw new Error(`def-vault "${this.vault}": get note ${id} — bad JSON: ${(err as Error).message}`);
     }
-    const n = (parsed ?? {}) as { id?: string; path?: string; note?: { id?: string; path?: string; content?: string; metadata?: Record<string, unknown> }; content?: string; metadata?: Record<string, unknown> };
+    const n = (parsed ?? {}) as { id?: string; path?: string; note?: { id?: string; path?: string; content?: string; metadata?: Record<string, unknown>; tags?: unknown }; content?: string; metadata?: Record<string, unknown>; tags?: unknown };
     const note = n.note ?? n;
     if (typeof note.id !== "string" || !note.id) return null;
     return {
@@ -615,6 +618,8 @@ export class DefVaultClient {
       ...(typeof note.path === "string" && note.path ? { path: note.path } : {}),
       content: note.content,
       metadata: note.metadata,
+      // Carry tags for the pack security gate (Phase B′ — reconcilePack reads `#pack`).
+      ...(note.tags !== undefined ? { tags: note.tags } : {}),
     };
   }
 
@@ -1314,6 +1319,123 @@ export class AgentDefRegistry {
       return "deregistered";
     }
     return (await this.instantiate(vault, note)) ? "instantiated" : "skipped";
+  }
+
+  /**
+   * Reconcile ONE PACK's grants (threads-only Phase B′ — DESIGN-2026-06-29-threads-only.md §4).
+   * Driven by the per-pack vault trigger (`POST /api/vault/pack` → here), NOT by load (load is
+   * per-turn). A pack is the GRANT-DECLARING note; its `wants:` is keyed on the hub by the pack's
+   * slugged PATH ({@link packPathKey}) — its OWN prune partition, so this reconcile can NEVER
+   * touch a def's grants or another pack's (the `feedback_cross_repo_derived_key_divergence`
+   * class is structurally avoided: the live set is trivially this one note's current `wants:`).
+   *
+   * Outcomes (mirrors the def-load grant discipline):
+   *   - `deleted` event (FORWARD-COMPATIBLE — the vault has no `deleted` trigger today, so the
+   *     live delete path is the 404 case below + the 60s loadAll poll; the explicit handling is
+   *     kept so a future `deleted` trigger Just Works), OR the note is gone (404), OR it no
+   *     longer carries `#pack`, OR it declares no `wants:`  → PRUNE that pack's partition to []
+   *     (`reconcileGrants(packKey, [])`). Per-pack, so safe.
+   *   - a clean parse of a `#pack` note's `wants:` → REGISTER each connection under `packKey`
+   *     (idempotent upsert) + RECONCILE to that live set (prune any want it no longer declares).
+   *   - a PARSE ERROR on `wants:` → stamp the note `status:error`, NEVER reconcile (a malformed
+   *     pack must not present a stale/empty live set that nukes its approved grants — the same
+   *     safety rule the def path uses).
+   *   - no grants client (hub not provisioned) → no-op (best-effort).
+   *
+   * Best-effort + non-fatal throughout — a reconcile/registration fault logs + returns; it never
+   * throws out of the webhook path. The pack's PATH is read off the note (fallback: the note id).
+   */
+  async reconcilePack(
+    vault: string,
+    noteId: string,
+    event?: "created" | "updated" | "deleted",
+  ): Promise<"reconciled" | "pruned" | "error" | "skipped"> {
+    if (!this.grants) return "skipped"; // hub not provisioned → no grant store to reconcile.
+    const client = this.clients.get(vault);
+    if (!client) {
+      console.warn(`agent-defs: pack reconcile for unknown vault "${vault}" — ignoring.`);
+      return "skipped";
+    }
+    // A delete event: the note is gone — prune its partition without a fetch (a CONFIRMED removal).
+    if (event === "deleted") {
+      await this.prunePackGrants(packPathKey(noteId));
+      return "pruned";
+    }
+    let note: Awaited<ReturnType<DefVaultClient["getNote"]>>;
+    try {
+      note = await client.getNote(noteId);
+    } catch (err) {
+      // A fetch FAILURE is NOT a confirmed removal — never prune from an inconclusive read.
+      console.error(`agent-defs: pack reconcile fetch of ${noteId} from "${vault}" failed: ${(err as Error).message}`);
+      return "skipped";
+    }
+    if (!note) {
+      // 404 — the pack is gone (deleted / no longer visible). CONFIRMED removal → prune its partition.
+      await this.prunePackGrants(packPathKey(noteId));
+      return "pruned";
+    }
+    // The grant key is the pack's PATH (slugged), mirroring the slug discipline grantId uses.
+    // Fall back to the note id when the vault didn't surface a path.
+    const packPath = typeof note.path === "string" && note.path ? note.path : noteId;
+    const packKey = packPathKey(packPath);
+    // THE SECURITY GATE: only a `#pack` note's `wants:` is honored. A note that lost the pack
+    // tag (or never had it) drops to prune-to-[] for its partition — its `wants:` is inert.
+    if (!isPackNote({ tags: (note as { tags?: unknown }).tags })) {
+      await this.prunePackGrants(packKey);
+      return "pruned";
+    }
+    let wants: ConnectionSpec[];
+    try {
+      wants = parseWants(note.metadata?.wants);
+    } catch (err) {
+      // A malformed `wants:` → stamp the note `status:error`, NEVER reconcile (don't present a
+      // stale/empty live set that would nuke this pack's approved grants). Best-effort stamp.
+      console.error(`agent-defs: pack ${noteId} in "${vault}" has a malformed wants: ${(err as Error).message}`);
+      await client.patchStatus(noteId, "error").catch(() => {});
+      return "error";
+    }
+    if (wants.length === 0) {
+      // The pack declares no wants (or dropped them) → prune its partition to [] (per-pack, safe).
+      await this.prunePackGrants(packKey);
+      return "pruned";
+    }
+    // REGISTER each want under the pack key (idempotent upsert) + RECONCILE to this live set.
+    const grants = this.grants;
+    for (const conn of wants) {
+      try {
+        await grants.registerGrant(packKey, conn);
+      } catch (err) {
+        // A single registration fault is non-fatal — the others still register; the operator
+        // approves later. (The reconcile below sends the live SPECS, so a missed register
+        // doesn't get pruned.)
+        console.warn(
+          `agent-defs: registering pack grant for "${packKey}" (${connectionKey(conn)}) failed ` +
+            `(continuing): ${(err as Error).message}`,
+        );
+      }
+    }
+    try {
+      const { pruned } = await grants.reconcileGrants(packKey, wants);
+      if (pruned > 0) console.log(`agent-defs: pruned ${pruned} stale grant(s) for pack "${packKey}".`);
+    } catch (err) {
+      console.warn(`agent-defs: reconciling pack grants for "${packKey}" failed (continuing): ${(err as Error).message}`);
+    }
+    return "reconciled";
+  }
+
+  /**
+   * Prune a pack's grant partition to [] (`reconcileGrants(packKey, [])`) — the per-pack GC for a
+   * deleted pack / a pack that dropped `wants:` / a note that lost the `#pack` tag. Per-pack, so
+   * it can never touch a def's or another pack's grants. Best-effort: a fault logs + returns.
+   */
+  private async prunePackGrants(packKey: string): Promise<void> {
+    if (!this.grants) return;
+    try {
+      const { pruned } = await this.grants.reconcileGrants(packKey, []);
+      if (pruned > 0) console.log(`agent-defs: pruned ${pruned} grant(s) for removed pack "${packKey}".`);
+    } catch (err) {
+      console.warn(`agent-defs: pruning pack grants for "${packKey}" failed (continuing): ${(err as Error).message}`);
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/src/backends/programmatic.test.ts
+++ b/src/backends/programmatic.test.ts
@@ -1397,6 +1397,100 @@ describe("ProgrammaticBackend.deliver — grant injection (4b)", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// threads-only Phase B′ — pack-keyed grant UNION (DESIGN-2026-06-29-threads-only.md §4)
+// ---------------------------------------------------------------------------
+
+/** A per-agent-key fake hub grants API (for union/legacy tests). `byAgent[key]` = that key's
+ *  approved grants; material keyed by grant id. Records the LIST keys queried. */
+function grantsClientByKey(opts: {
+  byAgent: Record<string, Array<{ id: string; connection: ConnectionSpec; status: string }>>;
+  material?: Record<string, GrantMaterial>;
+  onListKey?: (key: string) => void;
+}): GrantsClient {
+  const fetchFn = (async (url: string | URL | Request) => {
+    const u = String(url);
+    if (u.includes("/admin/grants/") && u.endsWith("/material")) {
+      const id = u.split("/admin/grants/")[1]!.replace("/material", "");
+      const m = opts.material?.[id];
+      if (!m) return new Response("no", { status: 404 });
+      return new Response(JSON.stringify(m), { status: 200 });
+    }
+    const key = decodeURIComponent(new URL(u).searchParams.get("agent") ?? "");
+    opts.onListKey?.(key);
+    const grants = (opts.byAgent[key] ?? []).map((g) => ({ id: g.id, agent: key, connection: g.connection, status: g.status }));
+    return new Response(JSON.stringify({ grants }), { status: 200, headers: { "content-type": "application/json" } });
+  }) as typeof fetch;
+  return new GrantsClient({ hubOrigin: "https://hub.example.com", managerBearer: "MGR", fetchFn });
+}
+
+describe("ProgrammaticBackend.deliver — pack-keyed grant union (Phase B′)", () => {
+  test("LEGACY CONTINUITY: a def with NO packKeys injects EXACTLY listGrants(spec.name) (only spec.name queried)", async () => {
+    mkDirs("pk-legacy");
+    const listKeys: string[] = [];
+    const conn: ConnectionSpec = { kind: "service", target: "github", inject: ["env"] };
+    const grants = grantsClientByKey({
+      byAgent: { eng: [{ id: "d1", connection: conn, status: "approved" }] },
+      material: { d1: { kind: "service", token: "ghp_DEF", inject: ["env"] } },
+      onListKey: (k) => listKeys.push(k),
+    });
+    const { fn, calls } = recordingSpawn({ stdout: successTurn("s", "ok") });
+    const backend = new ProgrammaticBackend(baseDeps(fn, { grants }));
+    const handle = await backend.start(specWithVault("eng"));
+    // No packKeys param (undefined) — the no-loadout path every current def agent takes.
+    await backend.deliver(handle, "hi", freshSession());
+    // ONLY the def's own name was queried (= the legacy single-source path).
+    expect(listKeys).toEqual(["eng"]);
+    // The def's grant injected; nothing else. Own-vault + the def's GITHUB_TOKEN, no pack entries.
+    expect(calls[0]!.env.GITHUB_TOKEN).toBe("ghp_DEF");
+    expect(Object.keys(readMcpServers("eng"))).toEqual([vaultEntryKey("default")]);
+  });
+
+  test("an EMPTY packKeys array is byte-identical to the no-packKeys legacy path", async () => {
+    mkDirs("pk-empty");
+    const listKeys: string[] = [];
+    const conn: ConnectionSpec = { kind: "service", target: "github", inject: ["env"] };
+    const grants = grantsClientByKey({
+      byAgent: { eng: [{ id: "d1", connection: conn, status: "approved" }] },
+      material: { d1: { kind: "service", token: "ghp_DEF", inject: ["env"] } },
+      onListKey: (k) => listKeys.push(k),
+    });
+    const { fn, calls } = recordingSpawn({ stdout: successTurn("s", "ok") });
+    const backend = new ProgrammaticBackend(baseDeps(fn, { grants }));
+    const handle = await backend.start(specWithVault("eng"));
+    // Explicit empty packKeys (a thread with no #pack-with-wants loaded) — same as legacy.
+    await backend.deliver(handle, "hi", freshSession(), undefined, undefined, undefined, undefined, undefined, []);
+    expect(listKeys).toEqual(["eng"]);
+    expect(calls[0]!.env.GITHUB_TOKEN).toBe("ghp_DEF");
+    expect(Object.keys(readMcpServers("eng"))).toEqual([vaultEntryKey("default")]);
+  });
+
+  test("a loaded pack key → the pack's grants are UNIONED with the def's (def + pack queried)", async () => {
+    mkDirs("pk-union");
+    const packKey = "pack--Packs-github";
+    const grants = grantsClientByKey({
+      byAgent: {
+        eng: [{ id: "d1", connection: { kind: "vault", target: "ops", access: "read" }, status: "approved" }],
+        [packKey]: [{ id: "p1", connection: { kind: "service", target: "github", inject: ["env"] }, status: "approved" }],
+      },
+      material: {
+        d1: { kind: "vault", token: "OPSTOK", mcpUrl: "https://hub/vault/ops/mcp" },
+        p1: { kind: "service", token: "ghp_PACK", inject: ["env"] },
+      },
+    });
+    const { fn, calls } = recordingSpawn({ stdout: successTurn("s", "ok") });
+    const backend = new ProgrammaticBackend(baseDeps(fn, { grants }));
+    const handle = await backend.start(specWithVault("eng"));
+    // The drain would pass the loaded pack's path key here.
+    await backend.deliver(handle, "hi", freshSession(), undefined, undefined, undefined, undefined, undefined, [packKey]);
+    // The pack's GITHUB_TOKEN (env) AND the def's granted ops vault (MCP) both injected.
+    expect(calls[0]!.env.GITHUB_TOKEN).toBe("ghp_PACK");
+    const servers = readMcpServers("eng");
+    expect(servers[vaultEntryKey("default")]).toBeDefined(); // own def-vault
+    expect(servers[grantVaultEntryKey("ops")]!.headers!.Authorization).toBe("Bearer OPSTOK"); // the def's grant
+  });
+});
+
 describe("ProgrammaticBackend.deliver — transient-error retry with incremental backoff", () => {
   const transientResult = (sid: string, msg: string) =>
     ndjson(

--- a/src/backends/programmatic.ts
+++ b/src/backends/programmatic.ts
@@ -76,7 +76,7 @@ import {
 } from "../mint-token.ts";
 import { buildAgentMcpConfigJson, vaultEntryKey } from "../agent-mcp-config.ts";
 import { resolveClaudeCredential, resolveChannelEnv } from "../credentials.ts";
-import { resolveInjectedGrants, type GrantsClient } from "../grants.ts";
+import { resolveInjectedGrantsUnion, type GrantsClient } from "../grants.ts";
 import { parseStreamJsonStream } from "./stream-json.ts";
 import { composeSystemPrompt } from "./types.ts";
 import type {
@@ -177,13 +177,17 @@ export interface ProgrammaticBackendDeps {
    */
   grants?: GrantsClient | null;
   /**
-   * The agent NAME used to key the agent's grants on the hub (`GET
-   * /admin/grants?agent=<name>`). Defaults to `spec.name` when absent. The grants are
-   * keyed by the agent name (= the def's name), which equals `spec.name` for a
-   * vault-native agent. Threaded explicitly so a future channel/agent-name split
-   * doesn't silently fetch the wrong agent's grants.
+   * The LEGACY-def grant KEY — the hub grant-holder string for the def's OWN grants
+   * (`GET /admin/grants?agent=<key>`). Defaults to `spec.name` when absent (= the def's
+   * `metadata.name`, the legacy continuity key — the 4 live def agents inject exactly
+   * `listGrants(spec.name)`). Renamed from `grantsAgentName` (threads-only Phase B′ —
+   * the locked lexicon drops the "agent" framing). It is the DORMANT per-thread override
+   * escape hatch: the PRIMARY grant path is the loadout-pack UNION (see `deliver` /
+   * resolveInjectedGrantsUnion), NOT this single key. Do NOT set it unless a thread
+   * genuinely needs creds keyed off something other than its def name (the rare per-thread
+   * override + the migration seam) — else you'd fetch the wrong source's grants.
    */
-  grantsAgentName?: string;
+  grantsKey?: string;
   /**
    * The subprocess spawner — runs the sandbox-wrapped `claude -p`. Tests inject a
    * fake that emits canned stream-json; the daemon uses the real Bun.spawn adapter.
@@ -446,6 +450,7 @@ export class ProgrammaticBackend implements AgentBackend {
     runContext?: RunContext,
     loadout?: LoadoutEntry[],
     subject?: string,
+    packKeys?: string[],
   ): Promise<DeliverResult> {
     const spec = handle.spec;
     if (!spec) {
@@ -528,22 +533,37 @@ export class ProgrammaticBackend implements AgentBackend {
     let grantMcpEntries: { name: string; url: string; token: string }[] = [];
     let grantEnv: Record<string, string> = {};
     if (this.deps.grants) {
-      // The grants are keyed on the hub by the AGENT name, which for vault-native defs
-      // is `spec.name`. `grantsAgentName` is an explicit override reserved for a future
-      // channel-name≠agent-name split; today no caller sets it, so it falls through to
-      // `spec.name` — do NOT set it unless that split lands (else you'd fetch the wrong
-      // agent's grants).
-      const agentName = this.deps.grantsAgentName ?? spec.name;
+      // GRANT INJECTION = UNION OF SOURCES (threads-only Phase B′ — §4). The injected
+      // grants for a turn are the union of:
+      //   1. the LEGACY def key — `grantsKey ?? spec.name` (UNCHANGED): a
+      //      `#agent/definition` keeps its grants keyed by its `metadata.name`. For the 4
+      //      live def agents (uni/steward/uni-evolve/eco-civilization) this is the only
+      //      source. `grantsKey` (was `grantsAgentName`) is the dormant per-thread override
+      //      escape hatch (§"Activate the dormant hook") — today no caller sets it, so it
+      //      falls through to `spec.name`. Do NOT make it the primary path; the primary is
+      //      this union.
+      //   2. each loaded PACK's path key (`packKeys`) — the slugged PATH (packPathKey) of
+      //      every loaded note in the thread's loadout that is a `#pack` declaring `wants:`.
+      //      The SECURITY GATE (a non-pack note's `wants:` is ignored) is enforced UPSTREAM
+      //      where packKeys is built (the transport's readThreadPackKeys), so a plain
+      //      content note's `wants:` never reaches here. Empty packKeys (every current
+      //      agent — no thread loads a `#pack` with `wants:` today) → the union is exactly
+      //      `[spec.name]` → BYTE-IDENTICAL to the legacy single-source path. (legacy continuity)
+      const legacyKey = this.deps.grantsKey ?? spec.name;
+      const sources = [legacyKey, ...(packKeys ?? [])];
       try {
-        const injected = await resolveInjectedGrants(this.deps.grants, agentName);
+        const injected = await resolveInjectedGrantsUnion(this.deps.grants, sources);
         grantMcpEntries = injected.mcpEntries;
         grantEnv = injected.env;
       } catch (err) {
-        // A failed grant LIST aborts only the cross-resource injection — the turn
-        // still runs with own-vault. (A revoked-mid-list / hub blip class.)
+        // resolveInjectedGrantsUnion is per-source best-effort (each source's list failure
+        // is logged + skipped inside it), so this catch is defense-in-depth — a surprise
+        // throw aborts only the cross-resource injection; the turn still runs with own-vault.
         console.warn(
-          `parachute-agent: resolving grants for "${agentName}" failed (running this turn ` +
-            `WITHOUT cross-resource grants — own-vault unaffected): ${(err as Error).message}`,
+          `parachute-agent: resolving grants for "${legacyKey}"` +
+            (packKeys && packKeys.length > 0 ? ` (+${packKeys.length} pack source(s))` : "") +
+            ` failed (running this turn WITHOUT cross-resource grants — own-vault unaffected): ` +
+            `${(err as Error).message}`,
         );
       }
     }

--- a/src/backends/registry.ts
+++ b/src/backends/registry.ts
@@ -554,6 +554,22 @@ export class ProgrammaticAgentRegistry {
     name: string,
     subject?: string,
   ) => Promise<LoadoutEntry[]>;
+  /**
+   * Optional pre-turn loaded-PACK grant-KEY read (threads-only Phase B′ —
+   * DESIGN-2026-06-29-threads-only.md §4). Resolves the SAME `metadata.loadout` paths as
+   * {@link readLoadout}, but reads the loaded notes' METADATA to find the `#pack` notes
+   * declaring `wants:`, returning each such pack's slugged-path grant key (`packPathKey`). Read
+   * in {@link drain} and passed to `deliver`, which UNIONS each pack's APPROVED grants with the
+   * def's own (`spec.name`). The SECURITY GATE (a non-pack note's `wants:` is ignored) lives in
+   * the resolver. SEPARATE from {@link readLoadout} so the prompt composition stays content-only
+   * (Phase A). UNWIRED / no pack with `wants:` → empty → the grant source set is exactly
+   * `[spec.name]` (legacy continuity — byte-identical injection for every current agent).
+   */
+  private readonly readPackKeys?: (
+    channel: string,
+    name: string,
+    subject?: string,
+  ) => Promise<string[]>;
   /** Base backoff (ms) between outbound retries (FIX 1). Injectable so tests run fast. */
   private readonly outboundRetryBaseMs: number;
 
@@ -580,6 +596,13 @@ export class ProgrammaticAgentRegistry {
      * alone, the no-loadout invariant). `subject` resolves the subject-scoped thread note.
      */
     readLoadout?: (channel: string, name: string, subject?: string) => Promise<LoadoutEntry[]>;
+    /**
+     * Read the thread's loaded-PACK grant KEYS (threads-only Phase B′) — the slugged paths of
+     * the loaded `#pack` notes that declare `wants:`. Optional — UNWIRED → no pack keys (the
+     * def's `spec.name` grants alone, legacy continuity). `subject` resolves the subject-scoped
+     * thread note.
+     */
+    readPackKeys?: (channel: string, name: string, subject?: string) => Promise<string[]>;
     /** Override the outbound-retry backoff base (ms). Default {@link OUTBOUND_RETRY_BASE_MS}. */
     outboundRetryBaseMs?: number;
   }) {
@@ -591,6 +614,7 @@ export class ProgrammaticAgentRegistry {
     if (deps.readSession) this.readSession = deps.readSession;
     if (deps.clearSession) this.clearSession = deps.clearSession;
     if (deps.readLoadout) this.readLoadout = deps.readLoadout;
+    if (deps.readPackKeys) this.readPackKeys = deps.readPackKeys;
     this.outboundRetryBaseMs = deps.outboundRetryBaseMs ?? OUTBOUND_RETRY_BASE_MS;
   }
 
@@ -1230,6 +1254,27 @@ export class ProgrammaticAgentRegistry {
         }
       }
 
+      // PACK GRANT KEYS (threads-only Phase B′ — DESIGN-2026-06-29-threads-only.md §4): resolve
+      // the loaded-PACK grant keys (the slugged paths of the loaded `#pack` notes declaring
+      // `wants:`) off the SAME thread note. The backend UNIONS each pack's APPROVED grants with
+      // the def's own (`spec.name`). SEPARATE metadata read from the content-only loadout (so the
+      // prompt composition is unchanged). The SECURITY GATE — a non-pack note's `wants:` is
+      // ignored — lives in the resolver. UNWIRED / no pack with `wants:` (every current thread)
+      // → empty → the grant sources are exactly `[spec.name]` (legacy continuity, byte-identical
+      // injection). Best-effort: a read failure logs + the turn injects the def's grants alone.
+      let packKeys: string[] = [];
+      if (this.readPackKeys) {
+        try {
+          packKeys = await this.readPackKeys(handle.channel, handle.spec.name, turnSubject);
+        } catch (err) {
+          console.error(
+            `parachute-agent: pack-key read for channel "${channel}"` +
+              (turnSubject ? ` subject "${turnSubject}"` : "") +
+              ` failed (turn injects the def's grants alone): ${(err as Error).message}`,
+          );
+        }
+      }
+
       let result;
       try {
         // Forward each interim event to the streaming-view sink (keyed by channel)
@@ -1254,6 +1299,10 @@ export class ProgrammaticAgentRegistry {
           // subjects of one agent never clobber each other's per-turn `.mcp.json` /
           // `system-prompt.txt` / HOME. Undefined → `sessions/<name>/` (HEAD, unchanged).
           turnSubject,
+          // threads-only Phase B′: the loaded-PACK grant keys — the backend unions each pack's
+          // APPROVED grants with the def's own (`spec.name`). Empty (every current thread) →
+          // the grant sources are exactly `[spec.name]` (legacy continuity, byte-identical).
+          packKeys,
         );
       } catch (err) {
         // The backend contract is failure-as-VALUE, never a throw — but defend so a

--- a/src/backends/types.ts
+++ b/src/backends/types.ts
@@ -361,6 +361,17 @@ export interface AgentBackend {
    * clobber each other. ADDITIVE — omitted/empty → `sessions/<name>/` (byte-identical to HEAD;
    * the null-subject invariant). Distinct from `loadout` (which is prompt CONTENT); this is
    * the workspace IDENTITY.
+   *
+   * `packKeys` (optional, threads-only Phase B′ — DESIGN-2026-06-29-threads-only.md §4) is the
+   * list of hub grant-holder KEYS for the loaded PACKS in this thread's loadout — the slugged
+   * PATH (`packPathKey`) of every loaded note that is a `#pack` declaring `wants:`. The
+   * programmatic backend UNIONS each pack's APPROVED grants with the def's own (`spec.name`),
+   * so a thread that loads a pack gains that pack's capabilities. This is SEPARATE from
+   * `loadout` (prompt content) by design: the SECURITY GATE — a non-pack note's `wants:` is
+   * IGNORED — is enforced where `packKeys` is built (the transport reads the loaded notes'
+   * METADATA, never folding it into the prompt). ADDITIVE — omitted/empty (every current agent;
+   * no thread loads a `#pack` with `wants:` today) → the grant source set is exactly
+   * `[spec.name]`, BYTE-IDENTICAL to the legacy single-source injection (legacy continuity).
    */
   deliver(
     handle: AgentHandle,
@@ -371,6 +382,7 @@ export interface AgentBackend {
     runContext?: RunContext,
     loadout?: LoadoutEntry[],
     subject?: string,
+    packKeys?: string[],
   ): Promise<DeliverResult>;
 
   /**

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -898,6 +898,27 @@ export function buildReadLoadout(
 }
 
 /**
+ * Build the {@link ProgrammaticAgentRegistry}'s pre-turn loaded-PACK grant-KEY read
+ * (threads-only Phase B′ — DESIGN-2026-06-29-threads-only.md §4). Resolves the channel's
+ * transport and reads the loaded `#pack` notes' grant keys (the slugged paths of the loadout
+ * notes that are `#pack`s declaring `wants:`) off the thread's `#agent/thread` note. The backend
+ * UNIONS each pack's APPROVED grants with the def's own (`spec.name`). Only the VaultTransport
+ * implements `readThreadPackKeys`; other transports omit it → no pack keys (the def's grants
+ * alone — legacy continuity). The SECURITY GATE (a non-pack note's `wants:` is ignored) lives in
+ * the transport resolver. Mirrors {@link buildReadLoadout}, but reads METADATA (pack-detection),
+ * not content (prompt).
+ */
+export function buildReadPackKeys(
+  channels: Map<string, Channel>,
+): (channel: string, name: string, subject?: string) => Promise<string[]> {
+  return async (channel, name, subject) => {
+    const ch = channels.get(channel);
+    if (!ch?.transport.readThreadPackKeys) return [];
+    return ch.transport.readThreadPackKeys(channel, name, subject);
+  };
+}
+
+/**
  * Build the REAL programmatic-agent registry — the {@link ProgrammaticBackend}
  * wired to the env-resolved spawn deps, plus the outbound-write + thread-note +
  * session-read seams over the live `channels`. The session UUID lives on the durable
@@ -960,6 +981,8 @@ export function createDefaultProgrammaticRegistry(
     // so the backend composes the arity-N system prompt. SUPERSEDES the never-wired
     // subjectDossier seam. Empty loadout (no metadata.loadout) → the def body alone.
     readLoadout: buildReadLoadout(channels),
+    // threads-only Phase B′: the pre-turn loaded-PACK grant-key read (union pack grants).
+    readPackKeys: buildReadPackKeys(channels),
     ...(onTurnEvent ? { onTurnEvent } : {}),
   });
 }
@@ -3126,6 +3149,66 @@ export function createFetchHandler(
           : undefined;
       const result = await agentDefs.reload(vault, noteId, event);
       return json({ ok: true, reloaded: result });
+    }
+
+    // ---------------------------------------------------------------------
+    // PACK grant-reconcile webhook — POST /api/vault/pack
+    // (threads-only Phase B′, DESIGN-2026-06-29-threads-only.md §4). A vault trigger on a
+    // `#pack` note created/updated POSTs here; we reconcile THAT pack's `wants:` under its
+    // path key (register each + prune its OWN partition). This is the PER-PACK reconcile —
+    // analogous to /api/vault/agent-def but keyed by the pack PATH, and it NEVER touches a
+    // def's grants or another pack's. Mirrors /api/vault/agent-def's auth (hub JWT, scope
+    // agent:send) + uniform-401 + vault resolution. Body: { event?, vault?, note: { id/path,
+    // metadata } }. A non-pack note / dropped-wants / parse-error is handled inside
+    // reconcilePack (prune-to-[] / status:error). Externally `<hub>/agent/api/vault/pack`.
+    // ---------------------------------------------------------------------
+    if (req.method === "POST" && url.pathname === "/api/vault/pack") {
+      const denied = await requireScope(req, url, SCOPE_SEND);
+      if (denied) return json({ error: "unauthorized" }, 401);
+      if (!agentDefs) {
+        // No def-vaults configured — nothing to reconcile. Clean ack.
+        return json({ ok: true, reconciled: "skipped" });
+      }
+      let body: {
+        event?: "created" | "updated" | "deleted";
+        vault?: string;
+        note?: { id?: string; path?: string; metadata?: Record<string, unknown> };
+      };
+      try {
+        body = (await req.json()) as typeof body;
+      } catch {
+        return json({ error: "invalid JSON body" }, 400);
+      }
+      const noteId =
+        typeof body.note?.id === "string" && body.note.id
+          ? body.note.id
+          : typeof body.note?.path === "string"
+            ? body.note.path
+            : undefined;
+      if (!noteId) {
+        return json({ error: "body must include note.id" }, 400);
+      }
+      // Resolve the source vault: the explicit `vault` field, else the sole configured
+      // def-vault (the single-vault default), else 400. (Identical to the agent-def path.)
+      let vault = typeof body.vault === "string" && body.vault ? body.vault : undefined;
+      if (!vault) {
+        const names = agentDefs.list();
+        const distinct = new Set([...names.map((d) => d.vault)]);
+        if (agentDefs.vaultCount === 1) {
+          vault = agentDefs.soleVaultName();
+        } else if (distinct.size === 1) {
+          vault = [...distinct][0];
+        }
+      }
+      if (!vault) {
+        return json({ error: "body.vault is required (multiple def-vaults configured)" }, 400);
+      }
+      const event =
+        body.event === "created" || body.event === "updated" || body.event === "deleted"
+          ? body.event
+          : undefined;
+      const result = await agentDefs.reconcilePack(vault, noteId, event);
+      return json({ ok: true, reconciled: result });
     }
 
     // ---------------------------------------------------------------------

--- a/src/def-vault-triggers.test.ts
+++ b/src/def-vault-triggers.test.ts
@@ -88,12 +88,27 @@ describe("buildDefVaultTriggers — the bare-keyed shapes", () => {
     return t;
   }
 
-  test("emits exactly three triggers: def-watch create, def-watch edit, inbound", () => {
+  test("emits five triggers: def-watch create/edit, inbound, pack-watch create/edit", () => {
     expect(triggers.map((t) => t.name)).toEqual([
       "conn_agentdefs-create-default",
       "conn_agentdefs-edit-default",
       "conn_agentinbound-default",
+      // threads-only Phase B′ — the per-pack reconcile triggers.
+      "conn_packs-create-default",
+      "conn_packs-edit-default",
     ]);
+  });
+
+  test("pack-watch triggers are bare `pack`-keyed and webhook the pack reconcile endpoint", () => {
+    for (const name of ["conn_packs-create-default", "conn_packs-edit-default"]) {
+      const t = byName(name);
+      expect(t.when.tags).toEqual(["pack"]);
+      expect(t.action.webhook).toBe(`${HUB}/agent/api/vault/pack`);
+      expect(t.action.send).toBe("json");
+      expect(t.action.auth?.bearer).toBe("BEARER");
+    }
+    expect(byName("conn_packs-create-default").events).toEqual(["created"]);
+    expect(byName("conn_packs-edit-default").events).toEqual(["updated"]);
   });
 
   test("def-watch triggers are BARE-keyed (agent/definition, NOT #agent/definition)", () => {
@@ -146,7 +161,7 @@ describe("buildDefVaultTriggers — the bare-keyed shapes", () => {
 });
 
 describe("registerDefVaultTriggers — the live registration path", () => {
-  test("mints agent:send + vault:<v>:admin, POSTs all three triggers with the admin bearer", async () => {
+  test("mints agent:send + vault:<v>:admin, POSTs all five triggers with the admin bearer", async () => {
     const { fetchFn, mintCalls, triggerCalls } = fakeFetch();
     const result = await registerDefVaultTriggers(BINDING, {
       hubOrigin: HUB,
@@ -158,14 +173,16 @@ describe("registerDefVaultTriggers — the live registration path", () => {
     expect(mintCalls.map((c) => c.scope).sort()).toEqual(["agent:send", "vault:default:admin"]);
     for (const c of mintCalls) expect(c.auth).toBe("Bearer OP-BEARER");
 
-    // All three triggers registered, posted to the vault's triggers API.
+    // All five triggers registered, posted to the vault's triggers API.
     expect(result.failures).toEqual([]);
     expect(result.registered).toEqual([
       "conn_agentdefs-create-default",
       "conn_agentdefs-edit-default",
       "conn_agentinbound-default",
+      "conn_packs-create-default",
+      "conn_packs-edit-default",
     ]);
-    expect(triggerCalls).toHaveLength(3);
+    expect(triggerCalls).toHaveLength(5);
     for (const c of triggerCalls) {
       expect(c.url).toBe("http://127.0.0.1:1940/vault/default/api/triggers");
       // The ADMIN token (not the write token) authenticates the triggers POST.
@@ -227,9 +244,9 @@ describe("registerDefVaultTriggers — the live registration path", () => {
       managerBearer: "OP-BEARER",
       fetchFn,
     });
-    expect(triggerCalls).toHaveLength(3); // all three attempted
+    expect(triggerCalls).toHaveLength(5); // all five attempted
     expect(result.registered).toEqual([]);
-    expect(result.failures).toHaveLength(3);
+    expect(result.failures).toHaveLength(5);
     for (const f of result.failures) expect(f).toContain("HTTP 403");
   });
 
@@ -257,10 +274,11 @@ describe("registerAllDefVaultTriggers — fan-out over bindings", () => {
     );
     expect(results.map((r) => r.vault)).toEqual(["default", "work"]);
     expect(results.every((r) => r.failures.length === 0)).toBe(true);
-    // 3 triggers × 2 vaults.
-    expect(triggerCalls).toHaveLength(6);
+    // 5 triggers × 2 vaults.
+    expect(triggerCalls).toHaveLength(10);
     const names = new Set(triggerCalls.map((c) => c.body.name));
     expect(names.has("conn_agentdefs-create-work")).toBe(true);
     expect(names.has("conn_agentinbound-default")).toBe(true);
+    expect(names.has("conn_packs-create-work")).toBe(true);
   });
 });

--- a/src/def-vault-triggers.ts
+++ b/src/def-vault-triggers.ts
@@ -72,6 +72,14 @@ import { AGENT_VAULT_TRIGGER_TEMPLATE } from "./transports/vault.ts";
 /** The bare def-discriminator tag the def-watch triggers filter on (post-canonicalization). */
 export const DEFINITION_TAG = "agent/definition";
 /**
+ * The bare PACK tag the pack-watch triggers filter on (threads-only Phase B′ —
+ * DESIGN-2026-06-29-threads-only.md §4). A `#pack` note save fires the pack webhook so the
+ * daemon reconciles that pack's `wants:` under its path key (register + prune-its-own-partition).
+ * This is the PER-PACK trigger — analogous to the def-watch triggers, NOT fired on every load
+ * (load is per-turn). Mirrors {@link PACK_TAG} in grants.ts.
+ */
+export const PACK_TAG = "pack";
+/**
  * The inbound trigger's `when` predicate. SOURCED from the existing
  * {@link AGENT_VAULT_TRIGGER_TEMPLATE} (`src/transports/vault.ts`) — the
  * module-owned shape the hub already substitutes — so the daemon's
@@ -132,6 +140,15 @@ export function inboundTriggerName(vault: string): string {
   return `conn_agentinbound-${vault}`;
 }
 
+/**
+ * The pack-watch trigger name for a (vault, kind) (threads-only Phase B′). Stable so the
+ * POST upserts in place. ONE pair (create + edit) per def-vault — they fire the pack webhook
+ * for ANY `#pack` note in the vault, which reconciles that pack's `wants:` under its path key.
+ */
+export function packWatchTriggerName(vault: string, kind: "create" | "edit"): string {
+  return `conn_packs-${kind}-${vault}`;
+}
+
 /** Build the webhook URL `<hub-origin>/agent/api/vault/<endpoint>`. */
 function buildWebhook(hubOrigin: string, endpoint: string): string {
   const origin = hubOrigin.replace(/\/+$/, "");
@@ -150,6 +167,7 @@ export function buildDefVaultTriggers(
 ): VaultTriggerInput[] {
   const defWebhook = buildWebhook(hubOrigin, "/api/vault/agent-def");
   const inboundWebhook = buildWebhook(hubOrigin, "/api/vault/inbound");
+  const packWebhook = buildWebhook(hubOrigin, "/api/vault/pack");
   const auth = { bearer: webhookBearer };
   return [
     // Def-watch CREATE — a new bare `agent/definition` note instantiates its agent live.
@@ -179,6 +197,27 @@ export function buildDefVaultTriggers(
         missing_metadata: [...INBOUND_WHEN.missing_metadata],
       },
       action: { webhook: inboundWebhook, send: "json", auth },
+    },
+    // PACK-watch CREATE — a new `#pack` note reconciles its `wants:` under its path key
+    // (threads-only Phase B′ §4). This is the PER-PACK reconcile trigger, analogous to the
+    // def-watch triggers — fired on SAVE, NOT on every load (load is per-turn). The webhook
+    // registers the pack's wants + prunes ONLY that pack's own grant partition.
+    {
+      name: packWatchTriggerName(vault, "create"),
+      events: ["created"],
+      when: { tags: [PACK_TAG] },
+      action: { webhook: packWebhook, send: "json", auth },
+    },
+    // PACK-watch EDIT — an edited `#pack` note re-reconciles (a removed `wants:` prunes that
+    // pack's partition to []). The vault has no `deleted` trigger event (validator allows only
+    // created/updated), so deletion is handled out-of-band; the create+edit pair covers
+    // save + drop-wants, which is the live reconcile surface. (Each pack is its OWN partition,
+    // so a reconcile can never touch a def's grants or another pack's — §4.)
+    {
+      name: packWatchTriggerName(vault, "edit"),
+      events: ["updated"],
+      when: { tags: [PACK_TAG] },
+      action: { webhook: packWebhook, send: "json", auth },
     },
   ];
 }
@@ -304,7 +343,7 @@ export async function registerAllDefVaultTriggers(
     if (r.failures.length === 0) {
       console.log(
         `parachute-agent: def-vault "${r.vault}" — auto-registered ${r.registered.length} trigger(s) ` +
-          `(def-watch create/edit + inbound, bare-keyed).`,
+          `(def-watch create/edit + inbound + pack-watch create/edit, bare-keyed).`,
       );
     } else {
       console.warn(

--- a/src/grants.test.ts
+++ b/src/grants.test.ts
@@ -21,11 +21,16 @@ import {
   connectionKey,
   resolveConnectionStatus,
   resolveInjectedGrants,
+  resolveInjectedGrantsUnion,
   serviceEnvVar,
   serviceMcpUrl,
   grantVaultEntryKey,
   grantServiceEntryKey,
   grantMcpEntryKey,
+  packPathKey,
+  isPackNote,
+  packWants,
+  PACK_TAG,
   GrantsClient,
   GrantsApiError,
   WantsParseError,
@@ -634,5 +639,207 @@ describe("resolveInjectedGrants", () => {
     // Two spawns → two material fetches (no cache between them — revocation takes
     // effect next spawn precisely because we re-fetch).
     expect(called).toEqual(["g1", "g1"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// threads-only Phase B′ — pack-only grants (DESIGN-2026-06-29-threads-only.md §4)
+// ---------------------------------------------------------------------------
+
+describe("packPathKey — the pack grant-holder key (slugged path, `pack--` prefixed)", () => {
+  test("slugs the path (non-slug chars → -) under a `pack--` prefix", () => {
+    expect(packPathKey("Uni/Packs/github")).toBe("pack--Uni-Packs-github");
+    expect(packPathKey("Packs/Read.ai")).toBe("pack--Packs-Read-ai");
+  });
+  test("the pack key namespace can never collide with a bare def name (a slug, no `--`)", () => {
+    // A def `metadata.name` is a `[a-zA-Z0-9_-]+` slug — it has no `--`, so the `pack--`
+    // prefix partitions the two grant-holder namespaces.
+    expect(packPathKey("steward").startsWith("pack--")).toBe(true);
+    expect("steward").not.toContain("--");
+  });
+});
+
+describe("isPackNote / packWants — the SECURITY GATE (wants only from PACKS)", () => {
+  test("PACK_TAG is the bare `pack` tag", () => {
+    expect(PACK_TAG).toBe("pack");
+  });
+  test("isPackNote: true for a `pack`-tagged note (array or string tags, tolerant of `#`)", () => {
+    expect(isPackNote({ tags: ["pack"] })).toBe(true);
+    expect(isPackNote({ tags: ["#pack"] })).toBe(true); // stray leading # tolerated
+    expect(isPackNote({ tags: "foo, pack, bar" })).toBe(true);
+    expect(isPackNote({ tags: ["other"] })).toBe(false);
+    expect(isPackNote({ tags: undefined })).toBe(false);
+    // A substring match must NOT count as `pack` (exact tag, not prefix).
+    expect(isPackNote({ tags: ["packaged"] })).toBe(false);
+    expect(isPackNote({ tags: ["pack/sub"] })).toBe(false);
+  });
+
+  test("a `#pack` note WITH wants → parsed specs", () => {
+    const note = { tags: ["pack"], metadata: { wants: "vault:research:read, env:github" } };
+    expect(packWants(note)).toEqual([
+      { kind: "vault", target: "research", access: "read" },
+      { kind: "service", target: "github", inject: ["env"] },
+    ]);
+  });
+
+  test("THE GATE: a NON-pack note with wants → null (its wants are IGNORED/inert)", () => {
+    // A plain content note declaring `wants:` must NOT contribute any capability.
+    const note = { tags: ["reference"], metadata: { wants: "vault:research:read, env:github" } };
+    expect(packWants(note)).toBeNull();
+    // Same content, but now tagged `pack` → honored. The ONLY difference is the tag.
+    expect(packWants({ tags: ["pack"], metadata: { wants: "vault:research:read" } })).not.toBeNull();
+  });
+
+  test("a pack with NO wants → null; a pack with empty wants → null", () => {
+    expect(packWants({ tags: ["pack"], metadata: {} })).toBeNull();
+    expect(packWants({ tags: ["pack"], metadata: { wants: "" } })).toBeNull();
+  });
+
+  test("a pack with a MALFORMED wants → null (the reconcile path stamps status:error)", () => {
+    expect(packWants({ tags: ["pack"], metadata: { wants: "garbage-no-colon" } })).toBeNull();
+  });
+});
+
+/**
+ * A grants client whose list returns DIFFERENT grants PER agent key (for union tests).
+ * Material is keyed by grant id. `byAgent` maps a grant-holder key → its grant list.
+ */
+function multiAgentClient(opts: {
+  byAgent: Record<string, Array<{ id: string; connection: ConnectionSpec; status: string }>>;
+  material?: Record<string, GrantMaterial>;
+  listStatusByAgent?: Record<string, number>; // force a non-200 LIST for a given agent key
+  onListCall?: (agent: string) => void;
+}): GrantsClient {
+  const fetchFn = (async (url: string | URL | Request) => {
+    const u = String(url);
+    if (u.includes("/admin/grants/") && u.endsWith("/material")) {
+      const id = u.split("/admin/grants/")[1]!.replace("/material", "");
+      const m = opts.material?.[id];
+      if (!m) return new Response("no", { status: 404 });
+      return new Response(JSON.stringify(m), { status: 200 });
+    }
+    // list — parse the ?agent=<key>
+    const agent = decodeURIComponent(new URL(u).searchParams.get("agent") ?? "");
+    opts.onListCall?.(agent);
+    const forced = opts.listStatusByAgent?.[agent];
+    if (forced && forced !== 200) return new Response("boom", { status: forced });
+    const grants = (opts.byAgent[agent] ?? []).map((g) => ({
+      id: g.id,
+      agent,
+      connection: g.connection,
+      status: g.status,
+    }));
+    return new Response(JSON.stringify({ grants }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof fetch;
+  return new GrantsClient({ hubOrigin: HUB, managerBearer: BEARER, fetchFn });
+}
+
+describe("resolveInjectedGrantsUnion — union of def key + pack keys", () => {
+  test("LEGACY CONTINUITY: a single source (no packs) === resolveInjectedGrants(spec.name)", async () => {
+    const conn: ConnectionSpec = { kind: "service", target: "github", inject: ["env"] };
+    const byAgent = { steward: [{ id: "g1", connection: conn, status: "approved" }] };
+    const material = { g1: { kind: "service" as const, token: "GHTOK", inject: ["env" as const] } };
+    // The exact same fake, queried both ways.
+    const single = multiAgentClient({ byAgent, material });
+    const unioned = multiAgentClient({ byAgent, material });
+    const fromSingle = await resolveInjectedGrants(single, "steward");
+    const fromUnion = await resolveInjectedGrantsUnion(unioned, ["steward"]);
+    // BYTE-IDENTICAL injected struct — the union with one source is the legacy path.
+    expect(fromUnion).toEqual(fromSingle);
+    expect(fromUnion.env).toEqual({ GITHUB_TOKEN: "GHTOK" });
+  });
+
+  test("a thread loading ONE pack → def grants UNIONED with the pack's path-keyed grants", async () => {
+    const packKey = packPathKey("Packs/github");
+    const client = multiAgentClient({
+      byAgent: {
+        steward: [
+          { id: "d1", connection: { kind: "vault", target: "ops", access: "read" }, status: "approved" },
+        ],
+        [packKey]: [
+          { id: "p1", connection: { kind: "service", target: "github", inject: ["env"] }, status: "approved" },
+        ],
+      },
+      material: {
+        d1: { kind: "vault", token: "OPSTOK", mcpUrl: "https://hub/vault/ops/mcp" },
+        p1: { kind: "service", token: "GHTOK", inject: ["env"] },
+      },
+    });
+    const out = await resolveInjectedGrantsUnion(client, ["steward", packKey]);
+    expect(out.env).toEqual({ GITHUB_TOKEN: "GHTOK" }); // from the pack
+    expect(out.mcpEntries).toEqual([
+      { name: grantVaultEntryKey("ops"), url: "https://hub/vault/ops/mcp", token: "OPSTOK" }, // from the def
+    ]);
+  });
+
+  test("TWO packs → all three sources unioned (def + pack A + pack B)", async () => {
+    const keyA = packPathKey("Packs/github");
+    const keyB = packPathKey("Packs/research");
+    const client = multiAgentClient({
+      byAgent: {
+        steward: [{ id: "d1", connection: { kind: "service", target: "cloudflare", inject: ["env"] }, status: "approved" }],
+        [keyA]: [{ id: "a1", connection: { kind: "service", target: "github", inject: ["env"] }, status: "approved" }],
+        [keyB]: [{ id: "b1", connection: { kind: "vault", target: "research", access: "read" }, status: "approved" }],
+      },
+      material: {
+        d1: { kind: "service", token: "CFTOK", inject: ["env"] },
+        a1: { kind: "service", token: "GHTOK", inject: ["env"] },
+        b1: { kind: "vault", token: "RTOK", mcpUrl: "https://hub/vault/research/mcp" },
+      },
+    });
+    const out = await resolveInjectedGrantsUnion(client, ["steward", keyA, keyB]);
+    expect(out.env).toEqual({ CLOUDFLARE_API_TOKEN: "CFTOK", GITHUB_TOKEN: "GHTOK" });
+    expect(out.mcpEntries).toEqual([
+      { name: grantVaultEntryKey("research"), url: "https://hub/vault/research/mcp", token: "RTOK" },
+    ]);
+  });
+
+  test("dedupe: a key appearing twice (or equal to spec.name) is fetched ONCE", async () => {
+    const calls: string[] = [];
+    const conn: ConnectionSpec = { kind: "service", target: "github", inject: ["env"] };
+    const client = multiAgentClient({
+      byAgent: { steward: [{ id: "g1", connection: conn, status: "approved" }] },
+      material: { g1: { kind: "service" as const, token: "GHTOK", inject: ["env" as const] } },
+      onListCall: (a) => calls.push(a),
+    });
+    const out = await resolveInjectedGrantsUnion(client, ["steward", "steward", ""]);
+    expect(calls).toEqual(["steward"]); // deduped + empty key skipped
+    expect(out.env).toEqual({ GITHUB_TOKEN: "GHTOK" });
+  });
+
+  test("dedupe on collision: first source wins an env-var / MCP-name collision (def first)", async () => {
+    const packKey = packPathKey("Packs/github");
+    const client = multiAgentClient({
+      byAgent: {
+        steward: [{ id: "d1", connection: { kind: "service", target: "github", inject: ["env"] }, status: "approved" }],
+        [packKey]: [{ id: "p1", connection: { kind: "service", target: "github", inject: ["env"] }, status: "approved" }],
+      },
+      material: {
+        d1: { kind: "service", token: "DEF-GHTOK", inject: ["env"] },
+        p1: { kind: "service", token: "PACK-GHTOK", inject: ["env"] },
+      },
+    });
+    const out = await resolveInjectedGrantsUnion(client, ["steward", packKey]);
+    // The def (first source) wins the GITHUB_TOKEN collision.
+    expect(out.env).toEqual({ GITHUB_TOKEN: "DEF-GHTOK" });
+  });
+
+  test("per-source isolation: ONE source's list failure is skipped, the others still inject", async () => {
+    const packKey = packPathKey("Packs/github");
+    const client = multiAgentClient({
+      byAgent: {
+        steward: [{ id: "d1", connection: { kind: "service", target: "github", inject: ["env"] }, status: "approved" }],
+        [packKey]: [{ id: "p1", connection: { kind: "vault", target: "x", access: "read" }, status: "approved" }],
+      },
+      material: { d1: { kind: "service", token: "GHTOK", inject: ["env"] } },
+      listStatusByAgent: { [packKey]: 500 }, // the pack's LIST fails
+    });
+    const out = await resolveInjectedGrantsUnion(client, ["steward", packKey]);
+    // The def still injected; the failing pack source is simply absent (never throws).
+    expect(out.env).toEqual({ GITHUB_TOKEN: "GHTOK" });
+    expect(out.mcpEntries).toEqual([]);
   });
 });

--- a/src/grants.ts
+++ b/src/grants.ts
@@ -656,6 +656,136 @@ export async function resolveInjectedGrants(
   return { mcpEntries, env };
 }
 
+/**
+ * UNION an agent's injected grants across MULTIPLE grant-source keys (threads-only
+ * Phase B′ — DESIGN-2026-06-29-threads-only.md §4). The injected grants for a turn are
+ * the union of `resolveInjectedGrants(client, key)` over `[spec.name, ...packKeys]`:
+ *
+ *   - `spec.name`  — the LEGACY def path (UNCHANGED): a `#agent/definition` keeps its
+ *     grants keyed by its `metadata.name`. For the 4 live def agents (uni, steward, …)
+ *     this is the ONLY key, so with no loaded packs the union has one source and the
+ *     result is byte-identical to {@link resolveInjectedGrants}(client, spec.name).
+ *   - each `packKey` — a slugged pack PATH ({@link packPathKey}) for every loaded note
+ *     that is a `#pack` declaring `wants:`. Loading a pack into a thread unions that
+ *     pack's path-keyed APPROVED grants in.
+ *
+ * Dedupe rule: MCP entries are deduped by their entry `name` (first source wins);
+ * env vars are deduped by var name (first source wins). The legacy `spec.name` source
+ * is conventionally first, so a def's own grant wins a name collision with a pack's.
+ *
+ * Keys are deduped + processed in order; a duplicate key (e.g. the same pack twice in
+ * a loadout, or a pack key that happens to equal `spec.name`) is fetched ONCE. A single
+ * source's grant-LIST failure is logged + SKIPPED (its grants are simply absent this
+ * turn — the others still inject), so a flaky hub on one pack never sinks the whole
+ * turn's injection. Material is fetched FRESH per source (never cached), same as the
+ * single-source path.
+ */
+export async function resolveInjectedGrantsUnion(
+  client: GrantsClient,
+  keys: string[],
+): Promise<InjectedGrants> {
+  const mcpByName = new Map<string, InjectedMcpEntry>();
+  const env: Record<string, string> = {};
+  const seenKeys = new Set<string>();
+
+  for (const key of keys) {
+    if (!key || seenKeys.has(key)) continue;
+    seenKeys.add(key);
+    let injected: InjectedGrants;
+    try {
+      injected = await resolveInjectedGrants(client, key);
+    } catch (err) {
+      // A single source's grant LIST failing must not sink the others — that source's
+      // grants are simply absent this turn (its own-vault is unaffected; another
+      // source's grants still inject). Never log a token (there is none in the error).
+      console.warn(
+        `parachute-agent: resolving grants for source "${key}" failed ` +
+          `(skipping this source's grants for this turn): ${(err as Error).message}`,
+      );
+      continue;
+    }
+    for (const entry of injected.mcpEntries) {
+      if (!mcpByName.has(entry.name)) mcpByName.set(entry.name, entry);
+    }
+    for (const [varName, value] of Object.entries(injected.env)) {
+      if (!(varName in env)) env[varName] = value;
+    }
+  }
+
+  return { mcpEntries: [...mcpByName.values()], env };
+}
+
+/**
+ * The hub grant-holder KEY for a PACK (threads-only Phase B′ §4) — the slugged note
+ * PATH, mirroring the slug discipline the hub's `grantId` uses (`/`→`-`, all non-slug
+ * chars collapse). Prefixed `pack--` so it reads UNAMBIGUOUSLY as a pack source and is
+ * practically partitioned from def keys: a def `metadata.name` is an operator-authored
+ * `[a-zA-Z0-9_-]+` slug (the live cast — `uni`, `steward`, … — have no `--`), so the
+ * `pack--` prefix keeps the two namespaces apart in normal operation. (The def-name regex
+ * technically accepts `--`, so a deliberately-crafted def named `pack--<x>` could share a
+ * pack's partition — but that's an operator-trust corner, not an exploitable boundary: an
+ * operator who can author such a def can author the pack too.) The hub keys
+ * `grantId(agent, spec) = ${agent}--${connectionKey}` on this opaque holder string;
+ * each pack is therefore its OWN prune partition on the hub (`listGrantsForAgent`),
+ * so a pack's reconcile can never touch a def's grants or another pack's.
+ *
+ * Examples: `Uni/Packs/github` → `pack--Uni-Packs-github`; `Packs/Read.ai` → `pack--Packs-Read-ai`.
+ */
+export function packPathKey(notePath: string): string {
+  // Mirror sandbox/types.ts `slug`: collapse every non-`[a-zA-Z0-9_-]` char to `-`.
+  const slugged = notePath.replace(/[^a-zA-Z0-9_-]/g, "-");
+  return `pack--${slugged}`;
+}
+
+/** The bare tag (post-canonicalization) that marks a note as a PACK. */
+export const PACK_TAG = "pack";
+
+/**
+ * Is this loaded note a PACK that declares `wants:`? — the SECURITY GATE (threads-only
+ * Phase B′ §"Security refinement — wants only from PACKS"). A note's `wants:` is honored
+ * ONLY if the note carries the `#pack`/`pack` tag; a plain content note's `wants:` is
+ * IGNORED (inert) even if present, so loading arbitrary notes for context can NEVER add
+ * capabilities. PURE — no I/O. Tag matching tolerates a stray leading `#` (pre-/post-
+ * canonicalization) so a `#pack`-authored note is recognized either way.
+ *
+ * Returns the parsed `wants:` connection specs when the note is a pack WITH a non-empty,
+ * cleanly-parsing `wants:`; otherwise `null` (not a pack, no `wants:`, or a parse error —
+ * a parse error is surfaced via {@link packWantsOrError}, this fast-path just returns null).
+ */
+export function packWants(note: {
+  tags?: unknown;
+  metadata?: Record<string, unknown>;
+}): ConnectionSpec[] | null {
+  if (!isPackNote(note)) return null;
+  const raw = note.metadata?.wants;
+  if (raw === undefined || raw === null) return null;
+  let specs: ConnectionSpec[];
+  try {
+    specs = parseWants(raw);
+  } catch {
+    return null; // parse error — the reconcile path stamps status:error; injection ignores it.
+  }
+  return specs.length > 0 ? specs : null;
+}
+
+/**
+ * Does this note carry the `#pack` tag? Tolerates the `tags` field being an array of
+ * strings (the vault REST shape) or a comma/space-joined string, and a stray leading
+ * `#` on the tag value. PURE.
+ */
+export function isPackNote(note: { tags?: unknown }): boolean {
+  const tags = note.tags;
+  let list: string[];
+  if (Array.isArray(tags)) {
+    list = tags.map((t) => (typeof t === "string" ? t : String(t)));
+  } else if (typeof tags === "string") {
+    list = tags.split(/[,\s]+/);
+  } else {
+    return false;
+  }
+  return list.some((t) => t.trim().replace(/^#/, "") === PACK_TAG);
+}
+
 /** MCP entry key for a GRANTED vault — namespaced so it never collides with the
  *  agent's OWN def-vault entry (`parachute-vault-<name>`). */
 export function grantVaultEntryKey(vault: string): string {

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -277,6 +277,24 @@ export interface Transport {
     subject?: string,
   ): Promise<{ path: string; content: string }[]>;
   /**
+   * Optional: read the thread's loaded-PACK grant KEYS (threads-only Phase B′ —
+   * DESIGN-2026-06-29-threads-only.md §4). Resolves the same `metadata.loadout` paths as
+   * {@link readThreadLoadout}, but reads each note's METADATA (not its content) to find the
+   * loaded notes that are PACKS — i.e. carry the `#pack` tag AND declare a non-empty `wants:`.
+   * Returns each such pack's hub grant-holder key (the slugged PATH, `packPathKey`). This is
+   * the SECURITY GATE: a plain content note's `wants:` is IGNORED (only `#pack` notes
+   * contribute), and the metadata read is DELIBERATELY SEPARATE from the content-only prompt
+   * read (loading a note for context never adds capabilities). The backend unions these with
+   * the def's own `spec.name` grants. `subject` resolves the subject-scoped thread note.
+   * Absent `metadata.loadout` / no pack with `wants:` → an empty array (every current thread).
+   * Only a durable transport (the VaultTransport) implements it; others omit it.
+   */
+  readThreadPackKeys?(
+    channel: string,
+    name: string,
+    subject?: string,
+  ): Promise<string[]>;
+  /**
    * Optional: write an agent-to-agent CALLBACK as an INBOUND note on THIS channel (the
    * "reply_to" substrate). A recipient agent's drain, on turn completion, calls this on the
    * SENDER's channel transport to wake the sender with a completion notification. The note

--- a/src/transports/vault.test.ts
+++ b/src/transports/vault.test.ts
@@ -26,6 +26,7 @@
 
 import { describe, test, expect, afterEach } from "bun:test";
 import { VaultTransport, AGENT_VAULT_TAG_SCHEMA, AGENT_THREAD_TAG, AGENT_JOB_TAG, InboundClaimConflictError, noteAgentKey, parseLoadoutPaths } from "./vault.ts";
+import { packPathKey } from "../grants.ts";
 import type { TransportContext, InboundMessage } from "../transport.ts";
 import { instantiateTransport } from "../registry.ts";
 
@@ -2416,5 +2417,114 @@ describe("VaultTransport — readThreadLoadout (the Phase A loader)", () => {
     const loadout = await t.readThreadLoadout("eng", "eng", "launch blockers");
     expect(loadout).toEqual([{ path: "Note/A", content: "A body" }]);
     expect(reads[0]).toBe("Threads/eng/eng--launch-blockers");
+  });
+});
+
+// ── threads-only Phase B′: readThreadPackKeys (the pack-detect SECURITY GATE) ──
+describe("VaultTransport — readThreadPackKeys (the Phase B′ pack-grant-key reader)", () => {
+  test("THE GATE: a loaded note with wants but NO #pack tag → IGNORED (no key)", async () => {
+    const noteByPath: Record<string, { metadata?: Record<string, unknown>; content?: string; tags?: unknown }> = {
+      "Threads/eng/eng": { metadata: { loadout: ["Refs/leaky"] }, content: "x" },
+      // A plain content note that DECLARES wants but is NOT a pack → its wants are inert.
+      "Refs/leaky": { tags: ["reference"], metadata: { wants: "vault:secrets:read, env:github" }, content: "body" },
+    };
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      const u = String(url);
+      const m = /\/api\/notes\/([^?]+)/.exec(u);
+      const path = m ? decodeURIComponent(m[1]!) : "";
+      const note = noteByPath[path];
+      if (!note) return new Response("not found", { status: 404 });
+      return new Response(JSON.stringify(note), { status: 200 });
+    }) as unknown as typeof fetch;
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+    // A non-pack note's wants contribute ZERO grant keys — loading context never adds caps.
+    expect(await t.readThreadPackKeys("eng", "eng")).toEqual([]);
+  });
+
+  test("a loaded #pack with wants → its slugged-path key; a non-pack sibling stays ignored", async () => {
+    const noteByPath: Record<string, { metadata?: Record<string, unknown>; content?: string; tags?: unknown }> = {
+      "Threads/eng/eng": { metadata: { loadout: ["Packs/github", "Projects/Surface"] }, content: "x" },
+      "Packs/github": { tags: ["pack"], metadata: { wants: "env:github" }, content: "pack body" },
+      // A plain project note (no #pack) — even if it had wants it would be ignored; here it has none.
+      "Projects/Surface": { tags: ["project"], metadata: { status: "active" }, content: "proj body" },
+    };
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      const u = String(url);
+      const m = /\/api\/notes\/([^?]+)/.exec(u);
+      const path = m ? decodeURIComponent(m[1]!) : "";
+      const note = noteByPath[path];
+      if (!note) return new Response("not found", { status: 404 });
+      return new Response(JSON.stringify(note), { status: 200 });
+    }) as unknown as typeof fetch;
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+    expect(await t.readThreadPackKeys("eng", "eng")).toEqual([packPathKey("Packs/github")]);
+  });
+
+  test("TWO packs with wants → both path keys (deduped, in loadout order)", async () => {
+    const noteByPath: Record<string, { metadata?: Record<string, unknown>; content?: string; tags?: unknown }> = {
+      "Threads/eng/eng": { metadata: { loadout: ["Packs/github", "Packs/research", "Packs/github"] }, content: "x" },
+      "Packs/github": { tags: ["pack"], metadata: { wants: "env:github" }, content: "a" },
+      "Packs/research": { tags: ["pack"], metadata: { wants: "vault:research:read" }, content: "b" },
+    };
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      const u = String(url);
+      const m = /\/api\/notes\/([^?]+)/.exec(u);
+      const path = m ? decodeURIComponent(m[1]!) : "";
+      const note = noteByPath[path];
+      if (!note) return new Response("not found", { status: 404 });
+      return new Response(JSON.stringify(note), { status: 200 });
+    }) as unknown as typeof fetch;
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+    // Deduped (github listed twice → one key), declared order preserved.
+    expect(await t.readThreadPackKeys("eng", "eng")).toEqual([
+      packPathKey("Packs/github"),
+      packPathKey("Packs/research"),
+    ]);
+  });
+
+  test("a #pack with NO wants → no key (only capability-declaring packs count)", async () => {
+    const noteByPath: Record<string, { metadata?: Record<string, unknown>; content?: string; tags?: unknown }> = {
+      "Threads/eng/eng": { metadata: { loadout: ["Packs/empty"] }, content: "x" },
+      "Packs/empty": { tags: ["pack"], metadata: {}, content: "a context-only pack" },
+    };
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      const u = String(url);
+      const m = /\/api\/notes\/([^?]+)/.exec(u);
+      const path = m ? decodeURIComponent(m[1]!) : "";
+      const note = noteByPath[path];
+      if (!note) return new Response("not found", { status: 404 });
+      return new Response(JSON.stringify(note), { status: 200 });
+    }) as unknown as typeof fetch;
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+    expect(await t.readThreadPackKeys("eng", "eng")).toEqual([]);
+  });
+
+  test("LEGACY CONTINUITY: no thread note / no loadout → empty (every current thread)", async () => {
+    globalThis.fetch = (async () => new Response("not found", { status: 404 })) as unknown as typeof fetch;
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+    expect(await t.readThreadPackKeys("eng", "eng")).toEqual([]);
+  });
+
+  test("a missing loadout path (404) is skipped (never throws)", async () => {
+    const noteByPath: Record<string, { metadata?: Record<string, unknown>; content?: string; tags?: unknown }> = {
+      "Threads/eng/eng": { metadata: { loadout: ["Gone/Stale", "Packs/github"] }, content: "x" },
+      "Packs/github": { tags: ["pack"], metadata: { wants: "env:github" }, content: "a" },
+    };
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      const u = String(url);
+      const m = /\/api\/notes\/([^?]+)/.exec(u);
+      const path = m ? decodeURIComponent(m[1]!) : "";
+      const note = noteByPath[path];
+      if (!note) return new Response("not found", { status: 404 });
+      return new Response(JSON.stringify(note), { status: 200 });
+    }) as unknown as typeof fetch;
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+    expect(await t.readThreadPackKeys("eng", "eng")).toEqual([packPathKey("Packs/github")]);
   });
 });

--- a/src/transports/vault.ts
+++ b/src/transports/vault.ts
@@ -70,6 +70,12 @@ import type {
 // subject-scoped deterministic thread-note leaf (`<name>--<slug(subject)>`) so the path
 // math matches the registry's drain key exactly (no drift).
 import { threadKey } from "../sandbox/types.ts";
+// threads-only Phase B′ (§4): the pure pack-detection helpers — `packWants` is the
+// SECURITY GATE (a note's `wants:` is honored only if it is a `#pack`), `packPathKey`
+// derives the hub grant-holder key from the pack's slugged path. The metadata read here
+// is DELIBERATELY SEPARATE from the content-only loadout read (loading a note for context
+// never adds capabilities).
+import { packWants, packPathKey, isPackNote } from "../grants.ts";
 
 /** The safe basename of a (possibly path-ful, possibly untrusted) string — the LAST
  *  path segment, with traversal markers stripped. Used to derive a display `filename`
@@ -1115,7 +1121,7 @@ export class VaultTransport implements Transport {
    */
   private async readThreadNote(
     path: string,
-  ): Promise<{ metadata?: Record<string, unknown>; content?: string } | undefined> {
+  ): Promise<{ metadata?: Record<string, unknown>; content?: string; tags?: unknown } | undefined> {
     const url = `${this.vaultUrl}/vault/${this.vault}/api/notes/${encodeURIComponent(path)}`;
     let res: Response;
     try {
@@ -1138,14 +1144,15 @@ export class VaultTransport implements Transport {
     try {
       const parsed = (await res.json()) as unknown;
       // Tolerate a bare note object OR a `{ note: {...} }` envelope OR a 1-element array.
+      // `tags` is carried through (Phase B′ — readThreadPackKeys needs it for pack-detection).
       if (Array.isArray(parsed)) {
-        return parsed[0] as { metadata?: Record<string, unknown>; content?: string } | undefined;
+        return parsed[0] as { metadata?: Record<string, unknown>; content?: string; tags?: unknown } | undefined;
       }
-      const obj = parsed as { note?: unknown; metadata?: unknown; content?: unknown };
+      const obj = parsed as { note?: unknown; metadata?: unknown; content?: unknown; tags?: unknown };
       if (obj.note && typeof obj.note === "object") {
-        return obj.note as { metadata?: Record<string, unknown>; content?: string };
+        return obj.note as { metadata?: Record<string, unknown>; content?: string; tags?: unknown };
       }
-      return obj as { metadata?: Record<string, unknown>; content?: string };
+      return obj as { metadata?: Record<string, unknown>; content?: string; tags?: unknown };
     } catch {
       // Bad JSON — treat as no prior (don't strand the write on a parse hiccup).
       return undefined;
@@ -1228,6 +1235,75 @@ export class VaultTransport implements Transport {
       out.push({ path, content: typeof note.content === "string" ? note.content : "" });
     }
     return out;
+  }
+
+  /**
+   * Read the thread's loaded-PACK grant KEYS (threads-only Phase B′ —
+   * DESIGN-2026-06-29-threads-only.md §4). Resolves the SAME `metadata.loadout` note paths as
+   * {@link readThreadLoadout}, but reads each note's METADATA (+ tags) — NOT its content — to
+   * find the loaded notes that are PACKS: a note carrying the `#pack` tag AND a non-empty,
+   * cleanly-parsing `wants:`. Each such pack contributes its hub grant-holder key (the slugged
+   * PATH via {@link packPathKey}); the backend unions `listGrants(packKey)` for each with the
+   * def's own `listGrants(spec.name)`.
+   *
+   * THE SECURITY GATE: a loaded note's `wants:` is honored ONLY if the note is a `#pack`
+   * (`packWants` returns null for a non-pack note even when it declares `wants:`). So loading
+   * an arbitrary content note for context can NEVER add capabilities. This metadata read is
+   * DELIBERATELY a SEPARATE pass from the content-only {@link readThreadLoadout} (the prompt
+   * composition is unchanged — Phase A content-only), at the cost of re-reading the loadout
+   * notes' metadata.
+   *
+   * Skip-and-warn per path (mirrors the loadout discipline): a 404/renamed path or a read
+   * error on one note is skipped — never thrown — so one stale path can't brick a turn. No
+   * thread note / absent `metadata.loadout` / no pack with `wants:` → an empty array (every
+   * current thread). Keys are deduped (a pack listed twice yields one key). `subject` resolves
+   * the subject-scoped thread note (path math reuses {@link singleThreadedPath}).
+   */
+  async readThreadPackKeys(channel: string, name: string, subject?: string): Promise<string[]> {
+    const thread = await this.readThreadNote(this.singleThreadedPath(channel, name, subject));
+    if (!thread) return []; // no thread note yet (first turn) → no packs.
+    const paths = parseLoadoutPaths(thread.metadata?.loadout);
+    if (paths.length === 0) return [];
+    const keys: string[] = [];
+    const seen = new Set<string>();
+    for (const path of paths) {
+      let note: { metadata?: Record<string, unknown>; content?: string; tags?: unknown } | undefined;
+      try {
+        note = await this.readThreadNote(path);
+      } catch (err) {
+        console.warn(
+          `parachute-agent: pack-detect read for loadout note "${path}" failed (skipping): ${(err as Error).message}`,
+        );
+        continue;
+      }
+      if (!note) continue; // 404 — a stale/renamed loadout path. Skip (the loadout reader warns).
+      // THE SECURITY GATE: honor `wants:` ONLY when the note is a `#pack`. A non-pack note's
+      // `wants:` returns null here → never contributes a grant source.
+      const wants = packWants(note);
+      if (!wants) {
+        // Observability: a `#pack` note whose `wants:` is present but unparseable contributes
+        // nothing here (it injects nothing this turn). The reconcile path (POST /api/vault/pack)
+        // stamps `status:error` on save — that's the primary surface — but warn here too so an
+        // operator can diagnose "my pack stopped working" from the daemon log. A non-pack note
+        // (the gate) or a pack with no `wants:` is silent (expected, not an error).
+        if (
+          note.metadata?.wants !== undefined &&
+          note.metadata?.wants !== null &&
+          isPackNote(note) // only warn for PACKS with bad wants, never plain (gated-out) notes.
+        ) {
+          console.warn(
+            `parachute-agent: loaded pack "${path}" has an unusable wants: — contributing no grants ` +
+              `this turn (the pack-save reconcile stamps status:error; check the note's wants:).`,
+          );
+        }
+        continue;
+      }
+      const key = packPathKey(path);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      keys.push(key);
+    }
+    return keys;
   }
 
   // react / edit / download: vault has no reactions; v1 is reply-only. Omitted.


### PR DESCRIPTION
## Phase B′ — the pack-only grant model

The grant model for the threads-only pivot (`DESIGN-2026-06-29-threads-only.md` §4 / §9 Phase B′). This feeds the LIVE agents' MCP/credential access (incl. the steward weave). **Additive; def-agent injection UNCHANGED; no hub change.** Lands on `@rc` (0.2.3-rc.15 → **rc.16**).

### The security gate — `wants:` only from PACKS
A loaded note's `wants:` is honored **only** if the note carries the `#pack` tag. A plain content note's `wants:` is **IGNORED (inert)** even when present — loading arbitrary notes for context can **never** add capabilities. The gate is two independent pure functions: `packWants()` (transport metadata read) and `isPackNote()` (registry reconcile). The pack-detection metadata read (`readThreadPackKeys`) is a **separate pass** from the content-only prompt read (`readThreadLoadout`) — prompt composition (Phase A) is untouched.

**Enforcement test:** `vault.test.ts` "THE GATE: a loaded note with wants but NO #pack tag → IGNORED (no key)"; `agent-defs.test.ts` "SECURITY GATE: a loaded note WITHOUT the #pack tag → prune-to-[] (its wants are inert)" — nothing registered.

### Grant injection = union of sources
For a turn, injected grants = `listGrants(spec.name)` (**the LEGACY def path, UNCHANGED**) ∪ `listGrants(packKey)` for **each** loaded note that is a `#pack` declaring `wants:`. Pack key = the pack's **slugged PATH** (`pack--<slug(path)>`, mirroring the hub's `grantId` slug discipline). `resolveInjectedGrantsUnion` fans out per source + unions material (MCP entries deduped by name, env by var; first source — the def — wins a collision; a per-source list failure is isolated, never sinks the turn). Two packs → all three sources union.

### Legacy continuity (load-bearing invariant)
A `#agent/definition` keeps its grants keyed by `metadata.name`. Since **no thread currently loads a `#pack` with `wants:`**, the pack-union is **empty** for all 4 live def agents (uni, steward, uni-evolve, eco-civilization) → the grant source set is exactly `[spec.name]` and injection is **byte-identical** to the prior single-source path. steward's pending read.ai grant (keyed `steward`) is untouched.

**Proof test:** `programmatic.test.ts` "LEGACY CONTINUITY: a def with NO packKeys injects EXACTLY listGrants(spec.name)" — a list-key spy asserts **only `["eng"]`** is queried with no `packKeys`, and the injected `.mcp.json` + env match HEAD. A second test asserts an explicit empty `packKeys: []` is identical to the no-`packKeys` path.

### Per-pack reconcile
A vault trigger on `#pack` create/edit (`POST /api/vault/pack` → `AgentDefRegistry.reconcilePack`) — analogous to `def-vault-triggers.ts`, **not** fired on every load. Clean parse → register + reconcile under the pack-path key; **parse error → stamp `status:error`, NEVER reconcile** (no nuke of approved grants); deleted / dropped-wants / not-a-pack → prune **only that pack's** partition to `[]`. **Each pack is its own prune partition** (structural: the pack key is the sole arg to `reconcileGrants`) — never cross-prunes a def or another pack. Tests cover all outcomes (reconciled / pruned / error / skipped) + partition isolation.

### No hub change
The hub is grant-key-agnostic (`grantId = ${agent}--${connectionKey}`, opaque `agent`, prune partitioned per agent string in `listGrantsForAgent`). Only **what string** the agent module sends as the grant holder changes. Verified against `parachute-hub/src/grants-store.ts`.

### Lexicon
The dormant `grantsAgentName` hook is renamed `grantsKey` (locked lexicon) and kept as the per-thread **override escape hatch** — not the primary path (the primary is the union).

## Gates
- `bun run typecheck` — **clean**
- `bun test ./src/` — **1345 pass / 0 fail** (web/ui vitest excluded). Baseline rc.15 was 1312; +33 new Phase B′ tests, and the 4 `def-vault-triggers` count tests were updated for the 2 new pack-watch triggers (3→5 per def-vault).

## Files
`grants.ts` (+`packPathKey`/`isPackNote`/`packWants`/`resolveInjectedGrantsUnion`), `backends/programmatic.ts` (union injection + `grantsKey` rename + `packKeys` param), `backends/types.ts` + `backends/registry.ts` (`packKeys` seam), `transport.ts` + `transports/vault.ts` (`readThreadPackKeys`), `daemon.ts` (`buildReadPackKeys` + `POST /api/vault/pack`), `agent-defs.ts` (`reconcilePack` + carry `tags` through `getNote`), `def-vault-triggers.ts` (pack-watch create/edit triggers) + tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)