### PR TITLE
fix(agent-ui): approvable surface/vault/service grants — Approve button for thread-carried grants

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/agent",
-  "version": "0.2.4-rc.2",
+  "version": "0.2.4-rc.3",
   "description": "Vault-native agents for Claude Code — a #agent/definition note + an inbound message becomes a sandboxed claude turn; the reply is written back as a note. Messaging gateway on :1941.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/web/ui/src/routes/Agents.tsx
+++ b/web/ui/src/routes/Agents.tsx
@@ -344,6 +344,14 @@ export function AgentDetail({
   const def = agent.def;
   // Edit/delete are only meaningful for a vault-native def (it has a note to mutate).
   const noteId = def?.noteId;
+  // "Pending approval" shows ONLY the legacy `uses:` names (raw strings with no grant to
+  // approve). Structured `wants:` connections are rendered as actionable rows below —
+  // mcp via ConnectionsSection (OAuth / paste-token), vault / service / surface via
+  // GrantsSection (simple approve) — so we drop them from the tag list to avoid showing a
+  // grant twice (once inert, once approvable). `connection.key` == the pending string for a
+  // structured want, so a set-difference isolates the legacy names.
+  const connectionKeys = new Set((def?.connections ?? []).map((c) => c.key));
+  const legacyPending = (def?.pending ?? []).filter((p) => !connectionKeys.has(p));
   const [mode, setMode] = useState<"view" | "edit" | "delete">("view");
 
   // Drop back to the read view whenever the selected agent changes.
@@ -423,11 +431,11 @@ export function AgentDetail({
             <p className="dim">Own-vault only — no extra connections requested.</p>
           )}
 
-          {def.pending.length > 0 ? (
+          {legacyPending.length > 0 ? (
             <>
               <h3>Pending approval</h3>
               <div className="tag-list">
-                {def.pending.map((p) => (
+                {legacyPending.map((p) => (
                   <span key={p} className="tag">
                     {p}
                   </span>
@@ -439,6 +447,12 @@ export function AgentDetail({
           {noteId ? (
             <ConnectionsSection noteId={noteId} def={def} onChanged={onChanged} />
           ) : null}
+
+          {/* Vault / service / surface grants — the SIMPLE-approve kinds (no OAuth). This is
+              what makes a thread-carried `surface:` grant approvable; it renders nothing when
+              there are no non-mcp connections. NOT noteId-gated: approve needs only the hub
+              grant id (which a thread-sourced agent carries), not a note to mutate. */}
+          <GrantsSection def={def} onChanged={onChanged} />
         </>
       ) : (
         <p className="dim" data-testid="detail-no-def">
@@ -1081,6 +1095,154 @@ export function ConnectionsSection({
 function connectErrMessage(err: unknown): string {
   if (err instanceof HubError) return err.message;
   return (err as Error).message;
+}
+
+// ---------------------------------------------------------------------------
+// GRANTS — the SIMPLE-approve connection kinds (vault / service / surface). Unlike an
+// mcp server (OAuth dance / static bearer, handled by ConnectionsSection above), these
+// approve with a bare cookie'd POST to the hub: `approveAgentGrant(grantId)` (empty body)
+// → the hub mints + flips the grant `approved`, no token, no redirect. This is the path
+// a thread-carried `surface:<name>:<access>` want takes (registered as a PENDING grant
+// keyed by the agent name); before this it rendered as an inert "Pending approval" tag
+// with no Approve button, so an operator couldn't approve it. The grant id comes FROM the
+// daemon (`connection.grantId`), never derived here; same-origin credentials are the hub's
+// CSRF belt (approveAgentGrant sets `credentials: "include"`) — no auth is weakened.
+// ---------------------------------------------------------------------------
+
+/**
+ * The connections to render in the simple-approve GRANTS section: every non-mcp
+ * connection (vault / service / surface). mcp is EXCLUDED — it has its own section
+ * (its OAuth / paste-token flow). Approved rows are kept so the operator sees the full
+ * picture (a "Connected" pill, no button). Empty for an older daemon that omits
+ * `def.connections` (nothing carries a grant id to approve).
+ */
+export function simpleApprovalRows(def: AgentDefRow): ConnectionInfoRow[] {
+  return (def.connections ?? []).filter((c) => c.kind !== "mcp");
+}
+
+/**
+ * The per-agent GRANTS section — vault / service / surface connections approved with a
+ * simple mint (no OAuth). Each pending row gets an Approve button that calls
+ * `approveAgentGrant(connection.grantId)` (no token) on the operator's OWN cookie'd,
+ * same-origin hub session; the hub mints + flips it approved, and `onChanged` refreshes so
+ * the pill goes Pending → Connected. Renders NOTHING when there are no non-mcp connections,
+ * so it's safe to always mount inside the def panel. Degrades daemon-direct exactly like
+ * ConnectionsSection (the approve needs the hub origin's cookie + CSRF belt).
+ */
+export function GrantsSection({
+  def,
+  onChanged,
+}: {
+  def: AgentDefRow;
+  onChanged: () => void;
+}) {
+  // The grant id mid-approve (so its button shows a spinner).
+  const [approving, setApproving] = useState<string | null>(null);
+  const [rowError, setRowError] = useState<string | null>(null);
+
+  const rows = simpleApprovalRows(def);
+  // The cookie→hub approve only works at the hub origin (the cookie + CSRF belt).
+  const daemonDirect = isDaemonDirectOrigin();
+
+  /** Approve the grant (no token → the hub mints, no redirect), then refresh in place. */
+  async function onApprove(grantId: string) {
+    setApproving(grantId);
+    setRowError(null);
+    try {
+      const listing = await approveAgentGrant(grantId);
+      // Simple-approve grants mint without a redirect. Defensive: if the hub ever hands
+      // back an authorizeUrl (an OAuth-shaped grant slipping through), honor it rather
+      // than silently no-op — mirrors ConnectionsSection's onConnect.
+      if (listing.authorizeUrl) {
+        window.location.assign(listing.authorizeUrl);
+        return;
+      }
+      onChanged();
+    } catch (err) {
+      setRowError(connectErrMessage(err));
+    } finally {
+      setApproving(null);
+    }
+  }
+
+  // Nothing to show — no non-mcp connections (or an older daemon without the field).
+  if (rows.length === 0) return null;
+
+  return (
+    <section className="detail-section" aria-label="Grants" data-testid="grants-section">
+      <div className="section-head">
+        <h3>Grants</h3>
+      </div>
+      <p className="muted">
+        Vault, service, and surface connections this agent requested. Approve one to grant it —
+        the hub mints on your approval (no sign-in step, unlike the MCP servers above).
+      </p>
+
+      {daemonDirect ? (
+        <div className="info-banner" role="status" data-testid="grants-daemon-direct">
+          Open this surface via your hub to approve grants — the approve step needs the hub
+          origin (you're on the loopback daemon).
+        </div>
+      ) : null}
+
+      {rowError ? (
+        <div className="error-banner" role="alert" data-testid="grants-row-error">
+          {rowError}
+        </div>
+      ) : null}
+
+      <table>
+        <thead>
+          <tr>
+            <th>Connection</th>
+            <th>Kind</th>
+            <th>Status</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((c) => {
+            const actionable = c.status !== "approved";
+            const canApprove = actionable && !!c.grantId && !daemonDirect;
+            return (
+              <tr key={c.key} data-testid={`grant-row-${c.key}`}>
+                <td className="cell-name">
+                  <code>{c.target}</code>
+                </td>
+                <td>
+                  <span className="pill">{c.kind}</span>
+                </td>
+                <td>
+                  <GrantStatusPill status={c.status} />
+                </td>
+                <td>
+                  {!actionable ? (
+                    <span className="cell-dim">—</span>
+                  ) : (
+                    <button
+                      type="button"
+                      disabled={!canApprove || approving === c.grantId}
+                      data-testid={`approve-${c.key}`}
+                      title={
+                        daemonDirect
+                          ? "Open the agent app via your hub origin to approve."
+                          : !c.grantId
+                            ? "No grant registered yet — reload after the daemon registers it."
+                            : undefined
+                      }
+                      onClick={() => void onApprove(c.grantId!)}
+                    >
+                      {approving === c.grantId ? "Approving…" : "Approve"}
+                    </button>
+                  )}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </section>
+  );
 }
 
 /**

--- a/web/ui/src/routes/Connections.test.tsx
+++ b/web/ui/src/routes/Connections.test.tsx
@@ -1,20 +1,29 @@
 /**
  * Connections / MCP-servers panel tests (this PR). Exercises the exported
- * `ConnectionsSection` + `AddMcpForm` + `mcpConnectionRows` directly (no full-page
- * wiring), mocking `../lib/api.ts` (the def PATCH) and `../lib/hub.ts` (the cookie→hub
- * approve + the daemon-direct detector). Asserts:
- *   - the row list + status pills (Connected / Pending / Needs reconnect);
+ * `ConnectionsSection` + `AddMcpForm` + `mcpConnectionRows` + `GrantsSection` +
+ * `simpleApprovalRows` directly (no full-page wiring), mocking `../lib/api.ts` (the def
+ * PATCH) and `../lib/hub.ts` (the cookie→hub approve + the daemon-direct detector). Asserts:
+ *   - the mcp row list + status pills (Connected / Pending / Needs reconnect);
  *   - Add MCP → PATCH wants APPENDS `mcp:<url>` (preserving existing wants);
  *   - Connect → `approveAgentGrant(grantId)` → full-page redirect to authorizeUrl;
  *   - Paste-token → `approveAgentGrant(grantId, token)` (no redirect);
- *   - daemon-direct degradation hides Connect + shows the inline hint.
+ *   - daemon-direct degradation hides Connect + shows the inline hint;
+ *   - GrantsSection: a pending SURFACE (/vault/service) grant renders an Approve button
+ *     that simple-approves via `approveAgentGrant(grantId)` (no token), skips mcp, and
+ *     degrades daemon-direct.
  */
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import * as api from "../lib/api.ts";
 import * as hub from "../lib/hub.ts";
-import { AddMcpForm, ConnectionsSection, mcpConnectionRows } from "./Agents.tsx";
+import {
+  AddMcpForm,
+  ConnectionsSection,
+  GrantsSection,
+  mcpConnectionRows,
+  simpleApprovalRows,
+} from "./Agents.tsx";
 
 vi.mock("../lib/api.ts", async (orig) => {
   const actual = (await orig()) as typeof api;
@@ -217,5 +226,83 @@ describe("AddMcpForm", () => {
     fireEvent.change(input, { target: { value: "https://dup/mcp" } });
     expect(screen.getByTestId("mcp-url-duplicate")).toBeInTheDocument();
     expect(screen.getByTestId("add-mcp-submit")).toBeDisabled();
+  });
+});
+
+describe("simpleApprovalRows", () => {
+  it("returns the non-mcp connections (surface / vault / service), excluding mcp", () => {
+    const def = defRow({
+      connections: [
+        { key: "mcp:https://a/mcp", kind: "mcp", target: "https://a/mcp", status: "pending", grantId: "g1" },
+        { key: "surface:proj:write", kind: "surface", target: "proj:write", status: "pending", grantId: "g2" },
+        { key: "vault:research:read", kind: "vault", target: "research", status: "approved", grantId: "g3" },
+      ],
+    });
+    expect(simpleApprovalRows(def).map((r) => r.key)).toEqual(["surface:proj:write", "vault:research:read"]);
+  });
+
+  it("is empty when the daemon omits the connections field (older daemon)", () => {
+    expect(simpleApprovalRows(defRow({ wants: ["surface:proj:write"], pending: ["surface:proj:write"] }))).toEqual([]);
+  });
+});
+
+describe("GrantsSection — surface / vault / service simple approve", () => {
+  it("renders an Approve button for a pending surface grant and approves with the server grantId (no token)", async () => {
+    approveAgentGrant.mockResolvedValue({
+      id: "g2",
+      agent: "alpha",
+      connection: { kind: "surface", target: "proj:write" },
+      status: "approved",
+    });
+    const onChanged = vi.fn();
+    const def = defRow({
+      connections: [
+        { key: "surface:proj:write", kind: "surface", target: "proj:write", status: "pending", grantId: "g2" },
+      ],
+    });
+    render(<GrantsSection def={def} onChanged={onChanged} />);
+    const btn = screen.getByTestId("approve-surface:proj:write");
+    expect(btn).toHaveTextContent("Approve");
+    fireEvent.click(btn);
+    // Surface approves like a vault grant: the server-supplied grant id, NO token (no OAuth).
+    await waitFor(() => expect(approveAgentGrant).toHaveBeenCalledWith("g2"));
+    await waitFor(() => expect(onChanged).toHaveBeenCalled());
+  });
+
+  it("shows a Connected pill and no Approve button for an already-approved grant", () => {
+    const def = defRow({
+      connections: [
+        { key: "vault:research:read", kind: "vault", target: "research", status: "approved", grantId: "g3" },
+      ],
+    });
+    render(<GrantsSection def={def} onChanged={() => {}} />);
+    expect(screen.getByTestId("conn-status-approved")).toBeInTheDocument();
+    expect(screen.queryByTestId("approve-vault:research:read")).toBeNull();
+  });
+
+  it("disables Approve + shows the hub-origin hint when served daemon-direct", () => {
+    isDaemonDirectOrigin.mockReturnValue(true);
+    const def = defRow({
+      connections: [
+        { key: "surface:proj:write", kind: "surface", target: "proj:write", status: "pending", grantId: "g2" },
+      ],
+    });
+    render(<GrantsSection def={def} onChanged={() => {}} />);
+    expect(screen.getByTestId("grants-daemon-direct")).toBeInTheDocument();
+    expect(screen.getByTestId("approve-surface:proj:write")).toBeDisabled();
+  });
+
+  it("renders nothing when there are only mcp connections (no simple-approve grants)", () => {
+    render(
+      <GrantsSection
+        def={defRow({
+          connections: [
+            { key: "mcp:https://a/mcp", kind: "mcp", target: "https://a/mcp", status: "pending", grantId: "g1" },
+          ],
+        })}
+        onChanged={() => {}}
+      />,
+    );
+    expect(screen.queryByTestId("grants-section")).toBeNull();
   });
 });


### PR DESCRIPTION
## The gap

A pending **`surface`-kind grant** on a **thread-sourced agent** showed under "Pending approval" as an inert **tag with no Approve button** — so an operator couldn't approve it. This blocked every surface-grant approval (and thread-carried grants generally).

## Diagnosis

The daemon (rc.2) already produces `def.connections` entries for a surface grant with `kind:"surface"`, a `target`, `status:"pending"`, and the **hub grant id** (`registerGrant` echoes it via `resolveStatusWithGrants`). A thread-sourced agent carries its `noteId` (= the thread note id) + those connections into `AgentDefRow`.

But the ops UI's only approve affordance — `ConnectionsSection` — renders `mcpConnectionRows(def)`, which filters `def.connections` to `kind === "mcp"` **only**. Every non-mcp grant (`surface`/`vault`/`service`) was dropped from that section and surfaced solely as a display-only `<span className="tag">` under "Pending approval" in `Agents.tsx`. No button, no way to approve.

## Fix (UI-only)

- **New `GrantsSection`** renders the **simple-approve** connection kinds (`vault`/`service`/`surface`) with an **Approve** button that calls `approveAgentGrant(connection.grantId)` — the **server-supplied grant id**, empty body, **no token, no OAuth** (the same simple mint a vault grant uses; the hub mints + flips it `approved`, then the list refreshes so the pill goes Pending → Connected).
- **MCP keeps its own** OAuth / paste-token section, untouched.
- The **"Pending approval" tag list** now shows only the legacy `uses:` names — structured `wants:` connections are rendered as actionable rows below (mcp in ConnectionsSection, the rest in GrantsSection) — so a grant never shows twice (once inert, once approvable).
- `GrantsSection` renders **nothing** when there are no non-mcp connections (safe to always mount; also the older-daemon-without-`connections` fallback), and **degrades daemon-direct** exactly like ConnectionsSection.

## Auth: unchanged, not weakened

Approve stays **same-origin `credentials:"include"`** (the hub's CSRF belt, via the existing `approveAgentGrant`). **No new endpoints.** The grant id is always the **daemon's server-supplied** `connection.grantId`, never derived client-side.

## Works for a thread-sourced agent

Verified the daemon path: `instantiateThread` stores the thread record in `this.live` with `noteId: note.id` + `connections` (surface kind + grantId + status), which `listDetailed()` surfaces to the SPA. GrantsSection is **not** `noteId`-gated (approve needs only the grant id), so it renders for a thread agent regardless.

## Tests + gates

- **6 new vitest cases** (`Connections.test.tsx`): `simpleApprovalRows` (non-mcp filter; older-daemon empty) + `GrantsSection` (surface approve calls `approveAgentGrant(grantId)` with **no token** + refreshes; approved → Connected pill, no button; daemon-direct disables + hints; mcp-only renders nothing).
- SPA vitest: **166 passed** (10 files; 160 prior + 6 new).
- SPA typecheck (`tsc --noEmit`): clean. Root typecheck: clean. Biome: clean on changed files (2 pre-existing `noExplicitAny` warnings in untouched `src/transports/vault.test.ts`).
- SPA build (`bun run build`): succeeds. `dist/` is **gitignored** (built on `prepack`/publish, not committed) — no dist commit needed.
- Version bumped `0.2.4-rc.2` → `0.2.4-rc.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T6HAzWsgiJy4ndsWSCWY5S