### PR TITLE
feat(agent): thread content as context, no faked summary (rc.18)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/agent",
-  "version": "0.2.3-rc.17",
+  "version": "0.2.3-rc.18",
   "description": "Vault-native agents for Claude Code — a #agent/definition note + an inbound message becomes a sandboxed claude turn; the reply is written back as a note. Messaging gateway on :1941.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/src/backends/compose.test.ts
+++ b/src/backends/compose.test.ts
@@ -118,3 +118,75 @@ describe("composeSystemPrompt — byte budget", () => {
     expect(LOADOUT_BUDGET_BYTES).toBe(600_000);
   });
 });
+
+describe("composeSystemPrompt — protectedCount (the def + thread-content protected prefix)", () => {
+  test("protectedCount=2 protects BOTH leading entries (def + thread content), tail-drops only the loadout (index ≥2)", () => {
+    // The shape the backend builds: [self(def), thread-content, ...loadout].
+    const self = { path: "Agents/uni", content: "DEF-" + "d".repeat(200) };
+    const threadContent = { path: "Threads/eng/uni", content: "THREAD-" + "t".repeat(200) };
+    const big = (p: string) => ({ path: p, content: p + "-" + "x".repeat(400) });
+    const warnings: string[] = [];
+    // Budget fits the two protected entries but not the loadout notes.
+    const budget = 600;
+    const out = composeSystemPrompt([self, threadContent, big("n1"), big("n2")], {
+      budgetBytes: budget,
+      protectedCount: 2,
+      onWarn: (m) => warnings.push(m),
+    });
+    // BOTH protected entries survive in full, in order (def first, thread content second).
+    expect(out).toBe(`# ${self.path}\n\n${self.content}\n\n---\n\n# ${threadContent.path}\n\n${threadContent.content}`);
+    // The loadout tail was shed (over budget), with a loud warn naming the dropped notes.
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("over budget");
+    expect(warnings[0]).toContain("n1");
+    expect(warnings[0]).toContain("n2");
+    // The warn names neither the def nor the thread content.
+    expect(warnings[0]).not.toContain("Agents/uni");
+    expect(warnings[0]).not.toContain("Threads/eng/uni");
+  });
+
+  test("protectedCount=2 keeps BOTH protected entries even when their COMBINED size alone exceeds the budget", () => {
+    const self = { path: "self", content: "S".repeat(1000) };
+    const threadContent = { path: "thread", content: "T".repeat(1000) };
+    const warnings: string[] = [];
+    const out = composeSystemPrompt([self, threadContent, { path: "n1", content: "x".repeat(50) }], {
+      budgetBytes: 100, // smaller than even the protected prefix
+      protectedCount: 2,
+      onWarn: (m) => warnings.push(m),
+    });
+    // Both protected entries are preserved whole — the no-truncate-prefix guarantee outweighs the cap.
+    expect(out).toBe(`# ${self.path}\n\n${self.content}\n\n---\n\n# ${threadContent.path}\n\n${threadContent.content}`);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("n1");
+  });
+
+  test("the thread-content entry renders BETWEEN the def and the loadout (ordered prefix)", () => {
+    const out = composeSystemPrompt(
+      [
+        { path: "Agents/uni", content: "def body" },
+        { path: "Threads/eng/uni", content: "thread mandate" },
+        { path: "Skills/Weave", content: "skill body" },
+      ],
+      { protectedCount: 2 },
+    );
+    expect(out).toBe(
+      "# Agents/uni\n\ndef body" +
+        "\n\n---\n\n# Threads/eng/uni\n\nthread mandate" +
+        "\n\n---\n\n# Skills/Weave\n\nskill body",
+    );
+  });
+
+  test("protectedCount defaults to 1 — only the self entry is protected (the no-thread-content path)", () => {
+    const self = { path: "self", content: "S".repeat(500) };
+    const big = (p: string) => ({ path: p, content: p + "-" + "x".repeat(400) });
+    const warnings: string[] = [];
+    // No protectedCount → default 1. Over budget → only self survives; the loadout sheds.
+    const out = composeSystemPrompt([self, big("n1"), big("n2")], {
+      budgetBytes: 600,
+      onWarn: (m) => warnings.push(m),
+    });
+    expect(out).toBe(`# ${self.path}\n\n${self.content}`);
+    expect(warnings[0]).toContain("n1");
+    expect(warnings[0]).toContain("n2");
+  });
+});

--- a/src/backends/programmatic.test.ts
+++ b/src/backends/programmatic.test.ts
@@ -676,6 +676,75 @@ describe("ProgrammaticBackend.deliver — composed system prompt (threads-only P
     );
   });
 
+  test("THREAD CONTENT composes BETWEEN the def and the loadout: [self, thread-content, ...loadout]", async () => {
+    mkDirs("compose-thread-content");
+    const { fn } = recordingSpawn({ stdout: successTurn("sess-TC1", "ok") });
+    const backend = new ProgrammaticBackend(baseDeps(fn));
+    const handle = await backend.start(specWithDef(ROLE, "Agents/uni", "eng"));
+
+    // deliver with a loadout (7th param) AND a threadContent (10th param).
+    await backend.deliver(
+      handle,
+      "go",
+      createSession("sess-TC1"),
+      undefined,
+      undefined,
+      undefined,
+      [{ path: "Skills/Weave", content: "Skill body." }],
+      undefined,
+      undefined,
+      { path: "Threads/eng/uni", content: "This thread's standing mandate." },
+    );
+
+    const promptPath = join(sessionWorkspace(sessionsDir, "eng"), "system-prompt.txt");
+    expect(readFileSync(promptPath, "utf8")).toBe(
+      `# Agents/uni\n\n${ROLE}` +
+        `\n\n---\n\n# Threads/eng/uni\n\nThis thread's standing mandate.` +
+        `\n\n---\n\n# Skills/Weave\n\nSkill body.`,
+    );
+  });
+
+  test("NO thread content (undefined) → [self, ...loadout], unchanged (the no-thread-content invariant)", async () => {
+    mkDirs("compose-no-thread-content");
+    const { fn } = recordingSpawn({ stdout: successTurn("sess-TC2", "ok") });
+    const backend = new ProgrammaticBackend(baseDeps(fn));
+    const handle = await backend.start(specWithDef(ROLE, "Agents/uni", "eng"));
+
+    // A loadout but NO threadContent (10th param omitted) → def + loadout only.
+    await backend.deliver(handle, "go", createSession("sess-TC2"), undefined, undefined, undefined, [
+      { path: "Skills/Weave", content: "Skill body." },
+    ]);
+
+    const promptPath = join(sessionWorkspace(sessionsDir, "eng"), "system-prompt.txt");
+    expect(readFileSync(promptPath, "utf8")).toBe(
+      `# Agents/uni\n\n${ROLE}\n\n---\n\n# Skills/Weave\n\nSkill body.`,
+    );
+  });
+
+  test("BLANK thread content → skipped (treated as no thread content); the prompt is the def alone", async () => {
+    mkDirs("compose-blank-thread-content");
+    const { fn } = recordingSpawn({ stdout: successTurn("sess-TC3", "ok") });
+    const backend = new ProgrammaticBackend(baseDeps(fn));
+    const handle = await backend.start(specWithDef(ROLE, "Agents/uni", "eng"));
+
+    // A whitespace-only thread content + no loadout → byte-identical to the no-loadout invariant.
+    await backend.deliver(
+      handle,
+      "go",
+      createSession("sess-TC3"),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { path: "Threads/eng/uni", content: "   \n\t  " },
+    );
+
+    const promptPath = join(sessionWorkspace(sessionsDir, "eng"), "system-prompt.txt");
+    expect(readFileSync(promptPath, "utf8")).toBe(`# Agents/uni\n\n${ROLE}`);
+  });
+
   test("no spec.systemPrompt + a loadout → NO system-prompt file (the role-less case is unchanged)", async () => {
     mkDirs("compose-noprompt");
     const { fn } = recordingSpawn({ stdout: successTurn("sess-CP4", "ok") });

--- a/src/backends/programmatic.ts
+++ b/src/backends/programmatic.ts
@@ -451,6 +451,7 @@ export class ProgrammaticBackend implements AgentBackend {
     loadout?: LoadoutEntry[],
     subject?: string,
     packKeys?: string[],
+    threadContent?: LoadoutEntry,
   ): Promise<DeliverResult> {
     const spec = handle.spec;
     if (!spec) {
@@ -617,15 +618,17 @@ export class ProgrammaticBackend implements AgentBackend {
     // robust to long/multiline prompts and keeps the prompt visible-on-disk. Its
     // lifecycle is tied to the workspace (like .mcp.json) — it disappears with it.
     //
-    // COMPOSED PROMPT (threads-only Phase A — DESIGN-2026-06-29-threads-only.md §1/§9):
-    // the system prompt is an ORDERED LIST of loaded notes — a direct arity-N generalization
-    // of the rc.13 arity-2 `roleBody [+ dossier]` seam. Entry 0 is the thread's SELF entry:
-    // the spec's `systemPrompt` (the def body), labeled with the def note's human-legible
-    // PATH (`spec.definitionPath`, e.g. `Agents/steward`; fallback `spec.name`). Entries
-    // 1..N are the resolved `loadout` notes (read CONTENT-only, never metadata).
-    // composeSystemPrompt dedupes by path, skips blank entries, renders each as
-    // `# <path>\n\n<content>`, joins with `\n\n---\n\n`, and enforces the byte budget
-    // (truncate loadout-notes-first, NEVER the self entry).
+    // COMPOSED PROMPT (threads-only Phase A — DESIGN-2026-06-29-threads-only.md §1/§9; thread
+    // content — DESIGN-2026-06-29-thread-content-and-skills.md): the system prompt is an ORDERED
+    // LIST of loaded notes — a direct arity-N generalization of the rc.13 arity-2 `roleBody
+    // [+ dossier]` seam. Entry 0 is the thread's SELF entry: the spec's `systemPrompt` (the def
+    // body), labeled with the def note's human-legible PATH (`spec.definitionPath`, e.g.
+    // `Agents/steward`; fallback `spec.name`). Entry 1 (when present) is THIS thread's CONTENT —
+    // the thread note's authored body, its per-thread standing mandate. Entries 2..N are the
+    // resolved `loadout` notes (read CONTENT-only, never metadata). composeSystemPrompt dedupes
+    // by path, skips blank entries, renders each as `# <path>\n\n<content>`, joins with
+    // `\n\n---\n\n`, and enforces the byte budget (truncate the LOADOUT TAIL first, NEVER the
+    // def or the thread content — the PROTECTED leading prefix).
     //
     // #169 — the self-entry header uses the def note's PATH, NOT its id. The note ID is a
     // timestamp-slug (`2026-06-20-07-30-56-487050`); the legible loadout path is
@@ -633,10 +636,11 @@ export class ProgrammaticBackend implements AgentBackend {
     // `note.path`); when absent (a spec not sourced from a def note, or a reader that didn't
     // surface a path) the header falls back to `spec.name`.
     //
-    // NO-LOADOUT INVARIANT (the live 4am steward weave path): a thread with NO loadout
-    // composes to EXACTLY `# <path>\n\n<def body>` — `<def body>` byte-identical to
-    // `spec.systemPrompt`. The single `# <path>` header is the ONLY change to a no-loadout
-    // prompt (design decision #4, accepted). The run-context preamble stays on the MESSAGE.
+    // NO-LOADOUT / NO-THREAD-CONTENT INVARIANT (the live 4am steward weave path): a thread with
+    // NO loadout AND no authored thread content composes to EXACTLY `# <path>\n\n<def body>` —
+    // `<def body>` byte-identical to `spec.systemPrompt`. The single `# <path>` header is the
+    // ONLY change to such a prompt (design decision #4, accepted). The run-context preamble
+    // stays on the MESSAGE.
     let systemPromptFile: string | undefined;
     if (typeof spec.systemPrompt === "string" && spec.systemPrompt.length > 0) {
       // Self entry: the def body, labeled by the def note's PATH (`spec.definitionPath`);
@@ -646,11 +650,21 @@ export class ProgrammaticBackend implements AgentBackend {
         typeof spec.definitionPath === "string" && spec.definitionPath.length > 0
           ? spec.definitionPath
           : spec.name;
+      // The thread-content entry sits BETWEEN the self entry and the loadout. Include it only
+      // when it carries real (non-blank) content — a blank thread note is the no-thread-content
+      // case. Gate the inclusion AND the protected-prefix count on the SAME non-blank check, so
+      // composeSystemPrompt's protected prefix (def [+ thread content]) stays exactly aligned
+      // with the entries actually inserted (a blank entry would be skipped, shifting the prefix).
+      const hasThreadContent =
+        !!threadContent && typeof threadContent.content === "string" && threadContent.content.trim().length > 0;
       const entries: LoadoutEntry[] = [
         { path: selfPath, content: spec.systemPrompt },
+        ...(hasThreadContent ? [threadContent!] : []),
         ...(loadout ?? []),
       ];
-      const composed = composeSystemPrompt(entries);
+      // Protect the def (always) and the thread content (when present) from budget truncation —
+      // both are load-bearing; only the loadout tail (entries beyond the prefix) sheds.
+      const composed = composeSystemPrompt(entries, { protectedCount: hasThreadContent ? 2 : 1 });
       systemPromptFile = join(workspace, "system-prompt.txt");
       writeFileSync(systemPromptFile, composed, { mode: 0o600 });
     }

--- a/src/backends/registry.test.ts
+++ b/src/backends/registry.test.ts
@@ -65,6 +65,8 @@ class FakeBackend implements AgentBackend {
     subject?: string;
     /** threads-only Phase A: the resolved LOADOUT entries the drain threaded in. */
     loadout?: LoadoutEntry[];
+    /** thread content: the thread's own authored body the drain threaded in (between def + loadout). */
+    threadContent?: LoadoutEntry;
   }[] = [];
   /** Max concurrent in-flight turns observed (must stay ≤ 1 for serial — PER drain key). */
   maxConcurrent = 0;
@@ -118,6 +120,8 @@ class FakeBackend implements AgentBackend {
     runContext?: RunContext,
     loadout?: LoadoutEntry[],
     subject?: string,
+    _packKeys?: string[],
+    threadContent?: LoadoutEntry,
   ): Promise<DeliverResult> {
     this.calls.push({
       channel: handle.channel,
@@ -126,6 +130,7 @@ class FakeBackend implements AgentBackend {
       ...(runContext ? { runContext } : {}),
       ...(subject ? { subject } : {}),
       ...(loadout ? { loadout } : {}),
+      ...(threadContent ? { threadContent } : {}),
     });
     this.inFlight++;
     this.maxConcurrent = Math.max(this.maxConcurrent, this.inFlight);
@@ -454,7 +459,7 @@ describe("ProgrammaticAgentRegistry — inbound enqueue + outbound", () => {
 });
 
 describe("ProgrammaticAgentRegistry — #agent/thread notes (unified lifecycle, BOTH modes)", () => {
-  test("a completed MULTI-THREADED turn materializes an #agent/thread note (status ok) carrying input/output/definition/mode/name", async () => {
+  test("a completed MULTI-THREADED turn materializes an #agent/thread note (status ok) carrying definition/mode/name", async () => {
     const backend = new FakeBackend();
     const rec = recorder();
     const threads = threadRecorder();
@@ -475,8 +480,6 @@ describe("ProgrammaticAgentRegistry — #agent/thread notes (unified lifecycle, 
     expect(thread.status).toBe("ok");
     expect(thread.mode).toBe("multi-threaded");
     expect(thread.definition).toBe("Agents/digest");
-    expect(thread.input).toBe("run the digest");
-    expect(thread.output).toBe("reply:run the digest");
     expect(typeof thread.started_at).toBe("string");
     expect(typeof thread.ended_at).toBe("string");
     // The start + end target the SAME per-fire note (same threadId) — no duplicate minted.
@@ -509,8 +512,6 @@ describe("ProgrammaticAgentRegistry — #agent/thread notes (unified lifecycle, 
     expect(threads.ends()[0]!.mode).toBe("single-threaded");
     expect(threads.ends()[0]!.name).toBe("eng");
     expect(threads.ends()[0]!.channel).toBe("eng");
-    expect(threads.ends()[0]!.input).toBe("hello");
-    expect(threads.ends()[0]!.output).toBe("reply:hello");
     // The single-threaded outbound reply was still written (no regression).
     expect(rec.calls).toHaveLength(1);
   });
@@ -542,8 +543,6 @@ describe("ProgrammaticAgentRegistry — #agent/thread notes (unified lifecycle, 
     expect(t2!.name).toBe("eng"); // SAME upsert key → same note, upserted.
     expect(t1!.channel).toBe("eng");
     expect(t2!.channel).toBe("eng");
-    expect(t1!.input).toBe("turn one");
-    expect(t2!.input).toBe("turn two");
   });
 
   test("a multi-threaded fire writes a thread note per fire (each carries this fire's turn — distinct records)", async () => {
@@ -561,7 +560,6 @@ describe("ProgrammaticAgentRegistry — #agent/thread notes (unified lifecycle, 
     // assigns each a fresh uuid path, so they're distinct records). Each fire's start-ensure
     // shares that fire's threadId (so start + end target the SAME per-fire note).
     expect(threads.ends()).toHaveLength(2);
-    expect(threads.ends().map((t) => t.input)).toEqual(["fire A", "fire B"]);
     expect(threads.ends().every((t) => t.mode === "multi-threaded")).toBe(true);
     expect(threads.starts()).toHaveLength(2);
     // Per fire the working-ensure + final record share a threadId (distinct across fires).
@@ -586,8 +584,8 @@ describe("ProgrammaticAgentRegistry — #agent/thread notes (unified lifecycle, 
     expect(threads.ends()).toHaveLength(1);
     expect(threads.ends()[0]!.mode).toBe("multi-threaded");
     expect(threads.ends()[0]!.status).toBe("error");
-    expect(threads.ends()[0]!.output).toBe("mint refused");
-    // A user-facing failure note IS now written for a failed turn (carries the reason).
+    // A user-facing failure note IS now written for a failed turn (carries the reason — the
+    // reason lives in that note + the turn event, NOT the thread body the daemon no longer writes).
     expect(rec.calls).toHaveLength(1);
     expect(rec.calls[0]!.reply).toContain("mint refused");
   });
@@ -610,13 +608,13 @@ describe("ProgrammaticAgentRegistry — #agent/thread notes (unified lifecycle, 
     expect(threads.ends()[0]!.mode).toBe("single-threaded");
     expect(threads.ends()[0]!.name).toBe("eng");
     expect(threads.ends()[0]!.status).toBe("error");
-    expect(threads.ends()[0]!.output).toBe("mint refused");
-    // A user-facing failure note IS now written for a failed turn (carries the reason).
+    // A user-facing failure note IS now written for a failed turn (carries the reason — the
+    // reason lives in that note + the turn event, NOT the thread body the daemon no longer writes).
     expect(rec.calls).toHaveLength(1);
     expect(rec.calls[0]!.reply).toContain("mint refused");
   });
 
-  test("a turn with an empty reply STILL materializes a thread note (status ok, empty output)", async () => {
+  test("a turn with an empty reply STILL materializes a thread note (status ok)", async () => {
     const backend = new FakeBackend();
     backend.resultFor = () => ({ ok: true, reply: "" });
     const rec = recorder();
@@ -626,11 +624,9 @@ describe("ProgrammaticAgentRegistry — #agent/thread notes (unified lifecycle, 
 
     reg.enqueue("digest", { content: "tool-only run" });
     await until(() => threads.ends().length === 1);
-    // The working-ensure (phase:start, no fake reply) preceded the empty-reply final record.
+    // The working-ensure (phase:start) preceded the empty-reply final record.
     expect(threads.starts()).toHaveLength(1);
-    expect(threads.starts()[0]!.output).toBe("");
     expect(threads.ends()[0]!.status).toBe("ok");
-    expect(threads.ends()[0]!.output).toBe("");
     // Empty reply → no outbound message note (the thread note IS the record).
     expect(rec.calls).toHaveLength(0);
   });
@@ -669,16 +665,74 @@ describe("ProgrammaticAgentRegistry — #agent/thread notes (unified lifecycle, 
     // First FINAL (optimistic) record was `ok`; the second re-records the failure so the
     // durable thread record does NOT falsely claim the reply landed.
     expect(threads.ends()[0]!.status).toBe("ok");
-    expect(threads.ends()[0]!.output).toBe("reply:fire it");
     expect(threads.ends()[1]!.status).toBe("error");
     expect(threads.ends()[1]!.mode).toBe("single-threaded");
-    // The undelivered reply text is preserved in the error record for recovery.
-    expect(threads.ends()[1]!.output).toContain("reply:fire it");
     // The re-record reuses the SAME per-turn threadId + sameTurn (no double-count, no dup).
     expect(threads.ends()[1]!.threadId).toBe(threads.ends()[0]!.threadId!);
     expect(threads.ends()[1]!.sameTurn).toBe(true);
     // Transient → the outbound was retried the full budget (1 initial + OUTBOUND_MAX_RETRIES).
     expect(outboundAttempts).toBe(1 + OUTBOUND_MAX_RETRIES);
+  });
+});
+
+describe("ProgrammaticAgentRegistry — thread content as context (DESIGN-2026-06-29-thread-content-and-skills.md)", () => {
+  test("the drain READS thread content (readThreadContent) + PASSES it to deliver (the threadContent param)", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const threads = threadRecorder();
+    const seen: { channel: string; name: string; subject?: string }[] = [];
+    const reg = new ProgrammaticAgentRegistry({
+      backend,
+      writeOutbound: rec.fn,
+      writeThread: threads.fn,
+      readThreadContent: async (channel, name, subject) => {
+        seen.push({ channel, name, ...(subject ? { subject } : {}) });
+        return { path: `Threads/${channel}/${name}`, content: "this thread's standing mandate" };
+      },
+    });
+    await reg.register(specFor("eng")); // single-threaded (default).
+
+    reg.enqueue("eng", { content: "go" });
+    await until(() => backend.calls.length === 1);
+
+    // The drain consulted readThreadContent with the channel + def name…
+    expect(seen).toEqual([{ channel: "eng", name: "eng" }]);
+    // …and passed the resolved entry to deliver as `threadContent` (composed into the prompt
+    // BETWEEN the def and the loadout — the composition order is asserted in programmatic.test.ts).
+    expect(backend.calls[0]!.threadContent).toEqual({
+      path: "Threads/eng/eng",
+      content: "this thread's standing mandate",
+    });
+  });
+
+  test("UNWIRED readThreadContent → deliver receives no thread content (the no-thread-content invariant)", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    await reg.register(specFor("eng"));
+
+    reg.enqueue("eng", { content: "go" });
+    await until(() => backend.calls.length === 1);
+    expect(backend.calls[0]!.threadContent).toBeUndefined();
+  });
+
+  test("a readThreadContent THROW is swallowed — the turn still runs (best-effort, no thread content)", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const reg = new ProgrammaticAgentRegistry({
+      backend,
+      writeOutbound: rec.fn,
+      readThreadContent: async () => {
+        throw new Error("vault unreachable");
+      },
+    });
+    await reg.register(specFor("eng"));
+
+    reg.enqueue("eng", { content: "go" });
+    await until(() => backend.calls.length === 1);
+    // The turn ran (the read failure didn't strand it) with no thread content.
+    expect(backend.calls[0]!.threadContent).toBeUndefined();
+    expect(rec.calls).toHaveLength(1);
   });
 });
 
@@ -934,10 +988,9 @@ describe("ProgrammaticAgentRegistry — outbound retry on transient failure (FIX
     expect(errorEvents.length).toBeGreaterThanOrEqual(1);
     expect(turn.events.some((e) => e.event.kind === "done")).toBe(false);
     // The FINAL thread record does NOT falsely claim a clean ok: the second final record is
-    // error, carrying the un-delivered reply text for recovery. (A working-ensure preceded.)
+    // error (status only — the daemon no longer writes the thread body). (A working-ensure preceded.)
     expect(threads.ends()).toHaveLength(2);
     expect(threads.ends()[1]!.status).toBe("error");
-    expect(threads.ends()[1]!.output).toContain("reply:doomed");
   });
 
   test("a PERMANENT (4xx) outbound failure does NOT retry — gives up immediately", async () => {
@@ -1713,8 +1766,6 @@ describe("ProgrammaticAgentRegistry — thread-as-container working-ensure (Part
     await until(() => backend.calls.length === 1);
     expect(threads.starts()).toHaveLength(1);
     expect(threads.starts()[0]!.status).toBe("working");
-    expect(threads.starts()[0]!.output).toBe(""); // NO fake reply while working.
-    expect(threads.starts()[0]!.input).toBe("do work");
     // The turn is in flight but hasn't produced its end record yet (gated).
     expect(backend.calls).toHaveLength(1);
     expect(threads.ends()).toHaveLength(0);
@@ -1726,7 +1777,7 @@ describe("ProgrammaticAgentRegistry — thread-as-container working-ensure (Part
     expect(threads.ends()[0]!.threadId).toBe(threads.starts()[0]!.threadId!);
   });
 
-  test("the start-ensure does NOT write a fake reply even though the turn ultimately replies", async () => {
+  test("the start-ensure is status:working and the end is status:ok (the daemon never writes the thread body)", async () => {
     const backend = new FakeBackend();
     const rec = recorder();
     const threads = threadRecorder();
@@ -1735,10 +1786,11 @@ describe("ProgrammaticAgentRegistry — thread-as-container working-ensure (Part
 
     reg.enqueue("eng", { content: "hi" });
     await until(() => threads.ends().length === 1);
-    // The working-ensure carries status:working + empty output; the end carries the reply.
+    // The working-ensure carries status:working; the end carries status:ok. Neither carries a
+    // body — the daemon writes metadata only (the reply lives in the outbound transcript note).
     expect(threads.starts()[0]!.status).toBe("working");
-    expect(threads.starts()[0]!.output).toBe("");
-    expect(threads.ends()[0]!.output).toBe("reply:hi");
+    expect(threads.ends()[0]!.status).toBe("ok");
+    expect(rec.calls[0]!.reply).toBe("reply:hi");
   });
 
   test("the OUTBOUND reply is stamped with the turn's thread id (definition→thread→message link); multi-threaded → the per-fire note leaf", async () => {
@@ -2367,8 +2419,9 @@ describe("ProgrammaticAgentRegistry — outbound metadata.thread is the resolvab
     expect(rec.calls[0]!.threadId).toMatch(/^[0-9a-f-]{36}$/);
     expect(rec.calls[1]!.threadId).toMatch(/^[0-9a-f-]{36}$/);
     expect(rec.calls[0]!.threadId).not.toBe(rec.calls[1]!.threadId);
-    // The stamped per-fire id is the leaf of that fire's written thread note.
-    const end0 = threads.ends().find((t) => t.input === "fire 1")!;
+    // The stamped per-fire id is the leaf of that fire's written thread note (FIFO drain →
+    // ends()[0] is fire 1).
+    const end0 = threads.ends()[0]!;
     expect(threads.idFor(end0)).toBe(`Threads/digest/${rec.calls[0]!.threadId}`);
   });
 

--- a/src/backends/registry.ts
+++ b/src/backends/registry.ts
@@ -132,14 +132,11 @@ export interface ThreadNote {
   mode: AgentMode;
   /**
    * Outcome / lifecycle state after THIS write — `working` (the start-ensure, written
-   * BEFORE the turn: input shown, no reply yet), `ok` (success), or `error` (failed).
-   * `working` is only valid alongside `phase: "start"`.
+   * BEFORE the turn finishes — the turn has started but not completed), `ok` (success), or
+   * `error` (failed). `working` is only valid alongside `phase: "start"`. This is metadata
+   * only — the daemon does not write the thread BODY (the authored thread content is preserved).
    */
   status: "ok" | "error" | "working";
-  /** The inbound text handed to the turn (the `-p` prompt). */
-  input: string;
-  /** The reply on success, the failure reason on error, or "" while `working`. */
-  output: string;
   /**
    * The Claude session UUID for this turn — the transport persists it to the thread
    * note's `metadata.session` (the thread≡session record), so the NEXT turn can
@@ -570,6 +567,20 @@ export class ProgrammaticAgentRegistry {
     name: string,
     subject?: string,
   ) => Promise<string[]>;
+  /**
+   * Optional pre-turn THREAD-CONTENT read (DESIGN-2026-06-29-thread-content-and-skills.md). The
+   * thread note's own authored BODY (`{ path, content }` — CONTENT only) becomes the prompt entry
+   * BETWEEN the def (self) and the loadout. Read in {@link drain} and passed to the backend's
+   * `deliver`, which composes `[self, thread-content, ...loadout]` (the def + thread content
+   * protected from budget truncation). The daemon NEVER writes this content. UNWIRED / no thread
+   * note / blank body → undefined → the prompt is `[self, ...loadout]` (the no-thread-content
+   * invariant). Best-effort: a read failure logs + the turn runs without thread content.
+   */
+  private readonly readThreadContent?: (
+    channel: string,
+    name: string,
+    subject?: string,
+  ) => Promise<{ path: string; content: string } | undefined>;
   /** Base backoff (ms) between outbound retries (FIX 1). Injectable so tests run fast. */
   private readonly outboundRetryBaseMs: number;
 
@@ -603,6 +614,18 @@ export class ProgrammaticAgentRegistry {
      * thread note.
      */
     readPackKeys?: (channel: string, name: string, subject?: string) => Promise<string[]>;
+    /**
+     * Read the thread's own CONTENT (DESIGN-2026-06-29-thread-content-and-skills.md) — the
+     * thread note's authored body as `{ path, content }`, composed BETWEEN the def and the
+     * loadout. Optional — UNWIRED / no thread note / blank body → undefined (the prompt is
+     * `[self, ...loadout]`, the no-thread-content invariant). `subject` resolves the
+     * subject-scoped thread note.
+     */
+    readThreadContent?: (
+      channel: string,
+      name: string,
+      subject?: string,
+    ) => Promise<{ path: string; content: string } | undefined>;
     /** Override the outbound-retry backoff base (ms). Default {@link OUTBOUND_RETRY_BASE_MS}. */
     outboundRetryBaseMs?: number;
   }) {
@@ -615,6 +638,7 @@ export class ProgrammaticAgentRegistry {
     if (deps.clearSession) this.clearSession = deps.clearSession;
     if (deps.readLoadout) this.readLoadout = deps.readLoadout;
     if (deps.readPackKeys) this.readPackKeys = deps.readPackKeys;
+    if (deps.readThreadContent) this.readThreadContent = deps.readThreadContent;
     this.outboundRetryBaseMs = deps.outboundRetryBaseMs ?? OUTBOUND_RETRY_BASE_MS;
   }
 
@@ -1197,7 +1221,7 @@ export class ProgrammaticAgentRegistry {
       // DETERMINISTIC `Threads/<safeChannel>/<safeName>` note (the same every turn) — so a
       // resolvable thread id is available BEFORE the turn runs, for the failure-note +
       // outbound `metadata.thread` stamping (agent#163), even on a turn that fails early.
-      const startThreadNoteId = await this.recordThread(handle, msg, "working", "", startedAt, undefined, {
+      const startThreadNoteId = await this.recordThread(handle, msg, "working", startedAt, undefined, {
         threadId: turnThreadId,
         phase: "start",
         // NO session on the start-ensure: it runs BEFORE claude, so claude may never
@@ -1275,6 +1299,26 @@ export class ProgrammaticAgentRegistry {
         }
       }
 
+      // THREAD CONTENT (DESIGN-2026-06-29-thread-content-and-skills.md): the thread note's own
+      // authored body — THIS thread's standing context — read CONTENT-only off its mode-correct
+      // `#agent/thread` note (subject-scoped when a subject narrows the thread). The backend
+      // composes it BETWEEN the def (self) and the loadout. Undefined (unwired / no thread note /
+      // blank body) → the no-thread-content invariant (the prompt is the def + loadout). The
+      // daemon NEVER writes this content. Best-effort: a read failure logs + the turn runs without
+      // thread content (never strands the queue).
+      let threadContent: LoadoutEntry | undefined;
+      if (this.readThreadContent) {
+        try {
+          threadContent = await this.readThreadContent(handle.channel, handle.spec.name, turnSubject);
+        } catch (err) {
+          console.error(
+            `parachute-agent: thread-content read for channel "${channel}"` +
+              (turnSubject ? ` subject "${turnSubject}"` : "") +
+              ` failed (turn runs without thread content): ${(err as Error).message}`,
+          );
+        }
+      }
+
       let result;
       try {
         // Forward each interim event to the streaming-view sink (keyed by channel)
@@ -1303,6 +1347,11 @@ export class ProgrammaticAgentRegistry {
           // APPROVED grants with the def's own (`spec.name`). Empty (every current thread) →
           // the grant sources are exactly `[spec.name]` (legacy continuity, byte-identical).
           packKeys,
+          // thread content (DESIGN-2026-06-29-thread-content-and-skills.md): THIS thread's
+          // authored standing context, composed BETWEEN the def and the loadout (def + thread
+          // content protected from budget truncation). Undefined / blank → the def + loadout
+          // alone (the no-thread-content invariant).
+          threadContent,
         );
       } catch (err) {
         // The backend contract is failure-as-VALUE, never a throw — but defend so a
@@ -1317,7 +1366,7 @@ export class ProgrammaticAgentRegistry {
         // thread note captures the turn outcome, so a failed turn is still a queryable
         // `status:error` (single-threaded upserts the rolling thread; multi-threaded writes
         // a per-fire note).
-        const threadNoteId = await this.recordThread(handle, msg, "error", reason, startedAt, undefined, {
+        const threadNoteId = await this.recordThread(handle, msg, "error", startedAt, undefined, {
           threadId: turnThreadId,
           phase: "end",
           // No `result` (the backend threw) → NO session to persist. We never write a
@@ -1347,7 +1396,7 @@ export class ProgrammaticAgentRegistry {
         // BOTH modes record the failed turn (status:error) on the thread note so a failure
         // always leaves a queryable trace (single-threaded upserts the rolling thread,
         // marking it errored; multi-threaded writes a per-fire status:error note).
-        const threadNoteId = await this.recordThread(handle, msg, "error", result.error, startedAt, undefined, {
+        const threadNoteId = await this.recordThread(handle, msg, "error", startedAt, undefined, {
           threadId: turnThreadId,
           phase: "end",
           // Persist ONLY the session claude ECHOED (FIX 2). A turn can fail AFTER
@@ -1380,7 +1429,7 @@ export class ProgrammaticAgentRegistry {
       // (agent#124). The same note id is reused for the outbound-failure re-record below
       // (sameTurn → same note), so a callback on either terminal path points at a pullable
       // thread record.
-      let threadNoteId = await this.recordThread(handle, msg, "ok", result.reply ?? "", startedAt, result.usage, {
+      let threadNoteId = await this.recordThread(handle, msg, "ok", startedAt, result.usage, {
         threadId: turnThreadId,
         phase: "end",
         // Persist the session claude ECHOED (FIX 2) so the next turn `--resume`s this
@@ -1422,8 +1471,10 @@ export class ProgrammaticAgentRegistry {
           //      single-threaded; writes/overwrites the per-fire note for multi-threaded).
           //   2. Resolve the live view to ERROR (not `done`) so the UI doesn't drop the
           //      in-progress bubble + poll for a note that isn't there (PR #83 nit).
-          // We do NOT re-run the `claude -p` turn (that forks/burns quota) — the reply text
-          // is preserved IN the error thread note's output for an operator to recover.
+          // We do NOT re-run the `claude -p` turn (that forks/burns quota). The reply text is
+          // not persisted (the transcript write is what failed, and the daemon no longer writes
+          // the thread body) — the turn is recorded `status:error` so the failure is visible and
+          // the `error` turn-event carries the "reply produced but not saved" reason.
           console.error(
             `parachute-agent: programmatic outbound write for channel "${channel}" failed ` +
               `after ${OUTBOUND_MAX_RETRIES} retries: ${delivered.error}`,
@@ -1438,8 +1489,6 @@ export class ProgrammaticAgentRegistry {
             handle,
             msg,
             "error",
-            `reply produced but NOT delivered (outbound write failed: ${delivered.error}). ` +
-              `Undelivered reply text: ${result.reply}`,
             startedAt,
             result.usage,
             {
@@ -1586,7 +1635,6 @@ export class ProgrammaticAgentRegistry {
     handle: ProgrammaticAgentHandle,
     msg: QueuedMessage,
     status: "ok" | "error" | "working",
-    output: string,
     startedAt: string,
     usage: ThreadNote["usage"],
     opts: { threadId?: string; sameTurn?: boolean; phase?: "start" | "end"; session?: string } = {},
@@ -1604,8 +1652,6 @@ export class ProgrammaticAgentRegistry {
       ...(handle.spec.definition ? { definition: handle.spec.definition } : {}),
       mode: handle.spec.mode ?? "single-threaded",
       status,
-      input: msg.content,
-      output,
       started_at: startedAt,
       ended_at: new Date().toISOString(),
       ...(usage ? { usage } : {}),

--- a/src/backends/types.ts
+++ b/src/backends/types.ts
@@ -141,9 +141,11 @@ export interface LoadoutEntry {
 }
 
 /**
- * The total composed-system-prompt BUDGET (bytes, UTF-8). When the composed loadout exceeds
- * this, the composer truncates the LOADOUT notes (entries 1..N) FIRST — NEVER the self entry
- * (entry 0, the def body) — with a loud warn (threads-only Phase A, §9.5 / R5).
+ * The total composed-system-prompt BUDGET (bytes, UTF-8). When the composed prompt exceeds
+ * this, the composer truncates the LOADOUT TAIL FIRST — NEVER the PROTECTED leading entries
+ * (the def body, entry 0, and — when present — the thread content, entry 1; see
+ * `protectedCount` on {@link composeSystemPrompt}) — with a loud warn (threads-only Phase A,
+ * §9.5 / R5; thread-content protection — DESIGN-2026-06-29-thread-content-and-skills.md).
  *
  * Chosen sane cap: 600_000 bytes (~150k tokens at ~4 bytes/token). Claude's context window is
  * ~200k tokens; this leaves headroom for the turn message, attachments, and tool I/O while
@@ -164,27 +166,36 @@ export const LOADOUT_BUDGET_BYTES = 600_000;
  *     .join("\n\n---\n\n")
  *
  * Then enforce {@link LOADOUT_BUDGET_BYTES}: if the composed byte length exceeds the cap,
- * drop trailing LOADOUT entries (index ≥ 1) until it fits — the self entry (index 0) is
- * NEVER truncated. A loud warn fires on truncation (via `onWarn`, defaulting to console.warn).
+ * drop trailing LOADOUT entries until it fits — the PROTECTED leading entries are NEVER
+ * truncated. `protectedCount` (default 1) is how many leading entries are load-bearing: 1
+ * protects just the self entry (index 0, the def body) — the no-loadout default; 2 protects
+ * the self entry AND the thread-content entry (index 1) once the caller has inserted it
+ * (DESIGN-2026-06-29-thread-content-and-skills.md — thread content is load-bearing like the
+ * def). Only entries beyond the protected prefix shed (tail-first). A loud warn fires on
+ * truncation (via `onWarn`, defaulting to console.warn).
  *
  * The NO-LOADOUT INVARIANT: with exactly one (self) entry whose content is the def body, the
  * result is `# <path>\n\n<body>` where `<body>` is byte-identical to the def body — the single
  * header line is the ONLY change to a no-loadout (e.g. the steward weave) prompt.
  *
- * PURE (apart from the injectable `onWarn`). The caller resolves the entries (self + loadout
- * notes) and supplies them in order; this function only dedupes, skips, renders, and budgets.
+ * PURE (apart from the injectable `onWarn`). The caller resolves the entries (self [+ thread
+ * content] + loadout notes) and supplies them in order, and tells us how many leading entries
+ * are protected; this function only dedupes, skips, renders, and budgets. The caller MUST keep
+ * `protectedCount` consistent with the entries it passed — only include a non-blank protected
+ * entry and count it (a blank protected entry would be skipped below, shifting the prefix).
  */
 export function composeSystemPrompt(
   entries: LoadoutEntry[],
-  opts?: { budgetBytes?: number; onWarn?: (msg: string) => void },
+  opts?: { budgetBytes?: number; onWarn?: (msg: string) => void; protectedCount?: number },
 ): string {
   const budget = opts?.budgetBytes ?? LOADOUT_BUDGET_BYTES;
   const warn = opts?.onWarn ?? ((m: string) => console.warn(m));
   const byteLen = (s: string): number => Buffer.byteLength(s, "utf8");
 
-  // Dedupe by path (first occurrence wins) + skip blank/whitespace content. The self entry
-  // (index 0) is processed exactly like the rest — but it is index 0, so the budget step
-  // below can never drop it (the steward's def body survives any over-budget loadout).
+  // Dedupe by path (first occurrence wins) + skip blank/whitespace content. The protected
+  // leading entries (the self entry at index 0, and the thread content at index 1 when the
+  // caller inserted it) are processed exactly like the rest — but they lead, so the budget
+  // step below never drops them (the def body + thread content survive any over-budget loadout).
   const seen = new Set<string>();
   const kept: LoadoutEntry[] = [];
   for (const e of entries) {
@@ -200,12 +211,13 @@ export function composeSystemPrompt(
   let composed = render(kept);
   if (byteLen(composed) <= budget) return composed;
 
-  // OVER BUDGET — keep the self entry (index 0) ALWAYS, then keep loadout entries from the
-  // front while they fit and STOP at the first that doesn't (tail-drop: the loadout's order
-  // IS its priority — earlier notes win, the tail is shed first). The self entry survives even
-  // if it alone exceeds the budget.
-  const fit: LoadoutEntry[] = kept.length > 0 ? [kept[0]!] : [];
-  for (let i = 1; i < kept.length; i++) {
+  // OVER BUDGET — keep the PROTECTED leading entries (the def body, and the thread content
+  // when present) ALWAYS, then keep loadout entries from the front while they fit and STOP at
+  // the first that doesn't (tail-drop: the loadout's order IS its priority — earlier notes win,
+  // the tail is shed first). The protected prefix survives even if it alone exceeds the budget.
+  const protect = Math.min(Math.max(opts?.protectedCount ?? 1, 0), kept.length);
+  const fit: LoadoutEntry[] = kept.slice(0, protect);
+  for (let i = protect; i < kept.length; i++) {
     if (byteLen(render([...fit, kept[i]!])) <= budget) fit.push(kept[i]!);
     else break;
   }
@@ -213,7 +225,7 @@ export function composeSystemPrompt(
   composed = render(fit);
   warn(
     `parachute-agent: LOADOUT over budget (${byteLen(render(kept))} > ${budget} bytes) — ` +
-      `truncated ${dropped.length} loadout note(s), NEVER the self entry. ` +
+      `truncated ${dropped.length} loadout note(s), NEVER the def or thread content. ` +
       `Dropped: ${dropped.join(", ")}`,
   );
   return composed;
@@ -372,6 +384,16 @@ export interface AgentBackend {
    * METADATA, never folding it into the prompt). ADDITIVE — omitted/empty (every current agent;
    * no thread loads a `#pack` with `wants:` today) → the grant source set is exactly
    * `[spec.name]`, BYTE-IDENTICAL to the legacy single-source injection (legacy continuity).
+   *
+   * `threadContent` (optional, DESIGN-2026-06-29-thread-content-and-skills.md) is THIS thread's
+   * own standing context — the thread note's authored BODY (`{ path, content }`, CONTENT only,
+   * the thread-note path as the header). The programmatic backend composes it as the entry
+   * BETWEEN the self entry and the loadout: `[self, thread-content, ...loadout]`. It is
+   * load-bearing like the def — composed with a protected prefix so an over-budget loadout
+   * sheds its tail but NEVER the def or the thread content. ADDITIVE — omitted, or blank/
+   * whitespace content → the thread-content entry is skipped and the prompt is `[self, ...loadout]`
+   * exactly as before (the no-thread-content invariant). The daemon NEVER writes this content;
+   * a human/agent authors it on the thread note and the backend reads it CONTENT-only each turn.
    */
   deliver(
     handle: AgentHandle,
@@ -383,6 +405,7 @@ export interface AgentBackend {
     loadout?: LoadoutEntry[],
     subject?: string,
     packKeys?: string[],
+    threadContent?: LoadoutEntry,
   ): Promise<DeliverResult>;
 
   /**

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -764,8 +764,6 @@ export function buildWriteThread(channels: Map<string, Channel>): WriteThread {
       ...(thread.definition ? { definition: thread.definition } : {}),
       mode: thread.mode,
       status: thread.status,
-      input: thread.input,
-      output: thread.output,
       started_at: thread.started_at,
       ended_at: thread.ended_at,
       ...(thread.usage ? { usage: thread.usage } : {}),
@@ -898,6 +896,25 @@ export function buildReadLoadout(
 }
 
 /**
+ * Build the {@link ProgrammaticAgentRegistry}'s pre-turn THREAD-CONTENT read
+ * (DESIGN-2026-06-29-thread-content-and-skills.md). Resolve the channel's transport and read the
+ * thread note's OWN authored body (`{ path, content }` — CONTENT only) off its `#agent/thread`
+ * note. Only the VaultTransport implements `readThreadContent`; other transports omit it →
+ * undefined (the no-thread-content case — the prompt is the def + loadout). The registry calls
+ * this BEFORE a turn so the backend composes the thread content BETWEEN the def and the loadout.
+ * Mirrors {@link buildReadLoadout}.
+ */
+export function buildReadThreadContent(
+  channels: Map<string, Channel>,
+): (channel: string, name: string, subject?: string) => Promise<{ path: string; content: string } | undefined> {
+  return async (channel, name, subject) => {
+    const ch = channels.get(channel);
+    if (!ch?.transport.readThreadContent) return undefined;
+    return ch.transport.readThreadContent(channel, name, subject);
+  };
+}
+
+/**
  * Build the {@link ProgrammaticAgentRegistry}'s pre-turn loaded-PACK grant-KEY read
  * (threads-only Phase B′ — DESIGN-2026-06-29-threads-only.md §4). Resolves the channel's
  * transport and reads the loaded `#pack` notes' grant keys (the slugged paths of the loadout
@@ -983,6 +1000,10 @@ export function createDefaultProgrammaticRegistry(
     readLoadout: buildReadLoadout(channels),
     // threads-only Phase B′: the pre-turn loaded-PACK grant-key read (union pack grants).
     readPackKeys: buildReadPackKeys(channels),
+    // thread content (DESIGN-2026-06-29-thread-content-and-skills.md): the pre-turn read of the
+    // thread note's own authored body — composed BETWEEN the def and the loadout. The daemon
+    // never WRITES it; this only READS it. Undefined / blank → the def + loadout alone.
+    readThreadContent: buildReadThreadContent(channels),
     ...(onTurnEvent ? { onTurnEvent } : {}),
   });
 }

--- a/src/runner.test.ts
+++ b/src/runner.test.ts
@@ -473,7 +473,6 @@ describe("Runner — a scheduled fire honors the def's mode", () => {
     expect(threads.ends()).toHaveLength(1);
     expect(threads.ends()[0]!.mode).toBe("multi-threaded");
     expect(threads.ends()[0]!.status).toBe("ok");
-    expect(threads.ends()[0]!.input).toBe("run the digest");
   });
 
   test("REGRESSION: a SINGLE-THREADED def's scheduled fire RESUMES the thread + materializes ONE thread note", async () => {

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -96,16 +96,14 @@ export interface ThreadRecord {
   /**
    * Outcome / lifecycle state of the thread after THIS write:
    *  - `working` — the turn has STARTED but not finished (the thread-as-container
-   *    start-ensure, written BEFORE `deliver()`): the input is shown, NO reply yet.
-   *    Only valid with `phase: "start"`.
-   *  - `ok` — the turn finished successfully (the reply landed in `output`).
-   *  - `error` — the turn failed (the reason is in `output`).
+   *    start-ensure, written BEFORE `deliver()`). Only valid with `phase: "start"`.
+   *  - `ok` — the turn finished successfully.
+   *  - `error` — the turn failed.
+   * This is a METADATA field; the turn's text (prompt + reply) lives in the `#agent/message`
+   * transcript notes, NOT the thread body (the daemon never writes the thread content —
+   * DESIGN-2026-06-29-thread-content-and-skills.md).
    */
   status: "ok" | "error" | "working";
-  /** The inbound text the turn was handed (the `-p` prompt). */
-  input: string;
-  /** The reply text on success, the failure reason on error, or "" while `working`. */
-  output: string;
   /** ISO timestamp the turn started (single-threaded preserves the FIRST turn's). */
   started_at: string;
   /** ISO timestamp the turn ended (becomes the thread's `last_turn_at`; not advanced on a start-ensure). */
@@ -261,6 +259,21 @@ export interface Transport {
    * (telegram) omit it.
    */
   clearThreadSession?(channel: string, name: string, subject?: string): Promise<void>;
+  /**
+   * Optional: read the thread's own CONTENT — its per-thread standing context
+   * (DESIGN-2026-06-29-thread-content-and-skills.md). The thread note's authored BODY (CONTENT
+   * only — NEVER metadata, as `{ path, content }`) becomes the prompt entry BETWEEN the def and
+   * the loadout. `subject` resolves the subject-scoped note; omitted → the def-named note (HEAD).
+   * Returns `undefined` when there is no thread note yet OR the body is blank/whitespace (the
+   * no-thread-content case — the prompt stays `[self, ...loadout]`). The daemon NEVER writes this
+   * content; a human/agent authors it. Only a durable transport (the VaultTransport) implements
+   * it; transports without a durable thread store omit it.
+   */
+  readThreadContent?(
+    channel: string,
+    name: string,
+    subject?: string,
+  ): Promise<{ path: string; content: string } | undefined>;
   /**
    * Optional: read the thread's LOADOUT (threads-only Phase A —
    * DESIGN-2026-06-29-threads-only.md §9) — the `metadata.loadout` array of note PATHS on the

--- a/src/transports/vault.test.ts
+++ b/src/transports/vault.test.ts
@@ -287,8 +287,6 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
       definition: "Agents/digest",
       mode: "multi-threaded",
       status: "ok",
-      input: "run the daily digest",
-      output: "digest complete: 3 items",
       started_at: "2026-06-18T07:00:00.000Z",
       ended_at: "2026-06-18T07:00:12.000Z",
       usage: { inputTokens: 100, outputTokens: 40, totalCostUsd: 0.002 },
@@ -309,7 +307,7 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
     expect((call.init.headers as Record<string, string>).authorization).toBe("Bearer write-token-xyz");
 
     const sent = JSON.parse(String(call.init.body)) as {
-      content: string;
+      content?: string;
       path: string;
       tags: string[];
       metadata: Record<string, string>;
@@ -339,11 +337,9 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
     expect(sent.metadata.input_tokens).toBe("100");
     expect(sent.metadata.output_tokens).toBe("40");
     expect(sent.metadata.total_cost_usd).toBe("0.002");
-    // The body is a rolling SUMMARY with the two documented sections.
-    expect(sent.content).toContain("## Summary");
-    expect(sent.content).toContain("## Latest turn");
-    expect(sent.content).toContain("run the daily digest");
-    expect(sent.content).toContain("digest complete: 3 items");
+    // METADATA-ONLY WRITE: the daemon NEVER writes the thread body — `content` is omitted from
+    // the PATCH, so the vault creates-empty / preserves any authored thread content.
+    expect("content" in sent).toBe(false);
     // Multi-threaded path leaf is a fresh uuid under Threads/<channel>/.
     expect(sent.path.startsWith("Threads/eng/")).toBe(true);
   });
@@ -374,8 +370,6 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
       name: "eng",
       mode: "single-threaded",
       status: "ok",
-      input: "hello",
-      output: "hi there",
       started_at: "2026-06-18T07:00:00.000Z",
       ended_at: "2026-06-18T07:00:05.000Z",
       usage: { inputTokens: 10, outputTokens: 5 },
@@ -392,7 +386,7 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
       path: string;
       tags: string[];
       metadata: Record<string, string>;
-      content: string;
+      content?: string;
       if_missing: string;
       force: boolean;
     };
@@ -404,8 +398,8 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
     expect(sent.metadata.turn_count).toBe("1"); // first turn (no prior).
     expect(sent.metadata.started_at).toBe("2026-06-18T07:00:00.000Z");
     expect(sent.metadata.last_turn_at).toBe("2026-06-18T07:00:05.000Z");
-    expect(sent.content).toContain("## Summary");
-    expect(sent.content).toContain("single-threaded thread for eng");
+    // METADATA-ONLY WRITE: no `content` in the PATCH (the daemon never writes the thread body).
+    expect("content" in sent).toBe(false);
   });
 
   test("SINGLE-THREADED over TWO turns: same deterministic path, turn_count==2, summed usage, preserved started_at", async () => {
@@ -435,8 +429,6 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
       name: "eng",
       mode: "single-threaded",
       status: "ok",
-      input: "turn one",
-      output: "reply one",
       started_at: "2026-06-18T07:00:00.000Z",
       ended_at: "2026-06-18T07:00:05.000Z",
       usage: { inputTokens: 10, outputTokens: 5, totalCostUsd: 0.001 },
@@ -448,8 +440,6 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
       name: "eng",
       mode: "single-threaded",
       status: "ok",
-      input: "turn two",
-      output: "reply two",
       started_at: "2026-06-18T08:00:00.000Z", // a LATER start — must NOT overwrite the first.
       ended_at: "2026-06-18T08:00:09.000Z",
       usage: { inputTokens: 20, outputTokens: 8, totalCostUsd: 0.002 },
@@ -463,10 +453,6 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
     expect(stored!.metadata.total_cost_usd).toBe("0.003"); // 0.001 + 0.002
     expect(stored!.metadata.started_at).toBe("2026-06-18T07:00:00.000Z"); // first turn's, preserved.
     expect(stored!.metadata.last_turn_at).toBe("2026-06-18T08:00:09.000Z"); // latest turn.
-    // The body's summary reflects 2 turns + the latest turn's content.
-    expect(stored!.content).toContain("2 turns");
-    expect(stored!.content).toContain("turn two");
-    expect(stored!.content).toContain("reply two");
   });
 
   test("SINGLE-THREADED re-record of the SAME turn (sameTurn) flips status WITHOUT double-counting turn_count (PR #3 FIX 1)", async () => {
@@ -492,19 +478,18 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
     await t.start(fakeCtx("eng"));
     await t.writeThread({
       channel: "eng", name: "eng", mode: "single-threaded", status: "ok",
-      input: "q", output: "a", started_at: "2026-06-18T07:00:00.000Z",
+      started_at: "2026-06-18T07:00:00.000Z",
       ended_at: "2026-06-18T07:00:05.000Z", threadId: "t1",
     });
     expect(stored!.metadata.turn_count).toBe("1");
     // Re-record the SAME turn as error (outbound delivery failed). sameTurn → no increment.
     await t.writeThread({
       channel: "eng", name: "eng", mode: "single-threaded", status: "error",
-      input: "q", output: "reply produced but NOT delivered", started_at: "2026-06-18T07:00:00.000Z",
+      started_at: "2026-06-18T07:00:00.000Z",
       ended_at: "2026-06-18T07:00:06.000Z", threadId: "t1", sameTurn: true,
     });
     expect(stored!.metadata.turn_count).toBe("1"); // NOT 2 — the same turn, not a new one.
     expect(stored!.metadata.status).toBe("error");
-    expect(stored!.content).toContain("NOT delivered");
   });
 
   test("SINGLE-THREADED FULL lifecycle start→end(ok)→end(error,sameTurn): count goes 0→1→1, never double-counts (thread-as-container + FIX 1)", async () => {
@@ -531,19 +516,19 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
     const t = new VaultTransport(baseConfig());
     await t.start(fakeCtx("eng"));
     const base = {
-      channel: "eng", name: "eng", mode: "single-threaded" as const, input: "q",
+      channel: "eng", name: "eng", mode: "single-threaded" as const,
       started_at: "2026-06-18T07:00:00.000Z", ended_at: "2026-06-18T07:00:05.000Z", threadId: "t1",
     };
     // 1) start-ensure (working) — the container, BEFORE the turn. Must NOT count.
-    await t.writeThread({ ...base, status: "working", output: "", phase: "start" });
+    await t.writeThread({ ...base, status: "working", phase: "start" });
     expect(stored!.metadata.turn_count).toBe("0");
     expect(stored!.metadata.status).toBe("working");
     // 2) end(ok) — the turn completed: count once.
-    await t.writeThread({ ...base, status: "ok", output: "a", phase: "end" });
+    await t.writeThread({ ...base, status: "ok", phase: "end" });
     expect(stored!.metadata.turn_count).toBe("1");
     expect(stored!.metadata.status).toBe("ok");
     // 3) end(error, sameTurn) — outbound write failed, re-record the SAME turn. No increment.
-    await t.writeThread({ ...base, status: "error", output: "reply produced but NOT delivered", phase: "end", sameTurn: true });
+    await t.writeThread({ ...base, status: "error", phase: "end", sameTurn: true });
     expect(stored!.metadata.turn_count).toBe("1"); // STILL 1 — start didn't count, sameTurn didn't re-count.
     expect(stored!.metadata.status).toBe("error");
   });
@@ -562,11 +547,11 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
     await t.start(fakeCtx("eng"));
     const base = {
       channel: "eng", name: "d", mode: "multi-threaded" as const,
-      input: "q", started_at: "2026-06-18T07:00:00.000Z", ended_at: "2026-06-18T07:00:05.000Z",
+      started_at: "2026-06-18T07:00:00.000Z", ended_at: "2026-06-18T07:00:05.000Z",
       threadId: "fixed-uuid",
     };
-    await t.writeThread({ ...base, status: "ok", output: "a" });
-    await t.writeThread({ ...base, status: "error", output: "undelivered", sameTurn: true });
+    await t.writeThread({ ...base, status: "ok" });
+    await t.writeThread({ ...base, status: "error", sameTurn: true });
     // Both writes hit the SAME per-fire path (the reused threadId) — without the fix the
     // second would mint a fresh uuid → a DIFFERENT path → a duplicate note for one turn.
     const threadPatches = patchPaths.filter((p) => p.includes("/Threads/eng/"));
@@ -602,8 +587,6 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
       name: "eng",
       mode: "single-threaded",
       status: "ok",
-      input: "turn one",
-      output: "reply one",
       started_at: "2026-06-18T07:00:00.000Z",
       ended_at: "2026-06-18T07:00:05.000Z",
     });
@@ -616,8 +599,6 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
       name: "eng",
       mode: "single-threaded",
       status: "error",
-      input: "turn two",
-      output: "claude -p exited 1: boom",
       started_at: "2026-06-18T08:00:00.000Z", // later — must NOT overwrite the first.
       ended_at: "2026-06-18T08:00:09.000Z",
     });
@@ -626,9 +607,6 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
     expect(stored!.metadata.status).toBe("error"); // the latest turn's outcome.
     expect(stored!.metadata.started_at).toBe("2026-06-18T07:00:00.000Z"); // preserved.
     expect(stored!.metadata.last_turn_at).toBe("2026-06-18T08:00:09.000Z"); // advanced.
-    // The body's latest-turn section is the Error block.
-    expect(stored!.content).toContain("**Error:**");
-    expect(stored!.content).toContain("claude -p exited 1: boom");
   });
 
   test("SINGLE-THREADED: a 500 on the read-back GET rejects (not a silent aggregate reset)", async () => {
@@ -652,8 +630,6 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
         name: "eng",
         mode: "single-threaded",
         status: "ok",
-        input: "x",
-        output: "y",
         started_at: "2026-06-18T07:00:00.000Z",
         ended_at: "2026-06-18T07:00:01.000Z",
       }),
@@ -685,8 +661,6 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
       name: "eng",
       mode: "single-threaded",
       status: "ok",
-      input: "one",
-      output: "r1",
       started_at: "2026-06-18T07:00:00.000Z",
       ended_at: "2026-06-18T07:00:05.000Z",
       usage: { totalCostUsd: 0.1 },
@@ -696,8 +670,6 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
       name: "eng",
       mode: "single-threaded",
       status: "ok",
-      input: "two",
-      output: "r2",
       started_at: "2026-06-18T08:00:00.000Z",
       ended_at: "2026-06-18T08:00:09.000Z",
       usage: { totalCostUsd: 0.2 },
@@ -708,9 +680,9 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
     expect(stored!.metadata.total_cost_usd).toBe("0.3");
   });
 
-  test("writeThread() on a MULTI-THREADED error turn records status:error + the failure reason in the body (NO read-back)", async () => {
+  test("writeThread() on a MULTI-THREADED error turn records status:error in METADATA, no content write (NO read-back)", async () => {
     const calls: { url: string; init: RequestInit }[] = [];
-    let captured: { tags: string[]; metadata: Record<string, string>; content: string } | undefined;
+    let captured: { tags: string[]; metadata: Record<string, string>; content?: string } | undefined;
     globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
       calls.push({ url: String(url), init: init ?? {} });
       if (String(url).includes("/api/notes/") && (init?.method ?? "GET") === "PATCH") {
@@ -725,8 +697,6 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
       channel: "eng",
       mode: "multi-threaded",
       status: "error",
-      input: "do the thing",
-      output: "claude -p exited 1: boom",
       started_at: "2026-06-18T07:00:00.000Z",
       ended_at: "2026-06-18T07:00:01.000Z",
     });
@@ -734,9 +704,9 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
     expect(captured!.metadata.status).toBe("error");
     // No definition → the field is absent (not an empty string).
     expect("definition" in captured!.metadata).toBe(false);
-    // The body's latest-turn section is the Error block on a failure.
-    expect(captured!.content).toContain("**Error:**");
-    expect(captured!.content).toContain("claude -p exited 1: boom");
+    // METADATA-ONLY WRITE: the failure is captured in metadata.status; the daemon never writes
+    // the thread body (no `content` in the PATCH).
+    expect("content" in captured!).toBe(false);
     // Multi-threaded does NO read-back even on the error path (fresh per fire).
     expect(
       calls.filter((c) => c.url.includes("/api/notes/") && (c.init.method ?? "GET") === "GET"),
@@ -758,8 +728,6 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
         channel: "eng",
         mode: "multi-threaded",
         status: "ok",
-        input: "x",
-        output: "y",
         started_at: "2026-06-18T07:00:00.000Z",
         ended_at: "2026-06-18T07:00:01.000Z",
       }),
@@ -794,28 +762,23 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
     // START-ENSURE (before the turn): status working, turn_count UNCHANGED (prior 0 → 0).
     await t.writeThread({
       channel: "eng", name: "eng", mode: "single-threaded", status: "working",
-      input: "turn one", output: "", started_at: "2026-06-18T07:00:00.000Z",
+      started_at: "2026-06-18T07:00:00.000Z",
       ended_at: "2026-06-18T07:00:00.000Z", threadId: "t1", phase: "start",
     });
     expect(stored!.metadata.status).toBe("working");
     expect(stored!.metadata.turn_count).toBe("0"); // NOT counted yet.
-    // The working body shows the input + an awaiting-reply state — NO fake reply.
-    expect(stored!.content).toContain("turn one");
-    expect(stored!.content).toContain("working");
-    expect(stored!.content).not.toContain("**Reply:**");
     // last_turn_at is not stamped on a brand-new working-ensure (no turn completed yet).
     expect(stored!.metadata.last_turn_at).toBeUndefined();
 
     // END (after the turn): status ok, turn_count now 1 (counted exactly once).
     await t.writeThread({
       channel: "eng", name: "eng", mode: "single-threaded", status: "ok",
-      input: "turn one", output: "reply one", started_at: "2026-06-18T07:00:00.000Z",
+      started_at: "2026-06-18T07:00:00.000Z",
       ended_at: "2026-06-18T07:00:05.000Z", threadId: "t1", phase: "end",
     });
     expect(stored!.metadata.status).toBe("ok");
     expect(stored!.metadata.turn_count).toBe("1"); // counted ONCE across start+end.
     expect(stored!.metadata.last_turn_at).toBe("2026-06-18T07:00:05.000Z");
-    expect(stored!.content).toContain("reply one");
   });
 
   test("SINGLE-THREADED turn 2 start preserves prior count (1), end increments to 2 — start never double-counts", async () => {
@@ -836,37 +799,37 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
     }) as typeof fetch;
     const t = new VaultTransport(baseConfig());
     await t.start(fakeCtx("eng"));
-    const tn = (status: "working" | "ok", input: string, output: string, ended: string, phase: "start" | "end") => ({
+    const tn = (status: "working" | "ok", ended: string, phase: "start" | "end") => ({
       channel: "eng", name: "eng", mode: "single-threaded" as const, status,
-      input, output, started_at: "2026-06-18T07:00:00.000Z", ended_at: ended, phase,
+      started_at: "2026-06-18T07:00:00.000Z", ended_at: ended, phase,
     });
 
     // Turn 1 — start (0) then end (1).
-    await t.writeThread(tn("working", "one", "", "2026-06-18T07:00:00.000Z", "start"));
+    await t.writeThread(tn("working", "2026-06-18T07:00:00.000Z", "start"));
     expect(stored!.metadata.turn_count).toBe("0");
-    await t.writeThread(tn("ok", "one", "reply one", "2026-06-18T07:00:05.000Z", "end"));
+    await t.writeThread(tn("ok", "2026-06-18T07:00:05.000Z", "end"));
     expect(stored!.metadata.turn_count).toBe("1");
 
     // Turn 2 — start reads prior=1 → writes 1 (UNCHANGED, the no-double-count invariant),
     // then end increments to 2. The start working-ensure must NOT bump the count.
-    await t.writeThread(tn("working", "two", "", "2026-06-18T08:00:00.000Z", "start"));
+    await t.writeThread(tn("working", "2026-06-18T08:00:00.000Z", "start"));
     expect(stored!.metadata.turn_count).toBe("1"); // start preserves the count.
     expect(stored!.metadata.status).toBe("working");
     expect(stored!.metadata.started_at).toBe("2026-06-18T07:00:00.000Z"); // first turn's, preserved.
-    await t.writeThread(tn("ok", "two", "reply two", "2026-06-18T08:00:09.000Z", "end"));
+    await t.writeThread(tn("ok", "2026-06-18T08:00:09.000Z", "end"));
     expect(stored!.metadata.turn_count).toBe("2"); // counted twice total — once per turn.
     expect(stored!.metadata.last_turn_at).toBe("2026-06-18T08:00:09.000Z");
   });
 
   test("MULTI-THREADED start writes turn_count 0 (working) at the per-fire path; end writes 1 at the SAME path", async () => {
-    const patches: { path: string; metadata: Record<string, string>; content: string }[] = [];
+    const patches: { path: string; metadata: Record<string, string>; hasContent: boolean }[] = [];
     globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
       const u = String(url);
       if (u.includes("/api/notes/") && (init?.method ?? "GET") === "PATCH") {
         const body = JSON.parse(String(init?.body)) as {
-          path: string; metadata: Record<string, string>; content: string;
+          path: string; metadata: Record<string, string>;
         };
-        patches.push({ path: decodeURIComponent(u), metadata: body.metadata, content: body.content });
+        patches.push({ path: decodeURIComponent(u), metadata: body.metadata, hasContent: "content" in body });
         return new Response(JSON.stringify({ id: "x" }), { status: 200 });
       }
       return new Response("{}", { status: 200 });
@@ -874,13 +837,13 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
     const t = new VaultTransport(baseConfig());
     await t.start(fakeCtx("eng"));
     const base = {
-      channel: "eng", name: "d", mode: "multi-threaded" as const, input: "q",
+      channel: "eng", name: "d", mode: "multi-threaded" as const,
       started_at: "2026-06-18T07:00:00.000Z", threadId: "fire-1",
     };
     // START — working, turn_count 0, the per-fire note created.
-    await t.writeThread({ ...base, status: "working", output: "", ended_at: "2026-06-18T07:00:00.000Z", phase: "start" });
+    await t.writeThread({ ...base, status: "working", ended_at: "2026-06-18T07:00:00.000Z", phase: "start" });
     // END — ok, turn_count 1, the SAME per-fire path (same threadId).
-    await t.writeThread({ ...base, status: "ok", output: "a", ended_at: "2026-06-18T07:00:05.000Z", phase: "end" });
+    await t.writeThread({ ...base, status: "ok", ended_at: "2026-06-18T07:00:05.000Z", phase: "end" });
 
     expect(patches).toHaveLength(2);
     expect(patches[0]!.metadata.status).toBe("working");
@@ -890,9 +853,10 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
     // Both writes hit the SAME per-fire path (the reused threadId) — start updates, not dupes.
     expect(patches[0]!.path).toContain("/Threads/eng/fire-1");
     expect(patches[1]!.path).toContain("/Threads/eng/fire-1");
-    // The working body shows no fake reply; the end body carries the real reply.
-    expect(patches[0]!.content).not.toContain("**Reply:**");
-    expect(patches[1]!.content).toContain("a");
+    // METADATA-ONLY WRITE: neither the start nor the end write a thread body (the daemon never
+    // writes content — the per-fire note is created with empty content).
+    expect(patches[0]!.hasContent).toBe(false);
+    expect(patches[1]!.hasContent).toBe(false);
   });
 
   // ── thread ≡ session (metadata.session — the unified record) ──────────────────────────
@@ -914,8 +878,6 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
       channel: "eng",
       mode: "multi-threaded",
       status: "ok",
-      input: "q",
-      output: "a",
       started_at: "2026-06-18T07:00:00.000Z",
       ended_at: "2026-06-18T07:00:05.000Z",
       session: "11111111-1111-4111-8111-111111111111",
@@ -947,7 +909,7 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
     // Turn 1 END establishes the session on the note.
     await t.writeThread({
       channel: "eng", name: "eng", mode: "single-threaded", status: "ok",
-      input: "one", output: "reply one", started_at: "2026-06-18T07:00:00.000Z",
+      started_at: "2026-06-18T07:00:00.000Z",
       ended_at: "2026-06-18T07:00:05.000Z", phase: "end",
       session: "sess-ESTABLISHED",
     });
@@ -956,7 +918,7 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
     // Turn 2 START-ENSURE carries NO session — the upsert must PRESERVE the prior one.
     await t.writeThread({
       channel: "eng", name: "eng", mode: "single-threaded", status: "working",
-      input: "two", output: "", started_at: "2026-06-18T08:00:00.000Z",
+      started_at: "2026-06-18T08:00:00.000Z",
       ended_at: "2026-06-18T08:00:00.000Z", phase: "start",
     });
     expect(stored!.metadata.session).toBe("sess-ESTABLISHED"); // preserved, not dropped.
@@ -991,13 +953,13 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
     // Fire 1 of subject "eco-civ" — creates the deterministic subject note, turn_count 1.
     const r1 = await t.writeThread({
       channel: "pm", name: "pm", subject: "eco-civ", mode: "multi-threaded", status: "ok",
-      input: "kickoff", output: "ok1", started_at: "2026-06-18T07:00:00.000Z",
+      started_at: "2026-06-18T07:00:00.000Z",
       ended_at: "2026-06-18T07:00:05.000Z", session: "sess-ECO", phase: "end",
     });
     // Fire 2 of the SAME subject — UPSERTS the same note (turn_count 2), proving continuity.
     const r2 = await t.writeThread({
       channel: "pm", name: "pm", subject: "eco-civ", mode: "multi-threaded", status: "ok",
-      input: "next", output: "ok2", started_at: "2026-06-18T08:00:00.000Z",
+      started_at: "2026-06-18T08:00:00.000Z",
       ended_at: "2026-06-18T08:00:09.000Z", session: "sess-ECO", phase: "end",
     });
 
@@ -1014,7 +976,7 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
     // A DIFFERENT subject of the same agent is a DISTINCT note (distinct leaf).
     const r3 = await t.writeThread({
       channel: "pm", name: "pm", subject: "ai-livelihood", mode: "multi-threaded", status: "ok",
-      input: "other", output: "ok3", started_at: "2026-06-18T09:00:00.000Z",
+      started_at: "2026-06-18T09:00:00.000Z",
       ended_at: "2026-06-18T09:00:03.000Z", phase: "end",
     });
     expect(r3.sent[0]).toBe("Threads/pm/pm--ai-livelihood");
@@ -1039,7 +1001,7 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
     const t = new VaultTransport(baseConfig());
     await t.start(fakeCtx("pm"));
     await t.writeThread({
-      channel: "pm", name: "pm", mode: "multi-threaded", status: "ok", input: "q", output: "a",
+      channel: "pm", name: "pm", mode: "multi-threaded", status: "ok",
       started_at: "2026-06-18T07:00:00.000Z", ended_at: "2026-06-18T07:00:01.000Z", threadId: "fire-xyz",
     });
     // Per-fire uuid leaf, NO read-back (HEAD multi-threaded behavior — byte-identical).
@@ -1072,7 +1034,7 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
     // Write a subject thread carrying a session…
     await t.writeThread({
       channel: "pm", name: "pm", subject: "eco-civ", mode: "multi-threaded", status: "ok",
-      input: "q", output: "a", started_at: "2026-06-18T07:00:00.000Z",
+      started_at: "2026-06-18T07:00:00.000Z",
       ended_at: "2026-06-18T07:00:05.000Z", session: "sess-SUBJECT", phase: "end",
     });
     // …readThreadSession(subject) reads it back off the SUBJECT-scoped path.
@@ -1110,7 +1072,7 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
     // Write a thread note carrying a session…
     await t.writeThread({
       channel: "eng", name: "eng", mode: "single-threaded", status: "ok",
-      input: "x", output: "y", started_at: "2026-06-18T07:00:00.000Z",
+      started_at: "2026-06-18T07:00:00.000Z",
       ended_at: "2026-06-18T07:00:05.000Z", phase: "end",
       session: "sess-ROUNDTRIP",
     });
@@ -1151,7 +1113,7 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
     // Establish a session, then RESET it.
     await t.writeThread({
       channel: "eng", name: "eng", mode: "single-threaded", status: "ok",
-      input: "x", output: "y", started_at: "2026-06-18T07:00:00.000Z",
+      started_at: "2026-06-18T07:00:00.000Z",
       ended_at: "2026-06-18T07:00:05.000Z", phase: "end", session: "sess-TO-CLEAR",
     });
     expect(await t.readThreadSession("eng", "eng")).toBe("sess-TO-CLEAR");
@@ -1191,6 +1153,60 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
     const t = new VaultTransport(baseConfig());
     await t.start(fakeCtx("eng"));
     await expect(t.clearThreadSession("eng", "eng")).rejects.toThrow(/clear thread session failed/);
+  });
+
+  test("PRESERVES authored thread content across an upsert — the PATCH omits content; metadata updates, the body is untouched", async () => {
+    // A stateful vault MIRRORING the real PATCH semantics (verified against routes.ts): omitting
+    // `content` leaves the existing body untouched on UPDATE; a create with no content → "".
+    const store = new Map<string, { metadata: Record<string, string>; content: string }>();
+    let sawContentKey = false;
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const u = decodeURIComponent(String(url));
+      const method = init?.method ?? "GET";
+      if (u.includes("/api/notes/") && method === "GET") {
+        const path = u.split("/api/notes/")[1]!;
+        const hit = store.get(path);
+        return hit ? new Response(JSON.stringify(hit), { status: 200 }) : new Response("nf", { status: 404 });
+      }
+      if (u.includes("/api/notes/") && method === "PATCH") {
+        const body = JSON.parse(String(init?.body)) as { path: string; metadata: Record<string, string>; content?: string };
+        if ("content" in body) sawContentKey = true;
+        const prior = store.get(body.path);
+        const content = "content" in body ? (body.content ?? "") : (prior?.content ?? ""); // omit → preserve / create-empty.
+        store.set(body.path, { metadata: { ...(prior?.metadata ?? {}), ...body.metadata }, content });
+        return new Response(JSON.stringify({ id: body.path }), { status: 200 });
+      }
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+
+    // A human/agent has AUTHORED this thread's standing context onto the note.
+    store.set("Threads/eng/eng", { metadata: { turn_count: "1" }, content: "AUTHORED standing mandate — keep me." });
+
+    // A turn completes → writeThread updates METADATA ONLY.
+    await t.writeThread({
+      channel: "eng", name: "eng", mode: "single-threaded", status: "ok",
+      started_at: "2026-06-18T07:00:00.000Z", ended_at: "2026-06-18T07:00:05.000Z",
+      session: "sess-KEEP",
+    });
+
+    const note = store.get("Threads/eng/eng")!;
+    // The authored content is UNTOUCHED…
+    expect(note.content).toBe("AUTHORED standing mandate — keep me.");
+    // …the PATCH carried NO content key (the metadata-only write)…
+    expect(sawContentKey).toBe(false);
+    // …and the metadata WAS updated (turn counted from the prior, session persisted).
+    expect(note.metadata.turn_count).toBe("2");
+    expect(note.metadata.session).toBe("sess-KEEP");
+    expect(note.metadata.status).toBe("ok");
+
+    // And it round-trips through readThreadContent for the next turn's prompt.
+    expect(await t.readThreadContent("eng", "eng")).toEqual({
+      path: "Threads/eng/eng",
+      content: "AUTHORED standing mandate — keep me.",
+    });
   });
 });
 
@@ -2416,6 +2432,72 @@ describe("VaultTransport — readThreadLoadout (the Phase A loader)", () => {
     await t.start(fakeCtx("eng"));
     const loadout = await t.readThreadLoadout("eng", "eng", "launch blockers");
     expect(loadout).toEqual([{ path: "Note/A", content: "A body" }]);
+    expect(reads[0]).toBe("Threads/eng/eng--launch-blockers");
+  });
+});
+
+// ── thread content as context (DESIGN-2026-06-29-thread-content-and-skills.md) ──
+describe("VaultTransport — readThreadContent (the thread's own authored body, composed as context)", () => {
+  test("returns { path, content } when the thread note has authored content (CONTENT only, never metadata)", async () => {
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      const u = decodeURIComponent(String(url)); // the path's `/` is percent-encoded in the URL.
+      if (u.includes("Threads/eng/eng")) {
+        return new Response(
+          JSON.stringify({
+            metadata: { session: "s1", loadout: ["Skills/Weave"] },
+            content: "This thread's standing mandate.",
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response("not found", { status: 404 });
+    }) as unknown as typeof fetch;
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+    expect(await t.readThreadContent("eng", "eng")).toEqual({
+      path: "Threads/eng/eng",
+      content: "This thread's standing mandate.",
+    });
+  });
+
+  test("no thread note yet (first turn, 404) → undefined (no thread content)", async () => {
+    globalThis.fetch = (async () => new Response("not found", { status: 404 })) as unknown as typeof fetch;
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+    expect(await t.readThreadContent("eng", "eng")).toBeUndefined();
+  });
+
+  test("a BLANK/whitespace thread body → undefined (the no-thread-content invariant)", async () => {
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      const u = decodeURIComponent(String(url)); // the path's `/` is percent-encoded in the URL.
+      if (u.includes("Threads/eng/eng")) {
+        return new Response(JSON.stringify({ metadata: { session: "s1" }, content: "   \n\t  " }), { status: 200 });
+      }
+      return new Response("not found", { status: 404 });
+    }) as unknown as typeof fetch;
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+    expect(await t.readThreadContent("eng", "eng")).toBeUndefined();
+  });
+
+  test("a SUBJECT resolves the subject-scoped thread note (Threads/eng/eng--subj)", async () => {
+    const reads: string[] = [];
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      const u = String(url);
+      const m = /\/api\/notes\/([^?]+)/.exec(u);
+      const path = m ? decodeURIComponent(m[1]!) : "";
+      reads.push(path);
+      if (path === "Threads/eng/eng--launch-blockers") {
+        return new Response(JSON.stringify({ metadata: {}, content: "subject mandate" }), { status: 200 });
+      }
+      return new Response("not found", { status: 404 });
+    }) as unknown as typeof fetch;
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+    expect(await t.readThreadContent("eng", "eng", "launch blockers")).toEqual({
+      path: "Threads/eng/eng--launch-blockers",
+      content: "subject mandate",
+    });
     expect(reads[0]).toBe("Threads/eng/eng--launch-blockers");
   });
 });

--- a/src/transports/vault.ts
+++ b/src/transports/vault.ts
@@ -382,63 +382,6 @@ export function parseLoadoutPaths(v: unknown): string[] {
 }
 
 /**
- * Build the `#agent/thread` note BODY — the rolling SUMMARY of the thread (design
- * 2026-06-18: "hold a summary of this thread in the content; maybe another agent
- * facilitates that"). The MODULE writes a useful default, STRUCTURED (`## Summary` /
- * `## Latest turn`) so the `## Summary` section is the slot a future summarizer agent is
- * EARMARKED to own/enrich; the `## Latest turn` block + the metadata roll-up are always
- * module-owned. The same shape serves both modes (multi-threaded = one turn).
- *
- * v1 LIMITATION — the module OVERWRITES the `## Summary` section every turn. This function
- * REGENERATES the whole body from scratch using only the rolled-up aggregates (passed in
- * from `prior.metadata`); it NEVER reads `prior.content`. So a summarizer agent's
- * enrichment of `## Summary` would be CLOBBERED on the next turn. Summarizer-agent
- * enrichment needs a read-prior-content → merge path (preserve a summarizer-owned section
- * across the regenerate), which is DEFERRED. Until then, "may own" means EARMARKED, not
- * PRESERVED.
- */
-function buildThreadSummaryBody(t: {
-  name: string;
-  mode: string;
-  turnCount: number;
-  status: "ok" | "error" | "working";
-  lastTurnAt: string;
-  input: string;
-  output: string;
-}): string {
-  const turns = t.turnCount === 1 ? "1 turn" : `${t.turnCount} turns`;
-  // `## Summary` is EARMARKED for a future summarizer agent — but v1 OVERWRITES it every
-  // turn (this body is fully regenerated from metadata; `prior.content` is never read), so
-  // it's a module-owned default for now, NOT a preserved slot (see the function doc).
-  // The `## Latest turn` block + the metadata roll-up are always module-owned.
-  //
-  // WORKING (the thread-as-container start-ensure, before the turn finishes): show the input
-  // and a clear "awaiting reply" state — NEVER print a fake reply. The thread is visible the
-  // moment processing starts; the end-record overwrites this body with the real ok/error
-  // reply once the turn completes.
-  if (t.status === "working") {
-    // No turn has COMPLETED yet, so don't print a (confusing) "0 turns" count — the prior
-    // completed count rides in the metadata for queries; the body just says it's working.
-    const priorTurns = t.turnCount === 0 ? "first turn" : `${turns} so far`;
-    const auto = `${t.mode} thread for ${t.name} — working on the ${t.turnCount === 0 ? "first turn" : "next turn"} (${priorTurns}, awaiting reply).`;
-    return (
-      `## Summary\n\n${auto}\n\n` +
-      `## Latest turn\n\n` +
-      `**Input:** ${t.input}\n\n` +
-      `**Status:** working — awaiting reply.\n`
-    );
-  }
-  const auto = `${t.mode} thread for ${t.name} — ${turns}, last ${t.status} at ${t.lastTurnAt}.`;
-  const turnHeading = t.status === "ok" ? "Reply" : "Error";
-  return (
-    `## Summary\n\n${auto}\n\n` +
-    `## Latest turn\n\n` +
-    `**Input:** ${t.input}\n\n` +
-    `**${turnHeading}:** ${t.output}\n`
-  );
-}
-
-/**
  * The module-owned root namespace tag. Declared (with the three children rolling up
  * to it via `parent_names`) so a human `tag:#agent` query expands to EVERYTHING the
  * module owns — definitions, messages, jobs. The module itself never queries by this
@@ -906,9 +849,12 @@ export class VaultTransport implements Transport {
    * Materialize a `#agent/thread` note for ONE completed turn — the UNIFIED model
    * (`definition -> thread -> message`). Written for BOTH execution-lifecycle modes
    * (the structural unification): EVERYTHING is a thread, a "run" was always a thread
-   * with one turn. The note BODY is a rolling SUMMARY of the thread; the metadata is the
-   * thread state. The INDEXED fields (`status`/`definition`/`mode`) make threads
-   * operator-queryable. This note carries `['#agent/thread']` EXACTLY — NOT a
+   * with one turn. This write touches METADATA ONLY (the thread state); the note BODY is
+   * the thread's per-thread standing CONTEXT, AUTHORED by a human/agent and NEVER written
+   * by the daemon (DESIGN-2026-06-29-thread-content-and-skills.md) — the note is created
+   * with EMPTY content when missing and its content is PRESERVED untouched on every later
+   * upsert (the PATCH omits `content`). The INDEXED fields (`status`/`definition`/`mode`)
+   * make threads operator-queryable. This note carries `['#agent/thread']` EXACTLY — NOT a
    * `#agent/message`, NO inbound child — so it can never wake a session (no loop).
    *
    * The MODE governs the thread's IDENTITY + whether it upserts:
@@ -1055,22 +1001,20 @@ export class VaultTransport implements Transport {
       if (costUsd) metadata.total_cost_usd = String(Math.round(costUsd * 1e9) / 1e9);
     }
 
-    const body = buildThreadSummaryBody({
-      name: thread.name ?? thread.channel,
-      mode: thread.mode,
-      turnCount,
-      status: thread.status,
-      lastTurnAt,
-      input: thread.input,
-      output: thread.output,
-    });
-
+    // CONTENT = the thread's per-thread standing context, AUTHORED by a human/agent — an INPUT
+    // to the prompt, NOT a module-generated summary (DESIGN-2026-06-29-thread-content-and-skills.md).
+    // The daemon NEVER writes or overwrites it: this PATCH omits `content` entirely, so the
+    // vault CREATES the note with EMPTY content when missing (its create branch defaults
+    // `content ?? ""`) and PRESERVES the existing content untouched on every later upsert (its
+    // update branch only touches `content` when the body carries it). The thread body is read
+    // back CONTENT-only and composed into the system prompt via `readThreadContent`.
+    //
     // Upsert by path via PATCH + `if_missing: "create"` (vault#309) — NOT POST. POST
     // /api/notes 409s `path_conflict` on an existing path (it does not upsert), so a
     // single-threaded thread note would create on turn 1 and 409 on every turn after.
     // PATCH-by-path is the real upsert: the vault resolves the (decoded) path, UPDATES it
-    // when present (single-threaded turn 2+: content replaced, metadata merged) or CREATES
-    // it when missing (turn 1, and every multi-threaded fresh-uuid fire). `force: true`
+    // when present (single-threaded turn 2+: metadata merged, content left as authored) or
+    // CREATES it when missing (turn 1, and every multi-threaded fresh-uuid fire). `force: true`
     // satisfies the vault's 428 mutation precondition (mirrors `setInboundStatus`). The
     // path is one URL segment (percent-encoded `/`); the route `decodeURIComponent`s it.
     // The `tags` array is consumed ONLY by the create branch. VERIFIED against the vault
@@ -1087,7 +1031,6 @@ export class VaultTransport implements Transport {
         authorization: `Bearer ${this.token}`,
       },
       body: JSON.stringify({
-        content: body,
         path,
         tags: [AGENT_THREAD_TAG],
         metadata,
@@ -1186,6 +1129,35 @@ export class VaultTransport implements Transport {
       const detail = await res.text().catch(() => "");
       throw new Error(`vault transport: clear thread session failed (${res.status}) ${detail}`.trim());
     }
+  }
+
+  /**
+   * Read the thread's own CONTENT — its per-thread standing context
+   * (DESIGN-2026-06-29-thread-content-and-skills.md). The thread note's authored BODY (CONTENT
+   * only — NEVER metadata) becomes the prompt entry BETWEEN the def and the loadout. `subject`
+   * resolves the subject-scoped thread note; omitted → the def-named note (HEAD). The path math
+   * reuses {@link singleThreadedPath}, so it agrees with writeThread / readThreadSession /
+   * readThreadLoadout.
+   *
+   * Returns `{ path, content }` ONLY when the note exists AND carries non-blank content (the
+   * path is the thread-note path, the composer's `# <path>` header). No thread note yet (404,
+   * the first turn before the start-ensure has run / a per-fire thread with no def-named note)
+   * OR blank/whitespace content → `undefined` (the no-thread-content case: the prompt is
+   * `[self, ...loadout]`, unchanged). Best-effort: a network blip surfaces as `undefined` (via
+   * {@link readThreadNote}, which logs it); an UNEXPECTED non-404 read error propagates to the
+   * registry's try/catch (the turn runs with the def body alone).
+   */
+  async readThreadContent(
+    channel: string,
+    name: string,
+    subject?: string,
+  ): Promise<{ path: string; content: string } | undefined> {
+    const path = this.singleThreadedPath(channel, name, subject);
+    const thread = await this.readThreadNote(path);
+    if (!thread) return undefined; // no thread note yet → no authored content.
+    const content = typeof thread.content === "string" ? thread.content : "";
+    if (content.trim().length === 0) return undefined; // blank body → no thread content.
+    return { path, content };
   }
 
   /**


### PR DESCRIPTION
## What

A thread note's **content** becomes a loaded prompt **input** — its per-thread standing context, authored by a human/agent and **preserved** across turns — and the daemon **stops** generating a templated "summary" body.

Implements the *three context layers* + *thread content = context, no faked summary* sections of `DESIGN-2026-06-29-thread-content-and-skills.md`.

The system prompt is now composed in order:

```
[ def body (entry 0, self) , thread content (entry 1) , ...loadout (entries 2..N) ]
```

## Changes

1. **Compose thread content into the prompt** (`src/backends/types.ts`, `src/backends/programmatic.ts`)
   - `composeSystemPrompt` gains a `protectedCount` option (default `1`). The `LOADOUT_BUDGET_BYTES` truncation now protects the **leading N entries** (def + thread content) and sheds only the loadout **tail**. Doc + warn message updated.
   - `ProgrammaticBackend.deliver` gains a `threadContent?: LoadoutEntry` param and builds `[self, ...(non-blank thread content), ...loadout]`, passing `protectedCount = hasThreadContent ? 2 : 1`. Inclusion and count are gated on the **same** non-blank check so the protected prefix stays aligned. Blank/absent → `[self, ...loadout]`, byte-identical to HEAD (the no-thread-content invariant).

2. **Daemon stops writing thread content** (`src/transports/vault.ts`)
   - Removed `buildThreadSummaryBody`. `writeThread` now writes **metadata only**: the PATCH **omits `content`**, so the vault **creates** the note with empty content when missing and **preserves** authored content untouched on every later upsert. Verified against `parachute-vault/src/routes.ts`: the PATCH update branch only sets content when `body.content !== undefined`; the `if_missing:create` branch defaults `content ?? ""`.
   - New `readThreadContent(channel, name, subject?)` reads the thread note's own body **CONTENT-only**, returning `undefined` on 404 / blank.

3. **Wiring** — `Transport.readThreadContent` (optional) + `daemon.buildReadThreadContent` + registry drain reads it pre-turn and passes it to `deliver` (best-effort: a read failure logs and the turn runs without thread content, never strands the queue).

4. **Cleanup** — removed the now-dead `input`/`output` fields from `ThreadRecord` / `ThreadNote` / `recordThread` (they only fed the deleted summary builder; the turn's text lives in the `#agent/message` transcript).

5. **rc bump** `0.2.3-rc.17` → `0.2.3-rc.18`.

## Tests
- `compose.test.ts`: protectedCount protects def + thread content under an over-budget loadout; thread content renders between def and loadout; default `1` unchanged.
- `programmatic.test.ts`: composed `system-prompt.txt` = `[self, thread-content, ...loadout]`; no thread content → `[self, ...loadout]`; blank thread content skipped.
- `vault.test.ts`: metadata-only write (PATCH carries no `content`); **authored content preserved across an upsert** (stateful stub mirroring real PATCH semantics); `readThreadContent` content/404/blank/subject. Summary-body assertions removed.
- `registry.test.ts`: the drain reads `readThreadContent` and passes it to `deliver`; unwired → undefined; a read throw is swallowed.

`bun run typecheck` clean. `bun test ./src/` — **1363 pass / 0 fail**.

## Deploy migration (run separately, NOT in this PR)
Existing `#agent/thread` notes hold old templated bodies; if left, they would inject as context after this ships. **Blank their content before the daemon upgrade** (see the report handed to the team-lead for the exact query + update).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T6HAzWsgiJy4ndsWSCWY5S