### PR TITLE
fix(agent): module-level CORS on the daemon HTTP path — unblocks cross-origin surface SSE (rc.17)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/agent",
-  "version": "0.2.3-rc.16",
+  "version": "0.2.3-rc.17",
   "description": "Vault-native agents for Claude Code — a #agent/definition note + an inbound message becomes a sandboxed claude turn; the reply is written back as a note. Messaging gateway on :1941.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/src/daemon-cors.test.ts
+++ b/src/daemon-cors.test.ts
@@ -1,0 +1,81 @@
+/**
+ * CORS — the agent daemon SELF-SETS module-level CORS headers on every response
+ * (mirroring the vault), so the browser surface's cross-origin reads aren't
+ * blocked behind the hub reverse proxy. The motivating bug: the "watch it work"
+ * turn-events SSE (`GET /api/channels/<ch>/turn-events`) opened cross-origin from
+ * the surface was CORS-blocked because the daemon set NO `Access-Control-*`
+ * headers on any response.
+ *
+ * Three things to lock here:
+ *  (a) a STREAMING (SSE) turn-events 200 carries `Access-Control-Allow-Origin`
+ *      AND its `text/event-stream` body survives the header-merge reconstruction
+ *      (a streaming Response's headers can't be mutated in place, so `withCors`
+ *      reconstructs — this is the load-bearing, easy-to-break part);
+ *  (b) a JSON API response carries the CORS headers;
+ *  (c) an `OPTIONS` preflight short-circuits to 204 + the CORS headers.
+ *
+ * Pure handler-level: we call the fetch handler returned by `createFetchHandler`
+ * DIRECTLY with a `Request` (no live port bound, no `Bun.serve`, no daemon
+ * booted). The SSE ticket is minted via `ui-ticket.ts` directly (the route gates
+ * on `requireSseTicket`), so no hub/JWKS is needed.
+ */
+import { describe, test, expect, beforeEach } from "bun:test";
+
+import { createFetchHandler } from "./daemon.ts";
+import { ClientRegistry } from "./routing.ts";
+import { mintTicket, _resetTicketsForTest } from "./ui-ticket.ts";
+import type { Channel } from "./registry.ts";
+
+beforeEach(() => {
+  _resetTicketsForTest();
+});
+
+/** A plain handler over empty channel/turn-event registries (no live deps). */
+function handler() {
+  const channels = new Map<string, Channel>();
+  const registry = new ClientRegistry();
+  const turnEvents = new ClientRegistry();
+  return createFetchHandler(channels, registry, { turnEvents });
+}
+
+describe("CORS — module self-sets Access-Control-* on every response", () => {
+  test("(a) turn-events SSE 200 carries CORS + preserves the text/event-stream body", async () => {
+    const fetch = handler();
+    const { ticket } = mintTicket(["agent:read"]);
+    const res = await fetch(
+      new Request(`http://x/api/channels/eng/turn-events?ticket=${ticket}`),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    // The streaming body must survive the header-merge reconstruction.
+    expect(res.headers.get("content-type")).toBe("text/event-stream");
+    const reader = res.body!.getReader();
+    const { value } = await reader.read();
+    // The route enqueues string chunks; read in-process they come back as
+    // strings (over the wire Bun serializes them to bytes) — handle both.
+    const chunk = typeof value === "string" ? value : new TextDecoder().decode(value!);
+    expect(chunk).toContain(": connected");
+    await reader.cancel();
+  });
+
+  test("(b) a JSON API response carries the CORS headers", async () => {
+    const fetch = handler();
+    const res = await fetch(new Request("http://x/health"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(res.headers.get("content-type")).toContain("application/json");
+    // The body still parses — reconstruction preserved it.
+    expect(((await res.json()) as { status: string }).status).toBe("ok");
+  });
+
+  test("(c) an OPTIONS preflight short-circuits to 204 + the CORS headers", async () => {
+    const fetch = handler();
+    const res = await fetch(
+      new Request("http://x/api/channels/eng/turn-events", { method: "OPTIONS" }),
+    );
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(res.headers.get("Access-Control-Allow-Methods")).toContain("POST");
+    expect(res.headers.get("Access-Control-Allow-Headers")).toContain("Authorization");
+  });
+});

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1214,6 +1214,51 @@ function redirect(location: string): Response {
 }
 
 // ---------------------------------------------------------------------------
+// CORS — the agent daemon SELF-SETS permissive CORS on every response, the same
+// posture as the vault (parachute-vault `module-config.ts` / `mirror-routes.ts`)
+// and the established ecosystem pattern (each module self-sets CORS; the hub
+// reverse proxy passes module CORS headers through). Without this the browser
+// surface's cross-origin reads — notably the "watch it work" turn-events SSE at
+// `/api/channels/<ch>/turn-events` — are CORS-blocked even though the request
+// itself is authorized.
+//
+// `*` is correct here because the browser-facing reads authenticate via a
+// `?token=`/`?ticket=` query param or a Bearer `Authorization` header, NOT
+// cookies — so there's no credentialed CORS, and `*` is valid (matches vault).
+// Allow-Methods/Headers let the surface's Bearer-authenticated POSTs (which the
+// browser preflights) succeed.
+// ---------------------------------------------------------------------------
+const CORS_HEADERS: Record<string, string> = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Authorization, Content-Type",
+};
+
+/**
+ * Merge the module CORS headers onto an existing Response.
+ *
+ * A streaming (SSE) Response's headers can't be mutated after construction, so
+ * we RECONSTRUCT — `new Response(resp.body, …)` preserves the `text/event-stream`
+ * body while letting us set the headers. We reconstruct uniformly (a null body
+ * for redirects/empty responses passes through cleanly), so the SSE path needs no
+ * special-casing. The daemon never sets `Access-Control-*` itself, so layering
+ * CORS on top of the response's own headers is conflict-free.
+ *
+ * Only ever called with a real `Response` — the websocket-upgrade path returns
+ * `undefined` (the socket is owned by the WS handlers) and is guarded out by the
+ * caller, never decorated.
+ */
+function withCors(resp: Response): Response {
+  const headers = new Headers(resp.headers);
+  for (const [name, value] of Object.entries(CORS_HEADERS)) headers.set(name, value);
+  return new Response(resp.body, {
+    status: resp.status,
+    statusText: resp.statusText,
+    headers,
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Auth gates
 //
 // Both layers share `requireScope` from `auth.ts` (validate a hub-issued JWT
@@ -1518,7 +1563,16 @@ export function createFetchHandler(
     return true;
   }
 
-  return async function fetch(req, server) {
+  // The core router. The returned `fetch` below wraps it to short-circuit the
+  // CORS preflight + merge the module CORS headers onto every Response. Typed
+  // explicitly (it's no longer in the return position, so it loses the contextual
+  // typing the wrapper inherits from createFetchHandler's declared return type).
+  // May return `undefined` on a successful websocket upgrade — the socket then
+  // belongs to the WS handlers and there is no Response to decorate.
+  const route = async function route(
+    req: Request,
+    server?: { upgrade: (req: Request, opts: { data: TerminalWsData }) => boolean },
+  ): Promise<Response | undefined> {
     const url = new URL(req.url);
 
     // -------------------------------------------------------------------
@@ -3481,6 +3535,23 @@ export function createFetchHandler(
     }
 
     return json({ error: "not found" }, 404);
+  };
+
+  // The handler returned to Bun.serve: short-circuit the CORS preflight, then
+  // merge the module CORS headers onto whatever Response `route` produced (the
+  // module self-sets CORS — see `CORS_HEADERS` / `withCors`).
+  return async function fetch(req, server) {
+    // CORS preflight — short-circuit OPTIONS with 204 + the CORS headers. A
+    // preflight is never a websocket upgrade, so handling it at the very top
+    // (before `route`) is safe and leaves the WS-upgrade path untouched.
+    if (req.method === "OPTIONS") {
+      return new Response(null, { status: 204, headers: CORS_HEADERS });
+    }
+    const resp = await route(req, server);
+    // The websocket-upgrade path returns `undefined` (the socket is owned by the
+    // WS handlers) — pass it through UNTOUCHED; only decorate real Responses.
+    if (!(resp instanceof Response)) return resp as unknown as Response;
+    return withCors(resp);
   };
 }
 


### PR DESCRIPTION
## The bug

The browser surface (`https://my.unforced.org`) opening the agent's "watch it work" SSE —
`GET https://<expose>/agent/api/channels/<ch>/turn-events?token=<JWT>` — was **CORS-blocked**:
`No 'Access-Control-Allow-Origin' header is present on the requested resource.`

Root cause: the agent daemon set **no** `Access-Control-*` headers on any response. It was the
lone module that doesn't self-set CORS. The vault self-sets `Access-Control-Allow-Origin: *`
(`parachute-vault/src/module-config.ts`, `mirror-routes.ts`) and the hub reverse proxy passes
module CORS headers through — which is why the vault's cross-origin SSE chat works through the
same proxy today. So the fix belongs in the agent daemon, mirroring the vault's posture.

## The fix (central seam)

In `createFetchHandler`'s returned `fetch` (`src/daemon.ts`):

- **OPTIONS preflight** → short-circuit to `204` + the CORS headers (top of the wrapper; a
  preflight is never a WS upgrade, so this leaves the upgrade path untouched).
- **Every Response** gets the CORS headers merged via a `withCors` helper:
  - `Access-Control-Allow-Origin: *` — valid here because browser-facing reads authenticate via a
    `?token=`/`?ticket=` query param or a Bearer `Authorization` header, **not cookies** (no
    credentialed CORS), matching the vault.
  - `Access-Control-Allow-Methods: GET, POST, OPTIONS`
  - `Access-Control-Allow-Headers: Authorization, Content-Type` (so the surface's Bearer-authenticated,
    browser-preflighted POSTs succeed).
- **SSE-safe**: a streaming Response's headers can't be mutated after construction, so `withCors`
  **reconstructs** (`new Response(resp.body, …)`), preserving the `text/event-stream` body.
- **WS-upgrade path untouched**: the upgrade returns `undefined`; the wrapper guards
  `resp instanceof Response` and passes the upgrade-return through unchanged — only real Responses
  are decorated.

The inner router was renamed `route` (explicitly typed, since it's no longer in the return position)
and the new `fetch` wraps it.

## Verification

- `bun run typecheck` — clean.
- New `src/daemon-cors.test.ts` (3 tests, all pass) asserts CORS on **(a)** a turn-events SSE `200`
  (and that the `text/event-stream` body survives the header-merge reconstruction), **(b)** a JSON
  response, **(c)** a `204` OPTIONS preflight.
- Full suite: `bun test ./src/` → **1348 pass, 0 fail** (the ECONNREFUSED/"boom"/"mint refused"
  console lines are test-injected error-path exercises, not failures). No test boots/launchctl-loads
  a real daemon or binds the live port (all use `Bun.serve({ port: 0 })`); nothing skipped.
- rc bumped `0.2.3-rc.16` → `0.2.3-rc.17`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T6HAzWsgiJy4ndsWSCWY5S