### PR TITLE
fix(sandbox): bind the engine's vendored apply-seccomp into the Linux sandbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/agent",
-  "version": "0.2.3-rc.22",
+  "version": "0.2.3-rc.23",
   "description": "Vault-native agents for Claude Code — a #agent/definition note + an inbound message becomes a sandboxed claude turn; the reply is written back as a note. Messaging gateway on :1941.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/src/spawn-deps.test.ts
+++ b/src/spawn-deps.test.ts
@@ -10,10 +10,10 @@
  */
 
 import { describe, test, expect, afterEach } from "bun:test";
-import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, writeFileSync, rmSync, existsSync } from "node:fs";
 import { tmpdir, homedir } from "node:os";
 import { join, resolve } from "node:path";
-import { resolveSpawnDeps, SpawnDepsError } from "./spawn-deps.ts";
+import { resolveSpawnDeps, SpawnDepsError, resolveSeccompReadBinds } from "./spawn-deps.ts";
 
 const savedHome = process.env.PARACHUTE_HOME;
 let tmp: string | undefined;
@@ -50,5 +50,41 @@ describe("resolveSpawnDeps", () => {
       expect(deps.claudeBin).toBe(bin);
       expect(deps.runtimeReadOnly).toContain(bin);
     }
+  });
+
+  test("binds the engine's vendored apply-seccomp helper into runtimeReadOnly", () => {
+    tmp = mkdtempSync(join(tmpdir(), "spawn-deps-seccomp-"));
+    process.env.PARACHUTE_HOME = tmp;
+    writeFileSync(join(tmp, "operator.token"), "fake-operator-bearer");
+    const deps = resolveSpawnDeps();
+    // On a supported arch (x64/arm64), the apply-seccomp read binds must be present —
+    // otherwise the home-tree deny tmpfs masks the engine's own helper inside bwrap and
+    // every Linux turn dies with `apply-seccomp: No such file or directory`.
+    const seccompBinds = resolveSeccompReadBinds();
+    for (const b of seccompBinds) expect(deps.runtimeReadOnly).toContain(b);
+  });
+});
+
+describe("resolveSeccompReadBinds — re-expose the engine's vendored apply-seccomp", () => {
+  const supportedArch = ["x64", "x86_64", "arm64", "aarch64"].includes(String(process.arch));
+
+  test("resolves the vendored apply-seccomp binary (the path the engine execs in bwrap)", () => {
+    const binds = resolveSeccompReadBinds();
+    if (!supportedArch) {
+      // No vendored binary for this arch — nothing to bind, by design.
+      expect(binds).toEqual([]);
+      return;
+    }
+    const bin = binds.find((p) => p.endsWith("apply-seccomp"));
+    expect(bin).toBeDefined();
+    // The resolved path must actually exist — a bind to a phantom path wouldn't
+    // re-expose anything and the ENOENT would persist. It must live under the
+    // sandbox-runtime vendor tree (where the engine looks).
+    expect(existsSync(bin!)).toBe(true);
+    expect(bin).toContain(join("@anthropic-ai", "sandbox-runtime", "vendor", "seccomp"));
+    // The CONTAINING dir of the binary is bound too (so an absolute-path exec inside
+    // the namespace resolves), as is the vendor root.
+    expect(binds).toContain(join(bin!, "..")); // .../vendor/seccomp/<arch>
+    expect(binds.some((p) => p.endsWith(join("sandbox-runtime", "vendor")))).toBe(true);
   });
 });

--- a/src/spawn-deps.ts
+++ b/src/spawn-deps.ts
@@ -14,6 +14,7 @@
  */
 
 import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { createRequire } from "node:module";
 import { homedir } from "node:os";
 import { resolve, join, dirname } from "node:path";
 import { type SpawnAgentBaseDeps } from "./spawn-agent.ts";
@@ -103,6 +104,74 @@ function resolveClaudeBin(): { bin: string; reads: string[] } | null {
   return { bin: sym, reads: [...reads] };
 }
 
+/**
+ * Map `process.arch` → the sandbox-runtime vendor dir name, or null if unsupported.
+ * Mirrors the runtime's own `getVendorArchitecture` (incl. its defensive `x86_64`/
+ * `aarch64` aliases) so we resolve the SAME vendor path it does. `arch` is widened to
+ * `string` because Node/Bun's `process.arch` literal type omits those aliases.
+ */
+function seccompVendorArch(): "x64" | "arm64" | null {
+  const arch: string = process.arch;
+  if (arch === "x64" || arch === "x86_64") return "x64";
+  if (arch === "arm64" || arch === "aarch64") return "arm64";
+  // Other arches have no vendored apply-seccomp binary — nothing to bind.
+  return null;
+}
+
+/**
+ * Resolve the read binds the sandbox needs to exec `@anthropic-ai/sandbox-runtime`'s
+ * own vendored `apply-seccomp` helper — the LINUX analogue of {@link resolveClaudeBin}.
+ *
+ * Why this matters (the Linux seccomp ENOENT): on Linux the engine enforces its
+ * unix-socket block by exec'ing its vendored `apply-seccomp` binary INSIDE the bwrap
+ * mount namespace (`<pkgRoot>/vendor/seccomp/<arch>/apply-seccomp`, an absolute host
+ * path). The scoped-read policy DENIES the whole home tree (`/home`) by mounting a
+ * tmpfs over it and re-allows ONLY the declared binds (mounts.ts §4.5). bun/npm install
+ * the package UNDER the home tree (`~/.bun/...`, `~/.npm-global/...`), so the deny tmpfs
+ * MASKS the engine's own helper inside the namespace — the turn dies with
+ * `apply-seccomp: No such file or directory` (an ENOENT for a file that exists on the
+ * host but is hidden in the sandbox). The runtime resolves the helper to an absolute
+ * path but never binds it back when the caller's denyRead covers it, and unlike `claude`
+ * (handled by {@link resolveClaudeBin}) nothing else re-exposes it.
+ *
+ * So we resolve the helper exactly as the runtime does and add it + its dir + the vendor
+ * tree to the read binds, which flow to `allowRead` and get re-bound over the deny
+ * tmpfs. This is a READ-ONLY bind of the engine's OWN static, library-linked helper —
+ * zero weakening of the boundary (it IS the boundary). Outside the home tree the binds
+ * are harmless no-ops (`--ro-bind / /` already exposes them); on macOS apply-seccomp is
+ * unused so the path resolution / bind never matters. Returns `[]` when the helper can't
+ * be located, in which case the engine degrades to its own resolution + the existing
+ * "unix socket access not restricted" warning, exactly as before.
+ */
+export function resolveSeccompReadBinds(): string[] {
+  const arch = seccompVendorArch();
+  if (!arch) return [];
+  try {
+    // Resolve the package ROOT via the module graph (library-resolved, never PATH) so we
+    // bind the same physical install the engine was imported from. `require.resolve` of
+    // the main entry → `<pkgRoot>/dist/index.js`; the root is two dirs up. This mirrors
+    // how the runtime locates the vendor dir (relative to its own dist/).
+    const req = createRequire(import.meta.url);
+    const pkgRoot = dirname(dirname(req.resolve("@anthropic-ai/sandbox-runtime")));
+    const bin = join(pkgRoot, "vendor", "seccomp", arch, "apply-seccomp");
+    if (!existsSync(bin)) return [];
+    const reads = new Set<string>([bin]);
+    try {
+      const real = realpathSync(bin);
+      reads.add(real);
+      reads.add(dirname(real)); // .../vendor/seccomp/<arch>
+      reads.add(dirname(dirname(dirname(real)))); // .../vendor
+    } catch {
+      // Broken symlink — bind the path we built; the dir bind below still applies.
+    }
+    reads.add(dirname(bin));
+    return [...reads];
+  } catch {
+    // Package not resolvable (shouldn't happen — it's a pinned dep) → bind nothing.
+    return [];
+  }
+}
+
 /** Absolute path to the operator token file (for error messages). */
 export function operatorTokenPath(): string {
   return resolve(parachuteHome(), "operator.token");
@@ -139,7 +208,13 @@ export function resolveSpawnDeps(): SpawnAgentBaseDeps {
   // bind (or expose) the operator's real ~/.claude. In TRUSTED mode reads are
   // broad and these binds are harmless no-ops. System paths (/usr,/lib,/opt) stay
   // readable; the per-session workspace (rw) is added by spawnAgent.
-  const runtimeReadOnly = [...(claude?.reads ?? [])];
+  //
+  // PLUS the engine's vendored `apply-seccomp` helper (Linux): the engine execs it
+  // INSIDE the bwrap namespace, but it installs under the home tree (~/.bun, ~/.npm-…)
+  // which confined mode denies via a tmpfs — so it must be re-allowed too, or every
+  // Linux turn dies with `apply-seccomp: No such file or directory`. See
+  // resolveSeccompReadBinds. No-op on macOS / outside the home tree.
+  const runtimeReadOnly = [...(claude?.reads ?? []), ...resolveSeccompReadBinds()];
 
   return {
     hubOrigin: getHubOrigin(),


### PR DESCRIPTION
## The bug (live, Amazon Linux 2023)

The programmatic (`claude -p`) backend dies on the **first exec inside the bwrap sandbox** on Linux:

```
claude -p exited 127: /usr/bin/bash: line 1:
/home/ec2-user/.bun/install/global/node_modules/@anthropic-ai/sandbox-runtime/vendor/seccomp/x64/apply-seccomp: No such file or directory
```

The binary **exists** on the host (valid `+x` static x86-64 ELF, runs standalone) — the ENOENT is about the **execution context** inside the sandbox.

## Root cause — scoped-read deny tmpfs masks the engine's own helper

An interaction between our scoped-read policy and how `@anthropic-ai/sandbox-runtime` (0.0.54) enforces its unix-socket block on Linux:

- The engine blocks `socket(AF_UNIX, …)` by exec'ing its **own vendored `apply-seccomp`** binary **inside** the bwrap mount namespace, by **absolute host path** (`<pkgRoot>/vendor/seccomp/<arch>/apply-seccomp`) — see `dist/sandbox/linux-sandbox-utils.js` `wrapCommandWithSandboxLinux` + `generate-seccomp-filter.js` `getApplySeccompBinaryPath`.
- Our scoped-read default **denies the whole home tree**. On Linux the runtime implements `denyRead: ['/home']` by mounting a fresh **`--tmpfs /home`** and re-binding **only** the declared `allowRead` paths over it (`generateFilesystemArgs`).
- bun/npm install the package **under** the home tree (`~/.bun/...`). So the deny tmpfs **masks the engine's own helper** inside the namespace → ENOENT for a file that exists on the host.

`claude` itself never hit this because `resolveClaudeBin` already re-binds it (it also lives under the home tree); `apply-seccomp` was the **one runtime helper** without the equivalent treatment. macOS never saw it: Seatbelt is path-policy (no tmpfs masking) and doesn't use apply-seccomp at all — **this is the first run of the Linux/seccomp path with a home-tree deny that contains the install.**

## The fix (minimal, security-preserving)

`resolveSeccompReadBinds()` in `src/spawn-deps.ts` — the Linux analogue of `resolveClaudeBin` — resolves the vendored apply-seccomp **exactly as the runtime does** (package root via the module graph, never PATH) and adds it + its dir + the vendor tree to `runtimeReadOnly`, which flows to `allowRead` and is re-bound over the deny tmpfs.

- **Read-only bind of the engine's own static, library-linked helper → zero weakening** of the boundary (it *is* the boundary). It does **not** disable the sandbox, set `IS_SANDBOX=1`, or `allowAllUnixSockets` — the seccomp filter still applies.
- **No-op** on macOS / when the package lives outside the home tree (`--ro-bind / /` already exposes it).
- **Degrades** to today's behavior (engine self-resolution + existing warning) when the helper can't be located.

## Verification

- `bun run typecheck` clean; `bun test src/sandbox src/spawn-agent.test.ts src/spawn-deps.test.ts src/programmatic-wiring.test.ts` → **181 pass**.
- Static end-to-end: `buildSandboxConfig` on Linux emits `denyRead: ['/home']` **and** the apply-seccomp path in `filesystem.allowRead` → sandbox-manager maps that to `allowWithinDeny` → re-bound over the `/home` tmpfs.
- (Pre-existing, unrelated: `web/ui/**` Vitest tests fail under a bare root `bun test` with `vi.mocked is not a function` — same on clean `main`.)

## How to test on the live EC2 box

1. Update the bun-linked checkout to this branch + rebuild if needed:
   ```bash
   cd ~/…/parachute-agent && git fetch && git checkout ag-seccomp-vendor-bind
   ```
2. Restart the agent daemon (hub supervisor or directly), then send a turn to a `programmatic` agent and watch it complete instead of `exited 127`.
3. Direct confirmation that apply-seccomp now resolves inside the wrap:
   ```bash
   # the resolved binds should include …/sandbox-runtime/vendor/seccomp/x64/apply-seccomp
   bun -e 'import {resolveSeccompReadBinds} from "./src/spawn-deps.ts"; console.log(resolveSeccompReadBinds())'
   ```
   Then trigger a real inbound message and confirm the reply is written back (no ENOENT in the daemon log).

Security-sensitive: the fix keeps the sandbox intact — it only re-exposes the engine's own seccomp helper read-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T6HAzWsgiJy4ndsWSCWY5S