### PR TITLE
fix(agent): Fable-cleanup slice — module.json agent key, fail-closed access.json, README npm status (0.2.5-rc.1)

### DIFF
--- a/.parachute/module.json
+++ b/.parachute/module.json
@@ -53,7 +53,7 @@
         "event": "note.created",
         "filter": {
           "tags": ["agent/message/inbound"],
-          "has_metadata": ["channel"],
+          "has_metadata": ["agent"],
           "missing_metadata": ["channel_inbound_rendered_at"]
         }
       },

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ Agent is `focus: experimental` and pre-1.0. What's solid vs. early:
 - **Solid:** the daemon/bridge fabric, the vault + Telegram + http-ui transports,
   hub registration + reverse-proxy, the web surface (Home/Chat/Agents/Terminal/
   Config), and vault-backed durable chat.
-- **Early / changing:** the npm package isn't published yet (run from source —
-  tracked in [#16](https://github.com/ParachuteComputer/parachute-agent/issues/16));
-  agent-session isolation is real but young; APIs may shift.
+- **Early / changing:** agent-session isolation is real but young; APIs may
+  shift between releases (pre-1.0, small breaking changes land without a
+  deprecation window).
 
 **Read this about agent sessions.** A spawned agent runs `claude` with
 `--dangerously-skip-permissions` (it's autonomous — no human at the terminal to
@@ -85,7 +85,14 @@ full multi-tenant isolation is future work.
 
 Agent runs alongside the rest of a Parachute install (the
 [hub](https://github.com/ParachuteComputer/parachute-hub) is the portal + OAuth
-issuer). Until the npm package ships, run it from source:
+issuer). Install from npm (`@openparachute/agent` publishes via tag-triggered CI):
+
+```bash
+parachute install agent           # via the hub CLI (the normal path)
+# or directly: bun add -g @openparachute/agent
+```
+
+For development, run it from source instead:
 
 ```bash
 git clone https://github.com/ParachuteComputer/parachute-agent
@@ -101,7 +108,7 @@ The daemon self-registers into `~/.parachute/services.json` and ships
 
 | | |
 |---|---|
-| npm | `@openparachute/agent` (publish pending [#16](https://github.com/ParachuteComputer/parachute-agent/issues/16)) |
+| npm | [`@openparachute/agent`](https://www.npmjs.com/package/@openparachute/agent) |
 | bins | `parachute-agent` (daemon), `parachute-agent-bridge` (session bridge) |
 | port | `1941` · paths `/agent` |
 | scopes | `agent:read` · `agent:write` · `agent:send` · `agent:admin` |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/agent",
-  "version": "0.2.4",
+  "version": "0.2.5-rc.1",
   "description": "Vault-native agents for Claude Code — a #agent/definition note + an inbound message becomes a sandboxed claude turn; the reply is written back as a note. Messaging gateway on :1941.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/src/transports/telegram.test.ts
+++ b/src/transports/telegram.test.ts
@@ -1,11 +1,15 @@
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import {
   isAllowedFor,
+  loadAccess,
   chunkText,
   TelegramTransport,
   type AccessConfig,
 } from "./telegram.ts";
 import { ChannelConfigError } from "../transport.ts";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 // ---------------------------------------------------------------------------
 // Access control — these cases moved here from the daemon. The policy is now a
@@ -170,5 +174,66 @@ describe("TelegramTransport", () => {
         input_preview: "ls",
       }),
     ).rejects.toBeInstanceOf(ChannelConfigError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadAccess — asymmetric failure handling: missing file is OPEN (fresh
+// install, matches the official plugin's default), but an EXISTING file that
+// can't be parsed FAILS CLOSED (allowlist, no users) — a corrupt access.json
+// must never silently disable gating the operator configured.
+// ---------------------------------------------------------------------------
+
+describe("loadAccess", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "agent-access-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("valid file: parsed config is returned as-is", () => {
+    const file = join(dir, "access.json");
+    writeFileSync(
+      file,
+      JSON.stringify({ dmPolicy: "allowlist", allowFrom: ["42"], groups: {}, pending: {} }),
+    );
+    const access = loadAccess(file);
+    expect(access.dmPolicy).toBe("allowlist");
+    expect(access.allowFrom).toEqual(["42"]);
+    expect(isAllowedFor(access, 42, 42)).toBe(true);
+    expect(isAllowedFor(access, 7, 7)).toBe(false);
+  });
+
+  test("missing file: open by design (fresh install)", () => {
+    const access = loadAccess(join(dir, "access.json"));
+    expect(access.dmPolicy).toBe("open");
+    expect(access.allowFrom).toEqual([]);
+    expect(isAllowedFor(access, 999, 999)).toBe(true);
+  });
+
+  test("corrupt file (invalid JSON): FAILS CLOSED — allowlist with no users", () => {
+    const file = join(dir, "access.json");
+    writeFileSync(file, "{ dmPolicy: open,, this is not json");
+    const access = loadAccess(file);
+    expect(access.dmPolicy).toBe("allowlist");
+    expect(access.allowFrom).toEqual([]);
+    // Nobody gets through — including ids that a previous valid file allowed.
+    expect(isAllowedFor(access, 42, 42)).toBe(false);
+    expect(isAllowedFor(access, 999, -100)).toBe(false);
+  });
+
+  test("valid JSON but not an object (null / array / scalar): FAILS CLOSED", () => {
+    const file = join(dir, "access.json");
+    for (const body of ["null", "[]", '"open"', "42"]) {
+      writeFileSync(file, body);
+      const access = loadAccess(file);
+      expect(access.dmPolicy).toBe("allowlist");
+      expect(access.allowFrom).toEqual([]);
+      expect(isAllowedFor(access, 42, 42)).toBe(false);
+    }
   });
 });

--- a/src/transports/telegram.test.ts
+++ b/src/transports/telegram.test.ts
@@ -236,4 +236,38 @@ describe("loadAccess", () => {
       expect(isAllowedFor(access, 42, 42)).toBe(false);
     }
   });
+
+  test("valid JSON object missing/mistyping gating fields: FAILS CLOSED cleanly (no throw downstream)", () => {
+    const file = join(dir, "access.json");
+    const bad = [
+      "{}", // the reviewer's case: object check passes, but no gating fields at all
+      '{"dmPolicy":"allowlist"}', // allowFrom missing
+      '{"allowFrom":["42"]}', // dmPolicy missing
+      '{"dmPolicy":"banana","allowFrom":["42"]}', // dmPolicy outside the union
+      '{"dmPolicy":"allowlist","allowFrom":"42"}', // allowFrom not an array
+      '{"dmPolicy":"allowlist","allowFrom":[42]}', // allowFrom not strings
+      '{"dmPolicy":"allowlist","allowFrom":["42"],"allowInChats":"42"}', // allowInChats mistyped
+    ];
+    for (const body of bad) {
+      writeFileSync(file, body);
+      const access = loadAccess(file);
+      expect(access.dmPolicy).toBe("allowlist");
+      expect(access.allowFrom).toEqual([]);
+      // The point of the shape check: isAllowedFor gets a well-formed config
+      // and denies cleanly — no raw TypeError for the poll loop to retry on.
+      expect(isAllowedFor(access, 42, 42)).toBe(false);
+      expect(isAllowedFor(access, 42, -100)).toBe(false);
+    }
+  });
+
+  test("minimal valid file omitting inert groups/pending loads with {} defaults", () => {
+    const file = join(dir, "access.json");
+    writeFileSync(file, '{"dmPolicy":"allowlist","allowFrom":["42"]}');
+    const access = loadAccess(file);
+    expect(access.dmPolicy).toBe("allowlist");
+    expect(access.groups).toEqual({});
+    expect(access.pending).toEqual({});
+    expect(isAllowedFor(access, 42, 42)).toBe(true);
+    expect(isAllowedFor(access, 7, 7)).toBe(false);
+  });
 });

--- a/src/transports/telegram.ts
+++ b/src/transports/telegram.ts
@@ -59,11 +59,47 @@ export interface AccessConfig {
   pending: Record<string, unknown>;
 }
 
+/**
+ * Load access.json with asymmetric failure handling:
+ *
+ *   - **Missing file (ENOENT)** → OPEN. A fresh install has no access.json yet;
+ *     open-by-default matches the official plugin's out-of-the-box behavior.
+ *   - **Existing file that can't be read or parsed** → FAIL CLOSED. An operator
+ *     who wrote an access.json expressed an intent to gate; silently falling
+ *     back to `dmPolicy: "open"` on a corrupt file would disable ALL gating
+ *     exactly when the operator believes it's on. We return an empty allowlist
+ *     (nobody allowed) and log loudly so the breakage is visible, not silent.
+ */
 export function loadAccess(accessFile: string): AccessConfig {
+  const failClosed: AccessConfig = { dmPolicy: "allowlist", allowFrom: [], groups: {}, pending: {} };
+  let raw: string;
   try {
-    return JSON.parse(readFileSync(accessFile, "utf8"));
-  } catch {
-    return { dmPolicy: "open", allowFrom: [], groups: {}, pending: {} };
+    raw = readFileSync(accessFile, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
+      // No access.json — fresh install, open by design.
+      return { dmPolicy: "open", allowFrom: [], groups: {}, pending: {} };
+    }
+    console.error(
+      `parachute-agent: access.json at ${accessFile} EXISTS but could not be read — ` +
+        `FAILING CLOSED (allowlist, no users). Fix the file to restore access.`,
+      err,
+    );
+    return failClosed;
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      throw new Error(`expected a JSON object, got ${Array.isArray(parsed) ? "array" : typeof parsed}`);
+    }
+    return parsed as AccessConfig;
+  } catch (err) {
+    console.error(
+      `parachute-agent: access.json at ${accessFile} is corrupt (invalid JSON) — ` +
+        `FAILING CLOSED (allowlist, no users). Fix or delete the file to restore access.`,
+      err,
+    );
+    return failClosed;
   }
 }
 

--- a/src/transports/telegram.ts
+++ b/src/transports/telegram.ts
@@ -59,16 +59,70 @@ export interface AccessConfig {
   pending: Record<string, unknown>;
 }
 
+function isStringArray(v: unknown): v is string[] {
+  return Array.isArray(v) && v.every((x) => typeof x === "string");
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function isDmPolicy(v: unknown): v is AccessConfig["dmPolicy"] {
+  return v === "open" || v === "pairing" || v === "allowlist";
+}
+
+/**
+ * Shape-validate a parsed access.json object into an AccessConfig, or return
+ * the reason it isn't one (the caller fails closed and logs the reason). The
+ * GATING fields must match the schema exactly — a missing/mistyped `dmPolicy`,
+ * `allowFrom`, or `allowInChats` means the operator's intent can't be trusted,
+ * and letting it through as a bare cast would surface later as a raw TypeError
+ * inside `isAllowedFor` (caught by the poll loop → a retry-loop of stack
+ * traces) instead of a clean fail-closed. The INERT bookkeeping fields
+ * (`groups` / `pending` — read for official-plugin file compatibility, never
+ * acted on here) default to `{}` when absent: their absence can't create a
+ * gating hazard, so a hand-written minimal file isn't punished for omitting
+ * them.
+ */
+function toAccessConfig(
+  parsed: Record<string, unknown>,
+): { ok: true; access: AccessConfig } | { ok: false; reason: string } {
+  const { dmPolicy, allowFrom, allowInChats, groups, pending } = parsed;
+  if (!isDmPolicy(dmPolicy)) {
+    return {
+      ok: false,
+      reason: `dmPolicy must be "open" | "pairing" | "allowlist", got ${JSON.stringify(dmPolicy)}`,
+    };
+  }
+  if (!isStringArray(allowFrom)) {
+    return { ok: false, reason: "allowFrom must be an array of strings" };
+  }
+  if (allowInChats !== undefined && !isStringArray(allowInChats)) {
+    return { ok: false, reason: "allowInChats, when present, must be an array of strings" };
+  }
+  if (groups !== undefined && !isPlainObject(groups)) {
+    return { ok: false, reason: "groups, when present, must be an object" };
+  }
+  if (pending !== undefined && !isPlainObject(pending)) {
+    return { ok: false, reason: "pending, when present, must be an object" };
+  }
+  return {
+    ok: true,
+    access: { dmPolicy, allowFrom, allowInChats, groups: groups ?? {}, pending: pending ?? {} },
+  };
+}
+
 /**
  * Load access.json with asymmetric failure handling:
  *
  *   - **Missing file (ENOENT)** → OPEN. A fresh install has no access.json yet;
  *     open-by-default matches the official plugin's out-of-the-box behavior.
- *   - **Existing file that can't be read or parsed** → FAIL CLOSED. An operator
- *     who wrote an access.json expressed an intent to gate; silently falling
- *     back to `dmPolicy: "open"` on a corrupt file would disable ALL gating
- *     exactly when the operator believes it's on. We return an empty allowlist
- *     (nobody allowed) and log loudly so the breakage is visible, not silent.
+ *   - **Existing file that can't be read, parsed, or shape-validated** → FAIL
+ *     CLOSED. An operator who wrote an access.json expressed an intent to gate;
+ *     silently falling back to `dmPolicy: "open"` on a corrupt file would
+ *     disable ALL gating exactly when the operator believes it's on. We return
+ *     an empty allowlist (nobody allowed) and log loudly so the breakage is
+ *     visible, not silent.
  */
 export function loadAccess(accessFile: string): AccessConfig {
   const failClosed: AccessConfig = { dmPolicy: "allowlist", allowFrom: [], groups: {}, pending: {} };
@@ -88,14 +142,16 @@ export function loadAccess(accessFile: string): AccessConfig {
     return failClosed;
   }
   try {
-    const parsed = JSON.parse(raw);
-    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    const parsed: unknown = JSON.parse(raw);
+    if (!isPlainObject(parsed)) {
       throw new Error(`expected a JSON object, got ${Array.isArray(parsed) ? "array" : typeof parsed}`);
     }
-    return parsed as AccessConfig;
+    const shaped = toAccessConfig(parsed);
+    if (!shaped.ok) throw new Error(shaped.reason);
+    return shaped.access;
   } catch (err) {
     console.error(
-      `parachute-agent: access.json at ${accessFile} is corrupt (invalid JSON) — ` +
+      `parachute-agent: access.json at ${accessFile} is corrupt (invalid JSON, or not a valid access config) — ` +
         `FAILING CLOSED (allowlist, no users). Fix or delete the file to restore access.`,
       err,
     );


### PR DESCRIPTION
Part of the Fable-cleanup batch on top of the 0.2.4 @latest baseline (204d1a2). Four scoped items, all verified findings from the 2026-07-01 ecosystem review.

## Items

1. **`.parachute/module.json` — `link-to-vault` trigger filter keys on `metadata.agent`.** The hub consumes this connectionTemplate 1:1 into a vault-trigger predicate; post-#133 (channel→agent routing-key CONTRACT) no inbound note carries `metadata.channel`, so hub-provisioned triggers never fired. Now `has_metadata: ["agent"]`, matching the module's own `AGENT_VAULT_TRIGGER_TEMPLATE` (`src/transports/vault.ts:600`) and the daemon auto-registration path. Audited the rest of the file: the `channel_inbound_rendered_at` marker is stable internal plumbing matching the code template byte-for-byte (kept), and the `channel`-name parameter is the transport/endpoint concept (kept). No test pinned the stale value — the code-side tests already asserted `["agent"]`; module.json was the one straggler.

2. **Telegram `access.json` fails closed on corruption** (`src/transports/telegram.ts` — `loadAccess`). Previously ANY read/parse failure fell back to `dmPolicy: "open"`, silently disabling all gating exactly when the operator believed it was on. Now asymmetric: missing file (ENOENT) stays open (fresh install, matches the official plugin's default — unchanged behavior); an EXISTING file that can't be read/parsed (or parses to a non-object) fails CLOSED (`allowlist`, empty `allowFrom`) with a loud `console.error`. New tests: valid file, missing file, corrupt file, non-object JSON (null/array/scalar).

3. **README npm-status refresh.** Three spots claimed "npm package isn't published yet (run from source — #16)". Reality: `@openparachute/agent` publishes via tag-triggered CI, `latest=0.2.4` (verified via `npm view`). Install path is now `parachute install agent` (verified present in hub's `KNOWN_MODULES`) / `bun add -g`; the source checkout + `bun link` remains documented as the dev path.

4. **Version 0.2.4 → 0.2.5-rc.1** (governance rule 2: new rc chain on the next patch). Lockfile unaffected (`bun install` — no changes).

## Gates

- `bun run typecheck` (tsc --noEmit): clean
- `bun test ./src`: **1454 pass, 0 fail** (4280 expect() calls, 59 files, 7.11s)
- `bunx biome check`: 143 files checked, **0 errors, 2 warnings** — both pre-existing (identical count on the untouched 204d1a2 baseline; `let body: any` in test files this PR doesn't touch)

Small breaking-behavior note (item 2): an operator running with a corrupt access.json was previously ungated-open; after this they're gated-closed until the file is fixed. That's the point — near-zero external users, acceptable per the cleanup batch's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XLZtmuSs1RirWGMGyCB1QB