### PR TITLE
feat(agent): #agent/role as the first composition layer (roles)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/agent",
-  "version": "0.2.3-rc.18",
+  "version": "0.2.3-rc.19",
   "description": "Vault-native agents for Claude Code — a #agent/definition note + an inbound message becomes a sandboxed claude turn; the reply is written back as a note. Messaging gateway on :1941.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/src/agent-defs.test.ts
+++ b/src/agent-defs.test.ts
@@ -22,7 +22,7 @@ import {
   type DefVaultBinding,
   type InstantiateDeps,
 } from "./agent-defs.ts";
-import { GrantsClient, connectionKey, packPathKey, type ConnectionSpec } from "./grants.ts";
+import { GrantsClient, connectionKey, rolePathKey, type ConnectionSpec } from "./grants.ts";
 import type { AgentSpec } from "./sandbox/types.ts";
 
 const realFetch = globalThis.fetch;
@@ -1530,42 +1530,42 @@ describe("AgentDefRegistry — deleteDef ordering + grant-GC surfacing (FIX 4/5,
 });
 
 // ---------------------------------------------------------------------------
-// AgentDefRegistry.reconcilePack — per-pack grant reconcile (threads-only Phase B′)
+// AgentDefRegistry.reconcileRole — per-role grant reconcile (threads-only Phase B′)
 // ---------------------------------------------------------------------------
 
-describe("AgentDefRegistry — reconcilePack (per-pack grant reconcile, Phase B′)", () => {
-  test("a clean #pack with wants → registers each under the pack PATH key + reconciles that set", async () => {
+describe("AgentDefRegistry — reconcileRole (per-role grant reconcile, Phase B′)", () => {
+  test("a clean #agent/role with wants → registers each under the role PATH key + reconciles that set", async () => {
     const { deps } = recorderDeps();
     const registered: Array<{ agent: string; connection: ConnectionSpec }> = [];
     const reconciled: Array<{ agent: string; liveConnections: ConnectionSpec[] }> = [];
     const grants = fakeGrantsClient({ registered, reconciled });
-    // The vault serves the pack note by id (getNote), with the #pack tag + wants.
+    // The vault serves the role note by id (getNote), with the #agent/role tag + wants.
     const fetchFn = vaultFetch({
       byId: {
-        "Packs/github": {
-          id: "Packs/github",
+        "Roles/github": {
+          id: "Roles/github",
           // tags carried through (cast: vaultFetch's byId type omits tags but serializes the object).
-          ...( { tags: ["pack"] } as Record<string, unknown> ),
-          content: "pack body",
+          ...( { tags: ["agent/role"] } as Record<string, unknown> ),
+          content: "role body",
           metadata: { wants: "vault:research:read, env:github" },
         } as never,
       },
     });
     const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn, grants });
-    const result = await reg.reconcilePack("default", "Packs/github", "created");
+    const result = await reg.reconcileRole("default", "Roles/github", "created");
     expect(result).toBe("reconciled");
 
-    const expectedKey = packPathKey("Packs/github");
-    // Each want registered UNDER THE PACK PATH KEY (not the thread, not any def name).
+    const expectedKey = rolePathKey("Roles/github");
+    // Each want registered UNDER THE ROLE PATH KEY (not the thread, not any def name).
     expect(registered.every((r) => r.agent === expectedKey)).toBe(true);
     expect(registered.map((r) => r.connection.target).sort()).toEqual(["github", "research"]);
-    // Reconcile sent the live SPECS under the SAME pack key (its OWN partition).
+    // Reconcile sent the live SPECS under the SAME role key (its OWN partition).
     expect(reconciled).toHaveLength(1);
     expect(reconciled[0]!.agent).toBe(expectedKey);
     expect(reconciled[0]!.liveConnections.map((c) => c.target).sort()).toEqual(["github", "research"]);
   });
 
-  test("SECURITY GATE: a loaded note WITHOUT the #pack tag → prune-to-[] (its wants are inert)", async () => {
+  test("SECURITY GATE: a loaded note WITHOUT the #agent/role tag → prune-to-[] (its wants are inert)", async () => {
     const { deps } = recorderDeps();
     const registered: Array<{ agent: string; connection: ConnectionSpec }> = [];
     const reconciled: Array<{ agent: string; liveConnections: ConnectionSpec[] }> = [];
@@ -1574,58 +1574,58 @@ describe("AgentDefRegistry — reconcilePack (per-pack grant reconcile, Phase B�
       byId: {
         "Refs/leaky": {
           id: "Refs/leaky",
-          ...( { tags: ["reference"] } as Record<string, unknown> ), // NOT a pack
+          ...( { tags: ["reference"] } as Record<string, unknown> ), // NOT a role
           content: "body",
           metadata: { wants: "vault:secrets:read" }, // declared but inert
         } as never,
       },
     });
     const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn, grants });
-    const result = await reg.reconcilePack("default", "Refs/leaky", "updated");
+    const result = await reg.reconcileRole("default", "Refs/leaky", "updated");
     expect(result).toBe("pruned");
     // NOTHING registered (the gate) — and its partition pruned to [].
     expect(registered).toHaveLength(0);
-    expect(reconciled).toEqual([{ agent: packPathKey("Refs/leaky"), liveConnections: [] }]);
+    expect(reconciled).toEqual([{ agent: rolePathKey("Refs/leaky"), liveConnections: [] }]);
   });
 
-  test("a #pack that DROPPED wants → prune-to-[] for ITS OWN partition only", async () => {
+  test("a #agent/role that DROPPED wants → prune-to-[] for ITS OWN partition only", async () => {
     const { deps } = recorderDeps();
     const reconciled: Array<{ agent: string; liveConnections: ConnectionSpec[] }> = [];
     const grants = fakeGrantsClient({ reconciled });
     const fetchFn = vaultFetch({
       byId: {
-        "Packs/github": {
-          id: "Packs/github",
-          ...( { tags: ["pack"] } as Record<string, unknown> ),
+        "Roles/github": {
+          id: "Roles/github",
+          ...( { tags: ["agent/role"] } as Record<string, unknown> ),
           content: "body",
           metadata: {}, // wants removed
         } as never,
       },
     });
     const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn, grants });
-    expect(await reg.reconcilePack("default", "Packs/github", "updated")).toBe("pruned");
-    expect(reconciled).toEqual([{ agent: packPathKey("Packs/github"), liveConnections: [] }]);
+    expect(await reg.reconcileRole("default", "Roles/github", "updated")).toBe("pruned");
+    expect(reconciled).toEqual([{ agent: rolePathKey("Roles/github"), liveConnections: [] }]);
   });
 
-  test("a deleted pack → prune-to-[] without a fetch (CONFIRMED removal), its partition only", async () => {
+  test("a deleted role → prune-to-[] without a fetch (CONFIRMED removal), its partition only", async () => {
     const { deps } = recorderDeps();
     const reconciled: Array<{ agent: string; liveConnections: ConnectionSpec[] }> = [];
     const grants = fakeGrantsClient({ reconciled });
     // byId is irrelevant — a delete event prunes without fetching.
     const fetchFn = vaultFetch({ byId: {} });
     const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn, grants });
-    expect(await reg.reconcilePack("default", "Packs/github", "deleted")).toBe("pruned");
-    expect(reconciled).toEqual([{ agent: packPathKey("Packs/github"), liveConnections: [] }]);
+    expect(await reg.reconcileRole("default", "Roles/github", "deleted")).toBe("pruned");
+    expect(reconciled).toEqual([{ agent: rolePathKey("Roles/github"), liveConnections: [] }]);
   });
 
-  test("a 404 on the pack note (gone) → prune-to-[] (confirmed removal)", async () => {
+  test("a 404 on the role note (gone) → prune-to-[] (confirmed removal)", async () => {
     const { deps } = recorderDeps();
     const reconciled: Array<{ agent: string; liveConnections: ConnectionSpec[] }> = [];
     const grants = fakeGrantsClient({ reconciled });
-    const fetchFn = vaultFetch({ byId: { "Packs/github": null } }); // 404
+    const fetchFn = vaultFetch({ byId: { "Roles/github": null } }); // 404
     const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn, grants });
-    expect(await reg.reconcilePack("default", "Packs/github", "updated")).toBe("pruned");
-    expect(reconciled).toEqual([{ agent: packPathKey("Packs/github"), liveConnections: [] }]);
+    expect(await reg.reconcileRole("default", "Roles/github", "updated")).toBe("pruned");
+    expect(reconciled).toEqual([{ agent: rolePathKey("Roles/github"), liveConnections: [] }]);
   });
 
   test("a MALFORMED wants → status:error stamped, NEVER reconciled (no nuke of approved grants)", async () => {
@@ -1636,19 +1636,19 @@ describe("AgentDefRegistry — reconcilePack (per-pack grant reconcile, Phase B�
     const fetchFn = vaultFetch({
       patches,
       byId: {
-        "Packs/bad": {
-          id: "Packs/bad",
-          ...( { tags: ["pack"] } as Record<string, unknown> ),
+        "Roles/bad": {
+          id: "Roles/bad",
+          ...( { tags: ["agent/role"] } as Record<string, unknown> ),
           content: "body",
           metadata: { wants: "garbage-no-colon" },
         } as never,
       },
     });
     const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn, grants });
-    expect(await reg.reconcilePack("default", "Packs/bad", "updated")).toBe("error");
-    // The note is stamped error; NO reconcile happened (a malformed pack must not present a
+    expect(await reg.reconcileRole("default", "Roles/bad", "updated")).toBe("error");
+    // The note is stamped error; NO reconcile happened (a malformed role must not present a
     // stale/empty live set that would prune its approved grants — the safety rule).
-    expect(patches.find((p) => p.id === "Packs/bad")!.status).toBe("error");
+    expect(patches.find((p) => p.id === "Roles/bad")!.status).toBe("error");
     expect(reconciled).toHaveLength(0);
   });
 
@@ -1656,37 +1656,37 @@ describe("AgentDefRegistry — reconcilePack (per-pack grant reconcile, Phase B�
     const { deps } = recorderDeps();
     const fetchFn = vaultFetch({ byId: {} });
     const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn }); // no grants
-    expect(await reg.reconcilePack("default", "Packs/github", "created")).toBe("skipped");
+    expect(await reg.reconcileRole("default", "Roles/github", "created")).toBe("skipped");
   });
 
   test("an unknown vault → skipped (never throws)", async () => {
     const { deps } = recorderDeps();
     const grants = fakeGrantsClient({});
     const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn: vaultFetch({}), grants });
-    expect(await reg.reconcilePack("ghost-vault", "Packs/github", "created")).toBe("skipped");
+    expect(await reg.reconcileRole("ghost-vault", "Roles/github", "created")).toBe("skipped");
   });
 
-  test("PARTITION ISOLATION: a pack reconcile never touches a def's grant key", async () => {
+  test("PARTITION ISOLATION: a role reconcile never touches a def's grant key", async () => {
     const { deps } = recorderDeps();
     const registered: Array<{ agent: string; connection: ConnectionSpec }> = [];
     const reconciled: Array<{ agent: string; liveConnections: ConnectionSpec[] }> = [];
     const grants = fakeGrantsClient({ registered, reconciled });
     const fetchFn = vaultFetch({
       byId: {
-        "Packs/github": {
-          id: "Packs/github",
-          ...( { tags: ["pack"] } as Record<string, unknown> ),
+        "Roles/github": {
+          id: "Roles/github",
+          ...( { tags: ["agent/role"] } as Record<string, unknown> ),
           content: "body",
           metadata: { wants: "env:github" },
         } as never,
       },
     });
     const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn, grants });
-    await reg.reconcilePack("default", "Packs/github", "created");
-    // Every register + reconcile addressed the PACK key — never `steward` or any bare def name.
-    const packKey = packPathKey("Packs/github");
-    expect(registered.every((r) => r.agent === packKey)).toBe(true);
-    expect(reconciled.every((r) => r.agent === packKey)).toBe(true);
+    await reg.reconcileRole("default", "Roles/github", "created");
+    // Every register + reconcile addressed the ROLE key — never `steward` or any bare def name.
+    const roleKey = rolePathKey("Roles/github");
+    expect(registered.every((r) => r.agent === roleKey)).toBe(true);
+    expect(reconciled.every((r) => r.agent === roleKey)).toBe(true);
     // Specifically: no def-name partition was touched.
     expect(registered.some((r) => r.agent === "steward")).toBe(false);
     expect(reconciled.some((r) => r.agent === "steward")).toBe(false);

--- a/src/agent-defs.ts
+++ b/src/agent-defs.ts
@@ -53,8 +53,8 @@ import {
   resolveConnectionStatus,
   WantsParseError,
   GrantsClient,
-  isPackNote,
-  packPathKey,
+  isRoleNote,
+  rolePathKey,
   type ConnectionSpec,
 } from "./grants.ts";
 
@@ -592,7 +592,7 @@ export class DefVaultClient {
   }
 
   /** Fetch ONE note by id (for a created/updated reload). Null on 404/miss. `tags` is carried
-   *  through (threads-only Phase B′ — reconcilePack needs it for the `#pack` security gate). */
+   *  through (reconcileRole needs it for the `#agent/role` security gate). */
   async getNote(
     id: string,
   ): Promise<{ id: string; path?: string; content?: string; metadata?: Record<string, unknown>; tags?: unknown } | null> {
@@ -618,7 +618,7 @@ export class DefVaultClient {
       ...(typeof note.path === "string" && note.path ? { path: note.path } : {}),
       content: note.content,
       metadata: note.metadata,
-      // Carry tags for the pack security gate (Phase B′ — reconcilePack reads `#pack`).
+      // Carry tags for the role security gate (reconcileRole reads `#agent/role`).
       ...(note.tags !== undefined ? { tags: note.tags } : {}),
     };
   }
@@ -1322,30 +1322,31 @@ export class AgentDefRegistry {
   }
 
   /**
-   * Reconcile ONE PACK's grants (threads-only Phase B′ — DESIGN-2026-06-29-threads-only.md §4).
-   * Driven by the per-pack vault trigger (`POST /api/vault/pack` → here), NOT by load (load is
-   * per-turn). A pack is the GRANT-DECLARING note; its `wants:` is keyed on the hub by the pack's
-   * slugged PATH ({@link packPathKey}) — its OWN prune partition, so this reconcile can NEVER
-   * touch a def's grants or another pack's (the `feedback_cross_repo_derived_key_divergence`
-   * class is structurally avoided: the live set is trivially this one note's current `wants:`).
+   * Reconcile ONE ROLE's grants (roles as the capability layer —
+   * DESIGN-2026-06-29-threads-roles-context.md). Driven by the per-role vault trigger
+   * (`POST /api/vault/role` → here), NOT by load (load is per-turn). A role is the
+   * GRANT-DECLARING note; its `wants:` is keyed on the hub by the role's slugged PATH
+   * ({@link rolePathKey}) — its OWN prune partition, so this reconcile can NEVER touch a def's
+   * grants or another role's (the `feedback_cross_repo_derived_key_divergence` class is
+   * structurally avoided: the live set is trivially this one note's current `wants:`).
    *
    * Outcomes (mirrors the def-load grant discipline):
    *   - `deleted` event (FORWARD-COMPATIBLE — the vault has no `deleted` trigger today, so the
    *     live delete path is the 404 case below + the 60s loadAll poll; the explicit handling is
    *     kept so a future `deleted` trigger Just Works), OR the note is gone (404), OR it no
-   *     longer carries `#pack`, OR it declares no `wants:`  → PRUNE that pack's partition to []
-   *     (`reconcileGrants(packKey, [])`). Per-pack, so safe.
-   *   - a clean parse of a `#pack` note's `wants:` → REGISTER each connection under `packKey`
+   *     longer carries `#agent/role`, OR it declares no `wants:`  → PRUNE that role's partition to
+   *     [] (`reconcileGrants(roleKey, [])`). Per-role, so safe.
+   *   - a clean parse of an `#agent/role` note's `wants:` → REGISTER each connection under `roleKey`
    *     (idempotent upsert) + RECONCILE to that live set (prune any want it no longer declares).
    *   - a PARSE ERROR on `wants:` → stamp the note `status:error`, NEVER reconcile (a malformed
-   *     pack must not present a stale/empty live set that nukes its approved grants — the same
+   *     role must not present a stale/empty live set that nukes its approved grants — the same
    *     safety rule the def path uses).
    *   - no grants client (hub not provisioned) → no-op (best-effort).
    *
    * Best-effort + non-fatal throughout — a reconcile/registration fault logs + returns; it never
-   * throws out of the webhook path. The pack's PATH is read off the note (fallback: the note id).
+   * throws out of the webhook path. The role's PATH is read off the note (fallback: the note id).
    */
-  async reconcilePack(
+  async reconcileRole(
     vault: string,
     noteId: string,
     event?: "created" | "updated" | "deleted",
@@ -1353,12 +1354,12 @@ export class AgentDefRegistry {
     if (!this.grants) return "skipped"; // hub not provisioned → no grant store to reconcile.
     const client = this.clients.get(vault);
     if (!client) {
-      console.warn(`agent-defs: pack reconcile for unknown vault "${vault}" — ignoring.`);
+      console.warn(`agent-defs: role reconcile for unknown vault "${vault}" — ignoring.`);
       return "skipped";
     }
     // A delete event: the note is gone — prune its partition without a fetch (a CONFIRMED removal).
     if (event === "deleted") {
-      await this.prunePackGrants(packPathKey(noteId));
+      await this.pruneRoleGrants(rolePathKey(noteId));
       return "pruned";
     }
     let note: Awaited<ReturnType<DefVaultClient["getNote"]>>;
@@ -1366,22 +1367,22 @@ export class AgentDefRegistry {
       note = await client.getNote(noteId);
     } catch (err) {
       // A fetch FAILURE is NOT a confirmed removal — never prune from an inconclusive read.
-      console.error(`agent-defs: pack reconcile fetch of ${noteId} from "${vault}" failed: ${(err as Error).message}`);
+      console.error(`agent-defs: role reconcile fetch of ${noteId} from "${vault}" failed: ${(err as Error).message}`);
       return "skipped";
     }
     if (!note) {
-      // 404 — the pack is gone (deleted / no longer visible). CONFIRMED removal → prune its partition.
-      await this.prunePackGrants(packPathKey(noteId));
+      // 404 — the role is gone (deleted / no longer visible). CONFIRMED removal → prune its partition.
+      await this.pruneRoleGrants(rolePathKey(noteId));
       return "pruned";
     }
-    // The grant key is the pack's PATH (slugged), mirroring the slug discipline grantId uses.
+    // The grant key is the role's PATH (slugged), mirroring the slug discipline grantId uses.
     // Fall back to the note id when the vault didn't surface a path.
-    const packPath = typeof note.path === "string" && note.path ? note.path : noteId;
-    const packKey = packPathKey(packPath);
-    // THE SECURITY GATE: only a `#pack` note's `wants:` is honored. A note that lost the pack
-    // tag (or never had it) drops to prune-to-[] for its partition — its `wants:` is inert.
-    if (!isPackNote({ tags: (note as { tags?: unknown }).tags })) {
-      await this.prunePackGrants(packKey);
+    const rolePath = typeof note.path === "string" && note.path ? note.path : noteId;
+    const roleKey = rolePathKey(rolePath);
+    // THE SECURITY GATE: only an `#agent/role` note's `wants:` is honored. A note that lost the
+    // role tag (or never had it) drops to prune-to-[] for its partition — its `wants:` is inert.
+    if (!isRoleNote({ tags: (note as { tags?: unknown }).tags })) {
+      await this.pruneRoleGrants(roleKey);
       return "pruned";
     }
     let wants: ConnectionSpec[];
@@ -1389,52 +1390,52 @@ export class AgentDefRegistry {
       wants = parseWants(note.metadata?.wants);
     } catch (err) {
       // A malformed `wants:` → stamp the note `status:error`, NEVER reconcile (don't present a
-      // stale/empty live set that would nuke this pack's approved grants). Best-effort stamp.
-      console.error(`agent-defs: pack ${noteId} in "${vault}" has a malformed wants: ${(err as Error).message}`);
+      // stale/empty live set that would nuke this role's approved grants). Best-effort stamp.
+      console.error(`agent-defs: role ${noteId} in "${vault}" has a malformed wants: ${(err as Error).message}`);
       await client.patchStatus(noteId, "error").catch(() => {});
       return "error";
     }
     if (wants.length === 0) {
-      // The pack declares no wants (or dropped them) → prune its partition to [] (per-pack, safe).
-      await this.prunePackGrants(packKey);
+      // The role declares no wants (or dropped them) → prune its partition to [] (per-role, safe).
+      await this.pruneRoleGrants(roleKey);
       return "pruned";
     }
-    // REGISTER each want under the pack key (idempotent upsert) + RECONCILE to this live set.
+    // REGISTER each want under the role key (idempotent upsert) + RECONCILE to this live set.
     const grants = this.grants;
     for (const conn of wants) {
       try {
-        await grants.registerGrant(packKey, conn);
+        await grants.registerGrant(roleKey, conn);
       } catch (err) {
         // A single registration fault is non-fatal — the others still register; the operator
         // approves later. (The reconcile below sends the live SPECS, so a missed register
         // doesn't get pruned.)
         console.warn(
-          `agent-defs: registering pack grant for "${packKey}" (${connectionKey(conn)}) failed ` +
+          `agent-defs: registering role grant for "${roleKey}" (${connectionKey(conn)}) failed ` +
             `(continuing): ${(err as Error).message}`,
         );
       }
     }
     try {
-      const { pruned } = await grants.reconcileGrants(packKey, wants);
-      if (pruned > 0) console.log(`agent-defs: pruned ${pruned} stale grant(s) for pack "${packKey}".`);
+      const { pruned } = await grants.reconcileGrants(roleKey, wants);
+      if (pruned > 0) console.log(`agent-defs: pruned ${pruned} stale grant(s) for role "${roleKey}".`);
     } catch (err) {
-      console.warn(`agent-defs: reconciling pack grants for "${packKey}" failed (continuing): ${(err as Error).message}`);
+      console.warn(`agent-defs: reconciling role grants for "${roleKey}" failed (continuing): ${(err as Error).message}`);
     }
     return "reconciled";
   }
 
   /**
-   * Prune a pack's grant partition to [] (`reconcileGrants(packKey, [])`) — the per-pack GC for a
-   * deleted pack / a pack that dropped `wants:` / a note that lost the `#pack` tag. Per-pack, so
-   * it can never touch a def's or another pack's grants. Best-effort: a fault logs + returns.
+   * Prune a role's grant partition to [] (`reconcileGrants(roleKey, [])`) — the per-role GC for a
+   * deleted role / a role that dropped `wants:` / a note that lost the `#agent/role` tag. Per-role,
+   * so it can never touch a def's or another role's grants. Best-effort: a fault logs + returns.
    */
-  private async prunePackGrants(packKey: string): Promise<void> {
+  private async pruneRoleGrants(roleKey: string): Promise<void> {
     if (!this.grants) return;
     try {
-      const { pruned } = await this.grants.reconcileGrants(packKey, []);
-      if (pruned > 0) console.log(`agent-defs: pruned ${pruned} grant(s) for removed pack "${packKey}".`);
+      const { pruned } = await this.grants.reconcileGrants(roleKey, []);
+      if (pruned > 0) console.log(`agent-defs: pruned ${pruned} grant(s) for removed role "${roleKey}".`);
     } catch (err) {
-      console.warn(`agent-defs: pruning pack grants for "${packKey}" failed (continuing): ${(err as Error).message}`);
+      console.warn(`agent-defs: pruning role grants for "${roleKey}" failed (continuing): ${(err as Error).message}`);
     }
   }
 

--- a/src/backends/compose.test.ts
+++ b/src/backends/compose.test.ts
@@ -34,12 +34,12 @@ describe("composeSystemPrompt — arity-N loadout", () => {
     const entries: LoadoutEntry[] = [
       { path: "Agents/steward", content: "self body" },
       { path: "Projects/Surface", content: "project body" },
-      { path: "Packs/GitHub", content: "pack body" },
+      { path: "Refs/GitHub", content: "ref body" },
     ];
     expect(composeSystemPrompt(entries)).toBe(
       "# Agents/steward\n\nself body" +
         "\n\n---\n\n# Projects/Surface\n\nproject body" +
-        "\n\n---\n\n# Packs/GitHub\n\npack body",
+        "\n\n---\n\n# Refs/GitHub\n\nref body",
     );
   });
 
@@ -119,7 +119,36 @@ describe("composeSystemPrompt — byte budget", () => {
   });
 });
 
-describe("composeSystemPrompt — protectedCount (the def + thread-content protected prefix)", () => {
+describe("composeSystemPrompt — protectedCount (the roles + def + thread-content protected prefix)", () => {
+  test("protectedCount=3 protects the WHOLE roles+def+thread prefix; only the layer-③ tail sheds", () => {
+    // The shape the backend builds with one role loaded: [role, self(def), thread-content, ...loadout].
+    const role = { path: "Roles/PM", content: "ROLE-" + "r".repeat(200) };
+    const self = { path: "Agents/uni", content: "DEF-" + "d".repeat(200) };
+    const threadContent = { path: "Threads/eng/uni", content: "THREAD-" + "t".repeat(200) };
+    const big = (p: string) => ({ path: p, content: p + "-" + "x".repeat(400) });
+    const warnings: string[] = [];
+    // Budget fits the three protected entries but not the extra-context loadout notes.
+    const budget = 900;
+    const out = composeSystemPrompt([role, self, threadContent, big("n1"), big("n2")], {
+      budgetBytes: budget,
+      protectedCount: 3,
+      onWarn: (m) => warnings.push(m),
+    });
+    // The role leads, then the def, then the thread content — all three survive whole, in order.
+    expect(out).toBe(
+      `# ${role.path}\n\n${role.content}` +
+        `\n\n---\n\n# ${self.path}\n\n${self.content}` +
+        `\n\n---\n\n# ${threadContent.path}\n\n${threadContent.content}`,
+    );
+    // Only the layer-③ tail was shed; the warn names neither the role, the def, nor the thread.
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("n1");
+    expect(warnings[0]).toContain("n2");
+    expect(warnings[0]).not.toContain("Roles/PM");
+    expect(warnings[0]).not.toContain("Agents/uni");
+    expect(warnings[0]).not.toContain("Threads/eng/uni");
+  });
+
   test("protectedCount=2 protects BOTH leading entries (def + thread content), tail-drops only the loadout (index ≥2)", () => {
     // The shape the backend builds: [self(def), thread-content, ...loadout].
     const self = { path: "Agents/uni", content: "DEF-" + "d".repeat(200) };

--- a/src/backends/programmatic.test.ts
+++ b/src/backends/programmatic.test.ts
@@ -644,14 +644,14 @@ describe("ProgrammaticBackend.deliver — composed system prompt (threads-only P
 
     await backend.deliver(handle, "go", createSession("sess-CP3"), undefined, undefined, undefined, [
       { path: "Projects/Surface", content: "Project body A." },
-      { path: "Packs/GitHub", content: "Pack body B." },
+      { path: "Roles/GitHub", content: "Role body B." },
     ]);
 
     const promptPath = join(sessionWorkspace(sessionsDir, "eng"), "system-prompt.txt");
     expect(readFileSync(promptPath, "utf8")).toBe(
       `# Agents/steward\n\n${ROLE}` +
         `\n\n---\n\n# Projects/Surface\n\nProject body A.` +
-        `\n\n---\n\n# Packs/GitHub\n\nPack body B.`,
+        `\n\n---\n\n# Roles/GitHub\n\nRole body B.`,
     );
   });
 
@@ -664,15 +664,15 @@ describe("ProgrammaticBackend.deliver — composed system prompt (threads-only P
     await backend.deliver(handle, "go", createSession("sess-CP5"), undefined, undefined, undefined, [
       { path: "Projects/Surface", content: "First wins." },
       { path: "Projects/Surface", content: "Duplicate — dropped." },
-      { path: "Packs/Blank", content: "   \n  " }, // whitespace-only → skipped
-      { path: "Packs/GitHub", content: "Kept." },
+      { path: "Roles/Blank", content: "   \n  " }, // whitespace-only → skipped
+      { path: "Roles/GitHub", content: "Kept." },
     ]);
 
     const promptPath = join(sessionWorkspace(sessionsDir, "eng"), "system-prompt.txt");
     expect(readFileSync(promptPath, "utf8")).toBe(
       `# Agents/steward\n\n${ROLE}` +
         `\n\n---\n\n# Projects/Surface\n\nFirst wins.` +
-        `\n\n---\n\n# Packs/GitHub\n\nKept.`,
+        `\n\n---\n\n# Roles/GitHub\n\nKept.`,
     );
   });
 
@@ -754,11 +754,130 @@ describe("ProgrammaticBackend.deliver — composed system prompt (threads-only P
     const handle = await backend.start(specWithVault("eng"));
 
     await backend.deliver(handle, "go", createSession("sess-CP4"), undefined, undefined, undefined, [
-      { path: "Packs/GitHub", content: "a note" },
+      { path: "Roles/GitHub", content: "a note" },
     ]);
 
     const promptPath = join(sessionWorkspace(sessionsDir, "eng"), "system-prompt.txt");
     expect(existsSync(promptPath)).toBe(false);
+  });
+
+  // ── roles as the layer-① composition (DESIGN-2026-06-29-threads-roles-context.md) ──
+  test("ROLES compose FIRST — before the def (self), each path-headered", async () => {
+    mkDirs("compose-role-first");
+    const { fn } = recordingSpawn({ stdout: successTurn("sess-RL1", "ok") });
+    const backend = new ProgrammaticBackend(baseDeps(fn));
+    const handle = await backend.start(specWithDef(ROLE, "Agents/uni", "eng"));
+
+    // roles is the 11th param — leave loadout/subject/roleKeys/threadContent undefined.
+    await backend.deliver(
+      handle,
+      "go",
+      createSession("sess-RL1"),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      [{ path: "Roles/PM", content: "You are a project manager." }],
+    );
+
+    const promptPath = join(sessionWorkspace(sessionsDir, "eng"), "system-prompt.txt");
+    // The role leads; the def (self) follows.
+    expect(readFileSync(promptPath, "utf8")).toBe(
+      `# Roles/PM\n\nYou are a project manager.` + `\n\n---\n\n# Agents/uni\n\n${ROLE}`,
+    );
+  });
+
+  test("FULL three-layer order: [...roles, self, thread-content, ...loadout]", async () => {
+    mkDirs("compose-three-layer");
+    const { fn } = recordingSpawn({ stdout: successTurn("sess-RL2", "ok") });
+    const backend = new ProgrammaticBackend(baseDeps(fn));
+    const handle = await backend.start(specWithDef(ROLE, "Agents/uni", "eng"));
+
+    await backend.deliver(
+      handle,
+      "go",
+      createSession("sess-RL2"),
+      undefined,
+      undefined,
+      undefined,
+      [{ path: "Skills/Weave", content: "Skill body." }], // loadout (layer ③, 7th param)
+      undefined,
+      undefined,
+      { path: "Threads/eng/uni", content: "This thread's mandate." }, // thread content (layer ②, 10th)
+      [
+        { path: "Roles/PM", content: "PM hat." },
+        { path: "Roles/Editor", content: "Editor hat." },
+      ], // roles (layer ①, 11th)
+    );
+
+    const promptPath = join(sessionWorkspace(sessionsDir, "eng"), "system-prompt.txt");
+    expect(readFileSync(promptPath, "utf8")).toBe(
+      `# Roles/PM\n\nPM hat.` +
+        `\n\n---\n\n# Roles/Editor\n\nEditor hat.` +
+        `\n\n---\n\n# Agents/uni\n\n${ROLE}` +
+        `\n\n---\n\n# Threads/eng/uni\n\nThis thread's mandate.` +
+        `\n\n---\n\n# Skills/Weave\n\nSkill body.`,
+    );
+  });
+
+  test("NO-ROLES INVARIANT: empty roles → [self, ...loadout], byte-identical to the no-roles path", async () => {
+    mkDirs("compose-no-roles");
+    const { fn } = recordingSpawn({ stdout: successTurn("sess-RL3", "ok") });
+    const backend = new ProgrammaticBackend(baseDeps(fn));
+    const handle = await backend.start(specWithDef(ROLE, "Agents/uni", "eng"));
+
+    // An explicit EMPTY roles array (the 11th param) + a loadout → composes exactly as before roles.
+    await backend.deliver(
+      handle,
+      "go",
+      createSession("sess-RL3"),
+      undefined,
+      undefined,
+      undefined,
+      [{ path: "Skills/Weave", content: "Skill body." }],
+      undefined,
+      undefined,
+      undefined,
+      [],
+    );
+
+    const promptPath = join(sessionWorkspace(sessionsDir, "eng"), "system-prompt.txt");
+    expect(readFileSync(promptPath, "utf8")).toBe(
+      `# Agents/uni\n\n${ROLE}\n\n---\n\n# Skills/Weave\n\nSkill body.`,
+    );
+  });
+
+  test("BLANK role entries are SKIPPED (the def stays present + the prefix count stays aligned)", async () => {
+    mkDirs("compose-blank-role");
+    const { fn } = recordingSpawn({ stdout: successTurn("sess-RL4", "ok") });
+    const backend = new ProgrammaticBackend(baseDeps(fn));
+    const handle = await backend.start(specWithDef(ROLE, "Agents/uni", "eng"));
+
+    await backend.deliver(
+      handle,
+      "go",
+      createSession("sess-RL4"),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      [
+        { path: "Roles/Blank", content: "   \n\t  " }, // whitespace-only → skipped
+        { path: "Roles/PM", content: "PM hat." },
+      ],
+    );
+
+    const promptPath = join(sessionWorkspace(sessionsDir, "eng"), "system-prompt.txt");
+    // Only the non-blank role composes (first), then the def.
+    expect(readFileSync(promptPath, "utf8")).toBe(
+      `# Roles/PM\n\nPM hat.` + `\n\n---\n\n# Agents/uni\n\n${ROLE}`,
+    );
   });
 });
 
@@ -1467,7 +1586,7 @@ describe("ProgrammaticBackend.deliver — grant injection (4b)", () => {
 });
 
 // ---------------------------------------------------------------------------
-// threads-only Phase B′ — pack-keyed grant UNION (DESIGN-2026-06-29-threads-only.md §4)
+// threads-only Phase B′ — role-keyed grant UNION (DESIGN-2026-06-29-threads-only.md §4)
 // ---------------------------------------------------------------------------
 
 /** A per-agent-key fake hub grants API (for union/legacy tests). `byAgent[key]` = that key's
@@ -1493,8 +1612,8 @@ function grantsClientByKey(opts: {
   return new GrantsClient({ hubOrigin: "https://hub.example.com", managerBearer: "MGR", fetchFn });
 }
 
-describe("ProgrammaticBackend.deliver — pack-keyed grant union (Phase B′)", () => {
-  test("LEGACY CONTINUITY: a def with NO packKeys injects EXACTLY listGrants(spec.name) (only spec.name queried)", async () => {
+describe("ProgrammaticBackend.deliver — role-keyed grant union (Phase B′)", () => {
+  test("LEGACY CONTINUITY: a def with NO roleKeys injects EXACTLY listGrants(spec.name) (only spec.name queried)", async () => {
     mkDirs("pk-legacy");
     const listKeys: string[] = [];
     const conn: ConnectionSpec = { kind: "service", target: "github", inject: ["env"] };
@@ -1506,16 +1625,16 @@ describe("ProgrammaticBackend.deliver — pack-keyed grant union (Phase B′)", 
     const { fn, calls } = recordingSpawn({ stdout: successTurn("s", "ok") });
     const backend = new ProgrammaticBackend(baseDeps(fn, { grants }));
     const handle = await backend.start(specWithVault("eng"));
-    // No packKeys param (undefined) — the no-loadout path every current def agent takes.
+    // No roleKeys param (undefined) — the no-loadout path every current def agent takes.
     await backend.deliver(handle, "hi", freshSession());
     // ONLY the def's own name was queried (= the legacy single-source path).
     expect(listKeys).toEqual(["eng"]);
-    // The def's grant injected; nothing else. Own-vault + the def's GITHUB_TOKEN, no pack entries.
+    // The def's grant injected; nothing else. Own-vault + the def's GITHUB_TOKEN, no role entries.
     expect(calls[0]!.env.GITHUB_TOKEN).toBe("ghp_DEF");
     expect(Object.keys(readMcpServers("eng"))).toEqual([vaultEntryKey("default")]);
   });
 
-  test("an EMPTY packKeys array is byte-identical to the no-packKeys legacy path", async () => {
+  test("an EMPTY roleKeys array is byte-identical to the no-roleKeys legacy path", async () => {
     mkDirs("pk-empty");
     const listKeys: string[] = [];
     const conn: ConnectionSpec = { kind: "service", target: "github", inject: ["env"] };
@@ -1527,33 +1646,33 @@ describe("ProgrammaticBackend.deliver — pack-keyed grant union (Phase B′)", 
     const { fn, calls } = recordingSpawn({ stdout: successTurn("s", "ok") });
     const backend = new ProgrammaticBackend(baseDeps(fn, { grants }));
     const handle = await backend.start(specWithVault("eng"));
-    // Explicit empty packKeys (a thread with no #pack-with-wants loaded) — same as legacy.
+    // Explicit empty roleKeys (a thread with no #agent/role-with-wants loaded) — same as legacy.
     await backend.deliver(handle, "hi", freshSession(), undefined, undefined, undefined, undefined, undefined, []);
     expect(listKeys).toEqual(["eng"]);
     expect(calls[0]!.env.GITHUB_TOKEN).toBe("ghp_DEF");
     expect(Object.keys(readMcpServers("eng"))).toEqual([vaultEntryKey("default")]);
   });
 
-  test("a loaded pack key → the pack's grants are UNIONED with the def's (def + pack queried)", async () => {
+  test("a loaded role key → the role's grants are UNIONED with the def's (def + role queried)", async () => {
     mkDirs("pk-union");
-    const packKey = "pack--Packs-github";
+    const roleKey = "role--Roles-github";
     const grants = grantsClientByKey({
       byAgent: {
         eng: [{ id: "d1", connection: { kind: "vault", target: "ops", access: "read" }, status: "approved" }],
-        [packKey]: [{ id: "p1", connection: { kind: "service", target: "github", inject: ["env"] }, status: "approved" }],
+        [roleKey]: [{ id: "p1", connection: { kind: "service", target: "github", inject: ["env"] }, status: "approved" }],
       },
       material: {
         d1: { kind: "vault", token: "OPSTOK", mcpUrl: "https://hub/vault/ops/mcp" },
-        p1: { kind: "service", token: "ghp_PACK", inject: ["env"] },
+        p1: { kind: "service", token: "ghp_ROLE", inject: ["env"] },
       },
     });
     const { fn, calls } = recordingSpawn({ stdout: successTurn("s", "ok") });
     const backend = new ProgrammaticBackend(baseDeps(fn, { grants }));
     const handle = await backend.start(specWithVault("eng"));
-    // The drain would pass the loaded pack's path key here.
-    await backend.deliver(handle, "hi", freshSession(), undefined, undefined, undefined, undefined, undefined, [packKey]);
-    // The pack's GITHUB_TOKEN (env) AND the def's granted ops vault (MCP) both injected.
-    expect(calls[0]!.env.GITHUB_TOKEN).toBe("ghp_PACK");
+    // The drain would pass the loaded role's path key here.
+    await backend.deliver(handle, "hi", freshSession(), undefined, undefined, undefined, undefined, undefined, [roleKey]);
+    // The role's GITHUB_TOKEN (env) AND the def's granted ops vault (MCP) both injected.
+    expect(calls[0]!.env.GITHUB_TOKEN).toBe("ghp_ROLE");
     const servers = readMcpServers("eng");
     expect(servers[vaultEntryKey("default")]).toBeDefined(); // own def-vault
     expect(servers[grantVaultEntryKey("ops")]!.headers!.Authorization).toBe("Bearer OPSTOK"); // the def's grant

--- a/src/backends/programmatic.ts
+++ b/src/backends/programmatic.ts
@@ -180,10 +180,10 @@ export interface ProgrammaticBackendDeps {
    * The LEGACY-def grant KEY — the hub grant-holder string for the def's OWN grants
    * (`GET /admin/grants?agent=<key>`). Defaults to `spec.name` when absent (= the def's
    * `metadata.name`, the legacy continuity key — the 4 live def agents inject exactly
-   * `listGrants(spec.name)`). Renamed from `grantsAgentName` (threads-only Phase B′ —
-   * the locked lexicon drops the "agent" framing). It is the DORMANT per-thread override
-   * escape hatch: the PRIMARY grant path is the loadout-pack UNION (see `deliver` /
-   * resolveInjectedGrantsUnion), NOT this single key. Do NOT set it unless a thread
+   * `listGrants(spec.name)`). Renamed from `grantsAgentName` (the locked lexicon drops the
+   * "agent" framing). It is the DORMANT per-thread override escape hatch: the PRIMARY grant
+   * path is the def + ROLES UNION (see `deliver` / resolveInjectedGrantsUnion), NOT this
+   * single key. Do NOT set it unless a thread
    * genuinely needs creds keyed off something other than its def name (the rare per-thread
    * override + the migration seam) — else you'd fetch the wrong source's grants.
    */
@@ -450,8 +450,9 @@ export class ProgrammaticBackend implements AgentBackend {
     runContext?: RunContext,
     loadout?: LoadoutEntry[],
     subject?: string,
-    packKeys?: string[],
+    roleKeys?: string[],
     threadContent?: LoadoutEntry,
+    roles?: LoadoutEntry[],
   ): Promise<DeliverResult> {
     const spec = handle.spec;
     if (!spec) {
@@ -534,24 +535,24 @@ export class ProgrammaticBackend implements AgentBackend {
     let grantMcpEntries: { name: string; url: string; token: string }[] = [];
     let grantEnv: Record<string, string> = {};
     if (this.deps.grants) {
-      // GRANT INJECTION = UNION OF SOURCES (threads-only Phase B′ — §4). The injected
-      // grants for a turn are the union of:
+      // GRANT INJECTION = UNION OF SOURCES (roles as the capability layer —
+      // DESIGN-2026-06-29-threads-roles-context.md). The injected grants for a turn are the
+      // union of:
       //   1. the LEGACY def key — `grantsKey ?? spec.name` (UNCHANGED): a
       //      `#agent/definition` keeps its grants keyed by its `metadata.name`. For the 4
       //      live def agents (uni/steward/uni-evolve/eco-civilization) this is the only
       //      source. `grantsKey` (was `grantsAgentName`) is the dormant per-thread override
-      //      escape hatch (§"Activate the dormant hook") — today no caller sets it, so it
-      //      falls through to `spec.name`. Do NOT make it the primary path; the primary is
-      //      this union.
-      //   2. each loaded PACK's path key (`packKeys`) — the slugged PATH (packPathKey) of
-      //      every loaded note in the thread's loadout that is a `#pack` declaring `wants:`.
-      //      The SECURITY GATE (a non-pack note's `wants:` is ignored) is enforced UPSTREAM
-      //      where packKeys is built (the transport's readThreadPackKeys), so a plain
-      //      content note's `wants:` never reaches here. Empty packKeys (every current
-      //      agent — no thread loads a `#pack` with `wants:` today) → the union is exactly
-      //      `[spec.name]` → BYTE-IDENTICAL to the legacy single-source path. (legacy continuity)
+      //      escape hatch — today no caller sets it, so it falls through to `spec.name`. Do
+      //      NOT make it the primary path; the primary is this union.
+      //   2. each loaded ROLE's path key (`roleKeys`) — the slugged PATH (rolePathKey) of
+      //      every note in the thread's `metadata.roles` that is an `#agent/role` declaring
+      //      `wants:`. The SECURITY GATE (a non-role note's `wants:` is ignored) is enforced
+      //      UPSTREAM where roleKeys is built (the transport's readThreadRoles), so a plain
+      //      content note's `wants:` never reaches here. Empty roleKeys (every current
+      //      agent — no thread loads a role with `wants:` today) → the union is exactly
+      //      `[spec.name]` → BYTE-IDENTICAL to the legacy single-source path. (no-roles invariant)
       const legacyKey = this.deps.grantsKey ?? spec.name;
-      const sources = [legacyKey, ...(packKeys ?? [])];
+      const sources = [legacyKey, ...(roleKeys ?? [])];
       try {
         const injected = await resolveInjectedGrantsUnion(this.deps.grants, sources);
         grantMcpEntries = injected.mcpEntries;
@@ -562,7 +563,7 @@ export class ProgrammaticBackend implements AgentBackend {
         // throw aborts only the cross-resource injection; the turn still runs with own-vault.
         console.warn(
           `parachute-agent: resolving grants for "${legacyKey}"` +
-            (packKeys && packKeys.length > 0 ? ` (+${packKeys.length} pack source(s))` : "") +
+            (roleKeys && roleKeys.length > 0 ? ` (+${roleKeys.length} role source(s))` : "") +
             ` failed (running this turn WITHOUT cross-resource grants — own-vault unaffected): ` +
             `${(err as Error).message}`,
         );
@@ -618,29 +619,27 @@ export class ProgrammaticBackend implements AgentBackend {
     // robust to long/multiline prompts and keeps the prompt visible-on-disk. Its
     // lifecycle is tied to the workspace (like .mcp.json) — it disappears with it.
     //
-    // COMPOSED PROMPT (threads-only Phase A — DESIGN-2026-06-29-threads-only.md §1/§9; thread
-    // content — DESIGN-2026-06-29-thread-content-and-skills.md): the system prompt is an ORDERED
-    // LIST of loaded notes — a direct arity-N generalization of the rc.13 arity-2 `roleBody
-    // [+ dossier]` seam. Entry 0 is the thread's SELF entry: the spec's `systemPrompt` (the def
-    // body), labeled with the def note's human-legible PATH (`spec.definitionPath`, e.g.
-    // `Agents/steward`; fallback `spec.name`). Entry 1 (when present) is THIS thread's CONTENT —
-    // the thread note's authored body, its per-thread standing mandate. Entries 2..N are the
-    // resolved `loadout` notes (read CONTENT-only, never metadata). composeSystemPrompt dedupes
-    // by path, skips blank entries, renders each as `# <path>\n\n<content>`, joins with
-    // `\n\n---\n\n`, and enforces the byte budget (truncate the LOADOUT TAIL first, NEVER the
-    // def or the thread content — the PROTECTED leading prefix).
+    // COMPOSED PROMPT — three layers, in order (DESIGN-2026-06-29-threads-roles-context.md):
+    //   ① ROLES         — `roles` entries, composed FIRST: the reusable "hat(s)" the thread wears.
+    //   ② SELF + THREAD — the SELF entry (the spec's `systemPrompt`, the def body) then THIS
+    //                     thread's authored CONTENT (`threadContent`, when non-blank).
+    //   ③ EXTRA CONTEXT — the `loadout` notes (skills, references), read CONTENT-only.
+    // composeSystemPrompt dedupes by path, skips blank entries, renders each as
+    // `# <path>\n\n<content>`, joins with `\n\n---\n\n`, and enforces the byte budget — truncating
+    // the layer-③ EXTRA-CONTEXT TAIL first, NEVER the PROTECTED leading prefix (roles + def +
+    // thread content). The self entry is labeled with the def note's human-legible PATH
+    // (`spec.definitionPath`, e.g. `Agents/steward`; fallback `spec.name`).
     //
     // #169 — the self-entry header uses the def note's PATH, NOT its id. The note ID is a
-    // timestamp-slug (`2026-06-20-07-30-56-487050`); the legible loadout path is
-    // `Agents/steward`. `spec.definitionPath` carries the path (set by parseAgentDef from
-    // `note.path`); when absent (a spec not sourced from a def note, or a reader that didn't
-    // surface a path) the header falls back to `spec.name`.
+    // timestamp-slug (`2026-06-20-07-30-56-487050`); the legible path is `Agents/steward`.
+    // `spec.definitionPath` carries the path (set by parseAgentDef from `note.path`); when
+    // absent (a spec not sourced from a def note) the header falls back to `spec.name`.
     //
-    // NO-LOADOUT / NO-THREAD-CONTENT INVARIANT (the live 4am steward weave path): a thread with
-    // NO loadout AND no authored thread content composes to EXACTLY `# <path>\n\n<def body>` —
-    // `<def body>` byte-identical to `spec.systemPrompt`. The single `# <path>` header is the
-    // ONLY change to such a prompt (design decision #4, accepted). The run-context preamble
-    // stays on the MESSAGE.
+    // NO-ROLES / NO-LOADOUT / NO-THREAD-CONTENT INVARIANT (the live 4am steward weave path): a
+    // thread with NO roles, NO loadout AND no authored thread content composes to EXACTLY
+    // `# <path>\n\n<def body>` — `<def body>` byte-identical to `spec.systemPrompt`. The single
+    // `# <path>` header is the ONLY change to such a prompt. The run-context preamble stays on
+    // the MESSAGE.
     let systemPromptFile: string | undefined;
     if (typeof spec.systemPrompt === "string" && spec.systemPrompt.length > 0) {
       // Self entry: the def body, labeled by the def note's PATH (`spec.definitionPath`);
@@ -650,21 +649,34 @@ export class ProgrammaticBackend implements AgentBackend {
         typeof spec.definitionPath === "string" && spec.definitionPath.length > 0
           ? spec.definitionPath
           : spec.name;
-      // The thread-content entry sits BETWEEN the self entry and the loadout. Include it only
-      // when it carries real (non-blank) content — a blank thread note is the no-thread-content
-      // case. Gate the inclusion AND the protected-prefix count on the SAME non-blank check, so
-      // composeSystemPrompt's protected prefix (def [+ thread content]) stays exactly aligned
-      // with the entries actually inserted (a blank entry would be skipped, shifting the prefix).
+      // Layer ① ROLES — filter to NON-BLANK content + dedupe by path so the protected-prefix
+      // COUNT below stays exactly aligned with the entries composeSystemPrompt keeps (a blank or
+      // duplicate role would be dropped, shifting the prefix into the layer-③ tail). They lead,
+      // so a later loadout note with a colliding path dedupes against the role (the role wins).
+      const roleEntries: LoadoutEntry[] = [];
+      const seenRolePaths = new Set<string>();
+      for (const r of roles ?? []) {
+        if (typeof r.content !== "string" || r.content.trim().length === 0) continue;
+        if (seenRolePaths.has(r.path)) continue;
+        seenRolePaths.add(r.path);
+        roleEntries.push(r);
+      }
+      // Layer ② thread content sits BETWEEN the self entry and the loadout. Include it only when
+      // it carries real (non-blank) content — a blank thread note is the no-thread-content case.
+      // Gate the inclusion AND the protected-prefix count on the SAME non-blank check.
       const hasThreadContent =
         !!threadContent && typeof threadContent.content === "string" && threadContent.content.trim().length > 0;
+      // Order: ① roles → ② self + thread-content → ③ extra-context loadout.
       const entries: LoadoutEntry[] = [
+        ...roleEntries,
         { path: selfPath, content: spec.systemPrompt },
         ...(hasThreadContent ? [threadContent!] : []),
         ...(loadout ?? []),
       ];
-      // Protect the def (always) and the thread content (when present) from budget truncation —
-      // both are load-bearing; only the loadout tail (entries beyond the prefix) sheds.
-      const composed = composeSystemPrompt(entries, { protectedCount: hasThreadContent ? 2 : 1 });
+      // Protect the WHOLE leading prefix — roles (①) + the def + the thread content (②) — from
+      // budget truncation; only the layer-③ extra-context tail (entries beyond the prefix) sheds.
+      const protectedCount = roleEntries.length + 1 + (hasThreadContent ? 1 : 0);
+      const composed = composeSystemPrompt(entries, { protectedCount });
       systemPromptFile = join(workspace, "system-prompt.txt");
       writeFileSync(systemPromptFile, composed, { mode: 0o600 });
     }

--- a/src/backends/registry.test.ts
+++ b/src/backends/registry.test.ts
@@ -63,10 +63,14 @@ class FakeBackend implements AgentBackend {
     runContext?: RunContext;
     /** roles×threads NEXT slice (#120, G): the thread subject the drain threaded in. */
     subject?: string;
-    /** threads-only Phase A: the resolved LOADOUT entries the drain threaded in. */
+    /** the resolved layer-③ EXTRA-CONTEXT (loadout) entries the drain threaded in. */
     loadout?: LoadoutEntry[];
-    /** thread content: the thread's own authored body the drain threaded in (between def + loadout). */
+    /** thread content (layer ②): the thread's own authored body the drain threaded in. */
     threadContent?: LoadoutEntry;
+    /** roles (layer ①): the resolved ROLE content entries the drain threaded in (composed FIRST). */
+    roles?: LoadoutEntry[];
+    /** the loaded-ROLE grant keys the drain threaded in (capability source). */
+    roleKeys?: string[];
   }[] = [];
   /** Max concurrent in-flight turns observed (must stay ≤ 1 for serial — PER drain key). */
   maxConcurrent = 0;
@@ -120,8 +124,9 @@ class FakeBackend implements AgentBackend {
     runContext?: RunContext,
     loadout?: LoadoutEntry[],
     subject?: string,
-    _packKeys?: string[],
+    roleKeys?: string[],
     threadContent?: LoadoutEntry,
+    roles?: LoadoutEntry[],
   ): Promise<DeliverResult> {
     this.calls.push({
       channel: handle.channel,
@@ -131,6 +136,10 @@ class FakeBackend implements AgentBackend {
       ...(subject ? { subject } : {}),
       ...(loadout ? { loadout } : {}),
       ...(threadContent ? { threadContent } : {}),
+      // Record roles/roleKeys only when NON-EMPTY, so an unwired/no-roles turn (the drain
+      // defaults both to `[]`) reads as absent — the no-roles invariant.
+      ...(roles && roles.length ? { roles } : {}),
+      ...(roleKeys && roleKeys.length ? { roleKeys } : {}),
     });
     this.inFlight++;
     this.maxConcurrent = Math.max(this.maxConcurrent, this.inFlight);
@@ -732,6 +741,69 @@ describe("ProgrammaticAgentRegistry — thread content as context (DESIGN-2026-0
     await until(() => backend.calls.length === 1);
     // The turn ran (the read failure didn't strand it) with no thread content.
     expect(backend.calls[0]!.threadContent).toBeUndefined();
+    expect(rec.calls).toHaveLength(1);
+  });
+});
+
+describe("ProgrammaticAgentRegistry — roles as the capability layer (DESIGN-2026-06-29-threads-roles-context.md)", () => {
+  test("the drain READS roles (readRoles) + PASSES content as `roles` (layer ①) AND keys as `roleKeys`", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const seen: { channel: string; name: string; subject?: string }[] = [];
+    const reg = new ProgrammaticAgentRegistry({
+      backend,
+      writeOutbound: rec.fn,
+      readRoles: async (channel, name, subject) => {
+        seen.push({ channel, name, ...(subject ? { subject } : {}) });
+        return {
+          entries: [{ path: `Roles/PM`, content: "PM hat." }],
+          grantKeys: ["role--Roles-PM"],
+        };
+      },
+    });
+    await reg.register(specFor("eng")); // single-threaded (default).
+
+    reg.enqueue("eng", { content: "go" });
+    await until(() => backend.calls.length === 1);
+
+    // The drain consulted readRoles with the channel + def name…
+    expect(seen).toEqual([{ channel: "eng", name: "eng" }]);
+    // …and threaded BOTH the content entries (layer ①, composed FIRST) AND the grant keys
+    // (the capability source unioned with the def's own — proved in programmatic.test.ts).
+    expect(backend.calls[0]!.roles).toEqual([{ path: "Roles/PM", content: "PM hat." }]);
+    expect(backend.calls[0]!.roleKeys).toEqual(["role--Roles-PM"]);
+  });
+
+  test("UNWIRED readRoles → deliver receives no roles + no role keys (the no-roles invariant)", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    await reg.register(specFor("eng"));
+
+    reg.enqueue("eng", { content: "go" });
+    await until(() => backend.calls.length === 1);
+    // The fake records `roles`/`roleKeys` only when non-empty → both absent (the no-roles path).
+    expect(backend.calls[0]!.roles).toBeUndefined();
+    expect(backend.calls[0]!.roleKeys).toBeUndefined();
+  });
+
+  test("a readRoles THROW is swallowed — the turn still runs (best-effort, def body + grants alone)", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const reg = new ProgrammaticAgentRegistry({
+      backend,
+      writeOutbound: rec.fn,
+      readRoles: async () => {
+        throw new Error("vault unreachable");
+      },
+    });
+    await reg.register(specFor("eng"));
+
+    reg.enqueue("eng", { content: "go" });
+    await until(() => backend.calls.length === 1);
+    // The turn ran (the read failure didn't strand it) with no roles + no role keys.
+    expect(backend.calls[0]!.roles).toBeUndefined();
+    expect(backend.calls[0]!.roleKeys).toBeUndefined();
     expect(rec.calls).toHaveLength(1);
   });
 });

--- a/src/backends/registry.ts
+++ b/src/backends/registry.ts
@@ -552,21 +552,21 @@ export class ProgrammaticAgentRegistry {
     subject?: string,
   ) => Promise<LoadoutEntry[]>;
   /**
-   * Optional pre-turn loaded-PACK grant-KEY read (threads-only Phase B′ —
-   * DESIGN-2026-06-29-threads-only.md §4). Resolves the SAME `metadata.loadout` paths as
-   * {@link readLoadout}, but reads the loaded notes' METADATA to find the `#pack` notes
-   * declaring `wants:`, returning each such pack's slugged-path grant key (`packPathKey`). Read
-   * in {@link drain} and passed to `deliver`, which UNIONS each pack's APPROVED grants with the
-   * def's own (`spec.name`). The SECURITY GATE (a non-pack note's `wants:` is ignored) lives in
-   * the resolver. SEPARATE from {@link readLoadout} so the prompt composition stays content-only
-   * (Phase A). UNWIRED / no pack with `wants:` → empty → the grant source set is exactly
-   * `[spec.name]` (legacy continuity — byte-identical injection for every current agent).
+   * Optional pre-turn ROLES read (layer ① — DESIGN-2026-06-29-threads-roles-context.md). Resolves
+   * the thread's `metadata.roles` notes in ONE pass to BOTH the ordered CONTENT entries (composed
+   * FIRST, before the def) AND the grant-holder keys (the slugged paths of the loaded `#agent/role`
+   * notes declaring `wants:`, `rolePathKey`). Read in {@link drain}: the entries pass to `deliver`
+   * as `roles` (prompt layer ①) and the grant keys as `roleKeys`, which UNIONS each role's APPROVED
+   * grants with the def's own (`spec.name`). The SECURITY GATE (a non-role note's `wants:` is
+   * ignored) lives in the resolver. UNWIRED / no roles → `{ entries: [], grantKeys: [] }` → the
+   * prompt is the def alone + the grant source set is exactly `[spec.name]` (the no-roles invariant,
+   * byte-identical to HEAD for every current agent).
    */
-  private readonly readPackKeys?: (
+  private readonly readRoles?: (
     channel: string,
     name: string,
     subject?: string,
-  ) => Promise<string[]>;
+  ) => Promise<{ entries: LoadoutEntry[]; grantKeys: string[] }>;
   /**
    * Optional pre-turn THREAD-CONTENT read (DESIGN-2026-06-29-thread-content-and-skills.md). The
    * thread note's own authored BODY (`{ path, content }` — CONTENT only) becomes the prompt entry
@@ -608,12 +608,17 @@ export class ProgrammaticAgentRegistry {
      */
     readLoadout?: (channel: string, name: string, subject?: string) => Promise<LoadoutEntry[]>;
     /**
-     * Read the thread's loaded-PACK grant KEYS (threads-only Phase B′) — the slugged paths of
-     * the loaded `#pack` notes that declare `wants:`. Optional — UNWIRED → no pack keys (the
-     * def's `spec.name` grants alone, legacy continuity). `subject` resolves the subject-scoped
-     * thread note.
+     * Read the thread's ROLES (layer ①) — the `metadata.roles` notes resolved in one pass to the
+     * ordered CONTENT entries (composed FIRST) + the grant keys (the slugged paths of the loaded
+     * `#agent/role` notes that declare `wants:`). Optional — UNWIRED → `{ entries: [], grantKeys: [] }`
+     * (the def alone + the def's `spec.name` grants, the no-roles invariant). `subject` resolves the
+     * subject-scoped thread note.
      */
-    readPackKeys?: (channel: string, name: string, subject?: string) => Promise<string[]>;
+    readRoles?: (
+      channel: string,
+      name: string,
+      subject?: string,
+    ) => Promise<{ entries: LoadoutEntry[]; grantKeys: string[] }>;
     /**
      * Read the thread's own CONTENT (DESIGN-2026-06-29-thread-content-and-skills.md) — the
      * thread note's authored body as `{ path, content }`, composed BETWEEN the def and the
@@ -637,7 +642,7 @@ export class ProgrammaticAgentRegistry {
     if (deps.readSession) this.readSession = deps.readSession;
     if (deps.clearSession) this.clearSession = deps.clearSession;
     if (deps.readLoadout) this.readLoadout = deps.readLoadout;
-    if (deps.readPackKeys) this.readPackKeys = deps.readPackKeys;
+    if (deps.readRoles) this.readRoles = deps.readRoles;
     if (deps.readThreadContent) this.readThreadContent = deps.readThreadContent;
     this.outboundRetryBaseMs = deps.outboundRetryBaseMs ?? OUTBOUND_RETRY_BASE_MS;
   }
@@ -1278,23 +1283,28 @@ export class ProgrammaticAgentRegistry {
         }
       }
 
-      // PACK GRANT KEYS (threads-only Phase B′ — DESIGN-2026-06-29-threads-only.md §4): resolve
-      // the loaded-PACK grant keys (the slugged paths of the loaded `#pack` notes declaring
-      // `wants:`) off the SAME thread note. The backend UNIONS each pack's APPROVED grants with
-      // the def's own (`spec.name`). SEPARATE metadata read from the content-only loadout (so the
-      // prompt composition is unchanged). The SECURITY GATE — a non-pack note's `wants:` is
-      // ignored — lives in the resolver. UNWIRED / no pack with `wants:` (every current thread)
-      // → empty → the grant sources are exactly `[spec.name]` (legacy continuity, byte-identical
-      // injection). Best-effort: a read failure logs + the turn injects the def's grants alone.
-      let packKeys: string[] = [];
-      if (this.readPackKeys) {
+      // ROLES (layer ① — DESIGN-2026-06-29-threads-roles-context.md): resolve the thread's
+      // `metadata.roles` notes off its `#agent/thread` note in ONE pass to BOTH the ordered
+      // CONTENT entries (`roles`, composed FIRST — before the def) AND the grant-holder keys
+      // (`roleKeys`, the slugged paths of the loaded `#agent/role` notes declaring `wants:`). The
+      // backend prepends `roles` and UNIONS each role's APPROVED grants with the def's own
+      // (`spec.name`). The SECURITY GATE — a non-role note's `wants:` is ignored — lives in the
+      // resolver (content loads either way; only a real `#agent/role` contributes a grant key).
+      // UNWIRED / no roles (every current thread) → empty → the prompt is the def alone + the
+      // grant sources are exactly `[spec.name]` (the no-roles invariant, byte-identical). Best-
+      // effort: a read failure logs + the turn runs with the def body + the def's grants alone.
+      let roles: LoadoutEntry[] = [];
+      let roleKeys: string[] = [];
+      if (this.readRoles) {
         try {
-          packKeys = await this.readPackKeys(handle.channel, handle.spec.name, turnSubject);
+          const resolved = await this.readRoles(handle.channel, handle.spec.name, turnSubject);
+          roles = resolved.entries;
+          roleKeys = resolved.grantKeys;
         } catch (err) {
           console.error(
-            `parachute-agent: pack-key read for channel "${channel}"` +
+            `parachute-agent: roles read for channel "${channel}"` +
               (turnSubject ? ` subject "${turnSubject}"` : "") +
-              ` failed (turn injects the def's grants alone): ${(err as Error).message}`,
+              ` failed (turn runs with the def body + the def's grants alone): ${(err as Error).message}`,
           );
         }
       }
@@ -1343,15 +1353,18 @@ export class ProgrammaticAgentRegistry {
           // subjects of one agent never clobber each other's per-turn `.mcp.json` /
           // `system-prompt.txt` / HOME. Undefined → `sessions/<name>/` (HEAD, unchanged).
           turnSubject,
-          // threads-only Phase B′: the loaded-PACK grant keys — the backend unions each pack's
-          // APPROVED grants with the def's own (`spec.name`). Empty (every current thread) →
-          // the grant sources are exactly `[spec.name]` (legacy continuity, byte-identical).
-          packKeys,
-          // thread content (DESIGN-2026-06-29-thread-content-and-skills.md): THIS thread's
-          // authored standing context, composed BETWEEN the def and the loadout (def + thread
-          // content protected from budget truncation). Undefined / blank → the def + loadout
-          // alone (the no-thread-content invariant).
+          // roles (capability layer): the loaded-ROLE grant keys — the backend unions each role's
+          // APPROVED grants with the def's own (`spec.name`). Empty (every current thread) → the
+          // grant sources are exactly `[spec.name]` (the no-roles invariant, byte-identical).
+          roleKeys,
+          // thread content (layer ②): THIS thread's authored standing context, composed BETWEEN
+          // the def and the loadout (inside the protected prefix). Undefined / blank → skipped
+          // (the no-thread-content invariant).
           threadContent,
+          // roles (layer ①): the role-note CONTENT entries — composed FIRST, before the def, as
+          // the reusable hat(s). Empty → the prompt is `[self, thread-content, ...loadout]` exactly
+          // as before this layer (the no-roles invariant). Capabilities ride on `roleKeys` above.
+          roles,
         );
       } catch (err) {
         // The backend contract is failure-as-VALUE, never a throw — but defend so a

--- a/src/backends/types.ts
+++ b/src/backends/types.ts
@@ -122,16 +122,16 @@ export interface RunContext {
 }
 
 /**
- * One entry in a thread's LOADOUT (threads-only Phase A — DESIGN-2026-06-29-threads-only.md
- * §1/§9). The composed system prompt is an ORDERED LIST of these — entry 0 is the thread's
- * "self" entry (the def body, labeled by the def note's PATH), entries 1..N are the notes the
- * thread loads from its `metadata.loadout` (an array of note PATHS). The composer reads the
- * note's CONTENT only — NEVER its metadata — and renders each as `# <path>\n\n<content>`.
+ * One entry in the composed system prompt — a `{ path, content }` pair the composer renders as
+ * `# <path>\n\n<content>` (CONTENT only — NEVER metadata). The composed prompt is an ORDERED
+ * LIST of these, three layers (DESIGN-2026-06-29-threads-roles-context.md): ① the thread's ROLES
+ * (composed FIRST), ② the "self" entry (the def body, labeled by the def note's PATH) then the
+ * thread's own CONTENT, ③ the EXTRA-CONTEXT loadout (`metadata.loadout` note paths). Each layer
+ * is a list of these entries; the backend concatenates them in order.
  *
- * This is the arity-N generalization of the rc.13 arity-2 `roleBody [+ subjectDossier]` seam:
- * a thread that loads no notes (every current agent, incl. the 4am steward weave) composes to
- * EXACTLY its def body, prefixed by a single `# <path>` header — the only change to a
- * no-loadout prompt (the no-loadout invariant; design decision #4, accepted).
+ * A thread that loads NOTHING (no roles, no thread content, no loadout — every current agent,
+ * incl. the 4am steward weave) composes to EXACTLY its def body, prefixed by a single
+ * `# <path>` header — the only change to such a prompt (the no-loadout/no-roles invariant).
  */
 export interface LoadoutEntry {
   /** The note PATH — rendered as the entry's `# <path>` header AND the dedupe key. */
@@ -167,12 +167,13 @@ export const LOADOUT_BUDGET_BYTES = 600_000;
  *
  * Then enforce {@link LOADOUT_BUDGET_BYTES}: if the composed byte length exceeds the cap,
  * drop trailing LOADOUT entries until it fits — the PROTECTED leading entries are NEVER
- * truncated. `protectedCount` (default 1) is how many leading entries are load-bearing: 1
- * protects just the self entry (index 0, the def body) — the no-loadout default; 2 protects
- * the self entry AND the thread-content entry (index 1) once the caller has inserted it
- * (DESIGN-2026-06-29-thread-content-and-skills.md — thread content is load-bearing like the
- * def). Only entries beyond the protected prefix shed (tail-first). A loud warn fires on
- * truncation (via `onWarn`, defaulting to console.warn).
+ * truncated. `protectedCount` (default 1) is how many leading entries are load-bearing — the
+ * caller counts its protected PREFIX: the ROLES (layer ①, composed first), the self entry (the
+ * def body), and the thread-content entry (layer ②) when present
+ * (DESIGN-2026-06-29-threads-roles-context.md). With no roles + no thread content it is 1 (the
+ * self entry alone — the no-loadout default); each role adds one, and thread content adds one.
+ * Only entries beyond the protected prefix (the layer-③ extra-context loadout) shed (tail-first).
+ * A loud warn fires on truncation (via `onWarn`, defaulting to console.warn).
  *
  * The NO-LOADOUT INVARIANT: with exactly one (self) entry whose content is the def body, the
  * result is `# <path>\n\n<body>` where `<body>` is byte-identical to the def body — the single
@@ -355,16 +356,17 @@ export interface AgentBackend {
    * message so the agent stamps ACCURATE times instead of fabricating them. ADDITIVE — omitted
    * → the turn message is exactly as before.
    *
-   * `loadout` (optional, threads-only Phase A — DESIGN-2026-06-29-threads-only.md §9) is the
-   * thread's ORDERED LIST of loaded notes (entries 1..N — the SELF entry is prepended by the
-   * backend from `spec.systemPrompt` + the def note path). The programmatic backend folds them
-   * into the SYSTEM prompt via {@link composeSystemPrompt}: `[self, ...loadout]` deduped by path,
+   * `loadout` (optional, the layer-③ EXTRA CONTEXT — DESIGN-2026-06-29-threads-roles-context.md)
+   * is the thread's ORDERED LIST of extra-context notes (skills, references), composed AFTER the
+   * thread content. The programmatic backend folds them into the SYSTEM prompt via
+   * {@link composeSystemPrompt}: `[...roles, self, thread-content, ...loadout]` deduped by path,
    * blank-skipped, each rendered `# <path>\n\n<content>`, joined by `\n\n---\n\n`, then budgeted
-   * ({@link LOADOUT_BUDGET_BYTES}, truncating loadout-notes-first, NEVER the self entry). This
-   * SUPERSEDES the rc.13 arity-2 `subjectDossier` string with an arity-N note list. ADDITIVE —
-   * omitted/empty → the system prompt is `# <path>\n\n<def body>`, byte-identical to HEAD APART
-   * FROM the single `# <path>` header (the no-loadout invariant; design decision #4, accepted).
-   * The run-context preamble is unaffected (it stays on the MESSAGE).
+   * ({@link LOADOUT_BUDGET_BYTES}, truncating loadout-notes-first, NEVER the protected prefix —
+   * roles + self + thread content). ADDITIVE — omitted/empty + no roles + no thread content → the
+   * system prompt is `# <path>\n\n<def body>`, byte-identical to HEAD APART FROM the single
+   * `# <path>` header (the no-loadout invariant). The run-context preamble is unaffected (it stays
+   * on the MESSAGE). Distinct from `roles`: loadout is CONTENT-only (never grants); roles carry
+   * capability and compose FIRST.
    *
    * `subject` (optional, roles×threads NEXT slice #120) is the thread SUBJECT — the programmatic
    * backend keys the agent's PER-THREAD private session workspace off it
@@ -374,26 +376,34 @@ export interface AgentBackend {
    * the null-subject invariant). Distinct from `loadout` (which is prompt CONTENT); this is
    * the workspace IDENTITY.
    *
-   * `packKeys` (optional, threads-only Phase B′ — DESIGN-2026-06-29-threads-only.md §4) is the
-   * list of hub grant-holder KEYS for the loaded PACKS in this thread's loadout — the slugged
-   * PATH (`packPathKey`) of every loaded note that is a `#pack` declaring `wants:`. The
-   * programmatic backend UNIONS each pack's APPROVED grants with the def's own (`spec.name`),
-   * so a thread that loads a pack gains that pack's capabilities. This is SEPARATE from
-   * `loadout` (prompt content) by design: the SECURITY GATE — a non-pack note's `wants:` is
-   * IGNORED — is enforced where `packKeys` is built (the transport reads the loaded notes'
-   * METADATA, never folding it into the prompt). ADDITIVE — omitted/empty (every current agent;
-   * no thread loads a `#pack` with `wants:` today) → the grant source set is exactly
-   * `[spec.name]`, BYTE-IDENTICAL to the legacy single-source injection (legacy continuity).
+   * `roleKeys` (optional, roles as the capability layer — DESIGN-2026-06-29-threads-roles-context.md)
+   * is the list of hub grant-holder KEYS for the thread's ROLES — the slugged PATH (`rolePathKey`)
+   * of every note in `metadata.roles` that is an `#agent/role` declaring `wants:`. The programmatic
+   * backend UNIONS each role's APPROVED grants with the def's own (`spec.name`), so a thread that
+   * loads a role gains that role's capabilities. The SECURITY GATE — a non-role note's `wants:` is
+   * IGNORED — is enforced where `roleKeys` is built (the transport reads the role notes' METADATA).
+   * ADDITIVE — omitted/empty (every current agent; no thread loads a role with `wants:` today) →
+   * the grant source set is exactly `[spec.name]`, BYTE-IDENTICAL to the legacy single-source
+   * injection (legacy continuity).
    *
-   * `threadContent` (optional, DESIGN-2026-06-29-thread-content-and-skills.md) is THIS thread's
-   * own standing context — the thread note's authored BODY (`{ path, content }`, CONTENT only,
-   * the thread-note path as the header). The programmatic backend composes it as the entry
-   * BETWEEN the self entry and the loadout: `[self, thread-content, ...loadout]`. It is
-   * load-bearing like the def — composed with a protected prefix so an over-budget loadout
-   * sheds its tail but NEVER the def or the thread content. ADDITIVE — omitted, or blank/
-   * whitespace content → the thread-content entry is skipped and the prompt is `[self, ...loadout]`
-   * exactly as before (the no-thread-content invariant). The daemon NEVER writes this content;
-   * a human/agent authors it on the thread note and the backend reads it CONTENT-only each turn.
+   * `threadContent` (optional, the layer-② THREAD content — DESIGN-2026-06-29-threads-roles-context.md)
+   * is THIS thread's own standing context — the thread note's authored BODY (`{ path, content }`,
+   * CONTENT only, the thread-note path as the header). The programmatic backend composes it
+   * BETWEEN the def (self) and the loadout: `[...roles, self, thread-content, ...loadout]`. It is
+   * load-bearing like the def — composed inside the protected prefix so an over-budget loadout
+   * sheds its tail but NEVER the roles, the def, or the thread content. ADDITIVE — omitted, or
+   * blank/whitespace content → the thread-content entry is skipped (the no-thread-content
+   * invariant). The daemon NEVER writes this content; a human/agent authors it on the thread note
+   * and the backend reads it CONTENT-only each turn.
+   *
+   * `roles` (optional, the layer-① ROLES — DESIGN-2026-06-29-threads-roles-context.md) is the
+   * thread's ORDERED LIST of role-note CONTENT entries (`{ path, content }`), composed FIRST —
+   * before the def (self) — as the reusable "hat(s)" the thread wears. The programmatic backend
+   * prepends them: `[...roles, self, thread-content, ...loadout]`, and they sit inside the
+   * PROTECTED prefix (never truncated). Each role's CAPABILITIES ride SEPARATELY on `roleKeys`
+   * (content here, grants there — one role note, read once). ADDITIVE — omitted/empty → the
+   * prompt is `[self, thread-content, ...loadout]` exactly as before this layer (the no-roles
+   * invariant). Blank/whitespace role entries are skipped (the composer skips blank content).
    */
   deliver(
     handle: AgentHandle,
@@ -404,8 +414,9 @@ export interface AgentBackend {
     runContext?: RunContext,
     loadout?: LoadoutEntry[],
     subject?: string,
-    packKeys?: string[],
+    roleKeys?: string[],
     threadContent?: LoadoutEntry,
+    roles?: LoadoutEntry[],
   ): Promise<DeliverResult>;
 
   /**

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -915,23 +915,27 @@ export function buildReadThreadContent(
 }
 
 /**
- * Build the {@link ProgrammaticAgentRegistry}'s pre-turn loaded-PACK grant-KEY read
- * (threads-only Phase B′ — DESIGN-2026-06-29-threads-only.md §4). Resolves the channel's
- * transport and reads the loaded `#pack` notes' grant keys (the slugged paths of the loadout
- * notes that are `#pack`s declaring `wants:`) off the thread's `#agent/thread` note. The backend
- * UNIONS each pack's APPROVED grants with the def's own (`spec.name`). Only the VaultTransport
- * implements `readThreadPackKeys`; other transports omit it → no pack keys (the def's grants
- * alone — legacy continuity). The SECURITY GATE (a non-pack note's `wants:` is ignored) lives in
- * the transport resolver. Mirrors {@link buildReadLoadout}, but reads METADATA (pack-detection),
- * not content (prompt).
+ * Build the {@link ProgrammaticAgentRegistry}'s pre-turn ROLES read (layer ① —
+ * DESIGN-2026-06-29-threads-roles-context.md). Resolves the channel's transport and reads the
+ * thread's `metadata.roles` notes off its `#agent/thread` note in ONE pass to BOTH the ordered
+ * CONTENT entries (the FIRST prompt layer) AND the grant-holder keys (the slugged paths of the
+ * loaded `#agent/role` notes declaring `wants:`). The backend prepends the entries before the def
+ * and UNIONS each role's APPROVED grants with the def's own (`spec.name`). Only the VaultTransport
+ * implements `readThreadRoles`; other transports omit it → `{ entries: [], grantKeys: [] }` (the
+ * def's body + grants alone — the no-roles invariant). The SECURITY GATE (a non-role note's
+ * `wants:` is ignored) lives in the transport resolver. Mirrors {@link buildReadLoadout}.
  */
-export function buildReadPackKeys(
+export function buildReadRoles(
   channels: Map<string, Channel>,
-): (channel: string, name: string, subject?: string) => Promise<string[]> {
+): (
+  channel: string,
+  name: string,
+  subject?: string,
+) => Promise<{ entries: LoadoutEntry[]; grantKeys: string[] }> {
   return async (channel, name, subject) => {
     const ch = channels.get(channel);
-    if (!ch?.transport.readThreadPackKeys) return [];
-    return ch.transport.readThreadPackKeys(channel, name, subject);
+    if (!ch?.transport.readThreadRoles) return { entries: [], grantKeys: [] };
+    return ch.transport.readThreadRoles(channel, name, subject);
   };
 }
 
@@ -998,8 +1002,9 @@ export function createDefaultProgrammaticRegistry(
     // so the backend composes the arity-N system prompt. SUPERSEDES the never-wired
     // subjectDossier seam. Empty loadout (no metadata.loadout) → the def body alone.
     readLoadout: buildReadLoadout(channels),
-    // threads-only Phase B′: the pre-turn loaded-PACK grant-key read (union pack grants).
-    readPackKeys: buildReadPackKeys(channels),
+    // roles (layer ①): the pre-turn ROLES read — content (composed FIRST) + the union of
+    // each role's grants with the def's own. UNWIRED / no roles → the def alone (no-roles invariant).
+    readRoles: buildReadRoles(channels),
     // thread content (DESIGN-2026-06-29-thread-content-and-skills.md): the pre-turn read of the
     // thread note's own authored body — composed BETWEEN the def and the loadout. The daemon
     // never WRITES it; this only READS it. Undefined / blank → the def + loadout alone.
@@ -3227,17 +3232,17 @@ export function createFetchHandler(
     }
 
     // ---------------------------------------------------------------------
-    // PACK grant-reconcile webhook — POST /api/vault/pack
-    // (threads-only Phase B′, DESIGN-2026-06-29-threads-only.md §4). A vault trigger on a
-    // `#pack` note created/updated POSTs here; we reconcile THAT pack's `wants:` under its
-    // path key (register each + prune its OWN partition). This is the PER-PACK reconcile —
-    // analogous to /api/vault/agent-def but keyed by the pack PATH, and it NEVER touches a
-    // def's grants or another pack's. Mirrors /api/vault/agent-def's auth (hub JWT, scope
-    // agent:send) + uniform-401 + vault resolution. Body: { event?, vault?, note: { id/path,
-    // metadata } }. A non-pack note / dropped-wants / parse-error is handled inside
-    // reconcilePack (prune-to-[] / status:error). Externally `<hub>/agent/api/vault/pack`.
+    // ROLE grant-reconcile webhook — POST /api/vault/role
+    // (roles as the capability layer, DESIGN-2026-06-29-threads-roles-context.md). A vault
+    // trigger on an `#agent/role` note created/updated POSTs here; we reconcile THAT role's
+    // `wants:` under its path key (register each + prune its OWN partition). This is the
+    // PER-ROLE reconcile — analogous to /api/vault/agent-def but keyed by the role PATH, and it
+    // NEVER touches a def's grants or another role's. Mirrors /api/vault/agent-def's auth (hub
+    // JWT, scope agent:send) + uniform-401 + vault resolution. Body: { event?, vault?, note: {
+    // id/path, metadata } }. A non-role note / dropped-wants / parse-error is handled inside
+    // reconcileRole (prune-to-[] / status:error). Externally `<hub>/agent/api/vault/role`.
     // ---------------------------------------------------------------------
-    if (req.method === "POST" && url.pathname === "/api/vault/pack") {
+    if (req.method === "POST" && url.pathname === "/api/vault/role") {
       const denied = await requireScope(req, url, SCOPE_SEND);
       if (denied) return json({ error: "unauthorized" }, 401);
       if (!agentDefs) {
@@ -3282,7 +3287,7 @@ export function createFetchHandler(
         body.event === "created" || body.event === "updated" || body.event === "deleted"
           ? body.event
           : undefined;
-      const result = await agentDefs.reconcilePack(vault, noteId, event);
+      const result = await agentDefs.reconcileRole(vault, noteId, event);
       return json({ ok: true, reconciled: result });
     }
 

--- a/src/def-vault-triggers.test.ts
+++ b/src/def-vault-triggers.test.ts
@@ -88,27 +88,27 @@ describe("buildDefVaultTriggers — the bare-keyed shapes", () => {
     return t;
   }
 
-  test("emits five triggers: def-watch create/edit, inbound, pack-watch create/edit", () => {
+  test("emits five triggers: def-watch create/edit, inbound, role-watch create/edit", () => {
     expect(triggers.map((t) => t.name)).toEqual([
       "conn_agentdefs-create-default",
       "conn_agentdefs-edit-default",
       "conn_agentinbound-default",
-      // threads-only Phase B′ — the per-pack reconcile triggers.
-      "conn_packs-create-default",
-      "conn_packs-edit-default",
+      // threads-only Phase B′ — the per-role reconcile triggers.
+      "conn_roles-create-default",
+      "conn_roles-edit-default",
     ]);
   });
 
-  test("pack-watch triggers are bare `pack`-keyed and webhook the pack reconcile endpoint", () => {
-    for (const name of ["conn_packs-create-default", "conn_packs-edit-default"]) {
+  test("role-watch triggers are bare `agent/role`-keyed and webhook the role reconcile endpoint", () => {
+    for (const name of ["conn_roles-create-default", "conn_roles-edit-default"]) {
       const t = byName(name);
-      expect(t.when.tags).toEqual(["pack"]);
-      expect(t.action.webhook).toBe(`${HUB}/agent/api/vault/pack`);
+      expect(t.when.tags).toEqual(["agent/role"]);
+      expect(t.action.webhook).toBe(`${HUB}/agent/api/vault/role`);
       expect(t.action.send).toBe("json");
       expect(t.action.auth?.bearer).toBe("BEARER");
     }
-    expect(byName("conn_packs-create-default").events).toEqual(["created"]);
-    expect(byName("conn_packs-edit-default").events).toEqual(["updated"]);
+    expect(byName("conn_roles-create-default").events).toEqual(["created"]);
+    expect(byName("conn_roles-edit-default").events).toEqual(["updated"]);
   });
 
   test("def-watch triggers are BARE-keyed (agent/definition, NOT #agent/definition)", () => {
@@ -179,8 +179,8 @@ describe("registerDefVaultTriggers — the live registration path", () => {
       "conn_agentdefs-create-default",
       "conn_agentdefs-edit-default",
       "conn_agentinbound-default",
-      "conn_packs-create-default",
-      "conn_packs-edit-default",
+      "conn_roles-create-default",
+      "conn_roles-edit-default",
     ]);
     expect(triggerCalls).toHaveLength(5);
     for (const c of triggerCalls) {
@@ -279,6 +279,6 @@ describe("registerAllDefVaultTriggers — fan-out over bindings", () => {
     const names = new Set(triggerCalls.map((c) => c.body.name));
     expect(names.has("conn_agentdefs-create-work")).toBe(true);
     expect(names.has("conn_agentinbound-default")).toBe(true);
-    expect(names.has("conn_packs-create-work")).toBe(true);
+    expect(names.has("conn_roles-create-work")).toBe(true);
   });
 });

--- a/src/def-vault-triggers.ts
+++ b/src/def-vault-triggers.ts
@@ -72,13 +72,13 @@ import { AGENT_VAULT_TRIGGER_TEMPLATE } from "./transports/vault.ts";
 /** The bare def-discriminator tag the def-watch triggers filter on (post-canonicalization). */
 export const DEFINITION_TAG = "agent/definition";
 /**
- * The bare PACK tag the pack-watch triggers filter on (threads-only Phase B′ —
- * DESIGN-2026-06-29-threads-only.md §4). A `#pack` note save fires the pack webhook so the
- * daemon reconciles that pack's `wants:` under its path key (register + prune-its-own-partition).
- * This is the PER-PACK trigger — analogous to the def-watch triggers, NOT fired on every load
- * (load is per-turn). Mirrors {@link PACK_TAG} in grants.ts.
+ * The bare ROLE tag the role-watch triggers filter on (roles as the capability layer —
+ * DESIGN-2026-06-29-threads-roles-context.md). An `#agent/role` note save fires the role webhook
+ * so the daemon reconciles that role's `wants:` under its path key (register + prune-its-own-
+ * partition). This is the PER-ROLE trigger — analogous to the def-watch triggers, NOT fired on
+ * every load (load is per-turn). Mirrors {@link ROLE_TAG} in grants.ts.
  */
-export const PACK_TAG = "pack";
+export const ROLE_TAG = "agent/role";
 /**
  * The inbound trigger's `when` predicate. SOURCED from the existing
  * {@link AGENT_VAULT_TRIGGER_TEMPLATE} (`src/transports/vault.ts`) — the
@@ -141,12 +141,12 @@ export function inboundTriggerName(vault: string): string {
 }
 
 /**
- * The pack-watch trigger name for a (vault, kind) (threads-only Phase B′). Stable so the
- * POST upserts in place. ONE pair (create + edit) per def-vault — they fire the pack webhook
- * for ANY `#pack` note in the vault, which reconciles that pack's `wants:` under its path key.
+ * The role-watch trigger name for a (vault, kind) (roles as the capability layer). Stable so the
+ * POST upserts in place. ONE pair (create + edit) per def-vault — they fire the role webhook
+ * for ANY `#agent/role` note in the vault, which reconciles that role's `wants:` under its path key.
  */
-export function packWatchTriggerName(vault: string, kind: "create" | "edit"): string {
-  return `conn_packs-${kind}-${vault}`;
+export function roleWatchTriggerName(vault: string, kind: "create" | "edit"): string {
+  return `conn_roles-${kind}-${vault}`;
 }
 
 /** Build the webhook URL `<hub-origin>/agent/api/vault/<endpoint>`. */
@@ -167,7 +167,7 @@ export function buildDefVaultTriggers(
 ): VaultTriggerInput[] {
   const defWebhook = buildWebhook(hubOrigin, "/api/vault/agent-def");
   const inboundWebhook = buildWebhook(hubOrigin, "/api/vault/inbound");
-  const packWebhook = buildWebhook(hubOrigin, "/api/vault/pack");
+  const roleWebhook = buildWebhook(hubOrigin, "/api/vault/role");
   const auth = { bearer: webhookBearer };
   return [
     // Def-watch CREATE — a new bare `agent/definition` note instantiates its agent live.
@@ -198,26 +198,26 @@ export function buildDefVaultTriggers(
       },
       action: { webhook: inboundWebhook, send: "json", auth },
     },
-    // PACK-watch CREATE — a new `#pack` note reconciles its `wants:` under its path key
-    // (threads-only Phase B′ §4). This is the PER-PACK reconcile trigger, analogous to the
+    // ROLE-watch CREATE — a new `#agent/role` note reconciles its `wants:` under its path key
+    // (roles as the capability layer). This is the PER-ROLE reconcile trigger, analogous to the
     // def-watch triggers — fired on SAVE, NOT on every load (load is per-turn). The webhook
-    // registers the pack's wants + prunes ONLY that pack's own grant partition.
+    // registers the role's wants + prunes ONLY that role's own grant partition.
     {
-      name: packWatchTriggerName(vault, "create"),
+      name: roleWatchTriggerName(vault, "create"),
       events: ["created"],
-      when: { tags: [PACK_TAG] },
-      action: { webhook: packWebhook, send: "json", auth },
+      when: { tags: [ROLE_TAG] },
+      action: { webhook: roleWebhook, send: "json", auth },
     },
-    // PACK-watch EDIT — an edited `#pack` note re-reconciles (a removed `wants:` prunes that
-    // pack's partition to []). The vault has no `deleted` trigger event (validator allows only
+    // ROLE-watch EDIT — an edited `#agent/role` note re-reconciles (a removed `wants:` prunes that
+    // role's partition to []). The vault has no `deleted` trigger event (validator allows only
     // created/updated), so deletion is handled out-of-band; the create+edit pair covers
-    // save + drop-wants, which is the live reconcile surface. (Each pack is its OWN partition,
-    // so a reconcile can never touch a def's grants or another pack's — §4.)
+    // save + drop-wants, which is the live reconcile surface. (Each role is its OWN partition,
+    // so a reconcile can never touch a def's grants or another role's.)
     {
-      name: packWatchTriggerName(vault, "edit"),
+      name: roleWatchTriggerName(vault, "edit"),
       events: ["updated"],
-      when: { tags: [PACK_TAG] },
-      action: { webhook: packWebhook, send: "json", auth },
+      when: { tags: [ROLE_TAG] },
+      action: { webhook: roleWebhook, send: "json", auth },
     },
   ];
 }
@@ -343,7 +343,7 @@ export async function registerAllDefVaultTriggers(
     if (r.failures.length === 0) {
       console.log(
         `parachute-agent: def-vault "${r.vault}" — auto-registered ${r.registered.length} trigger(s) ` +
-          `(def-watch create/edit + inbound + pack-watch create/edit, bare-keyed).`,
+          `(def-watch create/edit + inbound + role-watch create/edit, bare-keyed).`,
       );
     } else {
       console.warn(

--- a/src/grants.test.ts
+++ b/src/grants.test.ts
@@ -27,10 +27,10 @@ import {
   grantVaultEntryKey,
   grantServiceEntryKey,
   grantMcpEntryKey,
-  packPathKey,
-  isPackNote,
-  packWants,
-  PACK_TAG,
+  rolePathKey,
+  isRoleNote,
+  roleWants,
+  ROLE_TAG,
   GrantsClient,
   GrantsApiError,
   WantsParseError,
@@ -643,60 +643,61 @@ describe("resolveInjectedGrants", () => {
 });
 
 // ---------------------------------------------------------------------------
-// threads-only Phase B′ — pack-only grants (DESIGN-2026-06-29-threads-only.md §4)
+// roles as the capability layer (DESIGN-2026-06-29-threads-roles-context.md)
 // ---------------------------------------------------------------------------
 
-describe("packPathKey — the pack grant-holder key (slugged path, `pack--` prefixed)", () => {
-  test("slugs the path (non-slug chars → -) under a `pack--` prefix", () => {
-    expect(packPathKey("Uni/Packs/github")).toBe("pack--Uni-Packs-github");
-    expect(packPathKey("Packs/Read.ai")).toBe("pack--Packs-Read-ai");
+describe("rolePathKey — the role grant-holder key (slugged path, `role--` prefixed)", () => {
+  test("slugs the path (non-slug chars → -) under a `role--` prefix", () => {
+    expect(rolePathKey("Uni/Roles/github")).toBe("role--Uni-Roles-github");
+    expect(rolePathKey("Roles/Read.ai")).toBe("role--Roles-Read-ai");
   });
-  test("the pack key namespace can never collide with a bare def name (a slug, no `--`)", () => {
-    // A def `metadata.name` is a `[a-zA-Z0-9_-]+` slug — it has no `--`, so the `pack--`
+  test("the role key namespace can never collide with a bare def name (a slug, no `--`)", () => {
+    // A def `metadata.name` is a `[a-zA-Z0-9_-]+` slug — it has no `--`, so the `role--`
     // prefix partitions the two grant-holder namespaces.
-    expect(packPathKey("steward").startsWith("pack--")).toBe(true);
+    expect(rolePathKey("steward").startsWith("role--")).toBe(true);
     expect("steward").not.toContain("--");
   });
 });
 
-describe("isPackNote / packWants — the SECURITY GATE (wants only from PACKS)", () => {
-  test("PACK_TAG is the bare `pack` tag", () => {
-    expect(PACK_TAG).toBe("pack");
+describe("isRoleNote / roleWants — the SECURITY GATE (wants only from #agent/role)", () => {
+  test("ROLE_TAG is the bare `agent/role` tag", () => {
+    expect(ROLE_TAG).toBe("agent/role");
   });
-  test("isPackNote: true for a `pack`-tagged note (array or string tags, tolerant of `#`)", () => {
-    expect(isPackNote({ tags: ["pack"] })).toBe(true);
-    expect(isPackNote({ tags: ["#pack"] })).toBe(true); // stray leading # tolerated
-    expect(isPackNote({ tags: "foo, pack, bar" })).toBe(true);
-    expect(isPackNote({ tags: ["other"] })).toBe(false);
-    expect(isPackNote({ tags: undefined })).toBe(false);
-    // A substring match must NOT count as `pack` (exact tag, not prefix).
-    expect(isPackNote({ tags: ["packaged"] })).toBe(false);
-    expect(isPackNote({ tags: ["pack/sub"] })).toBe(false);
+  test("isRoleNote: true for an `agent/role`-tagged note (array or string tags, tolerant of `#`)", () => {
+    expect(isRoleNote({ tags: ["agent/role"] })).toBe(true);
+    expect(isRoleNote({ tags: ["#agent/role"] })).toBe(true); // stray leading # tolerated
+    expect(isRoleNote({ tags: "foo, agent/role, bar" })).toBe(true);
+    expect(isRoleNote({ tags: ["other"] })).toBe(false);
+    expect(isRoleNote({ tags: undefined })).toBe(false);
+    // A near-miss must NOT count as `agent/role` (exact tag, not prefix/substring).
+    expect(isRoleNote({ tags: ["agent/roles"] })).toBe(false);
+    expect(isRoleNote({ tags: ["agent/role/sub"] })).toBe(false);
+    expect(isRoleNote({ tags: ["agent"] })).toBe(false);
   });
 
-  test("a `#pack` note WITH wants → parsed specs", () => {
-    const note = { tags: ["pack"], metadata: { wants: "vault:research:read, env:github" } };
-    expect(packWants(note)).toEqual([
+  test("an `#agent/role` note WITH wants → parsed specs", () => {
+    const note = { tags: ["agent/role"], metadata: { wants: "vault:research:read, env:github" } };
+    expect(roleWants(note)).toEqual([
       { kind: "vault", target: "research", access: "read" },
       { kind: "service", target: "github", inject: ["env"] },
     ]);
   });
 
-  test("THE GATE: a NON-pack note with wants → null (its wants are IGNORED/inert)", () => {
+  test("THE GATE: a NON-role note with wants → null (its wants are IGNORED/inert)", () => {
     // A plain content note declaring `wants:` must NOT contribute any capability.
     const note = { tags: ["reference"], metadata: { wants: "vault:research:read, env:github" } };
-    expect(packWants(note)).toBeNull();
-    // Same content, but now tagged `pack` → honored. The ONLY difference is the tag.
-    expect(packWants({ tags: ["pack"], metadata: { wants: "vault:research:read" } })).not.toBeNull();
+    expect(roleWants(note)).toBeNull();
+    // Same content, but now tagged `agent/role` → honored. The ONLY difference is the tag.
+    expect(roleWants({ tags: ["agent/role"], metadata: { wants: "vault:research:read" } })).not.toBeNull();
   });
 
-  test("a pack with NO wants → null; a pack with empty wants → null", () => {
-    expect(packWants({ tags: ["pack"], metadata: {} })).toBeNull();
-    expect(packWants({ tags: ["pack"], metadata: { wants: "" } })).toBeNull();
+  test("a role with NO wants → null; a role with empty wants → null", () => {
+    expect(roleWants({ tags: ["agent/role"], metadata: {} })).toBeNull();
+    expect(roleWants({ tags: ["agent/role"], metadata: { wants: "" } })).toBeNull();
   });
 
-  test("a pack with a MALFORMED wants → null (the reconcile path stamps status:error)", () => {
-    expect(packWants({ tags: ["pack"], metadata: { wants: "garbage-no-colon" } })).toBeNull();
+  test("a role with a MALFORMED wants → null (the reconcile path stamps status:error)", () => {
+    expect(roleWants({ tags: ["agent/role"], metadata: { wants: "garbage-no-colon" } })).toBeNull();
   });
 });
 
@@ -737,8 +738,8 @@ function multiAgentClient(opts: {
   return new GrantsClient({ hubOrigin: HUB, managerBearer: BEARER, fetchFn });
 }
 
-describe("resolveInjectedGrantsUnion — union of def key + pack keys", () => {
-  test("LEGACY CONTINUITY: a single source (no packs) === resolveInjectedGrants(spec.name)", async () => {
+describe("resolveInjectedGrantsUnion — union of def key + role keys", () => {
+  test("LEGACY CONTINUITY: a single source (no roles) === resolveInjectedGrants(spec.name)", async () => {
     const conn: ConnectionSpec = { kind: "service", target: "github", inject: ["env"] };
     const byAgent = { steward: [{ id: "g1", connection: conn, status: "approved" }] };
     const material = { g1: { kind: "service" as const, token: "GHTOK", inject: ["env" as const] } };
@@ -752,14 +753,14 @@ describe("resolveInjectedGrantsUnion — union of def key + pack keys", () => {
     expect(fromUnion.env).toEqual({ GITHUB_TOKEN: "GHTOK" });
   });
 
-  test("a thread loading ONE pack → def grants UNIONED with the pack's path-keyed grants", async () => {
-    const packKey = packPathKey("Packs/github");
+  test("a thread loading ONE role → def grants UNIONED with the role's path-keyed grants", async () => {
+    const roleKey = rolePathKey("Roles/github");
     const client = multiAgentClient({
       byAgent: {
         steward: [
           { id: "d1", connection: { kind: "vault", target: "ops", access: "read" }, status: "approved" },
         ],
-        [packKey]: [
+        [roleKey]: [
           { id: "p1", connection: { kind: "service", target: "github", inject: ["env"] }, status: "approved" },
         ],
       },
@@ -768,16 +769,16 @@ describe("resolveInjectedGrantsUnion — union of def key + pack keys", () => {
         p1: { kind: "service", token: "GHTOK", inject: ["env"] },
       },
     });
-    const out = await resolveInjectedGrantsUnion(client, ["steward", packKey]);
-    expect(out.env).toEqual({ GITHUB_TOKEN: "GHTOK" }); // from the pack
+    const out = await resolveInjectedGrantsUnion(client, ["steward", roleKey]);
+    expect(out.env).toEqual({ GITHUB_TOKEN: "GHTOK" }); // from the role
     expect(out.mcpEntries).toEqual([
       { name: grantVaultEntryKey("ops"), url: "https://hub/vault/ops/mcp", token: "OPSTOK" }, // from the def
     ]);
   });
 
-  test("TWO packs → all three sources unioned (def + pack A + pack B)", async () => {
-    const keyA = packPathKey("Packs/github");
-    const keyB = packPathKey("Packs/research");
+  test("TWO roles → all three sources unioned (def + role A + role B)", async () => {
+    const keyA = rolePathKey("Roles/github");
+    const keyB = rolePathKey("Roles/research");
     const client = multiAgentClient({
       byAgent: {
         steward: [{ id: "d1", connection: { kind: "service", target: "cloudflare", inject: ["env"] }, status: "approved" }],
@@ -811,34 +812,34 @@ describe("resolveInjectedGrantsUnion — union of def key + pack keys", () => {
   });
 
   test("dedupe on collision: first source wins an env-var / MCP-name collision (def first)", async () => {
-    const packKey = packPathKey("Packs/github");
+    const roleKey = rolePathKey("Roles/github");
     const client = multiAgentClient({
       byAgent: {
         steward: [{ id: "d1", connection: { kind: "service", target: "github", inject: ["env"] }, status: "approved" }],
-        [packKey]: [{ id: "p1", connection: { kind: "service", target: "github", inject: ["env"] }, status: "approved" }],
+        [roleKey]: [{ id: "p1", connection: { kind: "service", target: "github", inject: ["env"] }, status: "approved" }],
       },
       material: {
         d1: { kind: "service", token: "DEF-GHTOK", inject: ["env"] },
-        p1: { kind: "service", token: "PACK-GHTOK", inject: ["env"] },
+        p1: { kind: "service", token: "ROLE-GHTOK", inject: ["env"] },
       },
     });
-    const out = await resolveInjectedGrantsUnion(client, ["steward", packKey]);
+    const out = await resolveInjectedGrantsUnion(client, ["steward", roleKey]);
     // The def (first source) wins the GITHUB_TOKEN collision.
     expect(out.env).toEqual({ GITHUB_TOKEN: "DEF-GHTOK" });
   });
 
   test("per-source isolation: ONE source's list failure is skipped, the others still inject", async () => {
-    const packKey = packPathKey("Packs/github");
+    const roleKey = rolePathKey("Roles/github");
     const client = multiAgentClient({
       byAgent: {
         steward: [{ id: "d1", connection: { kind: "service", target: "github", inject: ["env"] }, status: "approved" }],
-        [packKey]: [{ id: "p1", connection: { kind: "vault", target: "x", access: "read" }, status: "approved" }],
+        [roleKey]: [{ id: "p1", connection: { kind: "vault", target: "x", access: "read" }, status: "approved" }],
       },
       material: { d1: { kind: "service", token: "GHTOK", inject: ["env"] } },
-      listStatusByAgent: { [packKey]: 500 }, // the pack's LIST fails
+      listStatusByAgent: { [roleKey]: 500 }, // the role's LIST fails
     });
-    const out = await resolveInjectedGrantsUnion(client, ["steward", packKey]);
-    // The def still injected; the failing pack source is simply absent (never throws).
+    const out = await resolveInjectedGrantsUnion(client, ["steward", roleKey]);
+    // The def still injected; the failing role source is simply absent (never throws).
     expect(out.env).toEqual({ GITHUB_TOKEN: "GHTOK" });
     expect(out.mcpEntries).toEqual([]);
   });

--- a/src/grants.ts
+++ b/src/grants.ts
@@ -657,26 +657,26 @@ export async function resolveInjectedGrants(
 }
 
 /**
- * UNION an agent's injected grants across MULTIPLE grant-source keys (threads-only
- * Phase B′ — DESIGN-2026-06-29-threads-only.md §4). The injected grants for a turn are
- * the union of `resolveInjectedGrants(client, key)` over `[spec.name, ...packKeys]`:
+ * UNION an agent's injected grants across MULTIPLE grant-source keys (roles as the
+ * capability layer — DESIGN-2026-06-29-threads-roles-context.md). The injected grants for a
+ * turn are the union of `resolveInjectedGrants(client, key)` over `[spec.name, ...roleKeys]`:
  *
  *   - `spec.name`  — the LEGACY def path (UNCHANGED): a `#agent/definition` keeps its
  *     grants keyed by its `metadata.name`. For the 4 live def agents (uni, steward, …)
- *     this is the ONLY key, so with no loaded packs the union has one source and the
+ *     this is the ONLY key, so with no loaded roles the union has one source and the
  *     result is byte-identical to {@link resolveInjectedGrants}(client, spec.name).
- *   - each `packKey` — a slugged pack PATH ({@link packPathKey}) for every loaded note
- *     that is a `#pack` declaring `wants:`. Loading a pack into a thread unions that
- *     pack's path-keyed APPROVED grants in.
+ *   - each `roleKey` — a slugged role PATH ({@link rolePathKey}) for every loaded note in
+ *     the thread's `metadata.roles` that is an `#agent/role` declaring `wants:`. Loading a
+ *     role into a thread unions that role's path-keyed APPROVED grants in.
  *
  * Dedupe rule: MCP entries are deduped by their entry `name` (first source wins);
  * env vars are deduped by var name (first source wins). The legacy `spec.name` source
- * is conventionally first, so a def's own grant wins a name collision with a pack's.
+ * is conventionally first, so a def's own grant wins a name collision with a role's.
  *
- * Keys are deduped + processed in order; a duplicate key (e.g. the same pack twice in
- * a loadout, or a pack key that happens to equal `spec.name`) is fetched ONCE. A single
+ * Keys are deduped + processed in order; a duplicate key (e.g. the same role twice in the
+ * roles list, or a role key that happens to equal `spec.name`) is fetched ONCE. A single
  * source's grant-LIST failure is logged + SKIPPED (its grants are simply absent this
- * turn — the others still inject), so a flaky hub on one pack never sinks the whole
+ * turn — the others still inject), so a flaky hub on one role never sinks the whole
  * turn's injection. Material is fetched FRESH per source (never cached), same as the
  * single-source path.
  */
@@ -716,47 +716,48 @@ export async function resolveInjectedGrantsUnion(
 }
 
 /**
- * The hub grant-holder KEY for a PACK (threads-only Phase B′ §4) — the slugged note
- * PATH, mirroring the slug discipline the hub's `grantId` uses (`/`→`-`, all non-slug
- * chars collapse). Prefixed `pack--` so it reads UNAMBIGUOUSLY as a pack source and is
- * practically partitioned from def keys: a def `metadata.name` is an operator-authored
- * `[a-zA-Z0-9_-]+` slug (the live cast — `uni`, `steward`, … — have no `--`), so the
- * `pack--` prefix keeps the two namespaces apart in normal operation. (The def-name regex
- * technically accepts `--`, so a deliberately-crafted def named `pack--<x>` could share a
- * pack's partition — but that's an operator-trust corner, not an exploitable boundary: an
- * operator who can author such a def can author the pack too.) The hub keys
- * `grantId(agent, spec) = ${agent}--${connectionKey}` on this opaque holder string;
- * each pack is therefore its OWN prune partition on the hub (`listGrantsForAgent`),
- * so a pack's reconcile can never touch a def's grants or another pack's.
+ * The hub grant-holder KEY for a ROLE (roles as the capability layer —
+ * DESIGN-2026-06-29-threads-roles-context.md) — the slugged note PATH, mirroring the slug
+ * discipline the hub's `grantId` uses (`/`→`-`, all non-slug chars collapse). Prefixed
+ * `role--` so it reads UNAMBIGUOUSLY as a role source and is practically partitioned from
+ * def keys: a def `metadata.name` is an operator-authored `[a-zA-Z0-9_-]+` slug (the live
+ * cast — `uni`, `steward`, … — have no `--`), so the `role--` prefix keeps the two
+ * namespaces apart in normal operation. (The def-name regex technically accepts `--`, so a
+ * deliberately-crafted def named `role--<x>` could share a role's partition — but that's an
+ * operator-trust corner, not an exploitable boundary: an operator who can author such a def
+ * can author the role too.) The hub keys `grantId(agent, spec) = ${agent}--${connectionKey}`
+ * on this opaque holder string; each role is therefore its OWN prune partition on the hub
+ * (`listGrantsForAgent`), so a role's reconcile can never touch a def's grants or another role's.
  *
- * Examples: `Uni/Packs/github` → `pack--Uni-Packs-github`; `Packs/Read.ai` → `pack--Packs-Read-ai`.
+ * Examples: `Uni/Roles/github` → `role--Uni-Roles-github`; `Roles/Read.ai` → `role--Roles-Read-ai`.
  */
-export function packPathKey(notePath: string): string {
+export function rolePathKey(notePath: string): string {
   // Mirror sandbox/types.ts `slug`: collapse every non-`[a-zA-Z0-9_-]` char to `-`.
   const slugged = notePath.replace(/[^a-zA-Z0-9_-]/g, "-");
-  return `pack--${slugged}`;
+  return `role--${slugged}`;
 }
 
-/** The bare tag (post-canonicalization) that marks a note as a PACK. */
-export const PACK_TAG = "pack";
+/** The bare tag (post-canonicalization) that marks a note as a ROLE — `#agent/role`. */
+export const ROLE_TAG = "agent/role";
 
 /**
- * Is this loaded note a PACK that declares `wants:`? — the SECURITY GATE (threads-only
- * Phase B′ §"Security refinement — wants only from PACKS"). A note's `wants:` is honored
- * ONLY if the note carries the `#pack`/`pack` tag; a plain content note's `wants:` is
+ * Is this loaded note a ROLE that declares `wants:`? — the SECURITY GATE (roles carry
+ * capability — DESIGN-2026-06-29-threads-roles-context.md). A note's `wants:` is honored
+ * ONLY if the note carries the `#agent/role` tag; a plain content note's `wants:` is
  * IGNORED (inert) even if present, so loading arbitrary notes for context can NEVER add
  * capabilities. PURE — no I/O. Tag matching tolerates a stray leading `#` (pre-/post-
- * canonicalization) so a `#pack`-authored note is recognized either way.
+ * canonicalization) so an `#agent/role`-authored note is recognized either way.
  *
- * Returns the parsed `wants:` connection specs when the note is a pack WITH a non-empty,
- * cleanly-parsing `wants:`; otherwise `null` (not a pack, no `wants:`, or a parse error —
- * a parse error is surfaced via {@link packWantsOrError}, this fast-path just returns null).
+ * Returns the parsed `wants:` connection specs when the note is a role WITH a non-empty,
+ * cleanly-parsing `wants:`; otherwise `null` (not a role, no `wants:`, or a parse error —
+ * a parse error stamps the note `status:error` via the reconcile path; this fast-path just
+ * returns null).
  */
-export function packWants(note: {
+export function roleWants(note: {
   tags?: unknown;
   metadata?: Record<string, unknown>;
 }): ConnectionSpec[] | null {
-  if (!isPackNote(note)) return null;
+  if (!isRoleNote(note)) return null;
   const raw = note.metadata?.wants;
   if (raw === undefined || raw === null) return null;
   let specs: ConnectionSpec[];
@@ -769,11 +770,11 @@ export function packWants(note: {
 }
 
 /**
- * Does this note carry the `#pack` tag? Tolerates the `tags` field being an array of
+ * Does this note carry the `#agent/role` tag? Tolerates the `tags` field being an array of
  * strings (the vault REST shape) or a comma/space-joined string, and a stray leading
  * `#` on the tag value. PURE.
  */
-export function isPackNote(note: { tags?: unknown }): boolean {
+export function isRoleNote(note: { tags?: unknown }): boolean {
   const tags = note.tags;
   let list: string[];
   if (Array.isArray(tags)) {
@@ -783,7 +784,7 @@ export function isPackNote(note: { tags?: unknown }): boolean {
   } else {
     return false;
   }
-  return list.some((t) => t.trim().replace(/^#/, "") === PACK_TAG);
+  return list.some((t) => t.trim().replace(/^#/, "") === ROLE_TAG);
 }
 
 /** MCP entry key for a GRANTED vault — namespaced so it never collides with the

--- a/src/programmatic-wiring.test.ts
+++ b/src/programmatic-wiring.test.ts
@@ -1083,7 +1083,7 @@ describe("the drain reads the thread loadout → deliver receives it (threads-on
         seen.push({ channel, name, ...(subject ? { subject } : {}) });
         return [
           { path: "Projects/Surface", content: "project body" },
-          { path: "Packs/GitHub", content: "pack body" },
+          { path: "Refs/GitHub", content: "ref body" },
         ];
       },
     });
@@ -1094,7 +1094,7 @@ describe("the drain reads the thread loadout → deliver receives it (threads-on
     await until(() => backend.calls.length === 1);
     expect(backend.calls[0]!.loadout).toEqual([
       { path: "Projects/Surface", content: "project body" },
-      { path: "Packs/GitHub", content: "pack body" },
+      { path: "Refs/GitHub", content: "ref body" },
     ]);
     // The loader is consulted for EVERY thread (no subject → resolves the def-named note).
     expect(seen).toEqual([{ channel: "worker", name: "worker" }]);

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -290,23 +290,24 @@ export interface Transport {
     subject?: string,
   ): Promise<{ path: string; content: string }[]>;
   /**
-   * Optional: read the thread's loaded-PACK grant KEYS (threads-only Phase B′ —
-   * DESIGN-2026-06-29-threads-only.md §4). Resolves the same `metadata.loadout` paths as
-   * {@link readThreadLoadout}, but reads each note's METADATA (not its content) to find the
-   * loaded notes that are PACKS — i.e. carry the `#pack` tag AND declare a non-empty `wants:`.
-   * Returns each such pack's hub grant-holder key (the slugged PATH, `packPathKey`). This is
-   * the SECURITY GATE: a plain content note's `wants:` is IGNORED (only `#pack` notes
-   * contribute), and the metadata read is DELIBERATELY SEPARATE from the content-only prompt
-   * read (loading a note for context never adds capabilities). The backend unions these with
-   * the def's own `spec.name` grants. `subject` resolves the subject-scoped thread note.
-   * Absent `metadata.loadout` / no pack with `wants:` → an empty array (every current thread).
-   * Only a durable transport (the VaultTransport) implements it; others omit it.
+   * Optional: read the thread's ROLES (layer ① — DESIGN-2026-06-29-threads-roles-context.md).
+   * Resolves the `metadata.roles` array of note PATHS on the thread's `#agent/thread` note in
+   * ONE pass to BOTH (a) the ordered CONTENT entries (`{ path, content }` — note content only)
+   * the backend composes as the FIRST prompt layer, and (b) the grant-holder KEYS (the slugged
+   * PATH, `rolePathKey`) for the loaded notes that are ROLES (carry the `#agent/role` tag AND
+   * declare a non-empty `wants:`). This is the SECURITY GATE: listing a plain content note in
+   * `metadata.roles` loads its content as context but its `wants:` is IGNORED (only `#agent/role`
+   * notes contribute grants) — loading context can never escalate. The backend prepends the
+   * entries before the def (self) and unions the grant keys with the def's own `spec.name` grants.
+   * `subject` resolves the subject-scoped thread note. Absent `metadata.roles` / no role → an
+   * empty `{ entries: [], grantKeys: [] }` (every current thread). Only a durable transport (the
+   * VaultTransport) implements it; others omit it.
    */
-  readThreadPackKeys?(
+  readThreadRoles?(
     channel: string,
     name: string,
     subject?: string,
-  ): Promise<string[]>;
+  ): Promise<{ entries: { path: string; content: string }[]; grantKeys: string[] }>;
   /**
    * Optional: write an agent-to-agent CALLBACK as an INBOUND note on THIS channel (the
    * "reply_to" substrate). A recipient agent's drain, on turn completion, calls this on the

--- a/src/transports/vault.test.ts
+++ b/src/transports/vault.test.ts
@@ -26,7 +26,7 @@
 
 import { describe, test, expect, afterEach } from "bun:test";
 import { VaultTransport, AGENT_VAULT_TAG_SCHEMA, AGENT_THREAD_TAG, AGENT_JOB_TAG, InboundClaimConflictError, noteAgentKey, parseLoadoutPaths } from "./vault.ts";
-import { packPathKey } from "../grants.ts";
+import { rolePathKey } from "../grants.ts";
 import type { TransportContext, InboundMessage } from "../transport.ts";
 import { instantiateTransport } from "../registry.ts";
 
@@ -1767,8 +1767,14 @@ describe("VaultTransport — ensureSchema (tag-schema declaration on connect)", 
     const defBody = JSON.parse(String(def.init.body)) as { parent_names?: string[] };
     expect(defBody.parent_names).toEqual(["agent"]);
 
+    // Role (NEW — roles as the capability layer) — name carries `/`; rolls up to the root.
+    const role = calls[2]!;
+    expect(decodeURIComponent(role.url.split("/api/tags/")[1]!)).toBe("agent/role");
+    const roleBody = JSON.parse(String(role.init.body)) as { parent_names?: string[] };
+    expect(roleBody.parent_names).toEqual(["agent"]);
+
     // Message parent (NEW) — rolls up to the namespace root.
-    const parent = calls[2]!;
+    const parent = calls[3]!;
     expect(parent.url).toBe(
       "http://127.0.0.1:1940/vault/default/api/tags/agent%2Fmessage",
     );
@@ -1784,7 +1790,7 @@ describe("VaultTransport — ensureSchema (tag-schema declaration on connect)", 
     // Inbound child (NEW) — name carries `/`. The vault route matches a
     // single path segment (`[^/]+`) then decodeURIComponent's it, so the `/` MUST
     // be encoded as `%2F` (a bare slash would fail the single-segment match → 404).
-    const inbound = calls[3]!;
+    const inbound = calls[4]!;
     expect(inbound.url).toBe(
       "http://127.0.0.1:1940/vault/default/api/tags/agent%2Fmessage%2Finbound",
     );
@@ -1801,7 +1807,7 @@ describe("VaultTransport — ensureSchema (tag-schema declaration on connect)", 
     );
 
     // Outbound child (NEW) — same encoding, parent declared.
-    const outbound = calls[4]!;
+    const outbound = calls[5]!;
     expect(outbound.url).toBe(
       "http://127.0.0.1:1940/vault/default/api/tags/agent%2Fmessage%2Foutbound",
     );
@@ -1812,21 +1818,22 @@ describe("VaultTransport — ensureSchema (tag-schema declaration on connect)", 
     expect(outboundBody.parent_names).toEqual(["agent/message"]);
 
     // Job (NEW) — rolls up to the namespace root.
-    const job = calls[5]!;
+    const job = calls[6]!;
     expect(decodeURIComponent(job.url.split("/api/tags/")[1]!)).toBe("agent/job");
     const jobBody = JSON.parse(String(job.init.body)) as { parent_names?: string[] };
     expect(jobBody.parent_names).toEqual(["agent"]);
   });
 
-  test("schema declares ONLY the #agent/* namespace rollup (CONTRACT dropped interim + legacy, 7 entries)", async () => {
+  test("schema declares ONLY the #agent/* namespace rollup (CONTRACT dropped interim + legacy, 8 entries)", async () => {
     // The `#agent/*` namespace (design 2026-06-17-vault-native-agents) rolls up
-    // definitions, messages, jobs, AND threads to the `#agent` root. The channel→agent
+    // definitions, ROLES, messages, jobs, AND threads to the `#agent` root. The channel→agent
     // CONTRACT dropped the interim flat `#agent-message*` AND legacy `#channel-message*`
-    // schema entries — exactly 7 entries, all under `#agent/*`.
+    // schema entries — exactly 8 entries, all under `#agent/*`.
     const names = AGENT_VAULT_TAG_SCHEMA.map((e) => e.name);
     expect(names).toEqual([
       "agent",
       "agent/definition",
+      "agent/role",
       "agent/message",
       "agent/message/inbound",
       "agent/message/outbound",
@@ -1839,6 +1846,7 @@ describe("VaultTransport — ensureSchema (tag-schema declaration on connect)", 
     // The namespace children all roll up to the `#agent` root (the human rollup).
     const byName = (n: string) => AGENT_VAULT_TAG_SCHEMA.find((e) => e.name === n)!;
     expect(byName("agent/definition").parent_names).toEqual(["agent"]);
+    expect(byName("agent/role").parent_names).toEqual(["agent"]);
     expect(byName("agent/message").parent_names).toEqual(["agent"]);
     expect(byName("agent/job").parent_names).toEqual(["agent"]);
     expect(byName("agent/thread").parent_names).toEqual(["agent"]);
@@ -2309,9 +2317,9 @@ describe("VaultTransport — setInboundStatus (FIX 3 compare-and-swap claim)", (
 
 describe("parseLoadoutPaths — the metadata.loadout parser", () => {
   test("a real string[] → kept (trimmed, blanks dropped)", () => {
-    expect(parseLoadoutPaths(["Projects/Surface", "  Packs/GitHub  ", "", "   "])).toEqual([
+    expect(parseLoadoutPaths(["Projects/Surface", "  Refs/GitHub  ", "", "   "])).toEqual([
       "Projects/Surface",
-      "Packs/GitHub",
+      "Refs/GitHub",
     ]);
   });
 
@@ -2344,9 +2352,9 @@ describe("VaultTransport — readThreadLoadout (the Phase A loader)", () => {
   test("reads metadata.loadout off the thread note + resolves each path's CONTENT, in order", async () => {
     // The thread note carries metadata.loadout = [two paths]; each path resolves to its body.
     const noteByPath: Record<string, { metadata?: Record<string, unknown>; content?: string }> = {
-      "Threads/eng/eng": { metadata: { loadout: ["Projects/Surface", "Packs/GitHub"] }, content: "thread summary" },
+      "Threads/eng/eng": { metadata: { loadout: ["Projects/Surface", "Refs/GitHub"] }, content: "thread summary" },
       "Projects/Surface": { metadata: { status: "active" }, content: "project body" },
-      "Packs/GitHub": { metadata: {}, content: "pack body" },
+      "Refs/GitHub": { metadata: {}, content: "ref body" },
     };
     const reads: string[] = [];
     globalThis.fetch = (async (url: string | URL | Request) => {
@@ -2366,18 +2374,18 @@ describe("VaultTransport — readThreadLoadout (the Phase A loader)", () => {
     // CONTENT only — never the metadata — in the declared order.
     expect(loadout).toEqual([
       { path: "Projects/Surface", content: "project body" },
-      { path: "Packs/GitHub", content: "pack body" },
+      { path: "Refs/GitHub", content: "ref body" },
     ]);
     // The thread note is read first, then each loadout path.
     expect(reads[0]).toBe("Threads/eng/eng");
     expect(reads).toContain("Projects/Surface");
-    expect(reads).toContain("Packs/GitHub");
+    expect(reads).toContain("Refs/GitHub");
   });
 
   test("a MISSING loadout path (404) is SKIPPED (never throws); the rest resolve", async () => {
     const noteByPath: Record<string, { metadata?: Record<string, unknown>; content?: string }> = {
-      "Threads/eng/eng": { metadata: { loadout: ["Gone/Stale", "Packs/GitHub"] }, content: "x" },
-      "Packs/GitHub": { metadata: {}, content: "pack body" },
+      "Threads/eng/eng": { metadata: { loadout: ["Gone/Stale", "Refs/GitHub"] }, content: "x" },
+      "Refs/GitHub": { metadata: {}, content: "ref body" },
       // "Gone/Stale" intentionally absent → 404 → skipped.
     };
     globalThis.fetch = (async (url: string | URL | Request) => {
@@ -2392,7 +2400,7 @@ describe("VaultTransport — readThreadLoadout (the Phase A loader)", () => {
     const t = new VaultTransport(baseConfig());
     await t.start(fakeCtx("eng"));
     const loadout = await t.readThreadLoadout("eng", "eng");
-    expect(loadout).toEqual([{ path: "Packs/GitHub", content: "pack body" }]);
+    expect(loadout).toEqual([{ path: "Refs/GitHub", content: "ref body" }]);
   });
 
   test("no thread note yet (first turn) → empty loadout", async () => {
@@ -2502,12 +2510,12 @@ describe("VaultTransport — readThreadContent (the thread's own authored body, 
   });
 });
 
-// ── threads-only Phase B′: readThreadPackKeys (the pack-detect SECURITY GATE) ──
-describe("VaultTransport — readThreadPackKeys (the Phase B′ pack-grant-key reader)", () => {
-  test("THE GATE: a loaded note with wants but NO #pack tag → IGNORED (no key)", async () => {
+// ── roles as the capability layer: readThreadRoles (content layer ① + the grant gate) ──
+describe("VaultTransport — readThreadRoles (the layer-① content + grant-key reader)", () => {
+  test("THE GATE: a role-listed note with wants but NO #agent/role tag → content loaded, NO grant key", async () => {
     const noteByPath: Record<string, { metadata?: Record<string, unknown>; content?: string; tags?: unknown }> = {
-      "Threads/eng/eng": { metadata: { loadout: ["Refs/leaky"] }, content: "x" },
-      // A plain content note that DECLARES wants but is NOT a pack → its wants are inert.
+      "Threads/eng/eng": { metadata: { roles: ["Refs/leaky"] }, content: "x" },
+      // A plain content note that DECLARES wants but is NOT a role → loaded as context, wants inert.
       "Refs/leaky": { tags: ["reference"], metadata: { wants: "vault:secrets:read, env:github" }, content: "body" },
     };
     globalThis.fetch = (async (url: string | URL | Request) => {
@@ -2520,16 +2528,19 @@ describe("VaultTransport — readThreadPackKeys (the Phase B′ pack-grant-key r
     }) as unknown as typeof fetch;
     const t = new VaultTransport(baseConfig());
     await t.start(fakeCtx("eng"));
-    // A non-pack note's wants contribute ZERO grant keys — loading context never adds caps.
-    expect(await t.readThreadPackKeys("eng", "eng")).toEqual([]);
+    // Its CONTENT loads (context never escalates) but its wants contribute ZERO grant keys.
+    expect(await t.readThreadRoles("eng", "eng")).toEqual({
+      entries: [{ path: "Refs/leaky", content: "body" }],
+      grantKeys: [],
+    });
   });
 
-  test("a loaded #pack with wants → its slugged-path key; a non-pack sibling stays ignored", async () => {
+  test("a loaded #agent/role with wants → content entry + its slugged-path key; a non-role sibling loads content only", async () => {
     const noteByPath: Record<string, { metadata?: Record<string, unknown>; content?: string; tags?: unknown }> = {
-      "Threads/eng/eng": { metadata: { loadout: ["Packs/github", "Projects/Surface"] }, content: "x" },
-      "Packs/github": { tags: ["pack"], metadata: { wants: "env:github" }, content: "pack body" },
-      // A plain project note (no #pack) — even if it had wants it would be ignored; here it has none.
-      "Projects/Surface": { tags: ["project"], metadata: { status: "active" }, content: "proj body" },
+      "Threads/eng/eng": { metadata: { roles: ["Roles/github", "Roles/Surface"] }, content: "x" },
+      "Roles/github": { tags: ["agent/role"], metadata: { wants: "env:github" }, content: "role body" },
+      // A plain project note (no #agent/role) — loaded as context, but contributes no grant key.
+      "Roles/Surface": { tags: ["project"], metadata: { status: "active" }, content: "proj body" },
     };
     globalThis.fetch = (async (url: string | URL | Request) => {
       const u = String(url);
@@ -2541,14 +2552,20 @@ describe("VaultTransport — readThreadPackKeys (the Phase B′ pack-grant-key r
     }) as unknown as typeof fetch;
     const t = new VaultTransport(baseConfig());
     await t.start(fakeCtx("eng"));
-    expect(await t.readThreadPackKeys("eng", "eng")).toEqual([packPathKey("Packs/github")]);
+    expect(await t.readThreadRoles("eng", "eng")).toEqual({
+      entries: [
+        { path: "Roles/github", content: "role body" },
+        { path: "Roles/Surface", content: "proj body" },
+      ],
+      grantKeys: [rolePathKey("Roles/github")], // ONLY the real #agent/role
+    });
   });
 
-  test("TWO packs with wants → both path keys (deduped, in loadout order)", async () => {
+  test("TWO roles with wants → both content entries + both grant keys (deduped, in declared order)", async () => {
     const noteByPath: Record<string, { metadata?: Record<string, unknown>; content?: string; tags?: unknown }> = {
-      "Threads/eng/eng": { metadata: { loadout: ["Packs/github", "Packs/research", "Packs/github"] }, content: "x" },
-      "Packs/github": { tags: ["pack"], metadata: { wants: "env:github" }, content: "a" },
-      "Packs/research": { tags: ["pack"], metadata: { wants: "vault:research:read" }, content: "b" },
+      "Threads/eng/eng": { metadata: { roles: ["Roles/github", "Roles/research", "Roles/github"] }, content: "x" },
+      "Roles/github": { tags: ["agent/role"], metadata: { wants: "env:github" }, content: "a" },
+      "Roles/research": { tags: ["agent/role"], metadata: { wants: "vault:research:read" }, content: "b" },
     };
     globalThis.fetch = (async (url: string | URL | Request) => {
       const u = String(url);
@@ -2560,17 +2577,21 @@ describe("VaultTransport — readThreadPackKeys (the Phase B′ pack-grant-key r
     }) as unknown as typeof fetch;
     const t = new VaultTransport(baseConfig());
     await t.start(fakeCtx("eng"));
-    // Deduped (github listed twice → one key), declared order preserved.
-    expect(await t.readThreadPackKeys("eng", "eng")).toEqual([
-      packPathKey("Packs/github"),
-      packPathKey("Packs/research"),
+    const out = await t.readThreadRoles("eng", "eng");
+    // Content for EVERY resolvable path (github twice → two content entries, declared order).
+    expect(out.entries).toEqual([
+      { path: "Roles/github", content: "a" },
+      { path: "Roles/research", content: "b" },
+      { path: "Roles/github", content: "a" },
     ]);
+    // Grant keys DEDUPED (github listed twice → one key), declared order preserved.
+    expect(out.grantKeys).toEqual([rolePathKey("Roles/github"), rolePathKey("Roles/research")]);
   });
 
-  test("a #pack with NO wants → no key (only capability-declaring packs count)", async () => {
+  test("an #agent/role with NO wants → content entry, no grant key (a context-only role)", async () => {
     const noteByPath: Record<string, { metadata?: Record<string, unknown>; content?: string; tags?: unknown }> = {
-      "Threads/eng/eng": { metadata: { loadout: ["Packs/empty"] }, content: "x" },
-      "Packs/empty": { tags: ["pack"], metadata: {}, content: "a context-only pack" },
+      "Threads/eng/eng": { metadata: { roles: ["Roles/empty"] }, content: "x" },
+      "Roles/empty": { tags: ["agent/role"], metadata: {}, content: "a context-only role" },
     };
     globalThis.fetch = (async (url: string | URL | Request) => {
       const u = String(url);
@@ -2582,20 +2603,23 @@ describe("VaultTransport — readThreadPackKeys (the Phase B′ pack-grant-key r
     }) as unknown as typeof fetch;
     const t = new VaultTransport(baseConfig());
     await t.start(fakeCtx("eng"));
-    expect(await t.readThreadPackKeys("eng", "eng")).toEqual([]);
+    expect(await t.readThreadRoles("eng", "eng")).toEqual({
+      entries: [{ path: "Roles/empty", content: "a context-only role" }],
+      grantKeys: [],
+    });
   });
 
-  test("LEGACY CONTINUITY: no thread note / no loadout → empty (every current thread)", async () => {
+  test("NO-ROLES INVARIANT: no thread note / no roles → { entries: [], grantKeys: [] } (every current thread)", async () => {
     globalThis.fetch = (async () => new Response("not found", { status: 404 })) as unknown as typeof fetch;
     const t = new VaultTransport(baseConfig());
     await t.start(fakeCtx("eng"));
-    expect(await t.readThreadPackKeys("eng", "eng")).toEqual([]);
+    expect(await t.readThreadRoles("eng", "eng")).toEqual({ entries: [], grantKeys: [] });
   });
 
-  test("a missing loadout path (404) is skipped (never throws)", async () => {
+  test("a missing role path (404) is skipped (never throws)", async () => {
     const noteByPath: Record<string, { metadata?: Record<string, unknown>; content?: string; tags?: unknown }> = {
-      "Threads/eng/eng": { metadata: { loadout: ["Gone/Stale", "Packs/github"] }, content: "x" },
-      "Packs/github": { tags: ["pack"], metadata: { wants: "env:github" }, content: "a" },
+      "Threads/eng/eng": { metadata: { roles: ["Gone/Stale", "Roles/github"] }, content: "x" },
+      "Roles/github": { tags: ["agent/role"], metadata: { wants: "env:github" }, content: "a" },
     };
     globalThis.fetch = (async (url: string | URL | Request) => {
       const u = String(url);
@@ -2607,6 +2631,10 @@ describe("VaultTransport — readThreadPackKeys (the Phase B′ pack-grant-key r
     }) as unknown as typeof fetch;
     const t = new VaultTransport(baseConfig());
     await t.start(fakeCtx("eng"));
-    expect(await t.readThreadPackKeys("eng", "eng")).toEqual([packPathKey("Packs/github")]);
+    // The stale path is skipped (not in entries, no key); the real role still resolves.
+    expect(await t.readThreadRoles("eng", "eng")).toEqual({
+      entries: [{ path: "Roles/github", content: "a" }],
+      grantKeys: [rolePathKey("Roles/github")],
+    });
   });
 });

--- a/src/transports/vault.ts
+++ b/src/transports/vault.ts
@@ -70,12 +70,12 @@ import type {
 // subject-scoped deterministic thread-note leaf (`<name>--<slug(subject)>`) so the path
 // math matches the registry's drain key exactly (no drift).
 import { threadKey } from "../sandbox/types.ts";
-// threads-only Phase B′ (§4): the pure pack-detection helpers — `packWants` is the
-// SECURITY GATE (a note's `wants:` is honored only if it is a `#pack`), `packPathKey`
-// derives the hub grant-holder key from the pack's slugged path. The metadata read here
-// is DELIBERATELY SEPARATE from the content-only loadout read (loading a note for context
-// never adds capabilities).
-import { packWants, packPathKey, isPackNote } from "../grants.ts";
+// roles as the capability layer (DESIGN-2026-06-29-threads-roles-context.md): the pure
+// role-detection helpers — `roleWants` is the SECURITY GATE (a note's `wants:` is honored
+// only if it is an `#agent/role`), `rolePathKey` derives the hub grant-holder key from the
+// role's slugged path. A role is read ONCE per turn: its CONTENT becomes the layer-① prompt
+// entry and its (gated) `wants:` becomes the grant keys — see `readThreadRoles`.
+import { roleWants, rolePathKey, isRoleNote } from "../grants.ts";
 
 /** The safe basename of a (possibly path-ful, possibly untrusted) string — the LAST
  *  path segment, with traversal markers stripped. Used to derive a display `filename`
@@ -349,10 +349,11 @@ function numFromMeta(v: unknown): number {
 }
 
 /**
- * Parse a thread note's `metadata.loadout` into an ordered list of note PATHS
- * (threads-only Phase A — DESIGN-2026-06-29-threads-only.md §9). The model home is an
- * ARRAY of path strings, but the vault stores metadata flexibly (a real JSON array, a
- * JSON-encoded array STRING, or — defensively — a single path string), so accept all three:
+ * Parse a thread note's note-path-array metadata field (`metadata.loadout` — the layer-③
+ * extra context; OR `metadata.roles` — the layer-① roles, DESIGN-2026-06-29-threads-roles-context.md)
+ * into an ordered list of note PATHS. The model home is an ARRAY of path strings, but the
+ * vault stores metadata flexibly (a real JSON array, a JSON-encoded array STRING, or —
+ * defensively — a single path string), so accept all three:
  *
  *  - a real `string[]` → kept (string entries only);
  *  - a `string` that JSON-parses to an array of strings → that array;
@@ -397,6 +398,17 @@ export const AGENT_ROOT_TAG = "agent";
  * The module reads these notes from a def-vault and instantiates each as a live agent.
  */
 export const AGENT_DEFINITION_TAG = "agent/definition";
+
+/**
+ * Role tag — a `#agent/role` note (roles as the capability layer,
+ * DESIGN-2026-06-29-threads-roles-context.md). A REUSABLE bundle: its BODY is loaded as the
+ * FIRST system-prompt layer (the "hat") and its `wants:` metadata declares the capabilities
+ * (MCPs / access / grants) a thread that loads it gains. It is the ONLY layer that grants
+ * capability — the security gate (`isRoleNote` / `roleWants` in grants.ts) honors `wants:`
+ * ONLY on a note carrying this tag, so loading plain context can never escalate. The
+ * elevation of the prior (unwired) `#pack`.
+ */
+export const AGENT_ROLE_TAG = "agent/role";
 
 /**
  * Scheduled-job tag — the runner's vault-native job store (design
@@ -445,6 +457,7 @@ const THREAD_PATH_PREFIX = "Threads";
  * declared via the vault's tag-schema API. We declare the full `#agent/*`
  * namespace rollup (design `2026-06-17-vault-native-agents.md`):
  *   - `#agent/definition`        → parent `#agent`
+ *   - `#agent/role`              → parent `#agent`
  *   - `#agent/message`           → parent `#agent`
  *   - `#agent/message/inbound`   → parent `#agent/message`
  *   - `#agent/message/outbound`  → parent `#agent/message`
@@ -487,6 +500,12 @@ export const AGENT_VAULT_TAG_SCHEMA: ReadonlyArray<{
     name: AGENT_DEFINITION_TAG,
     parent_names: [AGENT_ROOT_TAG],
     description: "A vault-native agent definition — body is the system prompt, metadata is the config.",
+  },
+  {
+    name: AGENT_ROLE_TAG,
+    parent_names: [AGENT_ROOT_TAG],
+    description:
+      "A reusable role — body is loaded as the first prompt layer; metadata.wants declares its capabilities (the only capability-granting layer).",
   },
   {
     name: AGENT_MESSAGE_TAG,
@@ -1087,7 +1106,7 @@ export class VaultTransport implements Transport {
     try {
       const parsed = (await res.json()) as unknown;
       // Tolerate a bare note object OR a `{ note: {...} }` envelope OR a 1-element array.
-      // `tags` is carried through (Phase B′ — readThreadPackKeys needs it for pack-detection).
+      // `tags` is carried through (readThreadRoles needs it for the role security gate).
       if (Array.isArray(parsed)) {
         return parsed[0] as { metadata?: Record<string, unknown>; content?: string; tags?: unknown } | undefined;
       }
@@ -1210,33 +1229,40 @@ export class VaultTransport implements Transport {
   }
 
   /**
-   * Read the thread's loaded-PACK grant KEYS (threads-only Phase B′ —
-   * DESIGN-2026-06-29-threads-only.md §4). Resolves the SAME `metadata.loadout` note paths as
-   * {@link readThreadLoadout}, but reads each note's METADATA (+ tags) — NOT its content — to
-   * find the loaded notes that are PACKS: a note carrying the `#pack` tag AND a non-empty,
-   * cleanly-parsing `wants:`. Each such pack contributes its hub grant-holder key (the slugged
-   * PATH via {@link packPathKey}); the backend unions `listGrants(packKey)` for each with the
-   * def's own `listGrants(spec.name)`.
+   * Read the thread's ROLES (layer ① — DESIGN-2026-06-29-threads-roles-context.md): the
+   * `metadata.roles` array of note PATHS on the thread's `#agent/thread` note, resolved in ONE
+   * pass to BOTH (a) the ordered CONTENT entries (`{ path, content }`) the backend composes as
+   * the FIRST prompt layer, and (b) the grant-holder KEYS (the slugged PATH via
+   * {@link rolePathKey}) for the loaded notes that are ROLES declaring `wants:`. The backend
+   * prepends the entries before the def (self) and unions `listGrants(roleKey)` for each grant
+   * key with the def's own `listGrants(spec.name)`.
    *
-   * THE SECURITY GATE: a loaded note's `wants:` is honored ONLY if the note is a `#pack`
-   * (`packWants` returns null for a non-pack note even when it declares `wants:`). So loading
-   * an arbitrary content note for context can NEVER add capabilities. This metadata read is
-   * DELIBERATELY a SEPARATE pass from the content-only {@link readThreadLoadout} (the prompt
-   * composition is unchanged — Phase A content-only), at the cost of re-reading the loadout
-   * notes' metadata.
+   * THE SECURITY GATE: a loaded note's `wants:` is honored ONLY if the note carries the
+   * `#agent/role` tag (`roleWants` returns null for a non-role note even when it declares
+   * `wants:`). So listing an arbitrary content note in `metadata.roles` loads its CONTENT as
+   * context but can NEVER add capabilities — only a real `#agent/role` contributes a grant key.
+   * This is the single read of each role note: content for layer ① + the gated `wants:` →
+   * grants, so a role declares its hat AND its access in one place.
    *
    * Skip-and-warn per path (mirrors the loadout discipline): a 404/renamed path or a read
-   * error on one note is skipped — never thrown — so one stale path can't brick a turn. No
-   * thread note / absent `metadata.loadout` / no pack with `wants:` → an empty array (every
-   * current thread). Keys are deduped (a pack listed twice yields one key). `subject` resolves
-   * the subject-scoped thread note (path math reuses {@link singleThreadedPath}).
+   * error on one note is skipped — never thrown — so one stale path can't brick a turn. A
+   * blank-bodied note is RETURNED in the entries (the composer skips blank entries by content).
+   * No thread note / absent `metadata.roles` → `{ entries: [], grantKeys: [] }` (every current
+   * thread — the no-roles invariant). Grant keys are deduped (a role listed twice yields one
+   * key). `subject` resolves the subject-scoped thread note (path math reuses
+   * {@link singleThreadedPath}, so it agrees with writeThread / readThreadLoadout).
    */
-  async readThreadPackKeys(channel: string, name: string, subject?: string): Promise<string[]> {
+  async readThreadRoles(
+    channel: string,
+    name: string,
+    subject?: string,
+  ): Promise<{ entries: { path: string; content: string }[]; grantKeys: string[] }> {
     const thread = await this.readThreadNote(this.singleThreadedPath(channel, name, subject));
-    if (!thread) return []; // no thread note yet (first turn) → no packs.
-    const paths = parseLoadoutPaths(thread.metadata?.loadout);
-    if (paths.length === 0) return [];
-    const keys: string[] = [];
+    if (!thread) return { entries: [], grantKeys: [] }; // no thread note yet (first turn) → no roles.
+    const paths = parseLoadoutPaths(thread.metadata?.roles);
+    if (paths.length === 0) return { entries: [], grantKeys: [] };
+    const entries: { path: string; content: string }[] = [];
+    const grantKeys: string[] = [];
     const seen = new Set<string>();
     for (const path of paths) {
       let note: { metadata?: Record<string, unknown>; content?: string; tags?: unknown } | undefined;
@@ -1244,38 +1270,45 @@ export class VaultTransport implements Transport {
         note = await this.readThreadNote(path);
       } catch (err) {
         console.warn(
-          `parachute-agent: pack-detect read for loadout note "${path}" failed (skipping): ${(err as Error).message}`,
+          `parachute-agent: role note "${path}" read failed (skipping): ${(err as Error).message}`,
         );
         continue;
       }
-      if (!note) continue; // 404 — a stale/renamed loadout path. Skip (the loadout reader warns).
-      // THE SECURITY GATE: honor `wants:` ONLY when the note is a `#pack`. A non-pack note's
-      // `wants:` returns null here → never contributes a grant source.
-      const wants = packWants(note);
+      if (!note) {
+        // 404 — a stale/renamed role path. Skip-and-warn (never throw); the def-load discipline.
+        console.warn(`parachute-agent: role note "${path}" not found (skipping)`);
+        continue;
+      }
+      // CONTENT (layer ①) — loaded for EVERY resolvable role path. A blank body is returned;
+      // the composer skips it. Loading content never escalates — only the gated `wants:` below does.
+      entries.push({ path, content: typeof note.content === "string" ? note.content : "" });
+      // THE SECURITY GATE: honor `wants:` ONLY when the note is an `#agent/role`. A non-role
+      // note's `wants:` returns null here → contributes context but never a grant source.
+      const wants = roleWants(note);
       if (!wants) {
-        // Observability: a `#pack` note whose `wants:` is present but unparseable contributes
-        // nothing here (it injects nothing this turn). The reconcile path (POST /api/vault/pack)
-        // stamps `status:error` on save — that's the primary surface — but warn here too so an
-        // operator can diagnose "my pack stopped working" from the daemon log. A non-pack note
-        // (the gate) or a pack with no `wants:` is silent (expected, not an error).
+        // Observability: an `#agent/role` note whose `wants:` is present but unparseable
+        // contributes no grants this turn. The reconcile path (POST /api/vault/role) stamps
+        // `status:error` on save — the primary surface — but warn here too so an operator can
+        // diagnose "my role stopped granting" from the daemon log. A non-role note (the gate)
+        // or a role with no `wants:` is silent (expected, not an error).
         if (
           note.metadata?.wants !== undefined &&
           note.metadata?.wants !== null &&
-          isPackNote(note) // only warn for PACKS with bad wants, never plain (gated-out) notes.
+          isRoleNote(note) // only warn for ROLES with bad wants, never plain (gated-out) notes.
         ) {
           console.warn(
-            `parachute-agent: loaded pack "${path}" has an unusable wants: — contributing no grants ` +
-              `this turn (the pack-save reconcile stamps status:error; check the note's wants:).`,
+            `parachute-agent: loaded role "${path}" has an unusable wants: — contributing no grants ` +
+              `this turn (the role-save reconcile stamps status:error; check the note's wants:).`,
           );
         }
         continue;
       }
-      const key = packPathKey(path);
+      const key = rolePathKey(path);
       if (seen.has(key)) continue;
       seen.add(key);
-      keys.push(key);
+      grantKeys.push(key);
     }
-    return keys;
+    return { entries, grantKeys };
   }
 
   // react / edit / download: vault has no reactions; v1 is reply-only. Omitted.


### PR DESCRIPTION
Phase 1 of the **threads-roles-context** flattening arc (`DESIGN-2026-06-29-threads-roles-context.md`): introduce **`#agent/role`** as the FIRST composed prompt layer AND the capability layer — the elevation + rename of the prior (unwired, unused) `#pack`. `#agent/definition` is untouched (it retires in a later phase).

## The three composed layers, in order
```
① ROLES         — metadata.roles, composed FIRST (content + grants)
② SELF + THREAD — the def body, then metadata-driven thread content
③ EXTRA CONTEXT — metadata.loadout (content-only, UNCHANGED)
```
Backend composes `[...roles, self, thread-content, ...loadout]`.

## What changed
- **New `metadata.roles` field** on the thread note, SEPARATE from `metadata.loadout`. `readThreadRoles` resolves it in ONE pass to BOTH the layer-① content entries AND the grant-holder keys (the wants→grants the old `readThreadPackKeys` did, now sourced from roles). Replaces `readThreadPackKeys`.
- **Compose order + protection:** roles compose FIRST, path-prefixed. The truncation-protected prefix generalizes to **roles + def + thread-content** (`protectedCount = roles.length + 1 + (threadContent ? 1 : 0)`); only the layer-③ extra-context tail sheds under budget.
- **Capabilities from roles only:** the wants→grants union now reads `metadata.roles`. The **security gate holds** — only `#agent/role` notes' `wants:` are honored; a non-role note listed in `roles` loads its content as context but its `wants:` is ignored (content can never escalate).
- **`#pack` → `#agent/role` throughout:** `grants.ts` (`isRoleNote`/`roleWants`/`rolePathKey`/`ROLE_TAG`, key prefix `pack--`→`role--`), `agent-defs` (`reconcileRole`/`pruneRoleGrants`), the def-vault **role-watch** triggers + the **`/api/vault/role`** webhook, and a new `agent/role` tag-schema entry. **Verified ZERO `#pack` notes in both live vaults** — clean rename, no read-tolerance kept.

## Backward-compat invariants (hold)
- No roles → `[self, thread-content, ...loadout]` **byte-identical to rc.18**.
- `metadata.loadout` still loads as layer-③ extra context.
- No roles → no grant change (grant source set is exactly `[spec.name]`).

## Tests
Added: `readThreadRoles` (content + the grant gate, non-role `wants:` ignored), roles compose FIRST, the full 3-layer order, the roles+def+thread protected prefix (`protectedCount=3`), the no-roles invariant, and the registry `readRoles` wiring (content→`roles`, keys→`roleKeys`).

`bun run typecheck` clean; `bun test ./src` → **1371 pass / 0 fail** (none boot a live daemon — `Bun.serve({port:0})` / injected fetch). rc.18 → **rc.19**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T6HAzWsgiJy4ndsWSCWY5S