### PR TITLE
docs: slim CLAUDE.md to purpose + gotchas (472 -> 157 lines)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,6 @@ number of sessions subscribe.
   Claims auto-release after a TTL, so a crashed session never strands the queue.
 - Env vars are documented by the code that reads them (grep `process.env` in
   `src/daemon.ts` and friends). One trap: job-failure alerting needs
-  `PARACHUTE_AGENT_ALERT_CHANNEL` **and** `PARACHUTE_AGENT_ALERT_CHAT_ID` set together —
   either alone is a partial config (logged, alerts disabled).
 
 ### The `=`-binding flag trap (bridge launch)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,8 +66,7 @@ number of sessions subscribe.
   oldest inbound, returns the agent's system prompt) → work → `reply { inReplyTo, text }`.
   Claims auto-release after a TTL, so a crashed session never strands the queue.
 - Env vars are documented by the code that reads them (grep `process.env` in
-  `src/daemon.ts` and friends). One trap: job-failure alerting needs
-  either alone is a partial config (logged, alerts disabled).
+  `src/daemon.ts` and friends).
 
 ### The `=`-binding flag trap (bridge launch)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,472 +1,157 @@
 # parachute-agent
 
 Vault-native agents for Claude Code. A `#agent/definition` note in a Parachute vault
-defines an agent; inbound messages (chat / vault note / scheduled job) become a turn;
-the reply flows back as an outbound `#agent/message/outbound` note. Telegram today,
-anything tomorrow.
+defines an agent; an inbound message (chat / vault note / scheduled job) becomes a turn;
+the reply flows back as an `#agent/message/outbound` note. Telegram today, anything
+tomorrow. **Experimental preview (L3)** — near-zero users, breaking changes OK.
 
 ## The model: agents + two backends
 
 An agent is a `#agent/definition` note (body = system prompt, metadata = config). Its
-**backend** is the axis, and there are exactly **two**
+**backend** is the axis, and there are exactly two
 (design [`2026-06-18-channel-backend.md`](./design/2026-06-18-channel-backend.md)):
 
-- **`programmatic`** (the DEFAULT) — the daemon runs each turn headless via
-  `claude -p --resume` (sandboxed, always-on). No resident process; an inbound message
-  becomes one on-demand turn, the reply is written as an outbound note.
-- **`attached`** — the turn is delivered over a channel to a Claude Code session **you
-  run yourself** (your machine, your env/creds, unsandboxed) and have connected to the
-  channel's MCP endpoint. The daemon runs no turn; the inbound notes accumulate as a
-  durable queue and your session **pulls** the next message, works, and **replies** via
-  MCP tools.
+- **`programmatic`** (the default) — the daemon runs each turn headless via
+  `claude -p --resume` (sandboxed, always-on); the reply is written as an outbound note.
+- **`attached`** — turns go to a Claude Code session **you run yourself** (your
+  machine/creds, unsandboxed), connected to the channel's MCP endpoint. Inbound notes
+  accumulate as a durable queue; your session pulls, works, and replies via MCP tools.
 
-> **Retired: the `interactive` (tmux) backend** (2026-06-19, design
-> [`2026-06-19-retire-interactive-backend.md`](./design/2026-06-19-retire-interactive-backend.md)).
-> It puppeted a tmux pane with send-keys and pushed onto an idle MCP stream to fake
-> message injection — and carried the deaf-on-restart / backlog-replay / idle-wake
-> fragility class. `attached` supersedes it. The PTY/tmux spawner is **parked** at
-> [`src/_parked/interactive-spawn.ts`](./src/_parked/interactive-spawn.ts) for future
-> terminal/process-management (a general capability, decoupled from the agent backend),
-> not maintained as a live backend.
+The `interactive` (tmux) backend is retired — `attached` supersedes it (design
+[`2026-06-19-retire-interactive-backend.md`](./design/2026-06-19-retire-interactive-backend.md));
+the PTY spawner is parked, unmaintained, at
+[`src/_parked/interactive-spawn.ts`](./src/_parked/interactive-spawn.ts).
 
 ## Architecture
 
-The **daemon** (port 1941, long-running, one per machine) is the only process that
-touches a transport's external API (e.g. Telegram's getUpdates long-poll — exclusive,
-no multi-consumer races). It owns the channel registry, routes inbound to the right
-backend (the **daemon routing fork**: `programmatic` → `ProgrammaticAgentRegistry`'s
-serial worker runs `claude -p`; `attached` → `AttachedQueueRegistry`, the durable
-note-queue a connected session pulls from), and writes outbound notes.
+The **daemon** (port 1941, one per machine) is the only process that touches a
+transport's external API (e.g. Telegram's getUpdates long-poll — exclusive, no
+multi-consumer races). It owns the channel registry, routes inbound by backend
+(`programmatic` → `ProgrammaticAgentRegistry`'s serial worker; `attached` →
+`AttachedQueueRegistry`'s durable queue), and writes outbound notes. New transports
+implement the `Transport` contract in `src/transports/<name>.ts`; the session-facing
+MCP contract is unchanged.
 
-A Claude Code session connects to a channel two ways:
+A session connects two ways:
 
-- **HTTP MCP (primary)** — the session adds `<hub>/agent/mcp/<channel>` as a pure HTTP
-  MCP server (URL + OAuth), exactly like the vault. The daemon serves a stateful
-  Streamable-HTTP MCP endpoint (`src/mcp-http.ts`): for an `attached`-backend agent it
-  exposes the **pull surface** (`pending` / `next-message` / `reply` / `release`); the
-  live `pushToChannel` wake streams the programmatic backend's interim "watch it work"
-  text + the live inbound wake onto the session's GET stream.
-- **stdio bridge (`src/bridge.ts`)** — the session spawns the bridge, which subscribes
-  to the daemon's SSE `/events` and forwards each event as a `notifications/claude/agent`
-  MCP notification; outbound tool calls proxy to the daemon's HTTP `/api/*`. Still
-  supported; the HTTP-MCP path is what the UI + launcher steer toward.
+- **HTTP MCP (primary)** — add `<hub>/agent/mcp/<channel>` as an HTTP MCP server
+  (URL + OAuth, exactly like the vault). `src/mcp-http.ts` serves it and resolves the
+  tool surface by the channel's backend: push tools (reply/react/edit/download) or, for
+  `attached`, the pull surface (`pending` / `next-message` / `reply` / `release`).
+  Tool schemas + the OAuth discovery contract (RFC 9728/8414 path-insertion, mirroring
+  vault): read `src/mcp-http.ts`.
+- **stdio bridge** (`src/bridge.ts`) — subscribes to the daemon's SSE `/events`,
+  forwards events as MCP notifications, proxies tool calls to `/api/*`. Still
+  supported; the SPA + launcher steer toward HTTP MCP.
 
-## Why not the official telegram plugin?
+## Why not the official Telegram plugin?
 
-The official plugin has a known bug (anthropics/claude-code#38098, open): every Claude Code session with the plugin enabled at any scope auto-spawns a Telegram poller child, even without `--channels`. This causes multi-consumer races that drop ~50% of messages. The plugin system's `enabledPlugins` resolution is session-global and can't be scoped to one session. This gateway solves the problem by design: one daemon, any number of subscribers.
+Known upstream bug (anthropics/claude-code#38098, open): every session with the plugin
+enabled at any scope auto-spawns a Telegram poller child, even without `--channels` —
+the multi-consumer races drop ~50% of messages, and `enabledPlugins` resolution is
+session-global, unscopeable. This gateway fixes it by design: one daemon polls, any
+number of sessions subscribe.
 
 ## Running
 
-### Daemon (start once, runs forever)
+- Daemon: `bun src/daemon.ts` (or via the hub supervisor / launchd). It self-registers
+  into `~/.parachute/services.json` at boot; hub reverse-proxies `<expose>/agent/*` to
+  it; admin SPA at `<hub-origin>/agent/app/` (locally `http://127.0.0.1:1941/agent/app/`).
+- Telegram bot tokens are **per-channel** in `~/.parachute/agent/channels.json`
+  (written via the SPA or directly) — the daemon does NOT read a global
+  `TELEGRAM_BOT_TOKEN`.
+- Connect an `attached` session:
+  `claude mcp add --transport http agent <hub-origin>/agent/mcp/<channel>` (OAuth
+  prompts on first use), then run the pull loop: `pending` → `next-message` (claims the
+  oldest inbound, returns the agent's system prompt) → work → `reply { inReplyTo, text }`.
+  Claims auto-release after a TTL, so a crashed session never strands the queue.
+- Env vars are documented by the code that reads them (grep `process.env` in
+  `src/daemon.ts` and friends). One trap: job-failure alerting needs
+  `PARACHUTE_AGENT_ALERT_CHANNEL` **and** `PARACHUTE_AGENT_ALERT_CHAT_ID` set together —
+  either alone is a partial config (logged, alerts disabled).
 
-```bash
-bun src/daemon.ts
-# or via the hub supervisor / launchd — see below
-```
+### The `=`-binding flag trap (bridge launch)
 
-Telegram channels carry a per-channel bot token in `channels.json` config — the daemon does NOT read a global `TELEGRAM_BOT_TOKEN`. Define channels via the admin SPA at `/agent/app/` (or by writing `~/.parachute/agent/channels.json` directly).
-
-### Connecting an `attached`-backend session (the easy path)
-
-```bash
-claude mcp add --transport http agent <hub-origin>/agent/mcp/<channel>
-```
-
-It prompts for OAuth the first time (like the vault). Then the session runs the pull
-loop: `pending` → `next-message` (claims the oldest inbound + returns the agent's system
-prompt to adopt) → do the work → `reply { inReplyTo, text }` (writes the outbound note +
-marks the inbound handled). A claimed message auto-releases after a TTL so a crashed
-session never strands the queue.
-
-### stdio bridge (alternative)
-
-Registered in a session's `.mcp.json`:
-```json
-{
-  "mcpServers": {
-    "parachute-agent": {
-      "command": "bun",
-      "args": ["<path>/src/bridge.ts"],
-      "env": { "PARACHUTE_AGENT_URL": "http://127.0.0.1:1941" }
-    }
-  }
-}
-```
-
-Launch Claude Code with:
-```bash
-claude --dangerously-load-development-channels=server:parachute-agent
-```
-
-The `=` binding is load-bearing. Space-separating the value (`--dangerously-load-development-channels server:parachute-agent`) works in `--print` mode but in interactive mode the parser swallows `server:parachute-agent` as the initial-prompt positional, leaving the flag with an empty channels list. At runtime this surfaces as `"server:parachute-agent · no MCP server configured with that name"`, which points operators at the wrong suspect (the MCP config is fine; the flag-parser is what dropped the value). Always use the `=` form — it's unambiguous in every mode. See [#8](https://github.com/ParachuteComputer/parachute-agent/issues/8).
-
-If you hit an adjacent issue:
-- The bridge warns on stderr if the capability isn't registered, so this misconfig surfaces immediately instead of looking like everything is fine until a message arrives — see [#9](https://github.com/ParachuteComputer/parachute-agent/issues/9).
-- A cosmetic `/mcp` display warning may appear even with the correct flag — expected, ignore. See [#10](https://github.com/ParachuteComputer/parachute-agent/issues/10).
-
-## Hub integration
-
-Agent self-registers into `~/.parachute/services.json` at boot and ships
-`.parachute/module.json`, so hub lists it in the portal and reverse-proxies
-`<expose>/agent/*` → the loopback daemon (`stripPrefix:true`; SSE survives the proxy).
-The admin / agents SPA is reachable at `<hub-origin>/agent/app/` over the expose, and at
-`http://127.0.0.1:1941/agent/app/` locally. (`/agents` `302`s to the SPA app root; the
-old server-rendered HTML pages — the `/ui` chat, the six-page nav — retired in Phase 4.
-`/terminal` remains as a demoted attach-to-a-tmux-session tool, not a backend.)
-
-## HTTP MCP endpoint detail (the discovery contract)
-
-The `<hub-origin>/agent/mcp/<channel>` endpoint a session adds (see "Connecting an
-`attached`-backend session" above) is a stateful Streamable-HTTP MCP server
-(`src/mcp-http.ts`). Discovery is RFC 9728 + RFC 8414, in the **path-insertion** form a
-Claude Code HTTP-MCP client probes (mirrors vault's `src/oauth-discovery.ts`), served
-PUBLIC (no auth) by the daemon:
-
-- `GET /.well-known/oauth-protected-resource/mcp/<channel>` → `resource` (the public MCP
-  URL, built from `X-Forwarded-Host`), `authorization_servers: [<hub-origin>]`,
-  `scopes_supported: ["agent:read","agent:write"]`, `bearer_methods_supported: ["header"]`.
-- `GET /.well-known/oauth-authorization-server/mcp/<channel>` → forwarder pointing
-  `authorization_endpoint` / `token_endpoint` / `registration_endpoint` / `jwks_uri` at the hub.
-- A no/invalid-bearer `POST /mcp/<channel>` returns **401 + `WWW-Authenticate: Bearer
-  resource_metadata="…/.well-known/oauth-protected-resource/mcp/<channel>"`** — the signal a
-  spec OAuth client follows to start the flow. (Only `/mcp/*` carries the challenge; `/events`
-  + `/api/*` stay plain 401.)
-
-For an `attached`-backend agent the endpoint serves the PULL surface
-(`pending` / `next-message` / `reply` / `release`, dispatched to `AttachedQueueRegistry`);
-the live `pushToChannel` wake streams the programmatic backend's interim text + the live
-inbound wake onto a session's GET stream. The stdio `bridge.ts` over `/events` + `/api/*`
-still works (Layer 1 below) — the HTTP MCP endpoint is **additive**, and is the path the
-SPA + the `claude mcp add` connect step steer toward.
+`claude --dangerously-load-development-channels=server:parachute-agent` — the `=` is
+load-bearing. The space form appears to work in `--print` mode, but in interactive mode
+the parser silently swallows the value as the initial-prompt positional and later
+surfaces `"server:parachute-agent · no MCP server configured with that name"` — blaming
+the wrong suspect (the MCP config is fine; the flag lost its value). Always use the `=`
+form ([#8](https://github.com/ParachuteComputer/parachute-agent/issues/8)). A cosmetic
+`/mcp` display warning can appear even with the correct flag — expected, ignore (#10).
 
 ## Auth
 
-**Layer 1 — session↔channel (done).** The bridge-facing daemon endpoints (`GET /events`,
-`POST /api/{reply,react,edit,permission,download}`) require a hub-issued JWT (`aud: agent`,
-scope `agent:read`/`agent:write`), validated via `@openparachute/scope-guard` against the
-hub's JWKS — exactly like a vault MCP client. The launcher mints the token
-(`parachute auth mint-token --scope "agent:read agent:write"`) and injects it as
-`PARACHUTE_AGENT_TOKEN`; the bridge presents it as a Bearer. Any session on any machine
-connects this way — no loopback trust.
+Daemon endpoints take hub-issued JWTs (`aud: agent`, scopes `agent:read/write/send/admin`)
+validated via `@openparachute/scope-guard` against the hub's JWKS — shared `requireScope`
+in `src/auth.ts`. The bridge presents the launcher-minted `PARACHUTE_AGENT_TOKEN`; the
+chat UI bootstraps a short-TTL token from the hub (`GET <hub-origin>/admin/agent-token`,
+cookie-gated). Browser SSE streams authenticate with a single-use ~60s ticket
+(`src/ui-ticket.ts`) so the JWT never rides a URL; the legacy `?token=` SSE path is gone.
 
-The daemon **must** have `PARACHUTE_HUB_ORIGIN` set to the hub's *public* origin (the hub stamps
-that as the token `iss`); the loopback fallback is dev-only. Hub-as-supervisor sets this when it
-starts the module; a manually-run daemon on an exposed box needs it in the environment.
+**Gotcha:** on any exposed box the daemon must have `PARACHUTE_HUB_ORIGIN` set to the
+hub's *public* origin (token-`iss` validation; the loopback fallback is dev-only).
+Hub-as-supervisor sets it — and `PARACHUTE_HUB_ORIGINS` for multi-origin boxes.
 
-**Layer 2 — human↔UI (done).** The chat-UI traffic endpoints (`POST /api/channels/<name>/send`
-→ scope `agent:send`; the browser SSE streams `GET /ui/events` + `GET /api/channels/<ch>/turn-events`
-→ scope `agent:read`) require a hub-issued JWT, validated the same way as Layer 1 (shared
-`requireScope` in `src/auth.ts`). The token comes from a hub endpoint —
-`GET <hub-origin>/admin/agent-token` (cookie-gated to the logged-in portal operator), returning
-`{ token, expires_at, scopes }` with `aud:agent` + `agent:read agent:send`, ~10min TTL. The chat
-page fetches it on load (`credentials: "include"`) and attaches it as a Bearer header on the send
-POST and the ticket mint. On a 401/SSE-error it re-fetches once and retries. `/ui`, `/health`, and
-`/.parachute/config[/schema]` stay OPEN — the page must load to bootstrap its token fetch, and the
-config listing is non-sensitive.
+### Step-up PIN — hard rules (agent#80)
 
-**SSE one-time ticket (agent#25).** An `EventSource` can't set an `Authorization` header, so the
-browser SSE streams used to take the hub JWT as a `?token=<JWT>` query param — which leaks the
-credential into any access/proxy log, browser history, or network trace (mitigated before only by
-the ~10min TTL). They now authenticate with a **one-time ticket** instead: the page POSTs its
-bearer to `POST /api/ui/sse-ticket` (Bearer-gated on `agent:read`, `mintSseTicket` in `src/auth.ts`),
-which returns `{ ticket, expires_at }` — an opaque 256-bit base64url nonce held only server-side in
-a TTL'd map (`src/ui-ticket.ts`, ≤60s) carrying the minting token's validated scopes. The page then
-opens `…?ticket=<nonce>`; the SSE consume path (`requireSseTicket`) looks it up, **consumes it
-single-use** (deletes immediately → a replay 401s), and establishes the stream with the ticket's
-scopes (never widened past the JWT's). So the JWT never appears in a URL. Each EventSource mints its
-own ticket; an SSE error re-mints and reconnects. The legacy `?token=` SSE path was REMOVED (pre-1.0,
-no deprecation window). The `agent:admin` terminal WebSocket still uses `?token=` — a separate
-operator-gated mechanism, out of this change's scope.
+The dangerous actions require a **step-up token** IN ADDITION to `agent:admin`:
+**set-credentials** (`/api/credentials/*` — can exfiltrate vault/channel/Claude tokens),
+the **terminal** WebSocket (raw host shell), and the **`filesystem: "full"` spawn**
+(whole-disk read). Ordinary sandboxed spawns and all reads stay frictionless.
 
-**Step-up auth — PIN second factor on the dangerous actions (agent#80).** A single
-`agent:admin` session can do anything dangerous with no re-confirm — set/rotate credentials
-(→ exfiltrate vault/channel/Claude tokens), open a **terminal** (→ raw host shell), or spawn a
-`filesystem: full` agent (→ read the whole disk). So those actions require a **step-up token**
-IN ADDITION to `agent:admin`. The operator sets a PIN once (hashed+salted via `Bun.password`
-argon2id in `~/.parachute/agent/step-up.json`, mode 0600 — `src/step-up.ts`); `POST /api/step-up
-{ pin }` validates it (rate-limited, 5 wrong / 5 min lockout) and mints an opaque CSPRNG nonce
-(TTL ~5min, server-side TTL'd map, REUSABLE within its window — like `ui-ticket.ts` but not
-single-use). `POST /api/step-up/pin { newPin, currentPin? }` sets/rotates the PIN (rotation
-requires the current PIN). The gate (`requireStepUp` in `src/auth.ts`) is enforced SERVER-side
-on: **set-credentials** (`POST`/`DELETE` `/api/credentials/env` + `/api/credentials/claude[/:channel]`),
-the **terminal** WS (`authorizeTerminalUpgrade`), and the **`filesystem: "full"` spawn** path
-(ordinary sandboxed spawns stay frictionless). A gate miss returns `403 { error:
-"step_up_required", reason: "setup"|"token" }` — DISTINCT from a plain 401 (no/invalid bearer) —
-so the SPA prompts (first-time setup vs PIN entry) instead of re-authenticating. The token rides
-the `X-Step-Up-Token` header (or `?step_up=` for the terminal WS, which can't set a header). The
-SPA holds it in memory and attaches it transparently in `lib/api.ts:authedFetch` (re-prompt on
-expiry); the PIN is never logged or returned. The step-up token NEVER widens scope — it's a
-second factor on top of `agent:admin`, never a substitute. (The PIN is 4–12 digits —
-convenience-grade, bounded by the 5-wrong/5-min lockout + the `agent:admin` barrier — by design.)
+- The gate (`requireStepUp`, `src/auth.ts`) is enforced SERVER-side. A miss returns
+  `403 { error: "step_up_required", reason: "setup"|"token" }` — distinct from a plain
+  401 — so the SPA prompts (first-time setup vs PIN entry) instead of re-authing.
+- The PIN (4–12 digits, convenience-grade by design) is argon2id-hashed
+  (`Bun.password`) in `~/.parachute/agent/step-up.json`, mode 0600 (`src/step-up.ts`).
+  `POST /api/step-up { pin }` is rate-limited (5 wrong → 5-min lockout) and mints an
+  opaque CSPRNG nonce (~5-min TTL, server-side map, reusable within its window).
+- The token rides `X-Step-Up-Token` (`?step_up=` only for the terminal WS, which can't
+  set headers). It NEVER widens scope — a second factor on top of `agent:admin`, never
+  a substitute. The PIN is never logged or returned.
+- Fresh upgrade: no PIN exists yet, so the first gated action returns
+  `403 (reason: "setup")` — set one via the admin UI or `POST /api/step-up/pin { newPin }`.
 
-> **Upgrade note (the step-up build).** Upgrading to the build that introduced step-up
-> (agent#80) makes the credential / terminal / full-filesystem-spawn actions require a step-up
-> PIN. On a fresh upgrade NO PIN is set yet, so the FIRST time you trigger one of those actions
-> the daemon returns `403 step_up_required` with `reason: "setup"` and the admin UI prompts you
-> to set a PIN (then immediately proceeds). If you script those endpoints directly (no UI),
-> you'll get the same `403 step_up_required (setup)` until you set a PIN via the admin UI (or
-> `POST /api/step-up/pin { newPin }`) and send the minted token as `X-Step-Up-Token`. Ordinary
-> sandboxed spawns + every read stay frictionless — only the three dangerous actions are gated.
+## Vault-backed channels (Stage 2)
 
-## Vault integration (Stage 2) — channels backed by `#agent/message` notes
+A `vault` transport backs channels with notes in the module-owned `#agent/*` namespace;
+the routing key is `metadata.agent` (post channel→agent rename, #133). Trap: a slash in
+a tag name is a namespace convention, NOT query inheritance — every message note carries
+BOTH the parent `#agent/message` (queryable) and a directional child, and the vault
+trigger fires on `#agent/message/inbound` only, so an outbound reply can never wake its
+own session. Full protocol (note shape, trigger YAML, webhook flow):
+[`design/2026-06-17-vault-native-agents.md`](./design/2026-06-17-vault-native-agents.md)
++ `src/transports/vault.ts`.
 
-A `vault` transport backs a channel with notes in a Parachute vault, so messages
-are durable, queryable, and a vault surface can render them. Multiple channels per
-vault: the note's routing-key metadata routes it.
+## `#agent/thread` — the thread record
 
-> **Routing-key CONTRACT landed (#133).** The data-model `channel → agent` rename's
-> CONTRACT phase is in: every note now writes the routing key under `metadata.agent`
-> ONLY (the `metadata.channel` dual-write is dropped), and the vault inbound trigger
-> keys on `has_metadata:["agent"]`. The `noteAgentKey` helper (`src/transports/vault.ts`)
-> still READS `agent ?? channel` as a read-only tolerance for any in-flight straggler
-> during the live cutover. The legacy `#channel-message*` / interim `#agent-message*`
-> tag dual-read + dual-schema were dropped too (we only ever wrote `#agent/message*`).
-> **Live cutover is a SEPARATE step:** merging this code has no live effect until the
-> vault trigger is re-registered to `has_metadata:["agent"]` and the daemon restarts.
-> Note the TRANSPORT/ENDPOINT "channel" concept is untouched — `channels.json`, the
-> `Channel` type, `/mcp/<channel>`, `InboundMessage.channel`, and the note path prefixes
-> all stay.
+Unified model: `definition → thread → message`. Every completed turn materializes an
+`#agent/thread` note — body is a rolling summary, metadata is the thread state including
+the Claude `session` UUID (the thread note IS the session record; there is no separate
+session store). `single-threaded` upserts one deterministic note per channel;
+`multi-threaded` writes one per fire. The note carries `['#agent/thread']` EXACTLY —
+never a message tag — so it can never wake a session. Detail:
+[`design/2026-06-18-agent-ui-v2-and-reactivity.md`](./design/2026-06-18-agent-ui-v2-and-reactivity.md).
 
-**The `#agent/*` namespace is module-owned** (design
-`design/2026-06-17-vault-native-agents.md`). Every vault object this module manages
-hangs off the `#agent` prefix: `#agent/definition` (a vault-native agent def — body
-is the system prompt, metadata is the config), `#agent/message{,/inbound,/outbound}`
-(a conversation turn), `#agent/job` (a scheduled trigger), `#agent/thread` (the durable
-record of one thread — see the `#agent/thread` subsection below). The tag schema declares
-`parent_names` so a human `tag:#agent` query rolls up to everything the module owns.
-The module always queries the EXACT leaf tag (never relies on prefix magic), and
-keeps the "tag both queryable parent + directional child literally" floor so loop
-avoidance + transcript listing work with zero per-vault schema dependency. The
-channel→agent CONTRACT dropped the prior flat `#agent-message*` / legacy
-`#channel-message*` tag dual-read — the module both WRITES and READS only the
-`#agent/message*` tags now.
+## No silent message loss (the high-water-mark rule)
 
-**Note shape** — TWO tags per note, carried literally (two orthogonal axes):
-- the parent `#agent/message` — the QUERYABLE membership tag. A UI lists a channel's
-  whole transcript (both directions) with one `tag: "#agent/message"` + `metadata.agent`
-  (the routing key) query, because the parent is literally on every note.
-- a directional child — the trigger DISCRIMINATOR: `#agent/message/inbound` (human→session)
-  or `#agent/message/outbound` (session reply).
-
-**The slash is a namespace, NOT query inheritance.** In a Parachute vault a slash in a tag
-NAME is a namespace convention only — `query-notes { tag: "#agent/message" }` matches
-descendants by the `tags.parent_names` graph (declared via `update-tag`), NOT by name-prefix.
-A note tagged ONLY `#agent/message/inbound` is INVISIBLE to a `tag: "#agent/message"`
-query unless that inheritance was separately declared — so we tag BOTH the parent and the
-child and don't depend on per-vault schema setup.
-
-Content = the message text; metadata: `{ agent, direction: "inbound"|"outbound", sender,
-in_reply_to (outbound), ts }` — `agent` is the routing key (the channel→agent CONTRACT moved
-it off the dropped `channel` field; `noteAgentKey` keeps an `agent ?? channel` read fallback
-for stragglers). Loop avoidance lives in the TAG, not metadata: the trigger fires on the inbound
-child tag only (exact match), which an outbound note never carries, so a reply never wakes its own
-session. **Inbound notes MUST carry BOTH `#agent/message` (parent, makes it queryable) AND
-`#agent/message/inbound` (child, fires the trigger), with the routing key in `metadata.agent`.**
-Outbound notes carry `#agent/message` + `#agent/message/outbound`.
-
-**Flow.** INBOUND (human→session): a new `#agent/message` + `#agent/message/inbound` note →
-a vault **trigger** POSTs a webhook → the agent daemon's `POST /api/vault/inbound` → routes by
-`noteAgentKey(note.metadata)` (reads `metadata.agent`) → `ctx.emit` wakes the session (fans to
-SSE bridges + HTTP-MCP sessions alike). OUTBOUND (session→human): the session's `reply` writes a `#agent/message` +
-`#agent/message/outbound` note via the vault REST API (`POST <vaultUrl>/vault/<vault>/api/notes`,
-Bearer `vault:<name>:write`).
-
-**channels.json** (the channel side):
-```json
-{ "name": "eng", "transport": "vault",
-  "config": { "vault": "default", "vaultUrl": "http://127.0.0.1:1940",
-              "token": "<vault:default:write JWT>", "webhookSecret": "<shared secret>" } }
-```
-
-**Vault side** (operator config — activates the inbound trigger):
-1. (Optional, for indexed queries) declare the `#agent/message` tag schema with
-   indexed `agent`/`direction`/`sender` fields (`update-tag`).
-2. Add a trigger to the vault's `config.yaml` that fires on new inbound notes and
-   webhooks the agent daemon. Loop avoidance is by tag: the vault predicate does
-   EXACT tag membership, so firing on the inbound CHILD tag (`#agent/message/inbound`)
-   never matches an outbound (reply) note — which carries `#agent/message/outbound`,
-   not the inbound child — so no `missing_metadata` clause is needed. (Both directions
-   also carry the parent `#agent/message`, but the trigger keys on the child only.)
-   ```yaml
-   triggers:
-     - name: channel_inbound
-       events: ["created"]
-       when:
-         tags: ["agent/message/inbound"]
-         has_metadata: ["agent"]
-         missing_metadata: ["channel_inbound_rendered_at"]
-       action:
-         webhook: "http://127.0.0.1:1941/api/vault/inbound?secret=<shared secret>"
-         send: "json"
-   ```
-   The shared secret rides in the URL — vault doesn't sign webhooks yet; a hub-JWT
-   auth block on the trigger is a follow-up. The daemon defends in depth too:
-   `ingestInbound` drops any note tagged `#agent/message/outbound`, so a reply can
-   never wake its own session.
-
-### `#agent/thread` — the thread record (the unified model)
-
-The unified model is `definition -> thread -> message`: **everything is a thread**, and
-EVERY completed turn materializes a `#agent/thread` note (a "run" was always a thread with
-one turn — the older `#agent/run` tag retired into this). The note is the durable,
-queryable record of one thread: its BODY is a rolling SUMMARY (`## Summary` /
-`## Latest turn`), and its metadata carries the thread state — `agent` (the routing key),
-`definition`, `mode`, `status`, `started_at`, `last_turn_at`, `turn_count`, cumulative `usage`, and the
-Claude `session` UUID. The INDEXED `status`/`definition`/`mode` fields make threads
-operator-queryable ("all failed threads", "all threads of agent X", "all multi-threaded
-threads").
-
-> **Thread ≡ session (#131).** The thread's Claude session UUID now lives on the thread
-> note itself as `metadata.session`: the daemon `--session-id`-CREATES the session on the
-> first turn and `--resume`-CONTINUES it on later turns, reading the UUID back off the
-> note. This replaces the retired separate `agent-session-state.json` store — the thread
-> note IS the session record.
-
-**v1 OVERWRITES the `## Summary` section every turn.** The module regenerates the whole
-body from the rolled-up metadata each turn (it never reads the prior note's content), so
-`## Summary` is a module-owned default, not a preserved slot. It is EARMARKED for a future
-summarizer agent, but summarizer-agent enrichment needs a read-prior-content → merge path
-(to preserve a summarizer-owned section across the regenerate), which is DEFERRED. "May
-own" means earmarked, not preserved.
-
-**Both execution modes materialize a thread note** — the mode governs the thread's
-IDENTITY (its path leaf) + whether it upserts:
-
-- **`single-threaded`** — exactly ONE thread note per channel at the DETERMINISTIC path
-  `Threads/<safeChannel>/<safeName>` (named after the definition). It UPSERTS in place
-  across turns: the transport READs the existing note, then writes the rolled-up
-  aggregates (`turn_count` incremented, `usage` summed, original `started_at` preserved,
-  `last_turn_at` advanced). Safe today because the drain is serial per channel and
-  single-threaded is one-thread-per-channel; concurrent-threads-per-channel (the deferred
-  continuation increment) will re-derive aggregates from the `#agent/message` children or
-  a vault atomic-merge instead.
-- **`multi-threaded`** — one thread note PER FIRE at `Threads/<safeChannel>/<uuid>`
-  (`turn_count` 1; usage = this fire's). No upsert.
-
-**Loop safety:** the thread note carries `['#agent/thread']` EXACTLY — never a message tag,
-never the inbound child — so it can never wake a session. It is also the PRIMARY record of
-the turn, written BEFORE the additive outbound transcript write, so a turn's record
-survives an outbound failure.
-
-## Environment variables
-
-| Variable | Default | Description |
-|---|---|---|
-| `PORT` | (unset) | **Highest-priority port input** — the hub supervisor injects this from the module's services.json `entry.port` (the canonical pattern vault/scribe follow). The daemon binds AND self-registers this port, so the supervisor's readiness probe + `/agent/*` proxy target agree (agent#41). Empty/non-numeric falls through. |
-| `PARACHUTE_AGENT_PORT` | `1941` | Daemon HTTP port — back-compat override for a daemon run *outside* the supervisor. Used only when `PORT` is unset. |
-| `PARACHUTE_AGENT_URL` | `http://127.0.0.1:1941` | Bridge → daemon URL |
-| `PARACHUTE_AGENT_STATE_DIR` | `~/.parachute/agent` | Token, access config, inbox |
-| `PARACHUTE_AGENT_SWEEP_MS` | `30000` | **Daemon:** cadence of the attached-backend claim-sweep tick (auto-releases `in-flight` inbound claims older than the 15-min TTL back to `pending`, so a crashed/abandoned session can't strand a channel queue). |
-| `PARACHUTE_AGENT_DISCOVERY` | `both` | **Daemon:** which note types the agent registry discovers agents from (Phase 4a dual-discovery). `both` (default) — `#agent/definition` AND `#agent/thread`, deduped by name with the DEF WINNING on a collision (additive + byte-identical to today for every def-backed agent). `thread` — `#agent/thread` only (prove thread-discovery in isolation before deleting defs). `def` — `#agent/definition` only (the escape hatch / today's behavior). The cutover is a flag-flip + restart, not a new build. |
-| `PARACHUTE_HUB_ORIGIN` | `http://127.0.0.1:1939` | **Daemon:** hub's public origin for JWT `iss` validation. Required on an exposed deployment (the loopback default is dev-only); hub-as-supervisor sets it. |
-| `PARACHUTE_HUB_ORIGINS` | (unset) | **Daemon:** the hub's FULL legitimate-origin SET (comma-separated) for multi-origin JWT `iss` validation (hub#692). A box reachable on several URLs at once (loopback + `<ip>.sslip.io` + a custom domain), or after `parachute hub set-origin`, mints tokens whose `iss` is whichever origin the request arrived on; the signing key is origin-independent, so a token minted under one origin must validate when this resource is reached via another on the SAME box. Hub-as-supervisor injects it. Layered onto scope-guard's `allowedIssuers` AFTER the JWKS signature verify (additive membership check, never a substitute). Unset → single-origin (`PARACHUTE_HUB_ORIGIN`) behavior, byte-identical to before. Parity with vault. |
-| `PARACHUTE_AGENT_TOKEN` | (none) | **Bridge:** hub-issued agent JWT presented as Bearer. The launcher mints + injects it; unset = no auth header (dev only). Default mint TTL is the hub's non-ephemeral default (~90d); re-launch re-mints. |
-
-## State directory
-
-`~/.parachute/agent/`:
-- `channels.json` — the channel registry. Each telegram channel carries its own bot token in `config.token` (created via the admin UI or written directly).
-- `.env` — optional generic env vars (e.g. `PARACHUTE_HUB_ORIGIN`). The daemon no longer consumes `TELEGRAM_BOT_TOKEN` here.
-- `access.json` — allowlist (compatible with the official plugin's format)
-- `inbox/` — downloaded attachments
-- `delivery-state.json` — per-channel last-delivered high-water-mark (`{ "<channel>": "<iso-ts>" }`), the spine of the no-silent-loss guarantee (below). Cheap, monotonic, write-through; losing it only costs a bounded re-replay.
-
-## No silent message loss (delivery high-water-mark + backlog replay)
-
-A connected vault-backed session used to go silently deaf after a daemon restart: MCP sessions drop on restart and only reconnect on the next interaction, and an inbound that lands with **zero** live subscribers reaches no one — yet the vault trigger acks success and stamps `..._rendered_at`, so it never re-fires. The message stays durable in the vault but is lost from the live wake.
-
-The fix (`src/delivery-state.ts`):
-- **Per-channel high-water-mark** — the ISO `ts` of the last inbound we actually delivered to ≥1 live subscriber. `contextFor.emit` advances it ONLY on a real delivery (SSE client count + MCP session count > 0); a 0-subscriber emit deliberately leaves the mark behind so the message replays later. Monotonic (never rewinds), persisted to `delivery-state.json`. A channel with no persisted mark defaults to the **daemon boot time** — so a first connect never replays ancient history, only the genuine deaf-window gap.
-- **Backlog replay on (re)connect** (`replayBacklog`, VAULT channels only) — when an MCP session registers or an SSE bridge reopens `/events`, the daemon loads the channel transcript (reusing the index-free `loadTranscript`), replays the inbound messages newer than the mark — oldest-first, capped at the newest 50 — to **that one new subscriber only** (a per-session MCP push / a write to that one SSE stream, so existing subscribers aren't re-woken), then advances the mark.
-
-`markSeen` (the webhook idempotency dedup that prevents the N-trigger fan-out from double-waking) is unchanged and orthogonal — the backlog path is gated by the mark, not by `markSeen`.
+MCP sessions drop on daemon restart, and an inbound that lands with zero live
+subscribers reaches no one — yet the vault trigger acks and never re-fires. The
+guarantee (`src/delivery-state.ts`): a per-channel high-water-mark (persisted in
+`~/.parachute/agent/delivery-state.json`) advances ONLY on a real delivery (≥1 live
+subscriber) — a 0-subscriber emit deliberately leaves it behind — and on (re)connect the
+daemon replays inbound newer than the mark (vault channels, oldest-first, capped at 50)
+to that one new subscriber. The mark is monotonic; a channel with no persisted mark
+defaults to daemon boot time, so a first connect never replays ancient history. When
+touching emit/delivery paths, preserve this invariant. (`markSeen` webhook dedup is
+orthogonal — it prevents double-wakes, not loss.)
 
 ## Access control (`access.json`)
 
-Schema is compatible with the official Telegram plugin, plus one parachute-agent extension: `allowInChats`.
-
-| Field | Type | Description |
-|---|---|---|
-| `dmPolicy` | `"open" \| "pairing" \| "allowlist"` | `"open"` disables all gating. Anything else requires `allowFrom`. |
-| `allowFrom` | `string[]` | User-ID allowlist. Matches `msg.from.id` / `cq.from.id`. |
-| `allowInChats` | `string[]` (optional) | **Optional** chat-ID allowlist. For DMs, it's an AND gate with `allowFrom`. For **groups** (negative chat_id), inclusion grants entry to any group member — `allowFrom` is bypassed so shared spaces don't need every participant enumerated. |
-| `groups`, `pending` | — | Used by the official plugin's pairing flow; read but not otherwise acted on here. |
-
-### `allowInChats` semantics
-
-- **Absent** → behave as today (user-allowlist only, no per-chat gating). Backwards-compatible.
-- **Present with entries** →
-  - **DMs** (positive chat_id, equals user_id): require BOTH `allowFrom` AND `allowInChats` to include the id.
-  - **Groups** (negative chat_id): inclusion in `allowInChats` grants entry to any group member. `allowFrom` is bypassed. This is the intended way to let the bot participate in shared spaces without enumerating every member.
-- **Present but empty (`[]`)** → **fail-closed**: no chats allowed. If you want user-only gating, omit the field rather than setting it to `[]`.
-
-Private DMs to the bot have `chat.id === user_id` (Telegram convention). To permit a user's DM while gating groups, list their user ID in `allowInChats` too:
-
-```json
-{
-  "dmPolicy": "allowlist",
-  "allowFrom": ["1190596288"],
-  "allowInChats": ["1190596288", "-1003765557903"],
-  "groups": {},
-  "pending": {}
-}
-```
-
-## MCP tools exposed to Claude
-
-The channel MCP endpoint serves ONE of two tool surfaces, resolved at connect time by
-the channel's backend (`src/mcp-http.ts`):
-
-**Push surface** (a non-`attached` channel / the bridge — the session is woken, then replies):
-
-| Tool | Description |
-|---|---|
-| `reply` | Send text + file attachments to a chat. Images → photos, .ogg → voice, others → documents. |
-| `react` | Add emoji reaction to a message |
-| `edit_message` | Edit a previously sent message |
-| `download_attachment` | Download a Telegram file by file_id, returns local path |
-
-**Pull surface** (an `attached`-backend agent — the session pulls the durable queue,
-dispatched to `AttachedQueueRegistry`):
-
-| Tool | Description |
-|---|---|
-| `pending` | How many inbound messages await + a peek (read-only, claims nothing) |
-| `next-message` | Claim the oldest unhandled inbound; returns `{ id, text, inReplyTo, systemPrompt }` and marks it in-flight |
-| `reply` | `{ inReplyTo, text }` → write the outbound note + mark the inbound handled |
-| `release` | Un-claim an in-flight message back to pending |
-
-## Testing
-
-```bash
-# Health check
-curl http://127.0.0.1:1941/health
-
-# Send a test message
-curl -X POST http://127.0.0.1:1941/api/reply \
-  -H "content-type: application/json" \
-  -d '{"chat_id":"<CHAT_ID>","text":"hello from parachute-agent"}'
-```
-
-## Future
-
-Two orthogonal axes extend cleanly:
-
-- **New transports** (how a channel reaches the outside world — Telegram, http-ui,
-  vault, …): add `src/transports/<name>.ts` implementing the `Transport` contract and
-  register it alongside the others. The session-facing MCP contract is unchanged.
-- **The two backends** (`programmatic` | `attached`) are the settled execution axis; the
-  retired `interactive` (tmux) path is parked, not extended (design
-  [`2026-06-19-retire-interactive-backend.md`](./design/2026-06-19-retire-interactive-backend.md)).
-  A future revival of the parked PTY code lands as a general terminal/process-management
-  capability, decoupled from the agent backend.
-
-## Post-merge hygiene
-
-When a PR is merged, locally:
-
-```
-git checkout main && git pull
-```
-
-Agent's steward does this already — captured here so it's durable and matches the convention now documented across every Parachute repo. Caught 2026-04-21 across vault/lens/scribe/cli where it wasn't being done.
+Schema-compatible with the official plugin, plus the `allowInChats` extension. DMs
+(positive chat_id, `chat.id === user_id`) require BOTH `allowFrom` AND `allowInChats`
+(when present — list a user's id in both to allow their DM). Groups (negative chat_id)
+listed in `allowInChats` admit ANY member — `allowFrom` is bypassed, by design for
+shared spaces. **An empty `allowInChats: []` is fail-closed** (no chats allowed); omit
+the field for user-allowlist-only gating.


### PR DESCRIPTION
Context-refit slice per the workspace's new conventions (`docs/process/context.md` in ParachuteComputer): CLAUDE.md = purpose + gotchas only, no derivable inventories, process -> pointers, no fast-changing metrics.

**Before/after:** 472 lines (~6k tokens) -> 157 lines (~2k tokens). Docs-only; no version bump.

## What moved to pointers (derivable from code/design docs)
- Vault-integration Stage-2 protocol block -> 8-line trigger summary + `design/2026-06-17-vault-native-agents.md` + `src/transports/vault.ts`
- `#agent/thread` model -> summary + `design/2026-06-18-agent-ui-v2-and-reactivity.md` (the vault-native-agents doc never mentions threads — this is the doc that actually defines the unified model)
- Env-var table -> cut; code that reads them is the reference. Kept one line: the `PARACHUTE_AGENT_ALERT_CHANNEL` + `PARACHUTE_AGENT_ALERT_CHAT_ID` must-set-together pairing trap
- MCP tools tables + OAuth discovery detail -> one pointer at `src/mcp-http.ts`
- State-dir listing, testing curl block, Future section -> cut (transports extension point folded into Architecture)
- Post-merge-hygiene section -> deleted (the workspace CLAUDE.md owns it)

## Crown jewels kept, compressed to their trigger
- The `=`-binding flag-parser trap (#8) — space form silently swallows the value in interactive mode
- The no-silent-message-loss high-water-mark rule (`src/delivery-state.ts`) — advance-only-on-real-delivery invariant
- Why-not-the-official-telegram-plugin (anthropics/claude-code#38098)
- Step-up PIN hard rules (agent#80) — kept as hard rules, prose tightened ~40%
- `allowInChats` semantics incl. the fail-closed empty-`[]` trap
- Repo purpose + the experimental/breaking-OK compatibility note

## Notes for the merger
- Every relative link verified against the tree (4 design docs + `src/_parked/interactive-spawn.ts` + all `src/*.ts` references).
- Open PR #191 (`job-failure-alerts`) adds two rows to the env-var table this PR deletes — whichever merges second will hit a trivial CLAUDE.md conflict. The alert-pairing trap is already captured here as a standalone line, so #191's CLAUDE.md hunk can simply be dropped if this lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XLZtmuSs1RirWGMGyCB1QB