### PR TITLE
feat(agent): a #agent/thread carries capability directly — register its wants as name-keyed pending grants

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/agent",
-  "version": "0.2.4-rc.1",
+  "version": "0.2.4-rc.2",
   "description": "Vault-native agents for Claude Code — a #agent/definition note + an inbound message becomes a sandboxed claude turn; the reply is written back as a note. Messaging gateway on :1941.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/src/agent-defs.test.ts
+++ b/src/agent-defs.test.ts
@@ -2007,3 +2007,157 @@ describe("AgentDefRegistry — dual-discovery (Phase 4a)", () => {
     expect(detailed[0]!.source).toBe("def");
   });
 });
+
+// ---------------------------------------------------------------------------
+// AgentDefRegistry — thread grant registration (a thread carries capability
+// DIRECTLY — the parity the retired `#agent/definition` had). Registers the
+// thread's `wants:` as PENDING grants keyed by the AGENT NAME on instantiate,
+// mirroring the def path's resolveStatusWithGrants + reconcile-GC discipline.
+// ---------------------------------------------------------------------------
+
+describe("AgentDefRegistry — thread grant registration + reconcile-GC", () => {
+  const SURFACE: ConnectionSpec = { kind: "surface", target: "foo", access: "write" };
+
+  test("a thread's `wants:` register as PENDING grants keyed by the AGENT NAME (status pending)", async () => {
+    const { deps } = recorderDeps();
+    const registered: Array<{ agent: string; connection: ConnectionSpec }> = [];
+    const reconciled: Array<{ agent: string; liveConnections: ConnectionSpec[] }> = [];
+    const grants = fakeGrantsClient({ registered, reconciled }); // all default "pending"
+    const fetchFn = dualFetch({
+      threads: [{ id: "Threads/eco/eco", path: "Threads/eco/eco", metadata: { agent: "eco", wants: "surface:foo:write" } }],
+    });
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn, grants, discovery: "thread" });
+    await reg.loadAll();
+    // Registered under the AGENT NAME (`eco` = metadata.agent), NOT the note path — symmetric
+    // with the injection union's `spec.name` source, so an approved grant injects at spawn.
+    expect(registered).toEqual([{ agent: "eco", connection: SURFACE }]);
+    // Nothing approved yet → status pending, listing the want key; still source=thread + live.
+    const detail = reg.listDetailed().find((d) => d.name === "eco")!;
+    expect(detail.source).toBe("thread");
+    expect(detail.status).toBe("pending");
+    expect(detail.pending).toEqual(["surface:foo:write"]);
+    expect(detail.connections).toEqual([
+      { key: "surface:foo:write", kind: "surface", target: "foo", status: "pending", grantId: "g-surface:foo:write" },
+    ]);
+    // Reconcile-GC ran from the confident live set, keyed by the NAME (its own partition).
+    expect(reconciled).toEqual([{ agent: "eco", liveConnections: [SURFACE] }]);
+  });
+
+  test("status flips to `enabled` once every thread want is approved", async () => {
+    const { deps } = recorderDeps();
+    const grants = fakeGrantsClient({ statusByKey: { [connectionKey(SURFACE)]: "approved" } });
+    const fetchFn = dualFetch({
+      threads: [{ id: "Threads/eco/eco", path: "Threads/eco/eco", metadata: { agent: "eco", wants: "surface:foo:write" } }],
+    });
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn, grants, discovery: "thread" });
+    await reg.loadAll();
+    expect(reg.listDetailed().find((d) => d.name === "eco")!.status).toBe("enabled");
+  });
+
+  test("a wants-free thread stays `enabled` with no grant traffic (byte-identical to before)", async () => {
+    const { deps } = recorderDeps();
+    const registered: Array<{ agent: string; connection: ConnectionSpec }> = [];
+    const reconciled: Array<{ agent: string; liveConnections: ConnectionSpec[] }> = [];
+    const grants = fakeGrantsClient({ registered, reconciled });
+    const fetchFn = dualFetch({ threads: [{ id: "Threads/eco/eco", metadata: { agent: "eco" } }] });
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn, grants, discovery: "thread" });
+    await reg.loadAll();
+    const detail = reg.listDetailed().find((d) => d.name === "eco")!;
+    expect(detail.status).toBe("enabled");
+    expect(detail.connections).toEqual([]);
+    // No wants → resolveStatusWithGrants short-circuits: NO register PUT, but the clean-load
+    // reconcile still runs (prunes any leftover grant from a want it no longer declares).
+    expect(registered).toEqual([]);
+    expect(reconciled).toEqual([{ agent: "eco", liveConnections: [] }]);
+  });
+
+  test("removing a thread want → reconcile-GC prunes to the reduced set (keyed by name)", async () => {
+    const { deps } = recorderDeps();
+    const reconciled: Array<{ agent: string; liveConnections: ConnectionSpec[] }> = [];
+    const grants = fakeGrantsClient({ reconciled });
+    // A single note object we MUTATE between reloads (dualFetch serves it by id).
+    const note = {
+      id: "Threads/eco/eco",
+      path: "Threads/eco/eco",
+      metadata: { agent: "eco", wants: "surface:foo:write, env:github" },
+    };
+    const reg = new AgentDefRegistry(deps, {
+      bindings: [binding],
+      fetchFn: dualFetch({ byId: { "Threads/eco/eco": note } }),
+      grants,
+      discovery: "thread",
+    });
+    await reg.reloadThread("default", "Threads/eco/eco", "created");
+    // First load reconciled to BOTH wants (its confident live set).
+    expect(reconciled.at(-1)!.liveConnections.map((c) => c.target).sort()).toEqual(["foo", "github"]);
+    // Drop the env want, reload → reconcile to just the surface (the hub prunes env:github).
+    note.metadata.wants = "surface:foo:write";
+    reconciled.length = 0;
+    await reg.reloadThread("default", "Threads/eco/eco", "updated");
+    expect(reconciled).toEqual([{ agent: "eco", liveConnections: [SURFACE] }]);
+  });
+
+  test("SAFETY: a malformed thread `wants:` → SKIPPED, NEVER registers or reconciles (approved grants NOT nuked)", async () => {
+    const { deps } = recorderDeps();
+    const registered: Array<{ agent: string; connection: ConnectionSpec }> = [];
+    const reconciled: Array<{ agent: string; liveConnections: ConnectionSpec[] }> = [];
+    const grants = fakeGrantsClient({ registered, reconciled });
+    const fetchFn = dualFetch({
+      // `vault:research` is malformed (a vault want needs a verb) → parseThreadSpec throws.
+      threads: [{ id: "Threads/bad/bad", metadata: { agent: "bad", wants: "vault:research" } }],
+    });
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn, grants, discovery: "thread" });
+    const n = await reg.loadAll();
+    expect(n).toBe(0); // not instantiated
+    expect(reg.listDetailed()).toHaveLength(0);
+    // THE SAFETY CASE: a parse failure presents NO confident live set → we never register and
+    // never reconcile, so a transient/malformed edit can't nuke this agent's approved grants.
+    expect(registered).toEqual([]);
+    expect(reconciled).toEqual([]);
+  });
+
+  test("a thread deduped by a same-name DEF registers NOTHING (def owns the name partition)", async () => {
+    const { deps } = recorderDeps();
+    const registered: Array<{ agent: string; connection: ConnectionSpec }> = [];
+    const reconciled: Array<{ agent: string; liveConnections: ConnectionSpec[] }> = [];
+    const grants = fakeGrantsClient({ registered, reconciled });
+    const fetchFn = dualFetch({
+      defs: [{ id: "Agents/eco", content: "", metadata: { name: "eco" } }], // no wants
+      // The thread declares a want — but it dedups against the def (def wins in `both`).
+      threads: [{ id: "Threads/eco/eco", path: "Threads/eco/eco", metadata: { agent: "eco", wants: "surface:foo:write" } }],
+    });
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn, grants }); // both
+    await reg.loadAll();
+    expect(reg.listDetailed().map((d) => `${d.name}:${d.source}`)).toEqual(["eco:def"]);
+    // The DEDUPED thread never reaches registration — so it can't register or reconcile the
+    // `eco` name partition (which the def owns). Only the def's clean-load reconcile ([] here) ran.
+    expect(registered).toEqual([]);
+    expect(reconciled).toEqual([{ agent: "eco", liveConnections: [] }]);
+  });
+
+  test("thread wants (keyed by NAME) + a role's wants (keyed by PATH) are SEPARATE partitions", async () => {
+    const { deps } = recorderDeps();
+    const registered: Array<{ agent: string; connection: ConnectionSpec }> = [];
+    const reconciled: Array<{ agent: string; liveConnections: ConnectionSpec[] }> = [];
+    const grants = fakeGrantsClient({ registered, reconciled });
+    const thread = { id: "Threads/eco/eco", path: "Threads/eco/eco", metadata: { agent: "eco", wants: "surface:foo:write" } };
+    const fetchFn = dualFetch({
+      threads: [thread],
+      byId: {
+        // A role note the operator loads into the thread — its own PATH-keyed capability layer.
+        "Roles/gh": { id: "Roles/gh", content: "role", metadata: { wants: "env:github" }, ...( { tags: ["agent/role"] } as Record<string, unknown> ) } as never,
+      },
+    });
+    const reg = new AgentDefRegistry(deps, { bindings: [binding], fetchFn, grants, discovery: "thread" });
+    await reg.loadAll(); // thread → registers surface:foo:write keyed by "eco"
+    expect(await reg.reconcileRole("default", "Roles/gh", "created")).toBe("reconciled"); // role → keyed by its path
+    const roleKey = rolePathKey("Roles/gh");
+    const GH: ConnectionSpec = { kind: "service", target: "github", inject: ["env"] };
+    // The thread's want landed under the NAME; the role's under its PATH — distinct partitions,
+    // neither clobbers the other (the injection union at spawn re-unions both, spec.name first).
+    expect(registered).toContainEqual({ agent: "eco", connection: SURFACE });
+    expect(registered).toContainEqual({ agent: roleKey, connection: GH });
+    expect(reconciled).toContainEqual({ agent: "eco", liveConnections: [SURFACE] });
+    expect(reconciled).toContainEqual({ agent: roleKey, liveConnections: [GH] });
+  });
+});

--- a/src/agent-defs.ts
+++ b/src/agent-defs.ts
@@ -528,12 +528,29 @@ export interface ParsedThreadSpec {
    *  SKIPS a `disabled` thread. */
   agentStatus: AgentEnableStatus;
   /**
-   * Structured `wants:` declared on the thread (PARSED + surfaced for parity), if any.
-   * NOT registered as grants in Phase 4a — only a `#agent/role` carries capability (the
-   * security layer, DESIGN §"Roles carry capability"); a thread's `wants:` is
-   * informational. Empty for the live agents.
+   * Structured `wants:` declared on the thread, if any. REGISTERED as pending grants
+   * keyed by the agent NAME on instantiate (a thread carries capability DIRECTLY —
+   * restoring the parity the retired `#agent/definition` had), exactly like a def and
+   * SYMMETRIC with the injection union's `spec.name` source. Roles (`#agent/role`,
+   * PATH-keyed) remain the separate composable/curated capability layer. Empty for the
+   * live agents.
    */
   wants: ConnectionSpec[];
+}
+
+/**
+ * The minimal grant-bearing shape the registry's grant registration + reconcile-GC
+ * ({@link AgentDefRegistry.resolveStatusWithGrants} + `reconcileLiveKeys`) operate on:
+ * an agent NAME plus its declared connections. BOTH a `#agent/definition`
+ * ({@link ParsedAgentDef}) and a `#agent/thread` ({@link ParsedThreadSpec}, passing
+ * `declaredConnections: []`) satisfy it — a thread's grants key by its agent name,
+ * exactly like a def's. (Roles are the separate PATH-keyed layer — {@link
+ * AgentDefRegistry.reconcileRole} — never routed through here.)
+ */
+interface GrantBearingSpec {
+  name: string;
+  wants: ConnectionSpec[];
+  declaredConnections: string[];
 }
 
 /**
@@ -614,8 +631,10 @@ export function parseThreadSpec(
   const rawEnable = metaStr(meta.agent_status);
   const agentStatus: AgentEnableStatus = rawEnable === "disabled" ? "disabled" : "enabled";
 
-  // `wants:` — PARSED for parity/surfacing, NOT registered as grants in 4a (only a role
-  // grants capability). A malformed value is an ERROR (mirrors the def discipline).
+  // `wants:` — PARSED here, REGISTERED as pending grants keyed by the agent name on
+  // instantiate (a thread carries capability directly, like a def). A malformed value is
+  // an ERROR (mirrors the def discipline) — so the instantiate path skips register+reconcile
+  // and never presents a stale/empty live set that would nuke approved grants.
   let wants: ConnectionSpec[];
   try {
     wants = parseWants(meta.wants);
@@ -641,7 +660,10 @@ export function parseThreadSpec(
  * (`resolveConnectionStatus` in grants.ts) — `enabled` only once every connection is
  * approved. This pure function is the no-hub fallback + the legacy-`uses:` path.
  */
-export function resolveDefStatus(def: ParsedAgentDef): {
+export function resolveDefStatus(def: {
+  declaredConnections: string[];
+  wants: ConnectionSpec[];
+}): {
   status: AgentDefStatus;
   pending?: string[];
 } {
@@ -1616,9 +1638,17 @@ export class AgentDefRegistry {
   /**
    * Reload ONE `#agent/thread` note by id (the reactive THREAD-discovery path — a thread-
    * watch trigger says this note changed; Phase 4a). The thread analogue of {@link reload},
-   * but ADDITIVE: present + enabled + not-deduped → (re)instantiate; deleted/404 → deregister
-   * ONLY the thread-sourced agent at this note's key (a def-sourced same-name agent keyed by a
-   * DIFFERENT note is left intact). NO grant-GC (threads register no grants — only roles do).
+   * but ADDITIVE: present + enabled + not-deduped → (re)instantiate ({@link instantiateThread}
+   * registers the thread's `wants:` + reconcile-GCs to the declared set, so removing a want on
+   * a later turn prunes it); deleted/404 → deregister ONLY the thread-sourced agent at this
+   * note's key (a def-sourced same-name agent keyed by a DIFFERENT note is left intact).
+   *
+   * The DELETE/404 branch does NOT prune the thread's name-keyed grants: a proper removed-thread
+   * GC needs a thread SEEN-SET + a confident removed-thread diff (mirroring {@link pruneRemovedDefs}
+   * — the poll, not the reactive path, is the real deletion-convergence path since the vault has no
+   * `deleted` trigger). That is a separate, larger change; the instantiate-path register + GC here
+   * is the parity restoration. A deleted thread's approved grants persist until then (a cleanliness
+   * gap, never an escalation — grants are always operator-approved).
    *
    * DISCOVERY-MODE GATE: a no-op in `def` mode (threads aren't a source then). DEDUP: in
    * `both` mode a thread whose name a def already registered is skipped (def wins). DISABLE:
@@ -2068,13 +2098,20 @@ export class AgentDefRegistry {
    *   2. agent_status: skip a thread whose `metadata.agent_status` is `disabled` (and tear
    *      down a previously thread-sourced-live agent that flips to disabled). DISTINCT from
    *      `metadata.status` (the turn outcome) — never read here.
-   *   3. NO status stamp + NO grant registration: we never write the thread note's metadata
-   *      (`status` is the turn outcome, owned by the worker) and threads carry no capability
-   *      (only `#agent/role` grants — the security layer). So this is read-only on the vault.
+   *   3. NO status stamp: we never write the thread note's metadata (`status` is the turn
+   *      outcome, owned by the worker) — read-only on the vault. But we DO register the
+   *      thread's `wants:` as PENDING grants keyed by the agent name (a thread carries
+   *      capability directly — the parity the retired `#agent/definition` had), mirroring
+   *      the def path's {@link resolveStatusWithGrants} + reconcile-GC. Registration is
+   *      hub-side (`PUT /admin/grants`), not a vault write; the operator still APPROVES each
+   *      grant (approval is the security boundary — this is not self-escalation). Roles
+   *      (`#agent/role`, PATH-keyed) stay the separate composable/curated layer.
    *
    * Returns true on a successful (re)registration. A parse failure / dedup-skip / disabled
-   * thread returns false (logged, no vault write). An instantiate failure leaves any prior
-   * registration intact (we don't tear down a working agent on a transient failure).
+   * thread returns false (logged, no vault write, NO grant register/reconcile — so a
+   * transient error never presents a stale/empty live set that nukes approved grants). An
+   * instantiate failure leaves any prior registration intact (we don't tear down a working
+   * agent on a transient failure).
    */
   private async instantiateThread(
     vault: string,
@@ -2125,23 +2162,44 @@ export class AgentDefRegistry {
       return false;
     }
 
-    // A thread-sourced agent has no def status flow → status `enabled` (it's live), no
-    // pending/connections (threads register no grants — roles are the capability layer).
+    // A thread carries capability DIRECTLY (the parity the retired `#agent/definition`
+    // had): register its `wants:` as PENDING grants keyed by the AGENT NAME + derive
+    // status from the hub's grant statuses, mirroring the def path's {@link
+    // resolveStatusWithGrants}. `declaredConnections: []` — a thread has no legacy `uses:`.
+    // Keyed by the name (`parsed.name` = `metadata.agent`), SYMMETRIC with the injection
+    // union's `spec.name` source (resolveInjectedGrantsUnion), so an approved thread grant
+    // injects at spawn. No `wants:` / no grants client → status `enabled` (byte-identical
+    // to before for the wants-free live agents). ONLY reached AFTER a confident parse +
+    // setup (a dedup/disabled/parse/setup failure returned above WITHOUT registering).
+    const threadAgent: GrantBearingSpec = {
+      name: parsed.name,
+      wants: parsed.wants,
+      declaredConnections: [],
+    };
+    const { status, pending, connections } = await this.resolveStatusWithGrants(threadAgent);
     this.live.set(key, {
       vault,
       noteId: note.id,
       name: parsed.name,
-      status: "enabled",
+      status,
       backend: parsed.spec.backend ?? "programmatic",
       mode: parsed.spec.mode ?? "single-threaded",
       systemPromptPreview: "", // identity composes at turn time — no prompt body here.
-      pending: [],
+      pending: pending ?? [],
       wants: parsed.wants.map((c) => connectionKey(c)),
-      connections: [],
+      connections,
       ...(parsed.spec.model ? { model: parsed.spec.model } : {}),
       source: "thread",
     });
-    console.log(`agent-defs: instantiated "${parsed.name}" from thread ${note.id} in "${vault}" (source=thread).`);
+    // Grant-GC (#96): a CLEAN successful thread load is a CONFIDENT live set, so prune any
+    // grant the thread no longer declares (e.g. a `wants:` entry removed on a later turn).
+    // SAFETY: only reached AFTER a successful parse + setup AND only when this thread
+    // EXCLUSIVELY owns the name (the dedup gate above returned false otherwise) — so this
+    // reconcile can never nuke a def's or another source's grants for the same name, and a
+    // transient parse/setup failure returns above without reconciling. Keyed by the name,
+    // its OWN partition — a role's PATH-keyed grants are untouched.
+    await this.reconcileLiveKeys(threadAgent);
+    console.log(`agent-defs: instantiated "${parsed.name}" from thread ${note.id} in "${vault}" (status=${status}, source=thread).`);
     return true;
   }
 
@@ -2157,54 +2215,61 @@ export class AgentDefRegistry {
 
   /**
    * Prune the agent's grants down to its CURRENTLY-declared connections (#96 grant-GC,
-   * the clean-load case). POSTs reconcile with the live connection SPECS (`def.wants`);
+   * the clean-load case). POSTs reconcile with the live connection SPECS (`agent.wants`);
    * the hub re-derives each key with its own connectionKey and tears down + removes every
-   * grant NOT in that set (e.g. a removed want). A def with no `wants:` sends an empty
+   * grant NOT in that set (e.g. a removed want). An agent with no `wants:` sends an empty
    * set, which prunes any leftover grant from a prior `wants:` it no longer declares.
    * Best-effort: no grants client → no-op; a reconcile failure logs a warning and never
-   * throws out of the load path.
+   * throws out of the load path. Shared by the def load path AND the thread instantiate
+   * path — both key by the agent NAME (`agent.name`); a thread's grants are ITS OWN
+   * name-keyed partition, never a role's (roles are PATH-keyed — {@link reconcileRole}).
    */
-  private async reconcileLiveKeys(def: ParsedAgentDef): Promise<void> {
+  private async reconcileLiveKeys(agent: GrantBearingSpec): Promise<void> {
     if (!this.grants) return;
-    // Pass the live connection SPECS (def.wants) — the hub derives the keys with
+    // Pass the live connection SPECS (agent.wants) — the hub derives the keys with
     // its own connectionKey. (Sending keys we computed via grants.ts connectionKey
     // would diverge from the hub's for service/tagged/mcp grants → wrong prunes.)
     try {
-      const { pruned } = await this.grants.reconcileGrants(def.name, def.wants);
+      const { pruned } = await this.grants.reconcileGrants(agent.name, agent.wants);
       if (pruned > 0) {
-        console.log(`agent-defs: pruned ${pruned} stale grant(s) for "${def.name}".`);
+        console.log(`agent-defs: pruned ${pruned} stale grant(s) for "${agent.name}".`);
       }
     } catch (err) {
       console.warn(
-        `agent-defs: reconciling grants for "${def.name}" failed (continuing): ${(err as Error).message}`,
+        `agent-defs: reconciling grants for "${agent.name}" failed (continuing): ${(err as Error).message}`,
       );
     }
   }
 
   /**
-   * Resolve a def's status, registering its `wants:` connections as PENDING grants
+   * Resolve an agent's status, registering its `wants:` connections as PENDING grants
    * when a grants client is wired (4b). For each declared connection: `PUT
    * /admin/grants {agent, connection}` (idempotent upsert), collect the returned
    * status, then derive `enabled` (every connection approved) vs `pending` (listing
    * the unapproved connection keys). Legacy `uses:` names are appended to `pending`
    * (they have no grants flow — informational only).
    *
+   * Keys every grant by `agent.name`. Shared by a `#agent/definition` (name = its
+   * `metadata.name`) AND a `#agent/thread` (name = its `metadata.agent`, `declaredConnections`
+   * empty) — both carry capability keyed by their agent name (the injection union reads the
+   * same `spec.name` source). Roles are the separate PATH-keyed layer ({@link reconcileRole}).
+   *
    * Best-effort + non-fatal: NO grants client, NO `wants:`, or a registration failure
    * all fall back to {@link resolveDefStatus} (a connection that couldn't register
-   * counts as unapproved → the def is `pending`, not `error` — the agent still runs
+   * counts as unapproved → the agent is `pending`, not `error` — it still runs
    * own-vault, the operator can retry the hub). A single connection's PUT failing is
    * logged + that connection counts as unapproved; the others still register.
    */
   private async resolveStatusWithGrants(
-    def: ParsedAgentDef,
+    agent: GrantBearingSpec,
   ): Promise<{ status: AgentDefStatus; pending?: string[]; connections: ConnectionInfo[] }> {
-    if (!this.grants || def.wants.length === 0) {
+    if (!this.grants || agent.wants.length === 0) {
       // No hub wiring / no structured connections → the pure fallback. The connections
       // list is still surfaced (status `pending`, NO grant id) so the ops panel can
       // list the agent's declared `mcp:` connections + show the degraded hint when
       // there's nothing to Connect against (no grant could be resolved here).
-      const fallback = resolveDefStatus(def);
-      const connections: ConnectionInfo[] = def.wants.map((c) => ({
+      const fallback = resolveDefStatus(agent);
+      const connections: ConnectionInfo[] = agent.wants.map((c) => ({
         key: connectionKey(c),
         kind: c.kind,
         target: c.target,
@@ -2215,14 +2280,14 @@ export class AgentDefRegistry {
     const grants = this.grants;
     const statusByKey = new Map<string, string>();
     // Per-connection grant info (id + status) for the ops panel — keyed by connectionKey
-    // so it lines up with the def's wants. The grant id comes FROM the hub (registerGrant
+    // so it lines up with the agent's wants. The grant id comes FROM the hub (registerGrant
     // is an idempotent upsert that echoes the existing grant's id + current status); we
     // never derive it client-side (the hub's id-slug impl must not be duplicated).
     const infoByKey = new Map<string, ConnectionInfo>();
-    for (const conn of def.wants) {
+    for (const conn of agent.wants) {
       const key = connectionKey(conn);
       try {
-        const rec = await grants.registerGrant(def.name, conn);
+        const rec = await grants.registerGrant(agent.name, conn);
         statusByKey.set(key, rec.status);
         infoByKey.set(key, {
           key,
@@ -2237,12 +2302,12 @@ export class AgentDefRegistry {
         // Surface it with status `pending` + no grant id (the panel shows it un-Connectable).
         infoByKey.set(key, { key, kind: conn.kind, target: conn.target, status: "pending" });
         console.warn(
-          `agent-defs: registering grant for "${def.name}" (${key}) failed ` +
+          `agent-defs: registering grant for "${agent.name}" (${key}) failed ` +
             `(treating as pending): ${(err as Error).message}`,
         );
       }
     }
-    const connections = def.wants.map(
+    const connections = agent.wants.map(
       (c) =>
         infoByKey.get(connectionKey(c)) ?? {
           key: connectionKey(c),
@@ -2251,9 +2316,9 @@ export class AgentDefRegistry {
           status: "pending",
         },
     );
-    const resolved = resolveConnectionStatus(def.wants, statusByKey);
+    const resolved = resolveConnectionStatus(agent.wants, statusByKey);
     // Surface legacy `uses:` names alongside the structured pending keys (no grant flow).
-    const pending = [...(resolved.pending ?? []), ...def.declaredConnections];
+    const pending = [...(resolved.pending ?? []), ...agent.declaredConnections];
     if (resolved.status === "enabled" && pending.length === 0) {
       return { status: "enabled", connections };
     }

--- a/src/grants.test.ts
+++ b/src/grants.test.ts
@@ -835,6 +835,20 @@ describe("resolveInjectedGrantsUnion — union of def key + role keys", () => {
     expect(fromUnion.env).toEqual({ GITHUB_TOKEN: "GHTOK" });
   });
 
+  test("a thread's OWN approved want (keyed by its agent name) injects — no roles needed", async () => {
+    // The spawn-time call for a thread that carries capability directly + loads no role:
+    // resolveInjectedGrantsUnion(grants, [spec.name]). The want was registered keyed by the
+    // agent NAME (see agent-defs instantiateThread), so it injects here keyed by the SAME name.
+    const client = multiAgentClient({
+      byAgent: {
+        eco: [{ id: "s1", connection: { kind: "surface", target: "brain", access: "write" }, status: "approved" }],
+      },
+      material: { s1: { kind: "surface", token: "SURFTOK", remoteUrl: "https://hub/git/brain" } },
+    });
+    const out = await resolveInjectedGrantsUnion(client, ["eco"]);
+    expect(out.gitCredentials).toEqual([{ remoteUrl: "https://hub/git/brain", token: "SURFTOK" }]);
+  });
+
   test("a thread loading ONE role → def grants UNIONED with the role's path-keyed grants", async () => {
     const roleKey = rolePathKey("Roles/github");
     const client = multiAgentClient({


### PR DESCRIPTION
## What

Restore the capability parity the retired `#agent/definition` had: a `#agent/thread` now **registers its own `wants:` as pending grants keyed by the agent name**, so a thread carries capability directly.

The threads-only model (#174–#178) made a thread *be* the agent, but `parseThreadSpec` left a thread's `wants:` **informational only** (`agent-defs.ts` "parsed for parity, not registered"; "threads register no grants — only roles do"). That was a regression: the retired `#agent/definition` *did* register its own wants keyed by the agent name. Only `#agent/role` (path-keyed) registered.

## Where the registration hooks in

`AgentDefRegistry.instantiateThread` — after a successful parse + `setupAndRegister`, it now:
1. `resolveStatusWithGrants({ name, wants, declaredConnections: [] })` — registers each want as a **pending** grant keyed by `parsed.name` (= `metadata.agent`) + derives status (`enabled` iff all approved, else `pending`), exactly like the def load path.
2. sets the live entry with the real `status` / `pending` / `connections` (was hardcoded `enabled` / `[]`).
3. `reconcileLiveKeys(threadAgent)` — the #96 grant-GC, reconciling to the thread's currently-declared wants.

The injection side was **already** correct: `resolveInjectedGrantsUnion(grants, [spec.name, ...roleKeys])` unions over `spec.name`, so an approved thread grant injects at spawn. **This is a registration-only change.** `resolveStatusWithGrants` / `reconcileLiveKeys` / `resolveDefStatus` generalize from `ParsedAgentDef` to a small `GrantBearingSpec` so a def and a thread share one path.

## Safety (mirrors the def discipline exactly)

- **Pending, not auto-granted** — the operator still approves each grant. Approval is the security boundary; this is not self-escalation. Roles remain the curated/shared layer, coexisting.
- **Reconcile-GC only from a confident live set** — register + reconcile run *after* a clean parse + setup, and *only when the thread exclusively owns the name* (the dedup gate returns `false` for a def-owned/other-source name **before** any grant traffic). A malformed `wants:` (`parseThreadSpec` throws `AgentDefParseError`) or a setup failure returns before register/reconcile, so a transient error can never present a stale/empty set that nukes approved grants.
- **Name partition, not role partition** — keyed by the agent name; a role's PATH-keyed grants (`reconcileRole`) are untouched. Injection dedups thread-own vs role wants with `spec.name` first (existing behavior, verified not re-implemented).
- **Disabled threads** register nothing (existing gate, unchanged).

## Not covered (documented follow-up)

A proper removed-thread grant GC on note **deletion** needs a thread seen-set + confident removed-thread diff (mirroring `pruneRemovedDefs` — the poll is the real deletion path since the vault has no `deleted` trigger). That is a separate, larger change; a deleted thread's approved grants persist until then — a cleanliness gap, never an escalation (grants are always operator-approved). Documented on `reloadThread`.

## Tests

New `agent-defs.test.ts` block + one `grants.test.ts` injection test:
- thread `wants:` register keyed by the **agent name**; status `pending`; connections surfaced with hub grant ids
- status → `enabled` once approved
- wants-free thread stays `enabled` with **no** register PUT (byte-identical to before)
- removing a want → reconcile-GC prunes to the reduced set (keyed by name)
- **safety:** malformed `wants:` → skipped, **never** register/reconcile (approved grants not nuked)
- a def-deduped thread registers nothing (def owns the name partition)
- thread name-partition + role path-partition coexist (neither clobbers)
- a thread's approved name-keyed want injects via `resolveInjectedGrantsUnion([name])`

## Gates

- `bun test ./src/` — **1450 pass, 0 fail** (the daemon gate; the `web/ui/src/` browser tests that fail under a loose `src/` glob are pre-existing + DOM-dependent, run via `test:spa`)
- `bun run typecheck` — clean
- `bun run lint` — exit 0 (2 pre-existing `noExplicitAny` warnings in `src/transports/vault.test.ts`, not touched here)

Version: `0.2.4-rc.1` → `0.2.4-rc.2`. rc tag pushed on merge (not here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T6HAzWsgiJy4ndsWSCWY5S