### PR TITLE
feat(agent): decouple system-prompt compose from the def body (Phase 2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/agent",
-  "version": "0.2.3-rc.19",
+  "version": "0.2.3-rc.20",
   "description": "Vault-native agents for Claude Code — a #agent/definition note + an inbound message becomes a sandboxed claude turn; the reply is written back as a note. Messaging gateway on :1941.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/src/backends/compose.test.ts
+++ b/src/backends/compose.test.ts
@@ -205,6 +205,34 @@ describe("composeSystemPrompt — protectedCount (the roles + def + thread-conte
     );
   });
 
+  test("def ABSENT (Phase 2): protectedCount=2 over [role, thread-content, ...loadout] → roles+thread protected, only the loadout tail sheds", () => {
+    // The shape the backend builds with an EMPTY def body + one role + thread content: NO self
+    // entry, so protectedCount = roles(1) + def(0) + thread(1) = 2. The role (①) and the thread
+    // content (②) lead; only the layer-③ loadout sheds. This is the def-absent alignment the
+    // backend's `roleEntries.length + selfEntries.length + (hasThreadContent ? 1 : 0)` produces.
+    const role = { path: "Roles/PM", content: "ROLE-" + "r".repeat(200) };
+    const threadContent = { path: "Threads/eng/uni", content: "THREAD-" + "t".repeat(200) };
+    const big = (p: string) => ({ path: p, content: p + "-" + "x".repeat(400) });
+    const warnings: string[] = [];
+    // Budget fits the two protected entries (role + thread) but not the loadout notes.
+    const budget = 600;
+    const out = composeSystemPrompt([role, threadContent, big("n1"), big("n2")], {
+      budgetBytes: budget,
+      protectedCount: 2,
+      onWarn: (m) => warnings.push(m),
+    });
+    // Role first, then thread content — both survive whole, in order, with NO def entry between.
+    expect(out).toBe(
+      `# ${role.path}\n\n${role.content}\n\n---\n\n# ${threadContent.path}\n\n${threadContent.content}`,
+    );
+    // Only the layer-③ loadout tail was shed; the warn names neither the role nor the thread.
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("n1");
+    expect(warnings[0]).toContain("n2");
+    expect(warnings[0]).not.toContain("Roles/PM");
+    expect(warnings[0]).not.toContain("Threads/eng/uni");
+  });
+
   test("protectedCount defaults to 1 — only the self entry is protected (the no-thread-content path)", () => {
     const self = { path: "self", content: "S".repeat(500) };
     const big = (p: string) => ({ path: p, content: p + "-" + "x".repeat(400) });

--- a/src/backends/programmatic.test.ts
+++ b/src/backends/programmatic.test.ts
@@ -745,12 +745,13 @@ describe("ProgrammaticBackend.deliver — composed system prompt (threads-only P
     expect(readFileSync(promptPath, "utf8")).toBe(`# Agents/uni\n\n${ROLE}`);
   });
 
-  test("no spec.systemPrompt + a loadout → NO system-prompt file (the role-less case is unchanged)", async () => {
+  test("no spec.systemPrompt + a loadout → file IS written from the loadout (def DECOUPLED, Phase 2)", async () => {
     mkDirs("compose-noprompt");
     const { fn } = recordingSpawn({ stdout: successTurn("sess-CP4", "ok") });
     const backend = new ProgrammaticBackend(baseDeps(fn));
-    // specWithVault carries NO systemPrompt — a loadout alone must NOT synthesize a prompt file
-    // (composing onto an empty self entry is out of scope; the role gate is unchanged).
+    // specWithVault carries NO systemPrompt (empty def body). Phase 2 DECOUPLES compose from the
+    // def body: the self entry is simply OMITTED, but the loadout (layer ③) still composes into a
+    // prompt file. (Pre-Phase-2 the empty def body suppressed the whole composition → no file.)
     const handle = await backend.start(specWithVault("eng"));
 
     await backend.deliver(handle, "go", createSession("sess-CP4"), undefined, undefined, undefined, [
@@ -758,7 +759,8 @@ describe("ProgrammaticBackend.deliver — composed system prompt (threads-only P
     ]);
 
     const promptPath = join(sessionWorkspace(sessionsDir, "eng"), "system-prompt.txt");
-    expect(existsSync(promptPath)).toBe(false);
+    // No self entry (empty def body) → the file is JUST the loadout note, path-headered.
+    expect(readFileSync(promptPath, "utf8")).toBe("# Roles/GitHub\n\na note");
   });
 
   // ── roles as the layer-① composition (DESIGN-2026-06-29-threads-roles-context.md) ──
@@ -877,6 +879,124 @@ describe("ProgrammaticBackend.deliver — composed system prompt (threads-only P
     // Only the non-blank role composes (first), then the def.
     expect(readFileSync(promptPath, "utf8")).toBe(
       `# Roles/PM\n\nPM hat.` + `\n\n---\n\n# Agents/uni\n\n${ROLE}`,
+    );
+  });
+
+  // ── def body DECOUPLED from compose (Phase 2 — the flatten) ───────────────────────────
+  // The def body is now ONE OPTIONAL layer, not the anchor that gates the whole composition.
+  // An EMPTY def body no longer suppresses the prompt: roles (①) / thread content (②) / loadout
+  // (③) still compose + write the file. The file is skipped (CC default) ONLY when EVERY layer is
+  // empty. (Pre-Phase-2 an empty def body silently dropped roles, thread content AND loadout.)
+  test("EMPTY def body + thread content → file IS written, contains the thread content (the key flatten case)", async () => {
+    mkDirs("compose-empty-def-thread");
+    const { fn } = recordingSpawn({ stdout: successTurn("sess-ED1", "ok") });
+    const backend = new ProgrammaticBackend(baseDeps(fn));
+    // specWithVault carries NO systemPrompt (empty def body) — the thread's IDENTITY lives in ②.
+    const handle = await backend.start(specWithVault("eng"));
+
+    // deliver with a thread content (10th param), no def body, no roles, no loadout.
+    await backend.deliver(
+      handle,
+      "go",
+      createSession("sess-ED1"),
+      undefined,
+      undefined,
+      undefined,
+      undefined, // no loadout
+      undefined,
+      undefined,
+      { path: "Threads/eng/uni", content: "I am this thread. Hold the eco-civ book club." }, // ② thread content
+    );
+
+    const promptPath = join(sessionWorkspace(sessionsDir, "eng"), "system-prompt.txt");
+    // The file IS written (was: dropped pre-Phase-2) and the identity is PRESERVED: NO self entry
+    // (empty def body), just the thread content, path-headered. THIS is the path the flatten needs.
+    expect(readFileSync(promptPath, "utf8")).toBe(
+      "# Threads/eng/uni\n\nI am this thread. Hold the eco-civ book club.",
+    );
+  });
+
+  test("EMPTY def body + roles + thread content + loadout → [roles, thread-content, loadout] in order; file written", async () => {
+    mkDirs("compose-empty-def-roles-thread");
+    const { fn } = recordingSpawn({ stdout: successTurn("sess-ED2", "ok") });
+    const backend = new ProgrammaticBackend(baseDeps(fn));
+    const handle = await backend.start(specWithVault("eng"));
+
+    await backend.deliver(
+      handle,
+      "go",
+      createSession("sess-ED2"),
+      undefined,
+      undefined,
+      undefined,
+      [{ path: "Skills/Weave", content: "Skill body." }], // ③ loadout
+      undefined,
+      undefined,
+      { path: "Threads/eng/uni", content: "Thread mandate." }, // ② thread content
+      [{ path: "Roles/PM", content: "PM hat." }], // ① roles
+    );
+
+    const promptPath = join(sessionWorkspace(sessionsDir, "eng"), "system-prompt.txt");
+    // No self entry (empty def) → roles (①) lead, then thread content (②), then the loadout (③).
+    // The self slot is simply absent — the prefix does NOT drift (no blank entry pushed).
+    expect(readFileSync(promptPath, "utf8")).toBe(
+      `# Roles/PM\n\nPM hat.` +
+        `\n\n---\n\n# Threads/eng/uni\n\nThread mandate.` +
+        `\n\n---\n\n# Skills/Weave\n\nSkill body.`,
+    );
+  });
+
+  test("ALL LAYERS EMPTY (no def, no roles, no thread, no loadout) → NO system-prompt file (CC default)", async () => {
+    mkDirs("compose-all-empty");
+    const { fn, calls } = recordingSpawn({ stdout: successTurn("sess-ED3", "ok") });
+    const backend = new ProgrammaticBackend(baseDeps(fn));
+    const handle = await backend.start(specWithVault("eng"));
+
+    // Empty def body + explicitly-EMPTY loadout AND roles arrays + undefined thread → all layers
+    // empty. The composition is "" → no file written, no `-file` flag (the one remaining no-file case).
+    await backend.deliver(
+      handle,
+      "go",
+      createSession("sess-ED3"),
+      undefined,
+      undefined,
+      undefined,
+      [], // empty loadout
+      undefined,
+      undefined,
+      undefined, // no thread content
+      [], // empty roles
+    );
+
+    const promptPath = join(sessionWorkspace(sessionsDir, "eng"), "system-prompt.txt");
+    expect(existsSync(promptPath)).toBe(false);
+    // And NO system-prompt flag on the turn → CC's default prompt.
+    expect(calls[0]!.argv[2]!).not.toContain("system-prompt-file");
+  });
+
+  test("NON-EMPTY def body is UNCHANGED by Phase 2: [self, thread-content] still composes byte-for-byte", async () => {
+    mkDirs("compose-nonempty-def-unchanged");
+    const { fn } = recordingSpawn({ stdout: successTurn("sess-ED5", "ok") });
+    const backend = new ProgrammaticBackend(baseDeps(fn));
+    const handle = await backend.start(specWithDef(ROLE, "Agents/uni", "eng"));
+
+    // A non-empty def body + thread content → the self entry is present, exactly as before Phase 2.
+    await backend.deliver(
+      handle,
+      "go",
+      createSession("sess-ED5"),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { path: "Threads/eng/uni", content: "Thread mandate." },
+    );
+
+    const promptPath = join(sessionWorkspace(sessionsDir, "eng"), "system-prompt.txt");
+    expect(readFileSync(promptPath, "utf8")).toBe(
+      `# Agents/uni\n\n${ROLE}\n\n---\n\n# Threads/eng/uni\n\nThread mandate.`,
     );
   });
 });

--- a/src/backends/programmatic.ts
+++ b/src/backends/programmatic.ts
@@ -675,7 +675,9 @@ export class ProgrammaticBackend implements AgentBackend {
     // narrows `spec.systemPrompt`, so the entry is well-typed without a non-null assertion; and
     // `selfEntries.length` (0 or 1) IS the def-present count fed into `protectedCount` below.
     const selfEntries: LoadoutEntry[] =
-      typeof spec.systemPrompt === "string" && spec.systemPrompt.length > 0
+      // `.trim()` to match composeSystemPrompt's blank-skip — a whitespace-only def body is
+      // omitted (and not counted), keeping protectedCount aligned (reviewer nit, #176).
+      typeof spec.systemPrompt === "string" && spec.systemPrompt.trim().length > 0
         ? [{ path: selfPath, content: spec.systemPrompt }]
         : [];
     // Thread content sits AFTER the self entry. Include it only when it carries real (non-blank)

--- a/src/backends/programmatic.ts
+++ b/src/backends/programmatic.ts
@@ -611,18 +611,23 @@ export class ProgrammaticBackend implements AgentBackend {
       }
     }
 
-    // System prompt (design 2026-06-16-channel-system-prompt.md). When the spec
-    // carries one, write it to a per-session file (0600) and pass the `-file` flag.
-    // The flag is PER-INVOCATION (not persistent), so we (re)write the file + pass
-    // it EVERY turn — including a `--resume` turn — so the role is always applied.
-    // Unset → no flag, no file (today's behavior unchanged). The `-file` form is
-    // robust to long/multiline prompts and keeps the prompt visible-on-disk. Its
-    // lifecycle is tied to the workspace (like .mcp.json) — it disappears with it.
+    // System prompt (design 2026-06-16-channel-system-prompt.md). The composed prompt is
+    // written to a per-session file (0600) and passed via the `-file` flag. The flag is
+    // PER-INVOCATION (not persistent), so we (re)write the file + pass it EVERY turn —
+    // including a `--resume` turn — so the prompt is always applied. The `-file` form is
+    // robust to long/multiline prompts and keeps the prompt visible-on-disk; its lifecycle
+    // is tied to the workspace (like .mcp.json) — it disappears with it.
     //
-    // COMPOSED PROMPT — three layers, in order (DESIGN-2026-06-29-threads-roles-context.md):
+    // COMPOSED PROMPT — three layers, in order (DESIGN-2026-06-29-threads-roles-context.md).
+    // The compose is DECOUPLED from the def body (Phase 2 of the flatten): the def body is
+    // ONE OPTIONAL layer, no longer the anchor that gates the whole composition. We compose +
+    // write the file whenever ANY layer has content; the file is skipped (CC's default prompt)
+    // ONLY when EVERY layer is empty.
     //   ① ROLES         — `roles` entries, composed FIRST: the reusable "hat(s)" the thread wears.
-    //   ② SELF + THREAD — the SELF entry (the spec's `systemPrompt`, the def body) then THIS
-    //                     thread's authored CONTENT (`threadContent`, when non-blank).
+    //   ② SELF + THREAD — the SELF entry (the spec's `systemPrompt`, the def body) WHEN non-empty,
+    //                     then THIS thread's authored CONTENT (`threadContent`, when non-blank).
+    //                     An empty/retired def body simply OMITS the self entry — a thread's
+    //                     identity can live entirely in its roles + thread content (the flatten).
     //   ③ EXTRA CONTEXT — the `loadout` notes (skills, references), read CONTENT-only.
     // composeSystemPrompt dedupes by path, skips blank entries, renders each as
     // `# <path>\n\n<content>`, joins with `\n\n---\n\n`, and enforces the byte budget — truncating
@@ -636,47 +641,67 @@ export class ProgrammaticBackend implements AgentBackend {
     // absent (a spec not sourced from a def note) the header falls back to `spec.name`.
     //
     // NO-ROLES / NO-LOADOUT / NO-THREAD-CONTENT INVARIANT (the live 4am steward weave path): a
-    // thread with NO roles, NO loadout AND no authored thread content composes to EXACTLY
-    // `# <path>\n\n<def body>` — `<def body>` byte-identical to `spec.systemPrompt`. The single
-    // `# <path>` header is the ONLY change to such a prompt. The run-context preamble stays on
-    // the MESSAGE.
+    // thread with a non-empty def body but NO roles, NO loadout AND no authored thread content
+    // composes to EXACTLY `# <path>\n\n<def body>` — `<def body>` byte-identical to
+    // `spec.systemPrompt`. The single `# <path>` header is the ONLY change to such a prompt. The
+    // run-context preamble stays on the MESSAGE.
+    //
+    // ALL-LAYERS-EMPTY → NO FILE: with no roles, no def body, no thread content AND no loadout
+    // (the genuinely-blank thread), composeSystemPrompt returns "" → we leave `systemPromptFile`
+    // undefined and pass no `-file` flag (CC's default prompt — the one remaining no-file case).
+    //
+    // Self entry: the def body, labeled by the def note's PATH (`spec.definitionPath`);
+    // fallback the spec name. The note ID (`spec.definition`) is deliberately NOT used —
+    // it's a timestamp-slug, not the legible path the header should read (#169).
+    const selfPath =
+      typeof spec.definitionPath === "string" && spec.definitionPath.length > 0
+        ? spec.definitionPath
+        : spec.name;
+    // Layer ① ROLES — filter to NON-BLANK content + dedupe by path so the protected-prefix
+    // COUNT below stays exactly aligned with the entries composeSystemPrompt keeps (a blank or
+    // duplicate role would be dropped, shifting the prefix into the layer-③ tail). They lead,
+    // so a later loadout note with a colliding path dedupes against the role (the role wins).
+    const roleEntries: LoadoutEntry[] = [];
+    const seenRolePaths = new Set<string>();
+    for (const r of roles ?? []) {
+      if (typeof r.content !== "string" || r.content.trim().length === 0) continue;
+      if (seenRolePaths.has(r.path)) continue;
+      seenRolePaths.add(r.path);
+      roleEntries.push(r);
+    }
+    // Layer ② — the SELF entry (the def body) is now OPTIONAL: included ONLY when `spec.systemPrompt`
+    // is a non-empty string. An empty/retired def body omits it entirely — don't push a blank entry
+    // (composeSystemPrompt would skip it and the protected-prefix count would drift). The ternary
+    // narrows `spec.systemPrompt`, so the entry is well-typed without a non-null assertion; and
+    // `selfEntries.length` (0 or 1) IS the def-present count fed into `protectedCount` below.
+    const selfEntries: LoadoutEntry[] =
+      typeof spec.systemPrompt === "string" && spec.systemPrompt.length > 0
+        ? [{ path: selfPath, content: spec.systemPrompt }]
+        : [];
+    // Thread content sits AFTER the self entry. Include it only when it carries real (non-blank)
+    // content — a blank thread note is the no-thread-content case. Gate the inclusion AND the
+    // protected-prefix count on the SAME non-blank check.
+    const hasThreadContent =
+      !!threadContent && typeof threadContent.content === "string" && threadContent.content.trim().length > 0;
+    // Order: ① roles → ② [self if present] + thread-content → ③ extra-context loadout.
+    const entries: LoadoutEntry[] = [
+      ...roleEntries,
+      ...selfEntries,
+      ...(hasThreadContent ? [threadContent!] : []),
+      ...(loadout ?? []),
+    ];
+    // Protect the WHOLE leading prefix — roles (①) + the def (WHEN present) + the thread content
+    // (②) — from budget truncation; only the layer-③ extra-context tail (entries beyond the
+    // prefix) sheds. Count the def entry only when it's actually present (`selfEntries.length` is
+    // 0 or 1), so the prefix stays aligned with the entries above (the off-by-one when the def
+    // body is empty).
+    const protectedCount = roleEntries.length + selfEntries.length + (hasThreadContent ? 1 : 0);
+    const composed = composeSystemPrompt(entries, { protectedCount });
+    // DECOUPLED from the def body: write the file whenever the composition is non-empty (ANY layer
+    // had content); leave `systemPromptFile` undefined only when EVERY layer was empty (the
+    // genuinely-blank thread → CC's default prompt, the one remaining no-file case).
     let systemPromptFile: string | undefined;
-    if (typeof spec.systemPrompt === "string" && spec.systemPrompt.length > 0) {
-      // Self entry: the def body, labeled by the def note's PATH (`spec.definitionPath`);
-      // fallback the spec name. The note ID (`spec.definition`) is deliberately NOT used —
-      // it's a timestamp-slug, not the legible path the header should read (#169).
-      const selfPath =
-        typeof spec.definitionPath === "string" && spec.definitionPath.length > 0
-          ? spec.definitionPath
-          : spec.name;
-      // Layer ① ROLES — filter to NON-BLANK content + dedupe by path so the protected-prefix
-      // COUNT below stays exactly aligned with the entries composeSystemPrompt keeps (a blank or
-      // duplicate role would be dropped, shifting the prefix into the layer-③ tail). They lead,
-      // so a later loadout note with a colliding path dedupes against the role (the role wins).
-      const roleEntries: LoadoutEntry[] = [];
-      const seenRolePaths = new Set<string>();
-      for (const r of roles ?? []) {
-        if (typeof r.content !== "string" || r.content.trim().length === 0) continue;
-        if (seenRolePaths.has(r.path)) continue;
-        seenRolePaths.add(r.path);
-        roleEntries.push(r);
-      }
-      // Layer ② thread content sits BETWEEN the self entry and the loadout. Include it only when
-      // it carries real (non-blank) content — a blank thread note is the no-thread-content case.
-      // Gate the inclusion AND the protected-prefix count on the SAME non-blank check.
-      const hasThreadContent =
-        !!threadContent && typeof threadContent.content === "string" && threadContent.content.trim().length > 0;
-      // Order: ① roles → ② self + thread-content → ③ extra-context loadout.
-      const entries: LoadoutEntry[] = [
-        ...roleEntries,
-        { path: selfPath, content: spec.systemPrompt },
-        ...(hasThreadContent ? [threadContent!] : []),
-        ...(loadout ?? []),
-      ];
-      // Protect the WHOLE leading prefix — roles (①) + the def + the thread content (②) — from
-      // budget truncation; only the layer-③ extra-context tail (entries beyond the prefix) sheds.
-      const protectedCount = roleEntries.length + 1 + (hasThreadContent ? 1 : 0);
-      const composed = composeSystemPrompt(entries, { protectedCount });
+    if (composed.trim().length > 0) {
       systemPromptFile = join(workspace, "system-prompt.txt");
       writeFileSync(systemPromptFile, composed, { mode: 0o600 });
     }


### PR DESCRIPTION
## Phase 2 of the threads-roles-context flatten

Make the def body just **one optional context layer**, not the required anchor for the whole system prompt.

### The problem
In `src/backends/programmatic.ts` the ENTIRE system-prompt composition was gated on a non-empty def body:

```ts
if (typeof spec.systemPrompt === "string" && spec.systemPrompt.length > 0) {
  // build [ ...roles, {self, def body}, ...(threadContent?), ...loadout ]
  // composeSystemPrompt(...) → write system-prompt.txt
}
```

So when the **def body is empty**, NONE of it ran — roles (①), thread content (②), and loadout (③) were all silently ignored and the agent fell back to CC's default prompt. This blocks the flatten: we want an agent's identity to live in its **thread content** (with an empty/retired def body), but today that yielded *no system prompt at all*.

### The fix
Decouple the compose from the def-body check. The def body becomes one optional entry among the layers:

- The self/def entry is included **only** when `spec.systemPrompt` is a non-empty string; an empty def body **omits** it entirely (no blank entry pushed).
- `protectedCount = roleEntries.length + selfEntries.length + (hasThreadContent ? 1 : 0)` — `selfEntries.length` is 0 or 1, so the protected prefix stays aligned when the def entry is absent (the off-by-one).
- Compose + write `system-prompt.txt` whenever `composed.trim().length > 0` (any layer had content); leave `systemPromptFile` undefined only when **every** layer is empty (CC default — the one remaining no-file case).
- `selfPath` (definitionPath→name) + the `--append`/`--replace-system-prompt-file` (systemPromptMode) behavior unchanged.

**Only behavioral change:** an empty def body with a populated role / thread content / loadout now composes correctly (was: ignored). Non-empty def bodies are **byte-identical** to before.

### Tests
- **Empty def body + thread content → file IS written, contains the thread content** (the key new case — identity preserved).
- Empty def + roles + thread content + loadout → `[roles, thread-content, loadout]` ordered compose; file written.
- All layers empty (no def, no roles, no thread, no loadout) → NO system-prompt file + no `-file` flag (CC default).
- Non-empty def body → unchanged (`[self, thread-content]` byte-for-byte).
- The pre-existing "no def + loadout → no file" test was **flipped** to assert the new behavior (file written from the loadout).
- `compose.test.ts`: protectedCount=2 over `[role, thread-content, ...loadout]` (def absent) → roles+thread protected, only loadout tail sheds.

### Verify
- `bun run typecheck` clean.
- `bun test ./src/` → **1376 pass, 0 fail**. No test boots a live daemon (both test `Bun.serve` calls bind `port: 0`).
- rc bump `0.2.3-rc.19` → `0.2.3-rc.20`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T6HAzWsgiJy4ndsWSCWY5S