### PR TITLE
release: agent 0.2.5 (@latest)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/agent",
-  "version": "0.2.5-rc.2",
+  "version": "0.2.5",
   "description": "Vault-native agents for Claude Code — a #agent/definition note + an inbound message becomes a sandboxed claude turn; the reply is written back as a note. Messaging gateway on :1941.",
   "license": "AGPL-3.0",
   "type": "module",


### PR DESCRIPTION
Promote the tested rc.2 chain to stable **0.2.5** (published @latest on the `v0.2.5` tag). Version-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)