### PR TITLE
release: agent 0.2.4 (@latest promotion)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/agent",
-  "version": "0.2.4-rc.3",
+  "version": "0.2.4",
   "description": "Vault-native agents for Claude Code — a #agent/definition note + an inbound message becomes a sandboxed claude turn; the reply is written back as a note. Messaging gateway on :1941.",
   "license": "AGPL-3.0",
   "type": "module",


### PR DESCRIPTION
## @latest stable promotion

Drops the `-rc` suffix and ships the same patch as stable: **0.2.4-rc.3 → 0.2.4**. Version-only bump.

## What ships
The 0.2.4 rc chain landed the **Surface Git Transport agent side** — the `surface` grant kind + per-spawn `GIT_ASKPASS` injection (#182) — plus **thread-carried capability** (a `#agent/thread`'s own `wants:` registers as name-keyed pending grants, #183) and the approvable surface/vault/service grants UI (#184).

## Why now
Aaron's call (2026-07-01): promote all libraries to @latest to **mark the baseline** before the upcoming coherence-cleanup batch (from the 2026-07-01 ecosystem review) lands as one clean upgrade. Known nit shipping as-is by design: `.parachute/module.json` `has_metadata: ["channel"]` (review finding #1) is deferred to the cleanup batch.

## Diff
- `package.json`: `0.2.4-rc.3` → `0.2.4` (version line only)
- `bun.lock`: unchanged — root version isn't tracked in the lockfile; `--frozen-lockfile` stays satisfied.

## Gates
- `bun install --frozen-lockfile` — no changes
- `bun run typecheck` — clean (tsc --noEmit, exit 0)
- Full test suite: PR CI (lint→typecheck→test)

After merge: push `v0.2.4` → CI publishes `@latest` with provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XLZtmuSs1RirWGMGyCB1QB