### PR TITLE
release: agent 0.2.3 (@latest promotion)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/agent",
-  "version": "0.2.3-rc.24",
+  "version": "0.2.3",
   "description": "Vault-native agents for Claude Code — a #agent/definition note + an inbound message becomes a sandboxed claude turn; the reply is written back as a note. Messaging gateway on :1941.",
   "license": "AGPL-3.0",
   "type": "module",


### PR DESCRIPTION
## @latest stable promotion

Drops the `-rc` suffix and ships the same patch as a stable release: **0.2.3-rc.24 → 0.2.3**. No code changes — version-only bump.

This graduates the **0.2.3-rc.24 rc chain** to `@latest`. That chain landed:
- **agent roles × threads** — role notes layered onto thread records
- **honoring the hub multi-origin issuer SET** (scope-guard 0.5.0 + `allowedIssuers`) (#180)

## Diff

Only the root version in `package.json`:

```diff
-  "version": "0.2.3-rc.24",
+  "version": "0.2.3",
```

`bun.lock` is unchanged — the root package's own version is not tracked in the lockfile, so syncing it produces no diff and `--frozen-lockfile` stays satisfied. No other dependency moved (scope-guard remains `^0.5.0` → 0.5.0).

## Gates

- `bun run typecheck` → exit 0
- `bun test ./src/` → **1423 pass, 0 fail** (4178 expect() calls, 59 files; the ECONNREFUSED/500 log lines are intentional error-path fixtures)
- `bun install --frozen-lockfile` → "no changes"

No git tag pushed; not merged — awaiting human merge per governance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T6HAzWsgiJy4ndsWSCWY5S