### PR TITLE
feat(agent): config onto the thread — model/backend self-carried, thread-first (rc.21)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/agent",
-  "version": "0.2.3-rc.20",
+  "version": "0.2.3-rc.21",
   "description": "Vault-native agents for Claude Code — a #agent/definition note + an inbound message becomes a sandboxed claude turn; the reply is written back as a note. Messaging gateway on :1941.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/src/backends/registry.test.ts
+++ b/src/backends/registry.test.ts
@@ -827,7 +827,8 @@ describe("ProgrammaticAgentRegistry — config THREAD-FIRST (Phase 3, DESIGN-202
 
     reg.enqueue("eng", { content: "go" });
     await until(() => threads.ends().length === 1);
-    // The thread note carries the resolved config (the transport stamps it write-if-absent).
+    // The registry→writeThread hand-off carries the resolved config from the spec onto the
+    // thread record (the transport's write-if-absent stamping is covered in vault.test.ts).
     expect(threads.ends()[0]!.model).toBe("opus");
     expect(threads.ends()[0]!.backend).toBe("programmatic");
   });

--- a/src/backends/registry.test.ts
+++ b/src/backends/registry.test.ts
@@ -71,6 +71,8 @@ class FakeBackend implements AgentBackend {
     roles?: LoadoutEntry[];
     /** the loaded-ROLE grant keys the drain threaded in (capability source). */
     roleKeys?: string[];
+    /** Phase 3: the EFFECTIVE model on the handle the drain handed deliver (thread-first / def fallback). */
+    model?: string;
   }[] = [];
   /** Max concurrent in-flight turns observed (must stay ≤ 1 for serial — PER drain key). */
   maxConcurrent = 0;
@@ -140,6 +142,9 @@ class FakeBackend implements AgentBackend {
       // defaults both to `[]`) reads as absent — the no-roles invariant.
       ...(roles && roles.length ? { roles } : {}),
       ...(roleKeys && roleKeys.length ? { roleKeys } : {}),
+      // Phase 3: the model on the handle deliver actually received — thread-first (effective)
+      // when the drain resolved a thread config, the def's spec.model otherwise.
+      ...(handle.spec?.model ? { model: handle.spec.model } : {}),
     });
     this.inFlight++;
     this.maxConcurrent = Math.max(this.maxConcurrent, this.inFlight);
@@ -742,6 +747,89 @@ describe("ProgrammaticAgentRegistry — thread content as context (DESIGN-2026-0
     // The turn ran (the read failure didn't strand it) with no thread content.
     expect(backend.calls[0]!.threadContent).toBeUndefined();
     expect(rec.calls).toHaveLength(1);
+  });
+});
+
+describe("ProgrammaticAgentRegistry — config THREAD-FIRST (Phase 3, DESIGN-2026-06-29-threads-roles-context.md)", () => {
+  test("the thread's model WINS over the def — deliver receives the thread-first model", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const seen: { channel: string; name: string; subject?: string }[] = [];
+    const reg = new ProgrammaticAgentRegistry({
+      backend,
+      writeOutbound: rec.fn,
+      readThreadConfig: async (channel, name, subject) => {
+        seen.push({ channel, name, ...(subject ? { subject } : {}) });
+        return { model: "sonnet" }; // the thread says sonnet…
+      },
+    });
+    await reg.register({ ...specFor("eng"), model: "opus" }); // …the def says opus.
+
+    reg.enqueue("eng", { content: "go" });
+    await until(() => backend.calls.length === 1);
+
+    // The drain consulted readThreadConfig with the channel + def name…
+    expect(seen).toEqual([{ channel: "eng", name: "eng" }]);
+    // …and handed deliver the THREAD's model (the thread wins; the def is the fallback).
+    expect(backend.calls[0]!.model).toBe("sonnet");
+  });
+
+  test("DEF FALLBACK: no thread model → deliver receives the def's spec.model", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const reg = new ProgrammaticAgentRegistry({
+      backend,
+      writeOutbound: rec.fn,
+      readThreadConfig: async () => ({}), // the thread carries no model.
+    });
+    await reg.register({ ...specFor("eng"), model: "opus" });
+
+    reg.enqueue("eng", { content: "go" });
+    await until(() => backend.calls.length === 1);
+    expect(backend.calls[0]!.model).toBe("opus"); // def fallback, unchanged.
+  });
+
+  test("UNWIRED readThreadConfig → deliver receives the def's spec.model (byte-identical to pre-Phase-3)", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn });
+    await reg.register({ ...specFor("eng"), model: "opus" });
+
+    reg.enqueue("eng", { content: "go" });
+    await until(() => backend.calls.length === 1);
+    expect(backend.calls[0]!.model).toBe("opus");
+  });
+
+  test("a readThreadConfig THROW is swallowed — the turn runs on the def config", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const reg = new ProgrammaticAgentRegistry({
+      backend,
+      writeOutbound: rec.fn,
+      readThreadConfig: async () => {
+        throw new Error("vault unreachable");
+      },
+    });
+    await reg.register({ ...specFor("eng"), model: "opus" });
+
+    reg.enqueue("eng", { content: "go" });
+    await until(() => backend.calls.length === 1);
+    expect(backend.calls[0]!.model).toBe("opus"); // fell back to the def config.
+    expect(rec.calls).toHaveLength(1);
+  });
+
+  test("recordThread STAMPS the def's model/backend onto the thread note (so it self-carries config)", async () => {
+    const backend = new FakeBackend();
+    const rec = recorder();
+    const threads = threadRecorder();
+    const reg = new ProgrammaticAgentRegistry({ backend, writeOutbound: rec.fn, writeThread: threads.fn });
+    await reg.register({ ...specFor("eng"), model: "opus", backend: "programmatic" });
+
+    reg.enqueue("eng", { content: "go" });
+    await until(() => threads.ends().length === 1);
+    // The thread note carries the resolved config (the transport stamps it write-if-absent).
+    expect(threads.ends()[0]!.model).toBe("opus");
+    expect(threads.ends()[0]!.backend).toBe("programmatic");
   });
 });
 

--- a/src/backends/registry.ts
+++ b/src/backends/registry.ts
@@ -1378,6 +1378,9 @@ export class ProgrammaticAgentRegistry {
       let effectiveModel = handle.spec.model;
       if (this.readThreadConfig) {
         try {
+          // Reads the thread note — which, on a brand-new thread, the start-ensure above just
+          // wrote seeded with the def config (write-if-absent), so a first turn resolves the
+          // def model (no change); a thread an operator/migration set diverges from the def here.
           const cfg = await this.readThreadConfig(handle.channel, handle.spec.name, turnSubject);
           if (cfg.model) effectiveModel = cfg.model;
         } catch (err) {

--- a/src/backends/registry.ts
+++ b/src/backends/registry.ts
@@ -42,7 +42,7 @@
  * `['#agent/thread']` EXACTLY — never a message tag — so it can never wake a session.
  */
 
-import type { AgentSpec, AgentMode } from "../sandbox/types.ts";
+import type { AgentSpec, AgentMode, AgentBackendKind } from "../sandbox/types.ts";
 import { normalizeChannel, threadKey } from "../sandbox/types.ts";
 import type { AgentBackend, AgentHandle, InterimTurnEvent, LoadoutEntry, RunContext, TurnSession } from "./types.ts";
 import type { InboundAttachment } from "../transport.ts";
@@ -130,6 +130,15 @@ export interface ThreadNote {
   definition?: string;
   /** The mode the turn ran under — governs thread identity + whether the note upserts. */
   mode: AgentMode;
+  /**
+   * The thread's CONFIG (Phase 3 — DESIGN-2026-06-29-threads-roles-context.md): the resolved
+   * `model` / `backend` (from the spec) the transport stamps onto the thread note so it
+   * SELF-CARRIES config (write-if-absent — see {@link ThreadRecord}). Absent → the keys aren't
+   * written. (`status`-config is deferred to Phase 4 — the thread's `status` here is the TURN
+   * outcome, never the def's enabled/pending/error.)
+   */
+  model?: string;
+  backend?: AgentBackendKind;
   /**
    * Outcome / lifecycle state after THIS write — `working` (the start-ensure, written
    * BEFORE the turn finishes — the turn has started but not completed), `ok` (success), or
@@ -581,6 +590,21 @@ export class ProgrammaticAgentRegistry {
     name: string,
     subject?: string,
   ) => Promise<{ path: string; content: string } | undefined>;
+  /**
+   * Optional pre-turn CONFIG read (Phase 3 — DESIGN-2026-06-29-threads-roles-context.md). Resolves
+   * the thread note's SELF-CARRIED `model` / `backend` (the daemon wires this to the transport's
+   * `readThreadConfig`). Read in {@link drain} so a turn's config resolves THREAD-FIRST: the
+   * thread's own value wins, the def (`handle.spec`) is the fallback. Only `model` has a per-turn
+   * consumer today (the programmatic backend's `--model`); `backend` is carried for Phase-4 routing
+   * (own-it-don't-route here). UNWIRED / no thread config → the def config entirely (byte-identical
+   * to before Phase 3 — every current agent until a thread carries config). Best-effort: a read
+   * failure logs + the turn runs on the def config.
+   */
+  private readonly readThreadConfig?: (
+    channel: string,
+    name: string,
+    subject?: string,
+  ) => Promise<{ model?: string; backend?: AgentBackendKind }>;
   /** Base backoff (ms) between outbound retries (FIX 1). Injectable so tests run fast. */
   private readonly outboundRetryBaseMs: number;
 
@@ -631,6 +655,17 @@ export class ProgrammaticAgentRegistry {
       name: string,
       subject?: string,
     ) => Promise<{ path: string; content: string } | undefined>;
+    /**
+     * Read the thread's SELF-CARRIED config (Phase 3) — `{ model?, backend? }` off the thread
+     * note. Optional — UNWIRED / no thread config → the def config (`handle.spec`) entirely (the
+     * no-thread-config invariant, byte-identical to before Phase 3). `subject` resolves the
+     * subject-scoped thread note.
+     */
+    readThreadConfig?: (
+      channel: string,
+      name: string,
+      subject?: string,
+    ) => Promise<{ model?: string; backend?: AgentBackendKind }>;
     /** Override the outbound-retry backoff base (ms). Default {@link OUTBOUND_RETRY_BASE_MS}. */
     outboundRetryBaseMs?: number;
   }) {
@@ -644,6 +679,7 @@ export class ProgrammaticAgentRegistry {
     if (deps.readLoadout) this.readLoadout = deps.readLoadout;
     if (deps.readRoles) this.readRoles = deps.readRoles;
     if (deps.readThreadContent) this.readThreadContent = deps.readThreadContent;
+    if (deps.readThreadConfig) this.readThreadConfig = deps.readThreadConfig;
     this.outboundRetryBaseMs = deps.outboundRetryBaseMs ?? OUTBOUND_RETRY_BASE_MS;
   }
 
@@ -1329,13 +1365,44 @@ export class ProgrammaticAgentRegistry {
         }
       }
 
+      // CONFIG (Phase 3 — DESIGN-2026-06-29-threads-roles-context.md): resolve the turn's config
+      // THREAD-FIRST. Read the thread note's SELF-CARRIED `model` (and `backend`, carried for
+      // Phase-4 routing); the thread's value WINS, the def (`handle.spec`) is the fallback. Only
+      // `model` has a per-turn consumer today — the programmatic backend's `--model`, read off
+      // `handle.spec.model` in `deliver` — so we overlay the effective model onto a SHALLOW-CLONED
+      // backend handle (AgentHandle is a plain data object — see ProgrammaticBackend.start) and
+      // hand THAT to deliver. `backend` is NOT overlaid (no per-turn consumer; the routing fork is
+      // def-based until Phase 4 — own-it-don't-route). UNWIRED / no thread model → the def model →
+      // `deliverHandle` is the original backendHandle (byte-identical to before Phase 3, every
+      // current agent). Best-effort: a read failure logs + the turn runs on the def config.
+      let effectiveModel = handle.spec.model;
+      if (this.readThreadConfig) {
+        try {
+          const cfg = await this.readThreadConfig(handle.channel, handle.spec.name, turnSubject);
+          if (cfg.model) effectiveModel = cfg.model;
+        } catch (err) {
+          console.error(
+            `parachute-agent: thread-config read for channel "${channel}"` +
+              (turnSubject ? ` subject "${turnSubject}"` : "") +
+              ` failed (turn runs on the def config): ${(err as Error).message}`,
+          );
+        }
+      }
+      // Hand deliver a handle whose spec carries the thread-first model. Only clone when it
+      // actually differs from the backend handle's spec model (else pass the original object —
+      // the no-thread-config invariant is literally the same handle).
+      const deliverHandle =
+        effectiveModel === handle.backendHandle.spec?.model
+          ? handle.backendHandle
+          : { ...handle.backendHandle, spec: { ...handle.backendHandle.spec, model: effectiveModel } as AgentSpec };
+
       let result;
       try {
         // Forward each interim event to the streaming-view sink (keyed by channel)
         // as the turn runs — the "watch it work" live progress. The sink swallows
         // its own throws (emitTurnEvent), so a dead live stream can't break the turn.
         result = await this.backend.deliver(
-          handle.backendHandle,
+          deliverHandle,
           msg.content,
           turnSession,
           (e) => this.emitTurnEvent(channel, e),
@@ -1664,6 +1731,12 @@ export class ProgrammaticAgentRegistry {
       ...(msg.subject?.trim() ? { subject: msg.subject } : {}),
       ...(handle.spec.definition ? { definition: handle.spec.definition } : {}),
       mode: handle.spec.mode ?? "single-threaded",
+      // Phase 3 (DESIGN-2026-06-29-threads-roles-context.md): carry the resolved config so the
+      // thread note SELF-CARRIES it. The transport stamps these WRITE-IF-ABSENT (an operator's /
+      // the migration's thread-set value wins; the def value only seeds a thread with none yet),
+      // so re-stamping the def value every turn never clobbers a thread that diverged.
+      ...(handle.spec.model ? { model: handle.spec.model } : {}),
+      ...(handle.spec.backend ? { backend: handle.spec.backend } : {}),
       status,
       started_at: startedAt,
       ended_at: new Date().toISOString(),

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -144,6 +144,7 @@ import {
 } from "./backends/attached-queue.ts";
 import { readPersistedSpec, sessionWorkspace } from "./spawn-agent.ts";
 import { normalizeChannel } from "./sandbox/types.ts";
+import type { AgentBackendKind } from "./sandbox/types.ts";
 import { CredentialNotConfiguredError } from "./credentials.ts";
 import { MintError } from "./mint-token.ts";
 import { validateHubJwt, getHubOrigin } from "./hub-jwt.ts";
@@ -763,6 +764,10 @@ export function buildWriteThread(channels: Map<string, Channel>): WriteThread {
       ...(thread.name ? { name: thread.name } : {}),
       ...(thread.definition ? { definition: thread.definition } : {}),
       mode: thread.mode,
+      // Phase 3 (DESIGN-2026-06-29-threads-roles-context.md): forward the resolved config so the
+      // transport stamps it onto the thread note (write-if-absent). Absent → not forwarded.
+      ...(thread.model ? { model: thread.model } : {}),
+      ...(thread.backend ? { backend: thread.backend } : {}),
       status: thread.status,
       started_at: thread.started_at,
       ended_at: thread.ended_at,
@@ -915,6 +920,29 @@ export function buildReadThreadContent(
 }
 
 /**
+ * Build the {@link ProgrammaticAgentRegistry}'s pre-turn CONFIG read (Phase 3 —
+ * DESIGN-2026-06-29-threads-roles-context.md). Resolve the channel's transport and read the
+ * thread note's SELF-CARRIED `{ model?, backend? }` off its `#agent/thread` note, so a turn's
+ * config resolves THREAD-FIRST (the thread's own value wins; the def is the registry's fallback).
+ * Only the VaultTransport implements `readThreadConfig`; other transports omit it → `{}` (no
+ * thread config → the def config entirely, byte-identical to before Phase 3). Mirrors
+ * {@link buildReadThreadContent}.
+ */
+export function buildReadThreadConfig(
+  channels: Map<string, Channel>,
+): (
+  channel: string,
+  name: string,
+  subject?: string,
+) => Promise<{ model?: string; backend?: AgentBackendKind }> {
+  return async (channel, name, subject) => {
+    const ch = channels.get(channel);
+    if (!ch?.transport.readThreadConfig) return {};
+    return ch.transport.readThreadConfig(channel, name, subject);
+  };
+}
+
+/**
  * Build the {@link ProgrammaticAgentRegistry}'s pre-turn ROLES read (layer ① —
  * DESIGN-2026-06-29-threads-roles-context.md). Resolves the channel's transport and reads the
  * thread's `metadata.roles` notes off its `#agent/thread` note in ONE pass to BOTH the ordered
@@ -1009,6 +1037,10 @@ export function createDefaultProgrammaticRegistry(
     // thread note's own authored body — composed BETWEEN the def and the loadout. The daemon
     // never WRITES it; this only READS it. Undefined / blank → the def + loadout alone.
     readThreadContent: buildReadThreadContent(channels),
+    // config (Phase 3 — DESIGN-2026-06-29-threads-roles-context.md): the pre-turn read of the
+    // thread note's SELF-CARRIED model/backend, so config resolves THREAD-FIRST (def fallback).
+    // UNWIRED / no thread config → the def config entirely (byte-identical to before Phase 3).
+    readThreadConfig: buildReadThreadConfig(channels),
     ...(onTurnEvent ? { onTurnEvent } : {}),
   });
 }

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -10,7 +10,7 @@
  * so a non-Telegram transport never has to invent Telegram fields.
  */
 
-import type { AgentMode } from "./sandbox/types.ts";
+import type { AgentMode, AgentBackendKind } from "./sandbox/types.ts";
 
 /**
  * A reference to a file attached to an inbound message (Phase 1: inbound file
@@ -93,6 +93,23 @@ export interface ThreadRecord {
   definition?: string;
   /** The mode the turn ran under — governs thread identity + whether the note upserts. */
   mode: AgentMode;
+  /**
+   * The thread's CONFIG (the flattened model — DESIGN-2026-06-29-threads-roles-context.md
+   * Phase 3): the resolved `model` / `backend` for the turn, so the thread note SELF-CARRIES
+   * its config and the `#agent/definition` is no longer needed for it. The transport stamps
+   * these onto `metadata.model` / `metadata.backend` with WRITE-IF-ABSENT semantics — a
+   * deterministic thread PRESERVES an existing value (an operator's or the migration's
+   * thread-set config wins; the def value only SEEDS a thread that has none yet), exactly
+   * like `started_at` / `session`. Absent (a transport that doesn't resolve config, or a
+   * record that carries none) → the keys aren't written (byte-identical to before Phase 3).
+   * `status` is DELIBERATELY NOT carried here: the thread's `metadata.status` already means
+   * the TURN OUTCOME (`ok`/`error`/`working`); the def's enabled/pending/error status is a
+   * discovery-state field that moves to the thread in Phase 4 (with discovery/routing),
+   * owned by `agent-defs.ts`, under a distinct key — never overloading the turn status.
+   */
+  model?: string;
+  /** The thread's resolved backend (see {@link model}). Stamped onto `metadata.backend`, write-if-absent. */
+  backend?: AgentBackendKind;
   /**
    * Outcome / lifecycle state of the thread after THIS write:
    *  - `working` — the turn has STARTED but not finished (the thread-as-container
@@ -251,6 +268,22 @@ export interface Transport {
    * VaultTransport) implements it; transports without a durable thread store (telegram) omit it.
    */
   readThreadSession?(channel: string, name: string, subject?: string): Promise<string | undefined>;
+  /**
+   * Optional: read the thread's CONFIG (the flattened model — Phase 3): the resolved
+   * `model` / `backend` carried on the thread's `#agent/thread` note (`metadata.model` /
+   * `metadata.backend`). The daemon reads this BEFORE a turn so config resolves THREAD-FIRST
+   * (the thread's own value wins), falling back to the def for any field the thread doesn't
+   * carry — the transition-safe path to retiring `#agent/definition` for config. `subject`
+   * resolves the subject-scoped note; omitted → the def-named note (HEAD). Returns the fields
+   * the note carries (each absent when the note doesn't have it / there's no thread note yet).
+   * Only a durable transport (the VaultTransport) implements it; transports without a durable
+   * thread store omit it → the daemon falls back to the def config entirely (today's behavior).
+   */
+  readThreadConfig?(
+    channel: string,
+    name: string,
+    subject?: string,
+  ): Promise<{ model?: string; backend?: AgentBackendKind }>;
   /**
    * Optional: CLEAR the persisted session on a thread's `#agent/thread` note so its next
    * turn starts a fresh Claude conversation (the per-agent restart / reset). `subject`

--- a/src/transports/vault.test.ts
+++ b/src/transports/vault.test.ts
@@ -1208,6 +1208,105 @@ describe("VaultTransport — writeThread (#agent/thread note, the unified model)
       content: "AUTHORED standing mandate — keep me.",
     });
   });
+
+  // ── Phase 3: the thread SELF-CARRIES config (model/backend) ───────────────────────────
+  test("stamps metadata.model + metadata.backend from the record (config onto the thread)", async () => {
+    const posts: { init: RequestInit }[] = [];
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const u = String(url);
+      const method = init?.method ?? "GET";
+      if (u.includes("/api/notes/") && method === "GET") return new Response("not found", { status: 404 });
+      if (u.includes("/api/notes/") && method === "PATCH") {
+        posts.push({ init: init ?? {} });
+        return new Response(JSON.stringify({ id: "thread-eng" }), { status: 200 });
+      }
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+    await t.writeThread({
+      channel: "eng",
+      name: "eng",
+      mode: "single-threaded",
+      status: "ok",
+      started_at: "2026-06-29T07:00:00.000Z",
+      ended_at: "2026-06-29T07:00:05.000Z",
+      model: "opus",
+      backend: "programmatic",
+    });
+
+    const sent = JSON.parse(String(posts[0]!.init.body)) as { metadata: Record<string, string> };
+    expect(sent.metadata.model).toBe("opus");
+    expect(sent.metadata.backend).toBe("programmatic");
+    // The turn-outcome `status` is untouched by config (it stays `ok`, NOT the def status).
+    expect(sent.metadata.status).toBe("ok");
+  });
+
+  test("WRITE-IF-ABSENT: an existing thread model/backend is PRESERVED (the def value never clobbers it)", async () => {
+    // The thread note already carries an operator-set / migration-backfilled config.
+    let stored: { metadata: Record<string, string>; content: string } | undefined = {
+      metadata: { model: "sonnet", backend: "programmatic", turn_count: "3", started_at: "2026-06-01T00:00:00.000Z" },
+      content: "",
+    };
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const u = String(url);
+      const method = init?.method ?? "GET";
+      if (u.includes("/api/notes/") && method === "GET") {
+        return stored ? new Response(JSON.stringify(stored), { status: 200 }) : new Response("nf", { status: 404 });
+      }
+      if (u.includes("/api/notes/") && method === "PATCH") {
+        const body = JSON.parse(String(init?.body)) as { metadata: Record<string, string>; content: string };
+        stored = { metadata: body.metadata, content: body.content };
+        return new Response(JSON.stringify({ id: "thread-eng" }), { status: 200 });
+      }
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+    // The turn re-stamps the DEF's model (opus) — but the thread already says sonnet, so sonnet wins.
+    await t.writeThread({
+      channel: "eng",
+      name: "eng",
+      mode: "single-threaded",
+      status: "ok",
+      started_at: "2026-06-29T07:00:00.000Z",
+      ended_at: "2026-06-29T07:00:05.000Z",
+      model: "opus",
+      backend: "attached",
+    });
+    expect(stored!.metadata.model).toBe("sonnet"); // preserved, NOT clobbered to opus.
+    expect(stored!.metadata.backend).toBe("programmatic"); // preserved, NOT clobbered to attached.
+  });
+
+  test("no config on the record → no model/backend keys written (byte-identical to pre-Phase-3)", async () => {
+    const posts: { init: RequestInit }[] = [];
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const u = String(url);
+      const method = init?.method ?? "GET";
+      if (u.includes("/api/notes/") && method === "GET") return new Response("not found", { status: 404 });
+      if (u.includes("/api/notes/") && method === "PATCH") {
+        posts.push({ init: init ?? {} });
+        return new Response(JSON.stringify({ id: "thread-eng" }), { status: 200 });
+      }
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+    await t.writeThread({
+      channel: "eng",
+      name: "eng",
+      mode: "single-threaded",
+      status: "ok",
+      started_at: "2026-06-29T07:00:00.000Z",
+      ended_at: "2026-06-29T07:00:05.000Z",
+    });
+    const sent = JSON.parse(String(posts[0]!.init.body)) as { metadata: Record<string, string> };
+    expect("model" in sent.metadata).toBe(false);
+    expect("backend" in sent.metadata).toBe(false);
+  });
 });
 
 describe("VaultTransport — loadTranscript (read the durable store)", () => {
@@ -2506,6 +2605,79 @@ describe("VaultTransport — readThreadContent (the thread's own authored body, 
       path: "Threads/eng/eng--launch-blockers",
       content: "subject mandate",
     });
+    expect(reads[0]).toBe("Threads/eng/eng--launch-blockers");
+  });
+});
+
+describe("VaultTransport — readThreadConfig (the thread's SELF-CARRIED config, Phase 3)", () => {
+  test("returns { model, backend } off the thread note metadata", async () => {
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      const u = decodeURIComponent(String(url));
+      if (u.includes("Threads/eng/eng")) {
+        return new Response(
+          JSON.stringify({ metadata: { model: "opus", backend: "programmatic", session: "s1" } }),
+          { status: 200 },
+        );
+      }
+      return new Response("not found", { status: 404 });
+    }) as unknown as typeof fetch;
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+    expect(await t.readThreadConfig("eng", "eng")).toEqual({ model: "opus", backend: "programmatic" });
+  });
+
+  test("no thread note yet (404) → {} (the def config is the fallback)", async () => {
+    globalThis.fetch = (async () => new Response("not found", { status: 404 })) as unknown as typeof fetch;
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+    expect(await t.readThreadConfig("eng", "eng")).toEqual({});
+  });
+
+  test("a field the note doesn't carry is omitted (per-field def fallback)", async () => {
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      const u = decodeURIComponent(String(url));
+      if (u.includes("Threads/eng/eng")) {
+        return new Response(JSON.stringify({ metadata: { model: "sonnet" } }), { status: 200 });
+      }
+      return new Response("not found", { status: 404 });
+    }) as unknown as typeof fetch;
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+    expect(await t.readThreadConfig("eng", "eng")).toEqual({ model: "sonnet" });
+  });
+
+  test("DUAL-READ the legacy backend value `channel` → `attached`; an invalid value is dropped", async () => {
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      const u = decodeURIComponent(String(url));
+      if (u.includes("Threads/legacy/legacy")) {
+        return new Response(JSON.stringify({ metadata: { backend: "channel" } }), { status: 200 });
+      }
+      if (u.includes("Threads/bad/bad")) {
+        return new Response(JSON.stringify({ metadata: { backend: "interactive", model: "opus" } }), { status: 200 });
+      }
+      return new Response("not found", { status: 404 });
+    }) as unknown as typeof fetch;
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("legacy"));
+    expect(await t.readThreadConfig("legacy", "legacy")).toEqual({ backend: "attached" });
+    // An unrecognized backend is dropped (→ def fallback); a valid sibling field still resolves.
+    expect(await t.readThreadConfig("bad", "bad")).toEqual({ model: "opus" });
+  });
+
+  test("a SUBJECT resolves the subject-scoped thread note", async () => {
+    const reads: string[] = [];
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      const m = /\/api\/notes\/([^?]+)/.exec(String(url));
+      const path = m ? decodeURIComponent(m[1]!) : "";
+      reads.push(path);
+      if (path === "Threads/eng/eng--launch-blockers") {
+        return new Response(JSON.stringify({ metadata: { model: "haiku" } }), { status: 200 });
+      }
+      return new Response("not found", { status: 404 });
+    }) as unknown as typeof fetch;
+    const t = new VaultTransport(baseConfig());
+    await t.start(fakeCtx("eng"));
+    expect(await t.readThreadConfig("eng", "eng", "launch blockers")).toEqual({ model: "haiku" });
     expect(reads[0]).toBe("Threads/eng/eng--launch-blockers");
   });
 });

--- a/src/transports/vault.ts
+++ b/src/transports/vault.ts
@@ -70,6 +70,7 @@ import type {
 // subject-scoped deterministic thread-note leaf (`<name>--<slug(subject)>`) so the path
 // math matches the registry's drain key exactly (no drift).
 import { threadKey } from "../sandbox/types.ts";
+import type { AgentBackendKind } from "../sandbox/types.ts";
 // roles as the capability layer (DESIGN-2026-06-29-threads-roles-context.md): the pure
 // role-detection helpers — `roleWants` is the SECURITY GATE (a note's `wants:` is honored
 // only if it is an `#agent/role`), `rolePathKey` derives the hub grant-holder key from the
@@ -933,6 +934,12 @@ export class VaultTransport implements Transport {
     let priorStartedAt: string | undefined;
     let priorLastTurnAt: string | undefined;
     let priorSession: string | undefined;
+    // The thread's SELF-CARRIED config (Phase 3 — DESIGN-2026-06-29-threads-roles-context.md).
+    // Preserved across an upsert (WRITE-IF-ABSENT): an operator's / the migration's thread-set
+    // model/backend WINS; the def value only seeds a thread that carries none yet. Same posture
+    // as `started_at` / `session` above — the daemon never clobbers an authored thread value.
+    let priorModel: string | undefined;
+    let priorBackend: string | undefined;
     if (deterministic) {
       const prior = await this.readThreadNote(path);
       if (prior) {
@@ -951,6 +958,13 @@ export class VaultTransport implements Transport {
         // than dropping continuity (the thread≡session record).
         if (typeof prior.metadata?.session === "string" && prior.metadata.session) {
           priorSession = prior.metadata.session;
+        }
+        // Preserve a thread-set config across the upsert (write-if-absent — see above).
+        if (typeof prior.metadata?.model === "string" && prior.metadata.model) {
+          priorModel = prior.metadata.model;
+        }
+        if (typeof prior.metadata?.backend === "string" && prior.metadata.backend) {
+          priorBackend = prior.metadata.backend;
         }
       }
     }
@@ -1009,6 +1023,16 @@ export class VaultTransport implements Transport {
     // note carries its own per-fire session each write (no preserve — each fire is fresh).
     const session = thread.session ?? (deterministic ? priorSession : undefined);
     if (session) metadata.session = session;
+    // The thread's SELF-CARRIED config (Phase 3). WRITE-IF-ABSENT for a DETERMINISTIC thread:
+    // an existing value (operator-set / migration-backfilled) is PRESERVED — the def value
+    // (`thread.model`/`thread.backend`) only seeds a thread with none yet, so the daemon never
+    // clobbers an authored config. A per-fire (multi-threaded, no-subject) note has no prior →
+    // it carries this turn's resolved config. Omitted entirely when neither side supplies one
+    // (e.g. a turn whose def carried no model) → byte-identical to before Phase 3.
+    const model = deterministic ? (priorModel ?? thread.model) : thread.model;
+    if (model) metadata.model = model;
+    const backend = deterministic ? (priorBackend ?? thread.backend) : thread.backend;
+    if (backend) metadata.backend = backend;
     // Usage is always present once a turn carried it OR we accumulated any — emit the
     // running totals so a query sees cumulative cost for the thread.
     if (deterministic || thread.usage) {
@@ -1130,6 +1154,41 @@ export class VaultTransport implements Transport {
     const prior = await this.readThreadNote(this.singleThreadedPath(channel, name, subject));
     const s = prior?.metadata?.session;
     return typeof s === "string" && s ? s : undefined;
+  }
+
+  /**
+   * Read the thread's SELF-CARRIED config (Phase 3 — DESIGN-2026-06-29-threads-roles-context.md):
+   * the `model` / `backend` on the thread's deterministic `#agent/thread` note, so the daemon
+   * resolves config THREAD-FIRST (the thread's own value wins; the def is the fallback). `subject`
+   * resolves the subject-scoped note; omitted → the def-named note (HEAD). Reuses
+   * {@link singleThreadedPath} + {@link readThreadNote}, so the path math agrees with writeThread /
+   * readThreadSession. No thread note yet (404) / a field the note doesn't carry → that field is
+   * undefined, and the caller falls back to the def for it (transition safety — byte-identical to
+   * today until a thread carries config). Best-effort: a network blip surfaces as no config (via
+   * readThreadNote, which logs it); an UNEXPECTED non-404 read error propagates to the caller's
+   * try/catch (the turn then runs on the def config).
+   *
+   * The backend value is DUAL-READ (`"channel"` → `"attached"`), mirroring {@link parseAgentDef},
+   * so a hand-authored legacy value still resolves to the canonical kind. A non-`programmatic`/
+   * `attached` value is dropped (treated as absent → def fallback) rather than passed through.
+   */
+  async readThreadConfig(
+    channel: string,
+    name: string,
+    subject?: string,
+  ): Promise<{ model?: string; backend?: AgentBackendKind }> {
+    const note = await this.readThreadNote(this.singleThreadedPath(channel, name, subject));
+    if (!note) return {};
+    const out: { model?: string; backend?: AgentBackendKind } = {};
+    const model = note.metadata?.model;
+    if (typeof model === "string" && model.trim().length > 0) out.model = model.trim();
+    const rawBackend = note.metadata?.backend;
+    if (typeof rawBackend === "string" && rawBackend.trim().length > 0) {
+      // DUAL-READ the legacy `"channel"` value → canonical `"attached"` (mirrors parseAgentDef).
+      const normalized = rawBackend.trim() === "channel" ? "attached" : rawBackend.trim();
+      if (normalized === "programmatic" || normalized === "attached") out.backend = normalized;
+    }
+    return out;
   }
 
   /** Clear a thread's persisted session so its next turn starts a fresh Claude conversation


### PR DESCRIPTION
**Phase 3** of the threads-roles-context flatten (`DESIGN-2026-06-29-threads-roles-context.md`). Make the `#agent/thread` note carry its own **config** (`model`/`backend`), so `#agent/definition` is no longer needed for config. Safe + additive — **a live agent never changes behavior**. (Phases 1 + 2 — `#agent/role`, thread-content-as-context — shipped in rc.19/rc.20.)

## What changed
- **`transport.ts`** — `ThreadRecord` gains `model?` / `backend?`; new optional `Transport.readThreadConfig(channel, name, subject?)` seam.
- **`transports/vault.ts`** — `writeThread` stamps `metadata.model` / `metadata.backend` **WRITE-IF-ABSENT**: an existing (operator-set / migration-backfilled) thread value is **preserved**; the def value only **seeds** a thread that has none yet — mirroring how `started_at` / `session` are preserved across an upsert, so re-stamping the def value every turn never clobbers a thread that diverged. New `readThreadConfig` reads them back (backend **dual-reads** legacy `channel`→`attached`; an unrecognized value is dropped → def fallback).
- **`backends/registry.ts`** — `recordThread` stamps config from `handle.spec`; the **drain resolves the turn's `model` THREAD-FIRST** (the thread's value wins; the def `handle.spec` is the fallback) and hands `deliver` a shallow-cloned effective handle. **No `deliver` signature change** (`model` flows via `handle.spec.model`, read off the effective handle).
- **`daemon.ts`** — `buildWriteThread` forwards `model`/`backend`; new `buildReadThreadConfig` wired into `createDefaultProgrammaticRegistry`.

Only `model` has a per-turn consumer today (the programmatic backend's `--model`). `backend` is **carried/readable** for Phase-4 routing but not overlaid into the turn (the routing fork stays def-based until Phase 4 — own-it-don't-route).

## Why `status` is NOT moved (deliberate)
The thread's `metadata.status` **already** means the **turn outcome** (`ok`/`error`/`working`) — load-bearing for `archiveThread` + the indexed thread queries. The def's `status` (`enabled`/`pending`/`error`) is a **discovery-state** field that (a) collides with the turn status, (b) isn't on `AgentSpec` (it's derived/owned by `agent-defs.ts`), and (c) has no turn-time consumer. It moves to the thread in **Phase 4**, with discovery/routing, owned by `agent-defs.ts`, under a **distinct key** — never overloading the turn status. (Full reasoning in the Phase-4 plan handed back to the team-lead.)

## Back-compat (the no-thread-config invariant)
With no thread config present, config resolves to the def entirely and `writeThread` writes no `model`/`backend` keys — **byte-identical to before Phase 3**. The live agents self-seed their thread config from the def on their next turn (write-if-absent); an explicit one-time migration is provided to the team-lead.

## Tests
- vault: `writeThread` stamps config; **write-if-absent preserve**; no-config → keys omitted; `readThreadConfig` (+ legacy-backend normalize, invalid drop, subject-scoped).
- registry: drain **thread-first model** wins; **def fallback**; unwired; read-throw swallowed; `recordThread` stamps config.
- `bun run typecheck` clean; `bun test ./src` **1389 pass / 0 fail**. All test servers use `Bun.serve({ port: 0 })` on loopback — none boot a live daemon.

rc bump `0.2.3-rc.20` → `0.2.3-rc.21`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T6HAzWsgiJy4ndsWSCWY5S