### PR TITLE
feat(agent): surface grant kind + GIT_ASKPASS injection (Surface Git Transport Phase 2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/agent",
-  "version": "0.2.3",
+  "version": "0.2.4-rc.1",
   "description": "Vault-native agents for Claude Code — a #agent/definition note + an inbound message becomes a sandboxed claude turn; the reply is written back as a note. Messaging gateway on :1941.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/src/agent-defs.ts
+++ b/src/agent-defs.ts
@@ -135,7 +135,7 @@ export function parseDiscoveryMode(raw: string | undefined): DiscoveryMode {
  */
 export interface ConnectionInfo {
   key: string;
-  kind: "vault" | "service" | "mcp";
+  kind: "vault" | "service" | "surface" | "mcp";
   target: string;
   status: string;
   grantId?: string;

--- a/src/backends/programmatic.test.ts
+++ b/src/backends/programmatic.test.ts
@@ -1658,6 +1658,65 @@ describe("ProgrammaticBackend.deliver — grant injection (4b)", () => {
     expect(Object.keys(servers)).toEqual([vaultEntryKey("default")]);
   });
 
+  test("approved SURFACE grant → a 0700 GIT_ASKPASS + git env; token NEVER in the env", async () => {
+    mkDirs("grant-surface");
+    const conn: ConnectionSpec = { kind: "surface", target: "gitcoin-brain", access: "write" };
+    const grants = grantsClientFor({
+      grants: [{ id: "g1", connection: conn, status: "approved" }],
+      material: {
+        g1: { kind: "surface", token: "STOK", remoteUrl: "https://hub.example.com/git/gitcoin-brain" },
+      },
+    });
+    const { fn, calls } = recordingSpawn({ stdout: successTurn("s", "ok") });
+    const backend = new ProgrammaticBackend(baseDeps(fn, { grants }));
+    const handle = await backend.start(specWithVault("eng"));
+    await backend.deliver(handle, "hi", freshSession());
+
+    // The askpass script exists in the PRIVATE session workspace, is 0700
+    // (private + EXECUTABLE — git execs it), and carries the token.
+    const askpassPath = join(sessionsDir, "eng", "git-askpass.sh");
+    expect(existsSync(askpassPath)).toBe(true);
+    expect(statSync(askpassPath).mode & 0o777).toBe(0o700);
+    expect(readFileSync(askpassPath, "utf8")).toContain("STOK");
+
+    // The launch env points git at the askpass + carries the discovery remote —
+    // but NEVER the token itself (it lives only in the 0700 askpass file).
+    const env = calls[0]!.env;
+    expect(env.GIT_ASKPASS).toBe(askpassPath);
+    expect(env.GIT_TERMINAL_PROMPT).toBe("0");
+    expect(env.PARACHUTE_SURFACE_GITCOIN_BRAIN_REMOTE).toBe(
+      "https://hub.example.com/git/gitcoin-brain",
+    );
+    expect(Object.values(env)).not.toContain("STOK");
+    // A single surface needs no path-scoping.
+    expect(env.GIT_CONFIG_COUNT).toBeUndefined();
+    // The managed Claude auth is untouched.
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe("OAUTH-CRED-PLACEHOLDER");
+    // No MCP entry + no env var for a surface grant (git-only injection).
+    expect(readMcpServers("eng")[vaultEntryKey("default")]).toBeDefined();
+  });
+
+  test("NO surface grant → no git-askpass.sh + no GIT_ASKPASS (byte-identical to today)", async () => {
+    mkDirs("grant-no-surface");
+    const grants = grantsClientFor({
+      grants: [
+        {
+          id: "g1",
+          connection: { kind: "service", target: "github", inject: ["env"] },
+          status: "approved",
+        },
+      ],
+      material: { g1: { kind: "service", token: "ghp_X", inject: ["env"] } },
+    });
+    const { fn, calls } = recordingSpawn({ stdout: successTurn("s", "ok") });
+    const backend = new ProgrammaticBackend(baseDeps(fn, { grants }));
+    const handle = await backend.start(specWithVault("eng"));
+    await backend.deliver(handle, "hi", freshSession());
+
+    expect(existsSync(join(sessionsDir, "eng", "git-askpass.sh"))).toBe(false);
+    expect(calls[0]!.env.GIT_ASKPASS).toBeUndefined();
+  });
+
   test("material is fetched FRESH each spawn (revocation takes effect next turn — no cache)", async () => {
     mkDirs("grant-fresh");
     const called: string[] = [];

--- a/src/backends/programmatic.ts
+++ b/src/backends/programmatic.ts
@@ -54,7 +54,7 @@
  * it is handed.
  */
 
-import { mkdirSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { AgentSpec } from "../sandbox/types.ts";
 import type { InboundAttachment } from "../transport.ts";
@@ -76,7 +76,13 @@ import {
 } from "../mint-token.ts";
 import { buildAgentMcpConfigJson, vaultEntryKey } from "../agent-mcp-config.ts";
 import { resolveClaudeCredential, resolveChannelEnv } from "../credentials.ts";
-import { resolveInjectedGrantsUnion, type GrantsClient } from "../grants.ts";
+import {
+  buildGitAskpassScript,
+  buildSurfaceGitEnv,
+  resolveInjectedGrantsUnion,
+  type GitCredential,
+  type GrantsClient,
+} from "../grants.ts";
 import { parseStreamJsonStream } from "./stream-json.ts";
 import { composeSystemPrompt } from "./types.ts";
 import type {
@@ -534,6 +540,7 @@ export class ProgrammaticBackend implements AgentBackend {
     // in 4b-1 (no OAuth) → getMaterial returns null for them → never injected.
     let grantMcpEntries: { name: string; url: string; token: string }[] = [];
     let grantEnv: Record<string, string> = {};
+    let grantGitCredentials: GitCredential[] = [];
     if (this.deps.grants) {
       // GRANT INJECTION = UNION OF SOURCES (roles as the capability layer —
       // DESIGN-2026-06-29-threads-roles-context.md). The injected grants for a turn are the
@@ -557,6 +564,7 @@ export class ProgrammaticBackend implements AgentBackend {
         const injected = await resolveInjectedGrantsUnion(this.deps.grants, sources);
         grantMcpEntries = injected.mcpEntries;
         grantEnv = injected.env;
+        grantGitCredentials = injected.gitCredentials;
       } catch (err) {
         // resolveInjectedGrantsUnion is per-source best-effort (each source's list failure
         // is logged + skipped inside it), so this catch is defense-in-depth — a surprise
@@ -585,6 +593,27 @@ export class ProgrammaticBackend implements AgentBackend {
     mkdirSync(workspace, { recursive: true });
     const mcpConfigPath = join(workspace, ".mcp.json");
     writeFileSync(mcpConfigPath, mcpConfigJson, { mode: 0o600 });
+
+    // ── SURFACE GIT GRANTS (Phase 2 §6a step 4) ────────────────────────────────────
+    // A surface grant carries a scoped `surface:<name>:write` token + the git remote.
+    // We wire it into `git` via a per-spawn GIT_ASKPASS script + env vars — so the
+    // agent can `git clone`/`git push` the surface's hub-hosted repo WITHOUT the token
+    // ever landing in `.git/config` or a URL. Written into the PRIVATE session
+    // workspace (like `.mcp.json`), 0700 (private + EXECUTABLE — git EXECs the askpass,
+    // so it needs the exec bit; the token inside makes it private). The clone itself is
+    // the AGENT's job in its cwd (clone-per-turn — the daemon pre-clones nothing), fed
+    // the remote via `PARACHUTE_SURFACE_<NAME>_REMOTE`. Absent surface grants → no git
+    // wiring at all (byte-identical to today). The token is fetched fresh per turn (via
+    // the grant material above), so a revoked surface grant stops working next turn.
+    let surfaceGitEnv: Record<string, string> = {};
+    if (grantGitCredentials.length > 0) {
+      const askpassPath = join(workspace, "git-askpass.sh");
+      writeFileSync(askpassPath, buildGitAskpassScript(grantGitCredentials), { mode: 0o700 });
+      // `mode` on writeFileSync only applies at CREATE; chmod unconditionally so an
+      // existing askpass from a prior turn is (re)tightened to 0700 (private + +x).
+      chmodSync(askpassPath, 0o700);
+      surfaceGitEnv = buildSurfaceGitEnv(grantGitCredentials, askpassPath);
+    }
 
     // ── INBOUND FILE ATTACHMENTS (Phase 1) ─────────────────────────────────────────
     // Stage each attached file into the agent's PRIVATE session workspace (under a SAFE
@@ -725,14 +754,21 @@ export class ProgrammaticBackend implements AgentBackend {
     );
     const homeEnv = seedAgentHome(workspace, { mcpServers: mcpServerNames, projectRoot: cwd });
 
-    // Merge the granted-service env (GITHUB_TOKEN, …) with the operator-scoped
-    // per-channel env. The per-channel store wins on a key collision (it's the
-    // explicit operator override); both go in at the SAME (lowest) precedence layer of
-    // buildAgentChildEnv — which then applies its denylist (ANTHROPIC_API_KEY /
-    // CLAUDE_API_KEY / CLAUDE_CODE_OAUTH_TOKEN can NEVER be set from either source) and
-    // sets CLAUDE_CODE_OAUTH_TOKEN LAST, so a granted var can never clobber the
-    // session's managed auth or the subscription-billing guarantee.
-    const mergedChannelEnv: Record<string, string> = { ...grantEnv, ...channelEnv };
+    // Merge the granted-service env (GITHUB_TOKEN, …) + the surface git env
+    // (GIT_ASKPASS / GIT_TERMINAL_PROMPT / PARACHUTE_SURFACE_*_REMOTE) with the
+    // operator-scoped per-channel env. The per-channel store wins on a key collision
+    // (it's the explicit operator override); all three go in at the SAME (lowest)
+    // precedence layer of buildAgentChildEnv — which then applies its denylist
+    // (ANTHROPIC_API_KEY / CLAUDE_API_KEY / CLAUDE_CODE_OAUTH_TOKEN can NEVER be set
+    // from any source) and sets CLAUDE_CODE_OAUTH_TOKEN LAST, so a granted var can
+    // never clobber the session's managed auth or the subscription-billing guarantee.
+    // None of the surface git vars are denylisted or in SANDBOX_ENV_ALLOWLIST, so they
+    // survive the scrub + the sandbox env merge intact.
+    const mergedChannelEnv: Record<string, string> = {
+      ...grantEnv,
+      ...surfaceGitEnv,
+      ...channelEnv,
+    };
 
     // Layer the scrubbed agent env UNDER the sandbox wrapper's env; the HOME/config/
     // temp vars layer LAST so they win. CLAUDE_CODE_OAUTH_TOKEN injected;

--- a/src/grants.test.ts
+++ b/src/grants.test.ts
@@ -34,7 +34,12 @@ import {
   GrantsClient,
   GrantsApiError,
   WantsParseError,
+  buildGitAskpassScript,
+  buildSurfaceGitEnv,
+  surfaceNameFromRemoteUrl,
+  surfaceRemoteEnvVar,
   type ConnectionSpec,
+  type GitCredential,
   type GrantMaterial,
 } from "./grants.ts";
 
@@ -58,6 +63,15 @@ describe("parseWants — spec forms", () => {
     ]);
     expect(parseWants("vault:research:read#published#wip")).toEqual([
       { kind: "vault", target: "research", access: "read", tags: ["#published", "#wip"] },
+    ]);
+  });
+
+  test("surface:<name>:<verb> → kind surface", () => {
+    expect(parseWants("surface:gitcoin-brain:write")).toEqual([
+      { kind: "surface", target: "gitcoin-brain", access: "write" },
+    ]);
+    expect(parseWants("surface:gitcoin-brain:read")).toEqual([
+      { kind: "surface", target: "gitcoin-brain", access: "read" },
     ]);
   });
 
@@ -141,6 +155,15 @@ describe("parseWants — malformed → WantsParseError", () => {
   test("service with a non-slug name", () => {
     expect(() => parseWants("env:bad.name")).toThrow(/slug/);
   });
+  test("surface without a verb", () => {
+    expect(() => parseWants("surface:gitcoin-brain")).toThrow(/needs a verb/);
+  });
+  test("surface with a bad verb", () => {
+    expect(() => parseWants("surface:gitcoin-brain:admin")).toThrow(/read.*write/);
+  });
+  test("surface with a non-slug name (slash → path traversal risk)", () => {
+    expect(() => parseWants("surface:bad/name:write")).toThrow(/slug/);
+  });
   test("mcp with a non-http(s) url-looking target is treated as a service slug → bad slug", () => {
     // "ftp://x" doesn't match http(s) → treated as a service name → not a slug.
     expect(() => parseWants("mcp:ftp://x")).toThrow(/slug/);
@@ -175,6 +198,14 @@ describe("connectionKey", () => {
     );
     expect(connectionKey({ kind: "vault", target: "ops", access: "write" })).toBe("vault:ops:write");
     expect(connectionKey({ kind: "mcp", target: "https://x/mcp" })).toBe("mcp:https://x/mcp");
+  });
+  test("surface key reflects the verb", () => {
+    expect(connectionKey({ kind: "surface", target: "gitcoin-brain", access: "write" })).toBe(
+      "surface:gitcoin-brain:write",
+    );
+    expect(connectionKey({ kind: "surface", target: "gitcoin-brain", access: "read" })).toBe(
+      "surface:gitcoin-brain:read",
+    );
   });
 });
 
@@ -459,6 +490,34 @@ describe("resolveInjectedGrants", () => {
     expect(out.env).toEqual({});
   });
 
+  test("approved surface grant → a gitCredential, NO mcp entry, NO env var", async () => {
+    const conn: ConnectionSpec = { kind: "surface", target: "gitcoin-brain", access: "write" };
+    const client = injectionClient({
+      grants: [{ id: "g1", connection: conn, status: "approved" }],
+      material: {
+        g1: { kind: "surface", token: "STOK", remoteUrl: "https://hub/git/gitcoin-brain" },
+      },
+    });
+    const out = await resolveInjectedGrants(client, "a");
+    expect(out.gitCredentials).toEqual([
+      { remoteUrl: "https://hub/git/gitcoin-brain", token: "STOK" },
+    ]);
+    expect(out.mcpEntries).toEqual([]);
+    expect(out.env).toEqual({});
+  });
+
+  test("a PENDING surface grant → no credential (never grantable pre-approval)", async () => {
+    const conn: ConnectionSpec = { kind: "surface", target: "gitcoin-brain", access: "write" };
+    // status pending → resolveInjectedGrants skips it (only approved grants inject);
+    // even if material were somehow fetched, a pending grant's /material 409s → null.
+    const client = injectionClient({
+      grants: [{ id: "g1", connection: conn, status: "pending" }],
+      material: { g1: "409" },
+    });
+    const out = await resolveInjectedGrants(client, "a");
+    expect(out.gitCredentials).toEqual([]);
+  });
+
   test("approved service grant (env) → an env var, no MCP entry", async () => {
     const conn: ConnectionSpec = { kind: "service", target: "github", inject: ["env"] };
     const client = injectionClient({
@@ -696,6 +755,18 @@ describe("isRoleNote / roleWants — the SECURITY GATE (wants only from #agent/r
     expect(roleWants({ tags: ["agent/role"], metadata: { wants: "" } })).toBeNull();
   });
 
+  test("THE GATE holds for surface: a non-role note's surface want is inert", () => {
+    // A plain note declaring a surface push want gains NO git capability — only a
+    // role's wants are honored (the note-can-only-REQUEST invariant, extended to surface).
+    expect(
+      roleWants({ tags: ["reference"], metadata: { wants: "surface:gitcoin-brain:write" } }),
+    ).toBeNull();
+    // The SAME wants on an `#agent/role` note → parsed.
+    expect(
+      roleWants({ tags: ["agent/role"], metadata: { wants: "surface:gitcoin-brain:write" } }),
+    ).toEqual([{ kind: "surface", target: "gitcoin-brain", access: "write" }]);
+  });
+
   test("a role with a MALFORMED wants → null (the reconcile path stamps status:error)", () => {
     expect(roleWants({ tags: ["agent/role"], metadata: { wants: "garbage-no-colon" } })).toBeNull();
   });
@@ -798,6 +869,33 @@ describe("resolveInjectedGrantsUnion — union of def key + role keys", () => {
     ]);
   });
 
+  test("surface grants union across sources; dedupe by remoteUrl (first source wins)", async () => {
+    const roleKey = rolePathKey("Roles/surfacer");
+    const client = multiAgentClient({
+      byAgent: {
+        steward: [
+          { id: "d1", connection: { kind: "surface", target: "brain-a", access: "write" }, status: "approved" },
+          // a duplicate remote also on the def — first-seen wins
+          { id: "d2", connection: { kind: "surface", target: "brain-a", access: "read" }, status: "approved" },
+        ],
+        [roleKey]: [
+          { id: "p1", connection: { kind: "surface", target: "brain-b", access: "write" }, status: "approved" },
+        ],
+      },
+      material: {
+        d1: { kind: "surface", token: "TOK-A-WRITE", remoteUrl: "https://hub/git/brain-a" },
+        d2: { kind: "surface", token: "TOK-A-READ", remoteUrl: "https://hub/git/brain-a" },
+        p1: { kind: "surface", token: "TOK-B", remoteUrl: "https://hub/git/brain-b" },
+      },
+    });
+    const out = await resolveInjectedGrantsUnion(client, ["steward", roleKey]);
+    // brain-a deduped to the first (write) token; brain-b from the role.
+    expect(out.gitCredentials).toEqual([
+      { remoteUrl: "https://hub/git/brain-a", token: "TOK-A-WRITE" },
+      { remoteUrl: "https://hub/git/brain-b", token: "TOK-B" },
+    ]);
+  });
+
   test("dedupe: a key appearing twice (or equal to spec.name) is fetched ONCE", async () => {
     const calls: string[] = [];
     const conn: ConnectionSpec = { kind: "service", target: "github", inject: ["env"] };
@@ -842,5 +940,104 @@ describe("resolveInjectedGrantsUnion — union of def key + role keys", () => {
     // The def still injected; the failing role source is simply absent (never throws).
     expect(out.env).toEqual({ GITHUB_TOKEN: "GHTOK" });
     expect(out.mcpEntries).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Surface git injection — the GIT_ASKPASS channel (design §6a step 4)
+// ---------------------------------------------------------------------------
+
+describe("surfaceNameFromRemoteUrl / surfaceRemoteEnvVar", () => {
+  test("extracts the surface name + the env var name", () => {
+    expect(surfaceNameFromRemoteUrl("https://hub.test/git/gitcoin-brain")).toBe("gitcoin-brain");
+    expect(surfaceRemoteEnvVar("https://hub.test/git/gitcoin-brain")).toBe(
+      "PARACHUTE_SURFACE_GITCOIN_BRAIN_REMOTE",
+    );
+    // loopback + a name with an underscore
+    expect(surfaceRemoteEnvVar("http://127.0.0.1:1939/git/my_surface")).toBe(
+      "PARACHUTE_SURFACE_MY_SURFACE_REMOTE",
+    );
+  });
+});
+
+describe("buildGitAskpassScript", () => {
+  const cred = (name: string, token: string): GitCredential => ({
+    remoteUrl: `https://hub.test/git/${name}`,
+    token,
+  });
+
+  test("single surface: any Password prompt echoes the one token; Username → sentinel", () => {
+    const script = buildGitAskpassScript([cred("brain", "STOK")]);
+    expect(script.startsWith("#!/bin/sh")).toBe(true);
+    // sentinel user for the hub's x-access-token Basic form
+    expect(script).toContain("printf %s 'x-access-token'");
+    // the token is present (single-quoted)
+    expect(script).toContain("printf %s 'STOK'");
+    // single-surface needs no path matching
+    expect(script).not.toContain("/git/brain'*");
+  });
+
+  test("multi surface: path-matches each surface's token + falls back to the first", () => {
+    const script = buildGitAskpassScript([cred("brain-a", "TOK-A"), cred("brain-b", "TOK-B")]);
+    expect(script).toContain("*'/git/brain-a'*) printf %s 'TOK-A' ;;");
+    expect(script).toContain("*'/git/brain-b'*) printf %s 'TOK-B' ;;");
+    // fallback (no path match) → the first token
+    expect(script).toContain("*) printf %s 'TOK-A' ;;");
+  });
+
+  test("the script actually returns the right token when RUN by /bin/sh", async () => {
+    // Prove the generated shell is VALID + selects correctly (not just string-matching).
+    // `sh -s <arg>` runs the script from stdin with $1=<arg> — exactly how git invokes
+    // GIT_ASKPASS (prompt as the single positional arg).
+    const script = buildGitAskpassScript([cred("brain-a", "TOK-A"), cred("brain-b", "TOK-B")]);
+    const run = async (prompt: string): Promise<string> => {
+      const proc = Bun.spawn(["/bin/sh", "-s", prompt], {
+        stdin: new TextEncoder().encode(script),
+        stdout: "pipe",
+      });
+      return (await new Response(proc.stdout).text()).trim();
+    };
+    // Username prompt → sentinel
+    expect(await run("Username for 'https://hub.test'")).toBe("x-access-token");
+    // Password prompt carrying brain-b's path → TOK-B
+    expect(await run("Password for 'https://x-access-token@hub.test/git/brain-b'")).toBe("TOK-B");
+    // Password prompt carrying brain-a's path → TOK-A
+    expect(await run("Password for 'https://x-access-token@hub.test/git/brain-a'")).toBe("TOK-A");
+    // An unknown path → the first token (graceful fallback, never a crash)
+    expect(await run("Password for 'https://x-access-token@hub.test/git/unknown'")).toBe("TOK-A");
+  });
+});
+
+describe("buildSurfaceGitEnv", () => {
+  const cred = (name: string, token: string): GitCredential => ({
+    remoteUrl: `https://hub.test/git/${name}`,
+    token,
+  });
+
+  test("no surface grants → no git env (byte-identical to today)", () => {
+    expect(buildSurfaceGitEnv([], "/w/git-askpass.sh")).toEqual({});
+  });
+
+  test("single surface: askpass + terminal-prompt-off + the remote env; NO useHttpPath", () => {
+    const env = buildSurfaceGitEnv([cred("brain", "STOK")], "/w/git-askpass.sh");
+    expect(env.GIT_ASKPASS).toBe("/w/git-askpass.sh");
+    expect(env.GIT_TERMINAL_PROMPT).toBe("0");
+    expect(env.PARACHUTE_SURFACE_BRAIN_REMOTE).toBe("https://hub.test/git/brain");
+    // No path-scoping needed for a single surface.
+    expect(env.GIT_CONFIG_COUNT).toBeUndefined();
+    // The token is NEVER in the env (it lives only in the askpass file).
+    expect(Object.values(env)).not.toContain("STOK");
+  });
+
+  test("multi surface: sets credential.useHttpPath so the askpass can disambiguate", () => {
+    const env = buildSurfaceGitEnv(
+      [cred("brain-a", "TOK-A"), cred("brain-b", "TOK-B")],
+      "/w/git-askpass.sh",
+    );
+    expect(env.PARACHUTE_SURFACE_BRAIN_A_REMOTE).toBe("https://hub.test/git/brain-a");
+    expect(env.PARACHUTE_SURFACE_BRAIN_B_REMOTE).toBe("https://hub.test/git/brain-b");
+    expect(env.GIT_CONFIG_COUNT).toBe("1");
+    expect(env.GIT_CONFIG_KEY_0).toBe("credential.useHttpPath");
+    expect(env.GIT_CONFIG_VALUE_0).toBe("true");
   });
 });

--- a/src/grants.test.ts
+++ b/src/grants.test.ts
@@ -75,6 +75,17 @@ describe("parseWants — spec forms", () => {
     ]);
   });
 
+  test("surface name is canonicalized to lowercase (matches the hub + git endpoint)", () => {
+    // A mixed-case name lowercases so the agent's status key matches the hub's echoed
+    // (lowercased) target, and the clone/push URL matches a lowercase-registered surface.
+    expect(parseWants("surface:GitCoin-Brain:write")).toEqual([
+      { kind: "surface", target: "gitcoin-brain", access: "write" },
+    ]);
+    expect(connectionKey(parseWants("surface:GitCoin-Brain:write")[0]!)).toBe(
+      "surface:gitcoin-brain:write",
+    );
+  });
+
   test("env:<service> → service inject:[env]", () => {
     expect(parseWants("env:github")).toEqual([
       { kind: "service", target: "github", inject: ["env"] },

--- a/src/grants.ts
+++ b/src/grants.ts
@@ -54,14 +54,14 @@ import { DENYLISTED_ENV } from "./credentials.ts";
  * — `access`/`tags` are vault-only; `inject` is service-only (`("env"|"mcp")[]`).
  */
 export interface ConnectionSpec {
-  /** Resource kind. `vault`/`service` are wired in 4b-1; `mcp` is parsed-but-deferred. */
-  kind: "vault" | "service" | "mcp";
+  /** Resource kind. `vault`/`service`/`surface` are wired; `mcp` is parsed-but-deferred. */
+  kind: "vault" | "service" | "surface" | "mcp";
   /**
    * The resource target — a vault name (`research`), a service name (`github`),
-   * or, for `kind:"mcp"`, the remote MCP https URL.
+   * a surface name (`gitcoin-brain`), or, for `kind:"mcp"`, the remote MCP https URL.
    */
   target: string;
-  /** Vault access verb. Vault-only. */
+  /** Access verb. Vault + surface (`surface:<name>:<verb>` — write ⊇ read at the git endpoint). */
   access?: "read" | "write";
   /** Vault tag-scope (one or more `#tag`). Vault-only. */
   tags?: string[];
@@ -84,7 +84,15 @@ export class WantsParseError extends Error {
  *
  *   vault   → `vault:<target>:<access>[#tag…]`   (tags sorted for stability)
  *   service → `<inject-joined>:<target>`          e.g. `env+mcp:github`
+ *   surface → `surface:<target>:<access>`
  *   mcp     → `mcp:<url>`
+ *
+ * NOTE: this key is used ONLY for the agent's OWN status resolution
+ * ({@link resolveConnectionStatus}) — where BOTH sides (the declared spec + the
+ * hub's echoed-back `connection`) run through THIS function, so it's internally
+ * consistent. It is DELIBERATELY NOT sent to the hub for reconcile: the agent
+ * sends SPECS and the hub re-derives keys with its own `connectionKey` (the
+ * cross-repo divergence lesson — agent#96/hub#674).
  */
 export function connectionKey(c: ConnectionSpec): string {
   if (c.kind === "vault") {
@@ -95,6 +103,9 @@ export function connectionKey(c: ConnectionSpec): string {
     const inject = (c.inject && c.inject.length > 0 ? [...c.inject].sort() : ["env"]).join("+");
     return `${inject}:${c.target}`;
   }
+  if (c.kind === "surface") {
+    return `surface:${c.target}:${c.access ?? "read"}`;
+  }
   return `mcp:${c.target}`;
 }
 
@@ -102,6 +113,13 @@ export function connectionKey(c: ConnectionSpec): string {
 const VAULT_NAME_SLUG = /^[a-zA-Z0-9_-]+$/;
 /** A service name slug — `github`, `cloudflare`, … */
 const SERVICE_NAME_SLUG = /^[a-zA-Z0-9_-]+$/;
+/**
+ * A surface name slug — the `<name>` segment in `surface:<name>:<verb>`. MATCHES
+ * the hub's `SURFACE_NAME_RE` (git-registry.ts) so a name this parser accepts is
+ * one the hub's PUT/registry + git-transport URL parser also accept (no slashes
+ * or dots → no path traversal in the git endpoint). Bounded length.
+ */
+const SURFACE_NAME_SLUG = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/;
 
 /**
  * Parse the `wants:` metadata field — a comma-separated list of connection specs —
@@ -196,6 +214,8 @@ function parseOneWant(entry: string): ConnectionSpec {
   switch (prefix) {
     case "vault":
       return parseVaultWant(entry, rest);
+    case "surface":
+      return parseSurfaceWant(entry, rest);
     case "env":
       return parseServiceWant(entry, rest, "env");
     case "mcp":
@@ -206,7 +226,7 @@ function parseOneWant(entry: string): ConnectionSpec {
     default:
       throw new WantsParseError(
         `wants: "${entry}" has unknown kind "${prefix}" — expected one of ` +
-          `vault | env | mcp.`,
+          `vault | surface | env | mcp.`,
       );
   }
 }
@@ -248,6 +268,37 @@ function parseVaultWant(entry: string, rest: string): ConnectionSpec {
     );
   }
   return { kind: "vault", target: name, access: verb, ...(tags ? { tags } : {}) };
+}
+
+/**
+ * Parse `surface:<name>:<read|write>` — a grant to a surface's hub-hosted git repo
+ * (Phase 2 §6a). Mirrors {@link parseVaultWant}'s `<name>:<verb>` split, minus the
+ * tag suffix (surfaces have no tag-scope). The verb is REQUIRED + explicit (like
+ * vault): `write` = clone+push, `read` = clone only. write ⊇ read at the git
+ * endpoint, so a `write` grant needs no separate read grant to clone.
+ */
+function parseSurfaceWant(entry: string, rest: string): ConnectionSpec {
+  const colon = rest.indexOf(":");
+  if (colon < 0) {
+    throw new WantsParseError(
+      `wants: "${entry}" is malformed — a surface connection needs a verb: ` +
+        `"surface:<name>:<read|write>".`,
+    );
+  }
+  const name = rest.slice(0, colon);
+  const verb = rest.slice(colon + 1).trim();
+  if (!SURFACE_NAME_SLUG.test(name)) {
+    throw new WantsParseError(
+      `wants: "${entry}" — surface name "${name}" must be a slug ` +
+        `(alphanumeric, dash, underscore; no slashes or dots).`,
+    );
+  }
+  if (verb !== "read" && verb !== "write") {
+    throw new WantsParseError(
+      `wants: "${entry}" — surface access must be "read" or "write" (got "${verb}").`,
+    );
+  }
+  return { kind: "surface", target: name, access: verb };
 }
 
 /** Parse `env:<service>` / `mcp:<service>` into one service connection. */
@@ -317,6 +368,7 @@ export interface GrantRecord {
 export type GrantMaterial =
   | { kind: "vault"; token: string; mcpUrl: string }
   | { kind: "service"; token: string; inject: ("env" | "mcp")[] }
+  | { kind: "surface"; token: string; remoteUrl: string }
   | { kind: "mcp"; token: string; mcpUrl: string };
 
 /** A failed grants-API call — carries the HTTP status for the caller to branch on. */
@@ -539,12 +591,32 @@ export interface InjectedMcpEntry {
   token: string;
 }
 
+/**
+ * One granted git credential (a surface grant) — the git remote the agent
+ * clones/pushes + the scoped hub token that authenticates it. The token is
+ * injected into `git` via a per-spawn 0600 GIT_ASKPASS (never `.git/config`), so
+ * it never persists on disk beyond the ephemeral workspace (design §6a step 4).
+ */
+export interface GitCredential {
+  /** The git remote — `<hubOrigin>/git/<name>` (the hub git-transport endpoint). */
+  remoteUrl: string;
+  /** The scoped `surface:<name>:<verb>` JWT (Basic `x-access-token:<jwt>` / Bearer). */
+  token: string;
+}
+
 /** The result of resolving an agent's approved grants into spawn-injectable bits. */
 export interface InjectedGrants {
   /** MCP servers to ADD to the existing per-spawn `.mcp.json` (vault + service-mcp). */
   mcpEntries: InjectedMcpEntry[];
   /** Env vars to set for the agent's shell tools (service env injections). */
   env: Record<string, string>;
+  /**
+   * Granted git credentials (surface grants) — the backend wires each into a
+   * per-spawn GIT_ASKPASS + a `PARACHUTE_SURFACE_<NAME>_REMOTE` env var so the
+   * agent can `git clone`/`git push` the surface's repo. Empty for an agent with
+   * no surface grants (today's behavior — no git wiring at all).
+   */
+  gitCredentials: GitCredential[];
 }
 
 /**
@@ -559,6 +631,10 @@ export interface InjectedGrants {
  *   - service material, inject includes `"mcp"`     → the service's MCP server entry
  *       (known-service→URL map; a service with no known MCP logs + SKIPS the mcp
  *       inject, keeping the env one).
+ *   - surface material (`{token, remoteUrl}`)        → a {@link GitCredential} (the
+ *       agent clones/pushes the surface's hub-hosted git repo). NOT an MCP entry +
+ *       NOT an env var — the backend wires it into a per-spawn GIT_ASKPASS + a
+ *       remote-URL env var.
  *   - mcp material (`{token, mcpUrl}`, 4b-2)         → an MCP server entry (the agent
  *       reaches the remote MCP / OAuth resource). An UNAPPROVED mcp grant has no
  *       material — `getMaterial` returns null (404/409), so it's simply absent.
@@ -578,6 +654,7 @@ export async function resolveInjectedGrants(
 ): Promise<InjectedGrants> {
   const mcpEntries: InjectedMcpEntry[] = [];
   const env: Record<string, string> = {};
+  const gitCredentials: GitCredential[] = [];
 
   const grants = await client.listGrants(agent); // throws → caller spawns without grants
   for (const g of grants) {
@@ -617,6 +694,15 @@ export async function resolveInjectedGrants(
       continue;
     }
 
+    if (material.kind === "surface") {
+      // Surface git grant (Phase 2 §6a): the material carries the scoped token +
+      // the git remote. The backend wires it into a per-spawn GIT_ASKPASS + a
+      // `PARACHUTE_SURFACE_<NAME>_REMOTE` env var — NEVER an MCP entry + NEVER
+      // `.git/config`. Just carry it through as a git credential.
+      gitCredentials.push({ remoteUrl: material.remoteUrl, token: material.token });
+      continue;
+    }
+
     if (material.kind === "service") {
       // service material — inject env and/or mcp per the material's `inject` list.
       const service = g.connection.target;
@@ -653,7 +739,7 @@ export async function resolveInjectedGrants(
     );
   }
 
-  return { mcpEntries, env };
+  return { mcpEntries, env, gitCredentials };
 }
 
 /**
@@ -670,8 +756,9 @@ export async function resolveInjectedGrants(
  *     role into a thread unions that role's path-keyed APPROVED grants in.
  *
  * Dedupe rule: MCP entries are deduped by their entry `name` (first source wins);
- * env vars are deduped by var name (first source wins). The legacy `spec.name` source
- * is conventionally first, so a def's own grant wins a name collision with a role's.
+ * env vars are deduped by var name (first source wins); git credentials are deduped
+ * by `remoteUrl` (first source wins). The legacy `spec.name` source is conventionally
+ * first, so a def's own grant wins a collision with a role's.
  *
  * Keys are deduped + processed in order; a duplicate key (e.g. the same role twice in the
  * roles list, or a role key that happens to equal `spec.name`) is fetched ONCE. A single
@@ -686,6 +773,7 @@ export async function resolveInjectedGrantsUnion(
 ): Promise<InjectedGrants> {
   const mcpByName = new Map<string, InjectedMcpEntry>();
   const env: Record<string, string> = {};
+  const gitByRemote = new Map<string, GitCredential>();
   const seenKeys = new Set<string>();
 
   for (const key of keys) {
@@ -710,9 +798,130 @@ export async function resolveInjectedGrantsUnion(
     for (const [varName, value] of Object.entries(injected.env)) {
       if (!(varName in env)) env[varName] = value;
     }
+    for (const cred of injected.gitCredentials) {
+      if (!gitByRemote.has(cred.remoteUrl)) gitByRemote.set(cred.remoteUrl, cred);
+    }
   }
 
-  return { mcpEntries: [...mcpByName.values()], env };
+  return {
+    mcpEntries: [...mcpByName.values()],
+    env,
+    gitCredentials: [...gitByRemote.values()],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Surface git injection — the GIT_ASKPASS credential channel (design §6a step 4)
+// ---------------------------------------------------------------------------
+
+/** POSIX single-quote-escape (for embedding a value inside `'…'` in the script). */
+function shSingleQuoteBody(s: string): string {
+  return s.replace(/'/g, `'\\''`);
+}
+
+/** The git URL path (`/git/<name>`) of a surface remote — used to disambiguate
+ *  tokens when an agent holds grants to MULTIPLE surfaces on the one hub host. */
+function gitRemotePath(remoteUrl: string): string {
+  try {
+    return new URL(remoteUrl).pathname;
+  } catch {
+    return remoteUrl;
+  }
+}
+
+/** The surface name (last `/git/<name>` segment) of a remote, or null. */
+export function surfaceNameFromRemoteUrl(remoteUrl: string): string | null {
+  const segs = gitRemotePath(remoteUrl).split("/").filter((s) => s.length > 0);
+  const last = segs[segs.length - 1];
+  return last && last.length > 0 ? last : null;
+}
+
+/** The `PARACHUTE_SURFACE_<NAME>_REMOTE` env var name for a surface remote. */
+export function surfaceRemoteEnvVar(remoteUrl: string): string | null {
+  const name = surfaceNameFromRemoteUrl(remoteUrl);
+  if (!name) return null;
+  return `PARACHUTE_SURFACE_${name.toUpperCase().replace(/[^A-Z0-9]+/g, "_")}_REMOTE`;
+}
+
+/**
+ * Build the per-spawn GIT_ASKPASS script that feeds a surface-scoped hub token to
+ * `git` on demand — so the token authenticates `git clone`/`git push` WITHOUT ever
+ * landing in `.git/config` or a URL (design §6a step 4). Git invokes the askpass as
+ * `askpass "<prompt>"`; the script answers on stdout:
+ *   - a `Username` prompt → the sentinel `x-access-token` (the hub accepts Basic
+ *     `x-access-token:<jwt>`, GitHub's compat form — see git-transport.ts extractToken);
+ *   - a `Password` prompt → the surface's token.
+ *
+ * SINGLE surface (the common case): any password prompt echoes the one token —
+ * host-keyed, unambiguous. MULTIPLE surfaces share the ONE hub host, so the caller
+ * sets `credential.useHttpPath=true` (see {@link buildSurfaceGitEnv}) which puts the
+ * repo PATH in the prompt; this script then path-matches `…/git/<name>…` to return
+ * the right token (falling back to the first token if no path matches — a graceful,
+ * debuggable 403 rather than a wrong-surface push, never a security hole).
+ *
+ * PURE + testable. The token is single-quoted (a JWT is `[A-Za-z0-9._-]` — never a
+ * quote — but we escape defensively). Empty `creds` → a no-op script (never wired).
+ */
+export function buildGitAskpassScript(creds: GitCredential[]): string {
+  const head = [
+    "#!/bin/sh",
+    "# Parachute surface git credentials — GIT_ASKPASS (per-spawn, 0700, ephemeral).",
+    "# The surface-scoped hub token is echoed on demand only — it NEVER lands in",
+    "# .git/config or a remote URL. Git invokes: askpass \"<prompt>\".",
+    'case "$1" in',
+    "  Username*|username*) printf %s 'x-access-token' ;;",
+    "  *)",
+  ];
+  const tail = ["esac", ""];
+  if (creds.length <= 1) {
+    const tok = creds[0]?.token ?? "";
+    return [...head, `    printf %s '${shSingleQuoteBody(tok)}' ;;`, ...tail].join("\n");
+  }
+  // Multi-surface: match the repo path in the prompt (needs credential.useHttpPath).
+  const inner = ['    case "$1" in'];
+  for (const c of creds) {
+    const path = gitRemotePath(c.remoteUrl);
+    inner.push(`      *'${shSingleQuoteBody(path)}'*) printf %s '${shSingleQuoteBody(c.token)}' ;;`);
+  }
+  inner.push(`      *) printf %s '${shSingleQuoteBody(creds[0]!.token)}' ;;`);
+  inner.push("    esac", "    ;;");
+  return [...head, ...inner, ...tail].join("\n");
+}
+
+/**
+ * Build the env vars that wire a surface-grant holder's `git` to the per-spawn
+ * askpass (design §6a step 4). Returns `{}` for no surface grants (no git wiring —
+ * today's behavior). For ≥1:
+ *   - `GIT_ASKPASS` → the askpass script path; `GIT_TERMINAL_PROMPT=0` (fail closed,
+ *     never block on an interactive prompt);
+ *   - `PARACHUTE_SURFACE_<NAME>_REMOTE` per surface → the clone/push URL, so the
+ *     agent DISCOVERS where to clone (the clone-per-turn model — the agent runs the
+ *     clone itself in its cwd; the daemon pre-clones nothing);
+ *   - for ≥2 surfaces (same hub host, distinct scoped tokens) → `credential.useHttpPath`
+ *     via GIT_CONFIG_* so git includes the repo PATH in the askpass prompt and the
+ *     script can return the RIGHT token per surface. None of these are secrets (the
+ *     token lives only in the askpass file) and none collide with the Claude-auth
+ *     denylist, so they ride the ordinary child-env path.
+ */
+export function buildSurfaceGitEnv(
+  creds: GitCredential[],
+  askpassPath: string,
+): Record<string, string> {
+  if (creds.length === 0) return {};
+  const env: Record<string, string> = {
+    GIT_ASKPASS: askpassPath,
+    GIT_TERMINAL_PROMPT: "0",
+  };
+  for (const c of creds) {
+    const varName = surfaceRemoteEnvVar(c.remoteUrl);
+    if (varName) env[varName] = c.remoteUrl;
+  }
+  if (creds.length >= 2) {
+    env.GIT_CONFIG_COUNT = "1";
+    env.GIT_CONFIG_KEY_0 = "credential.useHttpPath";
+    env.GIT_CONFIG_VALUE_0 = "true";
+  }
+  return env;
 }
 
 /**

--- a/src/grants.ts
+++ b/src/grants.ts
@@ -276,6 +276,12 @@ function parseVaultWant(entry: string, rest: string): ConnectionSpec {
  * tag suffix (surfaces have no tag-scope). The verb is REQUIRED + explicit (like
  * vault): `write` = clone+push, `read` = clone only. write ⊇ read at the git
  * endpoint, so a `write` grant needs no separate read grant to clone.
+ *
+ * The name is NORMALIZED to lowercase (the canonical form): the hub lowercases it too
+ * (admin-agent-grants.ts parseConnectionSpec) so both repos' keys agree, and the hub's
+ * `grantId` slug + minted `surface:<name>:<verb>` scope + `/git/<name>` remote are all
+ * lowercase — surfaces are lowercase-kebab by convention (surface-host registers them
+ * lowercase). Validated case-permissively (SURFACE_NAME_SLUG), then lowercased.
  */
 function parseSurfaceWant(entry: string, rest: string): ConnectionSpec {
   const colon = rest.indexOf(":");
@@ -298,7 +304,7 @@ function parseSurfaceWant(entry: string, rest: string): ConnectionSpec {
       `wants: "${entry}" — surface access must be "read" or "write" (got "${verb}").`,
     );
   }
-  return { kind: "surface", target: name, access: verb };
+  return { kind: "surface", target: name.toLowerCase(), access: verb };
 }
 
 /** Parse `env:<service>` / `mcp:<service>` into one service connection. */
@@ -594,8 +600,9 @@ export interface InjectedMcpEntry {
 /**
  * One granted git credential (a surface grant) — the git remote the agent
  * clones/pushes + the scoped hub token that authenticates it. The token is
- * injected into `git` via a per-spawn 0600 GIT_ASKPASS (never `.git/config`), so
- * it never persists on disk beyond the ephemeral workspace (design §6a step 4).
+ * injected into `git` via a per-spawn 0700 GIT_ASKPASS (private + executable — git
+ * execs it; never `.git/config`), so it never persists on disk beyond the ephemeral
+ * workspace (design §6a step 4).
  */
 export interface GitCredential {
   /** The git remote — `<hubOrigin>/git/<name>` (the hub git-transport endpoint). */

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -276,7 +276,7 @@ export type AgentDefStatus = "enabled" | "pending" | "error" | string;
  */
 export interface ConnectionInfoRow {
   key: string;
-  kind: "vault" | "service" | "mcp";
+  kind: "vault" | "service" | "surface" | "mcp";
   target: string;
   status: "pending" | "approved" | "revoked" | "needs_consent" | string;
   grantId?: string;

--- a/web/ui/src/lib/hub.ts
+++ b/web/ui/src/lib/hub.ts
@@ -256,7 +256,7 @@ export async function ensureDefReloadConnections(
 export interface GrantListing {
   id: string;
   agent: string;
-  connection: { kind: "vault" | "service" | "mcp"; target: string };
+  connection: { kind: "vault" | "service" | "surface" | "mcp"; target: string };
   status: "pending" | "approved" | "revoked" | "needs_consent";
   reason?: string;
   approvedAt?: string;


### PR DESCRIPTION
## Surface Git Transport — Phase 2 (agent half)

Lets a `#agent/role` declare `wants: surface:<name>:write` and — once the operator approves it in the hub — wires the minted `surface:<name>:write` token into the turn's `git`, so the agent can `git clone`/`git push` a surface's hub-hosted repo. This is the exact capability Aaron asked for: "as we define an agent, grant it `surface:<name>:write`."

Paired with the parachute-hub PR (the authority half that mints + governs the grant). Design: `parachute.computer/design/2026-06-30-surface-git-transport.md` §6a. The Linux confinement gate (Phase 0c) is cleared, so non-operator writers are safe.

### What changed
- **`grants.ts`** — `surface` grant kind (`ConnectionSpec`, `parseSurfaceWant`, `connectionKey`, a `GrantMaterial` `{token, remoteUrl}` variant); `InjectedGrants.gitCredentials`; `resolveInjectedGrants` routes surface material to `gitCredentials` (not an MCP entry, not an env var); the union merges by `remoteUrl`. **The one new runtime piece:** `buildGitAskpassScript` + `buildSurfaceGitEnv` (pure, tested) — the per-spawn GIT_ASKPASS credential channel.
- **`backends/programmatic.ts`** — on a turn with surface grants, write a **0700** `git-askpass.sh` beside the ephemeral `.mcp.json` in the PRIVATE workspace (0700 = private + **executable** — git execs the askpass), and set `GIT_ASKPASS` / `GIT_TERMINAL_PROMPT=0` / `PARACHUTE_SURFACE_<NAME>_REMOTE`. Fetched fresh per turn (revocation = next turn).
- **`web/ui`** — add `surface` to the SPA's two connection `kind` unions (type accuracy; a surface-grant management UI is a follow-up).

### Sub-decisions (asked for in the brief)
- **cwd model = CLONE-PER-TURN, performed by the agent.** The daemon injects the credential channel + the remote URL (`PARACHUTE_SURFACE_*_REMOTE`) + egress; the agent runs `git clone` in its writable cwd, edits, pushes. No pre-clone, no `spec.mounts`. Rationale: matches the fetched-fresh / revocation-next-turn discipline (a fresh clone is always current); a push workflow needs no persistent working tree; the sandbox already gives a writable cwd.
- **One token per grant.** `write ⊇ read` at the git endpoint (`git-transport.ts:381-384`) — a write grant clones AND pushes; a read grant mints `surface:<name>:read`. No separate read token (that'd be extra credential surface for zero function).
- **Egress is already covered — no code needed.** The surface git host **is** the hub origin, which is unconditionally in the non-removable egress base (`egress.ts` `baseEgressAllowlist`), so a surface push reaches the hub under `network:"open"` **and** `"restricted"`.

### Security
- The token lives ONLY in the 0700 askpass file (ephemeral workspace) + the child-env indirection — **NEVER** in `.git/config`, a URL, or a vault note. The child-env scrub (Claude-auth trio) is untouched.
- The **role gate** covers surface unchanged: a plain note's `wants:` is inert — only an `#agent/role` grants capability (a note can REQUEST, never GRANT). Tested.
- Least-privilege: the token is scoped `surface:<name>:<verb>` for exactly one surface.

### Multi-surface note
An agent with grants to 2+ surfaces (same hub host, distinct scoped tokens): `buildSurfaceGitEnv` sets `credential.useHttpPath=true` so git includes the repo path in the askpass prompt, and the script path-matches to return the right token (fallback = first token → a graceful 403, never a wrong-surface push). The common single-surface case needs none of this (host-keyed, unambiguous).

### Tests
parse (form/malformed/slug-traversal), connectionKey, resolveInjectedGrants surface→gitCredential (pending→absent), union dedupe-by-remoteUrl, the **role gate for surface**, `buildGitAskpassScript` (single/multi + **actually RUN through /bin/sh** — selects the right token per path), `buildSurfaceGitEnv` (single = no useHttpPath; multi = useHttpPath; **token never in the env**), and a programmatic turn writing the **0700** askpass + git env with the **token absent from the env**.

**Gate:** `bun run test` (typecheck + `bun test ./src/`) — 1441 pass / 0 fail; web/ui vitest 160/160 + SPA typecheck clean; biome clean. Version → `0.2.4-rc.1`.

Do NOT merge — paired with the parachute-hub Phase 2 PR; awaiting review + Aaron.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T6HAzWsgiJy4ndsWSCWY5S